### PR TITLE
Some changes to "remove simple equations" and related stuff

### DIFF
--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -8269,21 +8269,21 @@ algorithm
   comp := BackendDAE.SINGLEEQUATION(eqIdx,varIdx);
 end makeSingleEquationComp;
 
-public function getAliasVars
+public function getAliasVars "author: lochel"
   input BackendDAE.BackendDAE inDAE;
   output BackendDAE.Variables outAliasVars;
 algorithm
   BackendDAE.DAE(shared=BackendDAE.SHARED(aliasVars=outAliasVars)) := inDAE;
 end getAliasVars;
 
-public function getKnownVars
+public function getKnownVars "author: lochel"
   input BackendDAE.BackendDAE inDAE;
   output BackendDAE.Variables outKnownVars;
 algorithm
   BackendDAE.DAE(shared=BackendDAE.SHARED(knownVars=outKnownVars)) := inDAE;
 end getKnownVars;
 
-public function setAliasVars
+public function setAliasVars "author: lochel"
   input BackendDAE.BackendDAE inDAE;
   input BackendDAE.Variables inAliasVars;
   output BackendDAE.BackendDAE outDAE;
@@ -8296,7 +8296,7 @@ algorithm
   outDAE := BackendDAE.DAE(eqs, shared);
 end setAliasVars;
 
-public function setKnownVars
+public function setKnownVars "author: lochel"
   input BackendDAE.BackendDAE inDAE;
   input BackendDAE.Variables inKnownVars;
   output BackendDAE.BackendDAE outDAE;

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -2312,23 +2312,27 @@ protected
   list<Absyn.Path> paths;
   list<String> paths_lst;
   String path_str;
+  Boolean unreplaceable;
+  String unreplaceableStr;
 algorithm
-  BackendDAE.VAR(varName = cr,
-                 varKind = kind,
-                 varDirection = dir,
-                 varType = var_type,
-                 arryDim = arrayDim,
-                 bindExp = bindExp,
-                 source = source,
-                 values = dae_var_attr,
-                 comment = comment,
-                 connectorType = ct) := inVar;
+  BackendDAE.VAR(varName=cr,
+                 varKind=kind,
+                 varDirection=dir,
+                 varType=var_type,
+                 arryDim=arrayDim,
+                 bindExp=bindExp,
+                 source=source,
+                 values=dae_var_attr,
+                 comment=comment,
+                 connectorType=ct,
+                 unreplaceable=unreplaceable) := inVar;
   paths := DAEUtil.getElementSourceTypes(source);
   paths_lst := List.map(paths, Absyn.pathString);
+  unreplaceableStr := if unreplaceable then " unreplaceable" else "";
   outStr := DAEDump.dumpDirectionStr(dir) + ComponentReference.printComponentRefStr(cr) + ":"
             + kindString(kind) + "(" + connectorTypeString(ct) + attributesString(dae_var_attr)
             + ") " + optExpressionString(bindExp,"") + DAEDump.dumpCommentAnnotationStr(comment)
-            + stringDelimitList(paths_lst, ", ") + " type: " + dumpTypeStr(var_type) + "["+ExpressionDump.dimensionsString(arrayDim)+"]";
+            + stringDelimitList(paths_lst, ", ") + " type: " + dumpTypeStr(var_type) + "["+ExpressionDump.dimensionsString(arrayDim) + "]" + unreplaceableStr;
 end varString;
 
 public function dumpKind

--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -114,11 +114,12 @@ protected
   Option<SCode.Comment> s;
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, _) := inVar;
+  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable) := inVar;
   oattr := if isSome(oattr) then oattr else SOME(getVariableAttributefromType(d));
   oattr := DAEUtil.setFixedAttr(oattr, SOME(DAE.BCONST(inBoolean)));
-  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, false);
+  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable);
 end setVarFixed;
 
 public function varFixed "author: PA
