### PR TITLE
Use Absyn path equality check function in SCode.hasExtendsOfExternalObject function

### DIFF
--- a/Compiler/FrontEnd/SCode.mo
+++ b/Compiler/FrontEnd/SCode.mo
@@ -5522,8 +5522,10 @@ algorithm
   res:= match (inEls)
     local
       list<Element> els;
+      Absyn.Path path;
     case {} then false;
-    case EXTENDS(baseClassPath = Absyn.IDENT("ExternalObject"))::_ then true;
+    case EXTENDS(baseClassPath = path)::_
+      guard( Absyn.pathEqual(path, Absyn.IDENT("ExternalObject")) ) then true;
     case _::els then hasExtendsOfExternalObject(els);
   end match;
 end hasExtendsOfExternalObject;


### PR DESCRIPTION
SCode.hasExtendsOfExternalObject fails to detect external object in cases where path is fully qualified.
So Absyn.pathEqual function should be used for equality check.