@@ -167,11 +168,12 @@ protected
   Option<SCode.Comment> s;
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct,io, _) := inVar;
+  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct,io, unreplaceable) := inVar;
   oattr := if isSome(oattr) then oattr else SOME(getVariableAttributefromType(d));
   oattr := DAEUtil.setStartAttr(oattr, inExp);
-  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct,io, false);
+  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct,io, unreplaceable);
 end setVarStartValue;
 
 public function setVarStartValueOption "author: Frenkel TUD
@@ -195,11 +197,12 @@ protected
   Option<SCode.Comment> s;
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, _) := inVar;
+  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable) := inVar;
   oattr := if isSome(oattr) then oattr else SOME(getVariableAttributefromType(d));
   oattr := DAEUtil.setStartAttrOption(oattr, inExp);
-  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, false);
+  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable);
 end setVarStartValueOption;
 
 public function setVarStartOrigin "author: Frenkel TUD
@@ -223,11 +226,12 @@ protected
   Option<SCode.Comment> s;
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, _) := inVar;
+  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable) := inVar;
   oattr := if isSome(oattr) then oattr else SOME(getVariableAttributefromType(d));
   oattr := DAEUtil.setStartOrigin(oattr, startOrigin);
-  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, false);
+  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable);
 end setVarStartOrigin;
 
 public function setVarAttributes "sets the variable attributes of a variable.
@@ -236,22 +240,23 @@ public function setVarAttributes "sets the variable attributes of a variable.
   input Option<DAE.VariableAttributes> attr;
   output BackendDAE.Var outV;
 protected
-   DAE.ComponentRef a;
-    BackendDAE.VarKind b;
-    DAE.VarDirection c;
-    DAE.VarParallelism prl;
-    BackendDAE.Type d;
-    Option<DAE.Exp> e;
-    Option<Values.Value> f;
-    list<DAE.Dimension> g;
-    DAE.ElementSource source;
-    Option<SCode.Comment> s;
+  DAE.ComponentRef a;
+  BackendDAE.VarKind b;
+  DAE.VarDirection c;
+  DAE.VarParallelism prl;
+  BackendDAE.Type d;
+  Option<DAE.Exp> e;
+  Option<Values.Value> f;
+  list<DAE.Dimension> g;
+  DAE.ElementSource source;
+  Option<SCode.Comment> s;
   Option<BackendDAE.TearingSelect> ts;
-    DAE.ConnectorType ct;
-    DAE.VarInnerOuter io;
+  DAE.ConnectorType ct;
+  DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(a,b,c,prl,d,e,f,g,source,_,ts,s,ct,io, _) := v;
-  outV := BackendDAE.VAR(a,b,c,prl,d,e,f,g,source,attr,ts,s,ct,io, false);
+  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, _, ts, s, ct, io, unreplaceable) := v;
+  outV := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, attr, ts, s, ct, io, unreplaceable);
 end setVarAttributes;
 
 public function varStartValue "author: PA
@@ -264,6 +269,14 @@ algorithm
   BackendDAE.VAR(values=attr) := v;
   sv := DAEUtil.getStartAttr(attr);
 end varStartValue;
+
+public function varUnreplaceable "author: lochel
+  Returns the unreplaceable attribute of a variable."
+  input BackendDAE.Var inVar;
+  output Boolean outUnreplaceable;
+algorithm
+  BackendDAE.VAR(unreplaceable=outUnreplaceable) := inVar;
+end varUnreplaceable;
 
 public function varStartValueFail "author: Frenkel TUD
   Returns the DAE.StartValue of a variable if there is one.
@@ -484,11 +497,12 @@ protected
   Option<SCode.Comment> s;
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, _) := inVar;
+  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable) := inVar;
   oattr := if isSome(oattr) then oattr else SOME(getVariableAttributefromType(d));
   oattr := DAEUtil.setStateSelect(oattr, stateSelect);
-  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, false);
+  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable);
 end setVarStateSelect;
 
 public function varStateDerivative "author: Frenkel TUD 2013-01
@@ -530,22 +544,24 @@ protected
   Option<SCode.Comment> s;
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
   BackendDAE.VAR(varName=a,
-              varKind=BackendDAE.STATE(index=indx),
-              varDirection=c,
-              varParallelism=prl,
-              varType=d,
-              bindExp=e,
-              bindValue=f,
-              arryDim=g,
-              source=source,
-              values=oattr,
-        tearingSelectOption = ts,
-              comment=s,
-              connectorType=ct,
-              innerOuter=io) := inVar;
-  outVar := BackendDAE.VAR(a,BackendDAE.STATE(indx,dcr),c,prl,d,e,f,g,source,oattr,ts,s,ct,io, false);
+                 varKind=BackendDAE.STATE(index=indx),
+                 varDirection=c,
+                 varParallelism=prl,
+                 varType=d,
+                 bindExp=e,
+                 bindValue=f,
+                 arryDim=g,
+                 source=source,
+                 values=oattr,
+                 tearingSelectOption = ts,
+                 comment=s,
+                 connectorType=ct,
+                 innerOuter=io,
+                 unreplaceable=unreplaceable) := inVar;
+  outVar := BackendDAE.VAR(a, BackendDAE.STATE(indx, dcr), c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable);
 end setStateDerivative;
 
 public function getVariableAttributefromType
@@ -589,11 +605,12 @@ protected
   Option<SCode.Comment> s;
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, _) := inVar;
+  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable) := inVar;
   oattr := if isSome(oattr) then oattr else SOME(getVariableAttributefromType(d));
   oattr := DAEUtil.setFinalAttr(oattr, finalPrefix);
-  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, false);
+  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable);
 end setVarFinal;
 
 public function setVarMinMax "author: Frenkel TUD
@@ -618,12 +635,13 @@ protected
   Option<SCode.Comment> s;
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
   if isSome(inMin) or isSome(inMax) then
-    BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, _) := inVar;
+    BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable) := inVar;
     oattr := if isSome(oattr) then oattr else SOME(getVariableAttributefromType(d));
     oattr := DAEUtil.setMinMax(oattr, inMin, inMax);
-    outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, false);
+    outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable);
   else
     outVar := inVar;
   end if;
@@ -650,11 +668,12 @@ protected
   Option<SCode.Comment> s;
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, _) := inVar;
+  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable) := inVar;
   oattr := if isSome(oattr) then oattr else SOME(getVariableAttributefromType(d));
   oattr := DAEUtil.setUnitAttr(oattr, inUnit);
-  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, false);
+  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable);
 end setUnit;
 
 public function varNominalValue "author: Frenkel TUD"
@@ -685,11 +704,12 @@ protected
   Option<SCode.Comment> s;
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, _) := inVar;
+  BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable) := inVar;
   oattr := if isSome(oattr) then oattr else SOME(getVariableAttributefromType(d));
   oattr := DAEUtil.setNominalAttr(oattr, inExp);
-  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, false);
+  outVar := BackendDAE.VAR(a, b, c, prl, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable);
 end setVarNominalValue;
 
 public function varType "author: PA
@@ -1738,21 +1758,23 @@ protected
   Option<SCode.Comment> comment;
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(varKind = kind,
-                 varDirection = dir,
-                 varParallelism = prl,
-                 varType = tp,
-                 bindExp = bind,
-                 bindValue = v,
-                 arryDim = dim,
-                 source = source,
-                 values = attr,
-         tearingSelectOption = ts,
-                 comment = comment,
-                 connectorType = ct,
-                 innerOuter = io) := inVar;
-  outVar := BackendDAE.VAR(cr, kind, dir, prl, tp, bind, v, dim, source, attr, ts, comment, ct, io, false);
+  BackendDAE.VAR(varKind=kind,
+                 varDirection=dir,
+                 varParallelism=prl,
+                 varType=tp,
+                 bindExp=bind,
+                 bindValue=v,
+                 arryDim=dim,
+                 source=source,
+                 values=attr,
+                 tearingSelectOption=ts,
+                 comment=comment,
+                 connectorType=ct,
+                 innerOuter=io,
+                 unreplaceable=unreplaceable) := inVar;
+  outVar := BackendDAE.VAR(cr, kind, dir, prl, tp, bind, v, dim, source, attr, ts, comment, ct, io, unreplaceable);
 end copyVarNewName;
 
 public function setVarKindForVar"updates the varkind for an indexed var inside the variable-array.
@@ -1798,21 +1820,23 @@ protected
   DAE.ConnectorType ct;
   BackendDAE.Var oVar;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(varName = cr,
-                 varDirection = dir,
-                 varParallelism = prl,
-                 varType = tp,
-                 bindExp = bind,
-                 bindValue = v,
-                 arryDim = dim,
-                 source = source,
-                 values = attr,
-         tearingSelectOption = ts,
-                 comment = comment,
-                 connectorType = ct,
-                 innerOuter = io) := inVar;
-  outVar := BackendDAE.VAR(cr, inVarKind, dir, prl, tp, bind, v, dim, source, attr, ts, comment, ct, io, false);
+  BackendDAE.VAR(varName=cr,
+                 varDirection=dir,
+                 varParallelism=prl,
+                 varType=tp,
+                 bindExp=bind,
+                 bindValue=v,
+                 arryDim=dim,
+                 source=source,
+                 values=attr,
+                 tearingSelectOption=ts,
+                 comment=comment,
+                 connectorType=ct,
+                 innerOuter=io,
+                 unreplaceable=unreplaceable) := inVar;
+  outVar := BackendDAE.VAR(cr, inVarKind, dir, prl, tp, bind, v, dim, source, attr, ts, comment, ct, io, unreplaceable);
   // referenceUpdate(inVar, 2, new_kind);
 end setVarKind;
 
@@ -1835,21 +1859,23 @@ protected
   DAE.ConnectorType ct;
   BackendDAE.Var oVar;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(varName = cr,
-                 varKind = varKind,
-                 varDirection = dir,
-                 varParallelism = prl,
-                 varType = tp,
-                 bindValue = v,
-                 arryDim = dim,
-                 source = source,
-                 values = attr,
-         tearingSelectOption = ts,
-                 comment = comment,
-                 connectorType = ct,
-                 innerOuter = io) := inVar;
-  outVar := BackendDAE.VAR(cr, varKind, dir, prl, tp, inBindExp, v, dim, source, attr, ts, comment, ct, io, false);
+  BackendDAE.VAR(varName=cr,
+                 varKind=varKind,
+                 varDirection=dir,
+                 varParallelism=prl,
+                 varType=tp,
+                 bindValue=v,
+                 arryDim=dim,
+                 source=source,
+                 values=attr,
+                 tearingSelectOption=ts,
+                 comment=comment,
+                 connectorType=ct,
+                 innerOuter=io,
+                 unreplaceable=unreplaceable) := inVar;
+  outVar := BackendDAE.VAR(cr, varKind, dir, prl, tp, inBindExp, v, dim, source, attr, ts, comment, ct, io, unreplaceable);
 end setBindExp;
 
 public function setBindValue "author: lochel"
@@ -1870,21 +1896,23 @@ protected
   Option<SCode.Comment> comment;
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  BackendDAE.VAR(varName = cr,
-                 varKind = varKind,
-                 varDirection = dir,
-                 varParallelism = prl,
-                 varType = tp,
-                 bindExp = bindExp,
-                 arryDim = dim,
-                 source = source,
-                 values = attr,
-         tearingSelectOption = ts,
-                 comment = comment,
-                 connectorType = ct,
-                 innerOuter = io) := inVar;
-  outVar := BackendDAE.VAR(cr, varKind, dir, prl, tp, bindExp, inBindValue, dim, source, attr, ts, comment, ct, io, false);
+  BackendDAE.VAR(varName=cr,
+                 varKind=varKind,
+                 varDirection=dir,
+                 varParallelism=prl,
+                 varType=tp,
+                 bindExp=bindExp,
+                 arryDim=dim,
+                 source=source,
+                 values=attr,
+                 tearingSelectOption=ts,
+                 comment=comment,
+                 connectorType=ct,
+                 innerOuter=io,
+                 unreplaceable=unreplaceable) := inVar;
+  outVar := BackendDAE.VAR(cr, varKind, dir, prl, tp, bindExp, inBindValue, dim, source, attr, ts, comment, ct, io, unreplaceable);
 end setBindValue;
 
 public function setVarDirectionTpl
@@ -1897,47 +1925,43 @@ algorithm
   dir := inDir;
 end setVarDirectionTpl;
 
-public function setVarDirection "author: Frenkel TUD 17-03-11
+public function setVarDirection "author: lochel
   Sets the DAE.VarDirection of a variable"
   input BackendDAE.Var inVar;
-  input DAE.VarDirection varDirection;
+  input DAE.VarDirection inVarDirection;
   output BackendDAE.Var outVar;
+protected
+  DAE.ComponentRef cr;
+  BackendDAE.VarKind kind;
+  DAE.VarParallelism prl;
+  BackendDAE.Type tp;
+  Option<DAE.Exp> bind;
+  Option<Values.Value> v;
+  list<DAE.Dimension> dim;
+  DAE.ElementSource source;
+  Option<DAE.VariableAttributes> attr;
+  Option<BackendDAE.TearingSelect> ts;
+  Option<SCode.Comment> comment;
+  DAE.ConnectorType ct;
+  BackendDAE.Var oVar;
+  DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  outVar := match (inVar,varDirection)
-    local
-      DAE.ComponentRef cr;
-      DAE.VarParallelism prl;
-      BackendDAE.VarKind kind;
-      BackendDAE.Type tp;
-      Option<DAE.Exp> bind;
-      Option<Values.Value> v;
-      list<DAE.Dimension> dim;
-      DAE.ElementSource source;
-      Option<DAE.VariableAttributes> attr;
-    Option<BackendDAE.TearingSelect> ts;
-      Option<SCode.Comment> comment;
-      DAE.ConnectorType ct;
-      BackendDAE.Var oVar;
-      DAE.VarInnerOuter io;
-
-    case (BackendDAE.VAR(varName = cr,
-              varKind = kind,
-              varParallelism = prl,
-              varType = tp,
-              bindExp = bind,
-              bindValue = v,
-              arryDim = dim,
-              source = source,
-              values = attr,
-        tearingSelectOption = ts,
-              comment = comment,
-              connectorType = ct,
-              innerOuter = io),_)
-    equation
-      oVar = BackendDAE.VAR(cr,kind,varDirection,prl,tp,bind,v,dim,source,attr,ts,comment,ct,io,false); // referenceUpdate(inVar, 3, varDirection);
-    then
-      oVar;
-  end match;
+  BackendDAE.VAR(varName=cr,
+                 varKind=kind,
+                 varParallelism=prl,
+                 varType=tp,
+                 bindExp=bind,
+                 bindValue=v,
+                 arryDim=dim,
+                 source=source,
+                 values=attr,
+                 tearingSelectOption=ts,
+                 comment=comment,
+                 connectorType=ct,
+                 innerOuter=io,
+                 unreplaceable=unreplaceable) := inVar;
+  outVar := BackendDAE.VAR(cr, kind, inVarDirection, prl, tp, bind, v, dim, source, attr, ts, comment, ct, io, unreplaceable); // referenceUpdate(inVar, 3, varDirection);
 end setVarDirection;
 
 public function getVarDirection "author: wbraun
@@ -2253,14 +2277,14 @@ algorithm
     local
       DAE.ComponentRef name;
 
-    case DAE.CREF(componentRef=name) then (name,false);
+    case DAE.CREF(componentRef=name) then (name, false);
     case DAE.UNARY(operator=DAE.UMINUS(_),exp=DAE.CREF(componentRef=name)) then (name,true);
     case DAE.UNARY(operator=DAE.UMINUS_ARR(_),exp=DAE.CREF(componentRef=name)) then (name,true);
     case DAE.LUNARY(operator=DAE.NOT(_),exp=DAE.CREF(componentRef=name)) then (name,true);
     case DAE.CALL(path=Absyn.IDENT(name = "der"), expLst={DAE.CREF(componentRef=name)})
       equation
         name = ComponentReference.crefPrefixDer(name);
-      then (name,false);
+      then (name, false);
     case DAE.UNARY(operator=DAE.UMINUS(_),exp=DAE.CALL(path=Absyn.IDENT(name = "der"), expLst={DAE.CREF(componentRef=name)}))
       equation
        name = ComponentReference.crefPrefixDer(name);
@@ -2884,7 +2908,7 @@ end existsVar;
 
 public function makeVar
  input DAE.ComponentRef cr;
- output BackendDAE.Var v = BackendDAE.VAR(cr, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(),false);
+ output BackendDAE.Var v = BackendDAE.VAR(cr, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
 end makeVar;
 
 public function addVarDAE
@@ -3362,7 +3386,7 @@ algorithm
       exp = DAE.RANGE(ty,DAE.ICONST(1),NONE(),DAE.ICONST(stop2));
     then (exp,true);
    else
-     then (inExp,false);
+     then (inExp, false);
   end matchcontinue;
 end computeRangeExps;
 
@@ -3819,47 +3843,45 @@ end traversingisAlgStateVarIndexFinder;
 
 
 public function mergeVariableOperations
-  input BackendDAE.Var var;
-  input list<DAE.SymbolicOperation> iops;
+  input BackendDAE.Var inVar;
+  input list<DAE.SymbolicOperation> inOps;
   output BackendDAE.Var outVar;
+protected
+  DAE.ComponentRef a;
+  BackendDAE.VarKind b;
+  DAE.VarDirection c;
+  DAE.VarParallelism p;
+  BackendDAE.Type d;
+  Option<DAE.Exp> e;
+  Option<Values.Value> f;
+  list<DAE.Dimension> g;
+  DAE.ElementSource source;
+  Option<DAE.VariableAttributes> oattr;
+  Option<BackendDAE.TearingSelect> ts;
+  Option<SCode.Comment> s;
+  DAE.ConnectorType ct;
+  list<DAE.SymbolicOperation> ops;
+  DAE.VarInnerOuter io;
+  Boolean unreplaceable;
 algorithm
-  outVar := match (var,iops)
-    local
-      DAE.ComponentRef a;
-      BackendDAE.VarKind b;
-      DAE.VarDirection c;
-      DAE.VarParallelism p;
-      BackendDAE.Type d;
-      Option<DAE.Exp> e;
-      Option<Values.Value> f;
-      list<DAE.Dimension> g;
-      DAE.ElementSource source;
-      Option<DAE.VariableAttributes> oattr;
-      Option<BackendDAE.TearingSelect> ts;
-      Option<SCode.Comment> s;
-      DAE.ConnectorType ct;
-      list<DAE.SymbolicOperation> ops;
-      DAE.VarInnerOuter io;
-
-    case (BackendDAE.VAR(varName = a,
-              varKind = b,
-              varDirection = c,
-              varParallelism = p,
-              varType = d,
-              bindExp = e,
-              bindValue = f,
-              arryDim = g,
-              source = source,
-              values = oattr,
-        tearingSelectOption = ts,
-              comment = s,
-              connectorType = ct,
-              innerOuter = io),_)
-      equation
-        ops = listReverse(iops);
-        source = List.foldr(ops,DAEUtil.addSymbolicTransformation,source);
-      then BackendDAE.VAR(a,b,c,p,d,e,f,g,source,oattr,ts,s,ct,io,false);
-  end match;
+  BackendDAE.VAR(varName=a,
+                 varKind=b,
+                 varDirection=c,
+                 varParallelism=p,
+                 varType=d,
+                 bindExp=e,
+                 bindValue=f,
+                 arryDim=g,
+                 source=source,
+                 values=oattr,
+                 tearingSelectOption=ts,
+                 comment=s,
+                 connectorType=ct,
+                 innerOuter=io,
+                 unreplaceable=unreplaceable) := inVar;
+  ops := listReverse(inOps);
+  source := List.foldr(ops, DAEUtil.addSymbolicTransformation, source);
+  outVar := BackendDAE.VAR(a, b, c, p, d, e, f, g, source, oattr, ts, s, ct, io, unreplaceable);
 end mergeVariableOperations;
 
 public function mergeAliasVars "author: Frenkel TUD 2011-04"
@@ -4386,16 +4408,7 @@ public function selfGeneratedVar
   input DAE.ComponentRef inCref;
   output Boolean b;
 algorithm
-  b := match(inCref)
-    local String ident;
-    case DAE.CREF_QUAL(ident = "$ZERO") then true;
-    case DAE.CREF_QUAL(ident = "$pDER") then true;
-    case DAE.CREF_QUAL(ident = "$DER",componentRef=DAE.CREF_QUAL(ident = "$DER")) then true;
-    // keep them a while untill we know which are needed
-    //case DAE.CREF_QUAL(ident = "$DER") then true;
-    case DAE.CREF_IDENT(ident = ident) then intEq(System.strncmp(ident,"$when",5),0);
-    else false;
-  end match;
+  b := substring(ComponentReference.crefStr(inCref), 1, 1) == "$";
 end selfGeneratedVar;
 
 public function varStateSelectPrioAlias "Helper function to calculateVarPriorities.
@@ -4430,8 +4443,7 @@ algorithm
   end match;
 end stateSelectToInteger;
 
-public function transformXToXd
-"author: PA
+public function transformXToXd "author: PA
   this function transforms x variables (in the state vector)
   to corresponding xd variable (in the derivatives vector)"
   input BackendDAE.Var inVar;
@@ -4447,35 +4459,32 @@ algorithm
       Option<Values.Value> v;
       list<DAE.Dimension> dim;
       Option<DAE.VariableAttributes> attr;
-    Option<BackendDAE.TearingSelect> ts;
+      Option<BackendDAE.TearingSelect> ts;
       Option<SCode.Comment> comment;
       DAE.ConnectorType ct;
       DAE.ElementSource source;
-      BackendDAE.Var backendVar;
       DAE.VarInnerOuter io;
+      Boolean unreplaceable;
 
-    case (BackendDAE.VAR(varName = cr,
-      varKind = BackendDAE.STATE(),
-      varDirection = dir,
-      varParallelism = prl,
-      varType = tp,
-      bindExp = exp,
-      bindValue = v,
-      arryDim = dim,
-      source = source,
-      values = attr,
-    tearingSelectOption = ts,
-      comment = comment,
-      connectorType = ct,
-      innerOuter = io))
-      equation
-        cr = ComponentReference.crefPrefixDer(cr);
-      then
-        BackendDAE.VAR(cr, BackendDAE.STATE_DER(), dir, prl, tp, exp, v, dim, source, attr, ts, comment, ct, io,false);
+    case (BackendDAE.VAR(varName=cr,
+                         varKind=BackendDAE.STATE(),
+                         varDirection=dir,
+                         varParallelism=prl,
+                         varType=tp,
+                         bindExp=exp,
+                         bindValue=v,
+                         arryDim=dim,
+                         source=source,
+                         values=attr,
+                         tearingSelectOption=ts,
+                         comment=comment,
+                         connectorType=ct,
+                         innerOuter=io,
+                         unreplaceable=unreplaceable)) equation
+      cr = ComponentReference.crefPrefixDer(cr);
+    then BackendDAE.VAR(cr, BackendDAE.STATE_DER(), dir, prl, tp, exp, v, dim, source, attr, ts, comment, ct, io, unreplaceable);
 
-    case (backendVar)
-    then
-      backendVar;
+    else inVar;
   end matchcontinue;
 end transformXToXd;
 
@@ -4489,7 +4498,7 @@ algorithm
       DAE.ComponentRef cref;
     case(BackendDAE.VAR(varName=cref))
       equation
-      then ComponentReference.traverseCref(cref,ComponentReference.crefIsRec,false);
+      then ComponentReference.traverseCref(cref,ComponentReference.crefIsRec, false);
   end match;
 end isRecordVar;
 

--- a/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/Compiler/BackEnd/FindZeroCrossings.mo
@@ -426,7 +426,7 @@ algorithm
       ht = BaseHashTable.add((inCondition, inIndex), inHT);
       crStr = "$whenCondition" + intString(inIndex);
 
-      var = BackendDAE.VAR(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_BOOL_DEFAULT, NONE(), NONE(), {}, inSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      var = BackendDAE.VAR(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_BOOL_DEFAULT, NONE(), NONE(), {}, inSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
       var = BackendVariable.setVarFixed(var, true);
       eqn = BackendDAE.EQUATION(DAE.CREF(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), DAE.T_BOOL_DEFAULT), inCondition, inSource, BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC);
 
@@ -604,7 +604,7 @@ algorithm
     case (DAE.ARRAY(array={condition})) equation
       crStr = "$whenCondition" + intString(inIndex);
 
-      var = BackendDAE.VAR(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_BOOL_DEFAULT, NONE(), NONE(), {}, inSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      var = BackendDAE.VAR(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_BOOL_DEFAULT, NONE(), NONE(), {}, inSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
       var = BackendVariable.setVarFixed(var, true);
       stmt = DAE.STMT_ASSIGN(DAE.T_BOOL_DEFAULT, DAE.CREF(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), DAE.T_BOOL_DEFAULT), condition, inSource);
 
@@ -620,7 +620,7 @@ algorithm
     case _ equation
       crStr = "$whenCondition" + intString(inIndex);
 
-      var = BackendDAE.VAR(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_BOOL_DEFAULT, NONE(), NONE(), {}, inSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      var = BackendDAE.VAR(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_BOOL_DEFAULT, NONE(), NONE(), {}, inSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
       var = BackendVariable.setVarFixed(var, true);
       stmt = DAE.STMT_ASSIGN(DAE.T_BOOL_DEFAULT, DAE.CREF(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), DAE.T_BOOL_DEFAULT), inCondition, inSource);
 

--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -2382,6 +2382,30 @@ algorithm
   end matchcontinue;
 end getRelations;
 
+public function getAllCrefs "author: lochel
+  This function extracts all crefs from the input expression, except 'time'."
+  input DAE.Exp inExp;
+  output list<DAE.ComponentRef> outCrefs;
+algorithm
+  (_, outCrefs) := traverseExpBottomUp(inExp, getAllCrefs2, {});
+end getAllCrefs;
+
+protected function getAllCrefs2
+   input DAE.Exp inExp;
+   input list<DAE.ComponentRef> inCrefList;
+   output DAE.Exp outExp = inExp;
+   output list<DAE.ComponentRef> outCrefList = inCrefList;
+protected
+  DAE.ComponentRef cr;
+algorithm
+  if isCref(inExp) then
+    DAE.CREF(componentRef=cr) := inExp;
+    if not ComponentReference.crefEqual(cr, DAE.crefTime) and not listMember(cr, inCrefList) then
+      outCrefList := cr::outCrefList;
+    end if;
+  end if;
+end getAllCrefs2;
+
 public function allTerms
 "simliar to terms, but also perform expansion of
  multiplications to reveal more terms, like for instance:


### PR DESCRIPTION
* [fixed] propagation of variable attribute "unreplaceable" within the back end
* [fixed] all variables that have unreplaceable=true will now get skipped by "removeSimpleEquations"
* [improved] reimplemented function selfGeneratedVar that is used to figure out if a variable was generated internally (by the back end)
* [prepared] After doing casualization no new alias variable will be introduced (substitutions will be still made) by the back end. This will be needed once the system get split up right after the casualization module into systems for initialization and simulation.