### PR TITLE
Refactor enumeration in SCode module

### DIFF
--- a/Compiler/FFrontEnd/FBuiltin.mo
+++ b/Compiler/FFrontEnd/FBuiltin.mo
@@ -153,7 +153,7 @@ protected constant SCode.Element strType = SCode.CLASS("StringType",commonPrefix
 protected constant SCode.Element boolType = SCode.CLASS("BooleanType",commonPrefixes,SCode.NOT_ENCAPSULATED(),SCode.NOT_PARTIAL(),SCode.R_PREDEFINED_BOOLEAN(),
           SCode.PARTS({},{},{},{},{},{},{},NONE()),SCode.noComment,Absyn.dummyInfo);
 
-protected constant SCode.Element enumType = SCode.CLASS("EnumType",commonPrefixes,SCode.NOT_ENCAPSULATED(),SCode.NOT_PARTIAL(),SCode.R_PREDEFINED_ENUMERATION(),
+protected constant SCode.Element enumType = SCode.CLASS("$EnumType",commonPrefixes,SCode.NOT_ENCAPSULATED(),SCode.NOT_PARTIAL(),SCode.R_PREDEFINED_ENUMERATION(),
           SCode.PARTS({},{},{},{},{},{},{},NONE()),SCode.noComment,Absyn.dummyInfo);
 
 protected constant SCode.Element unit = SCode.COMPONENT("unit",commonPrefixes,
@@ -224,23 +224,23 @@ protected constant SCode.Element distribution = SCode.COMPONENT("distribution",c
 
 protected constant list<SCode.Element> stateSelectComps = {
           SCode.COMPONENT("never",commonPrefixes,
-          attrConst,Absyn.TPATH(Absyn.IDENT("EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
+          attrConst,Absyn.TPATH(Absyn.IDENT("$EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
           SCode.COMPONENT("avoid",commonPrefixes,
-          attrConst,Absyn.TPATH(Absyn.IDENT("EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
+          attrConst,Absyn.TPATH(Absyn.IDENT("$EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
           SCode.COMPONENT("default",commonPrefixes,
-          attrConst,Absyn.TPATH(Absyn.IDENT("EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
+          attrConst,Absyn.TPATH(Absyn.IDENT("$EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
           SCode.COMPONENT("prefer",commonPrefixes,
-          attrConst,Absyn.TPATH(Absyn.IDENT("EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
+          attrConst,Absyn.TPATH(Absyn.IDENT("$EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
           SCode.COMPONENT("always",commonPrefixes,
-          attrConst,Absyn.TPATH(Absyn.IDENT("EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo)} "The StateSelect enumeration" ;
+          attrConst,Absyn.TPATH(Absyn.IDENT("$EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo)} "The StateSelect enumeration" ;
 
 protected constant list<SCode.Element> uncertaintyComps = {
           SCode.COMPONENT("given",commonPrefixes,
-          attrConst,Absyn.TPATH(Absyn.IDENT("EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
+          attrConst,Absyn.TPATH(Absyn.IDENT("$EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
           SCode.COMPONENT("sought",commonPrefixes,
-          attrConst,Absyn.TPATH(Absyn.IDENT("EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
+          attrConst,Absyn.TPATH(Absyn.IDENT("$EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
           SCode.COMPONENT("refine",commonPrefixes,
-          attrConst,Absyn.TPATH(Absyn.IDENT("EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo)} "The Uncertainty enumeration" ;
+          attrConst,Absyn.TPATH(Absyn.IDENT("$EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo)} "The Uncertainty enumeration" ;
 
 protected constant SCode.Element stateSelectType = SCode.CLASS("StateSelect",commonPrefixes,SCode.NOT_ENCAPSULATED(),SCode.NOT_PARTIAL(),SCode.R_ENUMERATION(),
           SCode.PARTS(stateSelectComps,{},{},{},{},{},{},NONE()),SCode.noComment,Absyn.dummyInfo) "The State Select Type";

--- a/Compiler/FFrontEnd/FGraphBuild.mo
+++ b/Compiler/FFrontEnd/FGraphBuild.mo
@@ -130,13 +130,12 @@ algorithm
 
     case (_, _, _, g)
       equation
-        cls = SCodeUtil.expandEnumerationClass(inClass);
-        SCode.CLASS(name = name, classDef = cdef) = cls;
-        (g, n) = FGraph.node(g, name, {inParentRef}, FCore.CL(cls, Prefix.NOPRE(), DAE.NOMOD(), inKind, FCore.VAR_UNTYPED()));
+        SCode.CLASS(name = name, classDef = cdef) = inClass;
+        (g, n) = FGraph.node(g, name, {inParentRef}, FCore.CL(inClass, Prefix.NOPRE(), DAE.NOMOD(), inKind, FCore.VAR_UNTYPED()));
         nr = FNode.toRef(n);
         FNode.addChildRef(inParentRef, name, nr);
         // add constrained by node
-        g = mkConstrainClass(cls, nr, inKind, g);
+        g = mkConstrainClass(inClass, nr, inKind, g);
         g = mkClassChildren(cdef, nr, inKind, g);
       then
         g;

--- a/Compiler/FFrontEnd/FGraphBuildEnv.mo
+++ b/Compiler/FFrontEnd/FGraphBuildEnv.mo
@@ -134,9 +134,8 @@ algorithm
 
     case (_, _, _, _, _, g)
       equation
-        cls = SCodeUtil.expandEnumerationClass(inClass);
-        SCode.CLASS(name = name) = cls;
-        (g, n) = FGraph.node(g, name, {inParentRef}, FCore.CL(cls, inPrefix, inMod, inKind, FCore.CLS_UNTYPED()));
+        SCode.CLASS(name = name) = inClass;
+        (g, n) = FGraph.node(g, name, {inParentRef}, FCore.CL(inClass, inPrefix, inMod, inKind, FCore.CLS_UNTYPED()));
         nr = FNode.toRef(n);
         FNode.addChildRef(inParentRef, name, nr);
         // g = mkRefNode(FNode.refNodeName, {}, nr, g);

--- a/Compiler/FrontEnd/Builtin.mo
+++ b/Compiler/FrontEnd/Builtin.mo
@@ -154,7 +154,7 @@ protected constant SCode.Element strType = SCode.CLASS("StringType",commonPrefix
 protected constant SCode.Element boolType = SCode.CLASS("BooleanType",commonPrefixes,SCode.NOT_ENCAPSULATED(),SCode.NOT_PARTIAL(),SCode.R_PREDEFINED_BOOLEAN(),
           SCode.PARTS({},{},{},{},{},{},{},NONE()),SCode.noComment,Absyn.dummyInfo);
 
-protected constant SCode.Element enumType = SCode.CLASS("EnumType",commonPrefixes,SCode.NOT_ENCAPSULATED(),SCode.NOT_PARTIAL(),SCode.R_PREDEFINED_ENUMERATION(),
+protected constant SCode.Element enumType = SCode.CLASS("$EnumType",commonPrefixes,SCode.NOT_ENCAPSULATED(),SCode.NOT_PARTIAL(),SCode.R_PREDEFINED_ENUMERATION(),
           SCode.PARTS({},{},{},{},{},{},{},NONE()),SCode.noComment,Absyn.dummyInfo);
 
 protected constant SCode.Element unit = SCode.COMPONENT("unit",commonPrefixes,
@@ -225,11 +225,11 @@ protected constant SCode.Element distribution = SCode.COMPONENT("distribution",c
 
 protected constant list<SCode.Element> uncertaintyComps = {
           SCode.COMPONENT("given",commonPrefixes,
-          attrConst,Absyn.TPATH(Absyn.IDENT("EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
+          attrConst,Absyn.TPATH(Absyn.IDENT("$EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
           SCode.COMPONENT("sought",commonPrefixes,
-          attrConst,Absyn.TPATH(Absyn.IDENT("EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
+          attrConst,Absyn.TPATH(Absyn.IDENT("$EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo),
           SCode.COMPONENT("refine",commonPrefixes,
-          attrConst,Absyn.TPATH(Absyn.IDENT("EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo)} "The Uncertainty enumeration" ;
+          attrConst,Absyn.TPATH(Absyn.IDENT("$EnumType"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),Absyn.dummyInfo)} "The Uncertainty enumeration" ;
 
 protected constant SCode.Element uncertaintyType = SCode.CLASS("Uncertainty",commonPrefixes,SCode.NOT_ENCAPSULATED(),SCode.NOT_PARTIAL(),SCode.R_ENUMERATION(),
           SCode.PARTS(uncertaintyComps,{},{},{},{},{},{},NONE()),SCode.noComment,Absyn.dummyInfo) "The Uncertainty Type";

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -2241,6 +2241,7 @@ algorithm
         // BTH: Search for Modelica State Machine states and update ih correspondingly.
         statesOfSM2 = InstSection.getSMStatesInContext(eqs_1);
         ih = List.fold1(statesOfSM2, InnerOuter.updateSMHierarchy, inPrefix3, ih);
+
         (cache,env5,ih,store,dae1,csets,ci_state2,vars,graph) =
           instElementList(cache, env4, ih, store, mods, pre, ci_state1,
             compelts_2, inst_dims, impl, callscope, graph, csets, true);

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -2241,7 +2241,6 @@ algorithm
         // BTH: Search for Modelica State Machine states and update ih correspondingly.
         statesOfSM2 = InstSection.getSMStatesInContext(eqs_1);
         ih = List.fold1(statesOfSM2, InnerOuter.updateSMHierarchy, inPrefix3, ih);
-
         (cache,env5,ih,store,dae1,csets,ci_state2,vars,graph) =
           instElementList(cache, env4, ih, store, mods, pre, ci_state1,
             compelts_2, inst_dims, impl, callscope, graph, csets, true);

--- a/Compiler/FrontEnd/InstExtends.mo
+++ b/Compiler/FrontEnd/InstExtends.mo
@@ -696,13 +696,6 @@ algorithm
       then
         (cache,env,ih,elt,eq,ieq,alg,ialg,mod);
 
-    case (cache,env,ih,mod,pre,SCode.CLASS(name=n, classDef = SCode.ENUMERATION(enumLst), cmt = cmt, info = info),impl,_,false,_)
-      equation
-        c = SCodeUtil.expandEnumeration(n, enumLst, cmt, info);
-        (cache,env,ih,elt,eq,ieq,alg,ialg,mod) = instDerivedClassesWork(cache, env, ih, mod, pre, c, impl,info, numIter >= Global.recursionDepthLimit, numIter+1);
-      then
-        (cache,env,ih,elt,eq,ieq,alg,ialg,mod);
-
     case (_,_,_,_,_,_,_,_,true,_)
       equation
         str1 = SCodeDump.unparseElementStr(inClass,SCodeDump.defaultOptions);
@@ -1168,7 +1161,6 @@ algorithm
         (cache,mod) = fixModifications(cache,env,mod,ht);
       then (cache,SCode.DERIVED(ts,mod,attr));
 
-    case (cache,_,cd as SCode.ENUMERATION(),_) then (cache,cd);
     case (cache,_,cd as SCode.OVERLOAD(),_) then (cache,cd);
     case (cache,_,cd as SCode.PDER(),_) then (cache,cd);
 

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -3189,23 +3189,6 @@ algorithm
       list<SCode.Element> elementLst;
       SourceInfo info1, info2;
 
-    //   Special cases for checking enumerations which can be represented differently
-    case(SCode.CLASS(classDef=SCode.ENUMERATION(enumLst=enumLst)), SCode.CLASS(restriction=SCode.R_ENUMERATION(),classDef=SCode.PARTS(elementLst=elementLst)))
-      equation
-        sl1=List.map(enumLst,SCode.enumName);
-        sl2=List.map(elementLst,SCode.elementName);
-        List.threadMapAllValue(sl1,sl2,stringEq,true);
-      then
-        ();
-
-    case(SCode.CLASS(restriction=SCode.R_ENUMERATION(),classDef=SCode.PARTS(elementLst=elementLst)), SCode.CLASS(classDef=SCode.ENUMERATION(enumLst=enumLst)))
-      equation
-        sl1=List.map(enumLst,SCode.enumName);
-        sl2=List.map(elementLst,SCode.elementName);
-        List.threadMapAllValue(sl1,sl2,stringEq,true);
-      then
-        ();
-
     // try equality first!
     case(oldCl,newCl)
       equation

--- a/Compiler/FrontEnd/Mod.mo
+++ b/Compiler/FrontEnd/Mod.mo
@@ -327,13 +327,6 @@ algorithm
       then
         ((SCode.CLASS(cn,SCode.PREFIXES(vis,redecl,fi,io,repl),enc,p,restr,SCode.DERIVED(tp1,mod,attr1),cmt,i),emod));
 
-    // replaceable type E=enumeration(e1,...,en), E=enumeration(:)
-    case(_,_,_,_,_,
-      SCode.CLASS(cn,
-        SCode.PREFIXES(vis,redecl,fi,io,repl),enc,p,restr,SCode.ENUMERATION(enumLst),cmt,i),_,_,_)
-      then
-        ((SCode.CLASS(cn,SCode.PREFIXES(vis,redecl,fi,io,repl),enc,p,restr,SCode.ENUMERATION(enumLst),cmt,i),DAE.NOMOD()));
-
     // redeclare of component declaration
     case(cache,env,ih,pre,_,SCode.COMPONENT(compname,prefixes as SCode.PREFIXES(vis,redecl,fi,io,repl),attr,tp,mod,cmt,cond,i),_,_,_)
       equation

--- a/Compiler/FrontEnd/NFSCodeEnv.mo
+++ b/Compiler/FrontEnd/NFSCodeEnv.mo
@@ -919,13 +919,6 @@ algorithm
       then
         env;
 
-    case (_, SCode.ENUMERATION(enumLst = enums), _, _, _)
-      equation
-        path = Absyn.IDENT(inClassName);
-        env = extendEnvWithEnumLiterals(enums, path, 1, inEnv, inInfo);
-      then
-        env;
-
     else inEnv;
   end match;
 end extendEnvWithClassComponents;

--- a/Compiler/FrontEnd/NFSCodeFlatten.mo
+++ b/Compiler/FrontEnd/NFSCodeFlatten.mo
@@ -98,6 +98,8 @@ algorithm
   {outClass} := flattenProgram({inClass});
 end flattenClass;
 
+protected import SCodeDump;
+protected import Lookup;
 public function flattenClassInProgram
   "Flattens a specific class in a program."
   input Absyn.Path inClassName;
@@ -117,12 +119,12 @@ algorithm
         System.tmpTickResetIndex(1, NFSCodeEnv.extendsTickIndex);
         // TODO: Enable this when NFSCodeEnv.tmpTickIndex is removed.
         //System.tmpTickResetIndex(0, NFSCodeEnv.tmpTickIndex);
-
         env = NFSCodeEnv.buildInitialEnv();
         env = NFSCodeEnv.extendEnvWithClasses(prog, env);
         env = NFEnvExtends.update(env);
 
         (prog, env) = NFSCodeDependency.analyse(inClassName, env, prog);
+//        print(SCodeDump.programStr(prog) + "\n");
         checkForCardinality(env);
         (prog, env) = NFSCodeFlattenImports.flattenProgram(prog, env);
 

--- a/Compiler/FrontEnd/NFSCodeFlatten.mo
+++ b/Compiler/FrontEnd/NFSCodeFlatten.mo
@@ -119,12 +119,12 @@ algorithm
         System.tmpTickResetIndex(1, NFSCodeEnv.extendsTickIndex);
         // TODO: Enable this when NFSCodeEnv.tmpTickIndex is removed.
         //System.tmpTickResetIndex(0, NFSCodeEnv.tmpTickIndex);
+
         env = NFSCodeEnv.buildInitialEnv();
         env = NFSCodeEnv.extendEnvWithClasses(prog, env);
         env = NFEnvExtends.update(env);
 
         (prog, env) = NFSCodeDependency.analyse(inClassName, env, prog);
-//        print(SCodeDump.programStr(prog) + "\n");
         checkForCardinality(env);
         (prog, env) = NFSCodeFlattenImports.flattenProgram(prog, env);
 

--- a/Compiler/FrontEnd/NFSCodeFlattenImports.mo
+++ b/Compiler/FrontEnd/NFSCodeFlattenImports.mo
@@ -89,7 +89,6 @@ algorithm
         (NFSCodeEnv.CLASS(env = {cls_env}, classType = cls_ty), _) =
           NFSCodeLookup.lookupInClass(name, inEnv);
         env = NFSCodeEnv.enterFrame(cls_env, inEnv);
-
         (cdef, cls_env :: env) = flattenClassDef(cdef, env, info);
         cls = SCode.setElementClassDefinition(cdef, inClass);
         item = NFSCodeEnv.newClassItem(cls, {cls_env}, cls_ty);
@@ -529,7 +528,8 @@ protected function flattenRedeclare
   input Env inEnv;
   output SCode.Element outElement;
 algorithm
-  outElement := match(inElement, inEnv)
+
+  outElement := match inElement
     local
       SCode.Ident name;
       SCode.Prefixes prefixes;
@@ -541,18 +541,18 @@ algorithm
       SCode.ClassDef cdef,cdef2;
       SCode.Comment cmt;
 
-    case (SCode.CLASS(name, prefixes, ep, pp, res,
-          cdef as SCode.DERIVED(), cmt, info), _)
+    case SCode.CLASS(name, prefixes, ep, pp, res,
+          cdef as SCode.DERIVED(), cmt, info)
       equation
+
         cdef2 = flattenDerivedClassDef(cdef, inEnv, info);
       then
         SCode.CLASS(name, prefixes, ep, pp, res, cdef2, cmt, info);
 
-    case (SCode.CLASS(classDef = SCode.ENUMERATION()), _)
-      then
-        inElement;
+    case SCode.CLASS(classDef = SCode.PARTS(), restriction = SCode.R_ENUMERATION())
+      then inElement;
 
-    case (SCode.COMPONENT(), _)
+    case SCode.COMPONENT()
       equation
         element = flattenComponent(inElement, inEnv);
       then

--- a/Compiler/FrontEnd/NFSCodeFlattenImports.mo
+++ b/Compiler/FrontEnd/NFSCodeFlattenImports.mo
@@ -89,6 +89,7 @@ algorithm
         (NFSCodeEnv.CLASS(env = {cls_env}, classType = cls_ty), _) =
           NFSCodeLookup.lookupInClass(name, inEnv);
         env = NFSCodeEnv.enterFrame(cls_env, inEnv);
+
         (cdef, cls_env :: env) = flattenClassDef(cdef, env, info);
         cls = SCode.setElementClassDefinition(cdef, inClass);
         item = NFSCodeEnv.newClassItem(cls, {cls_env}, cls_ty);
@@ -528,7 +529,6 @@ protected function flattenRedeclare
   input Env inEnv;
   output SCode.Element outElement;
 algorithm
-
   outElement := match inElement
     local
       SCode.Ident name;
@@ -544,7 +544,6 @@ algorithm
     case SCode.CLASS(name, prefixes, ep, pp, res,
           cdef as SCode.DERIVED(), cmt, info)
       equation
-
         cdef2 = flattenDerivedClassDef(cdef, inEnv, info);
       then
         SCode.CLASS(name, prefixes, ep, pp, res, cdef2, cmt, info);

--- a/Compiler/FrontEnd/NFSCodeLookup.mo
+++ b/Compiler/FrontEnd/NFSCodeLookup.mo
@@ -226,6 +226,7 @@ public constant SCode.Element BUILTIN_STATESELECT_ALWAYS = SCode.COMPONENT(
   "always", BUILTIN_PREFIXES, BUILTIN_CONST_ATTRIBUTES, BUILTIN_ENUMTYPE_SPEC,
   SCode.NOMOD(), SCode.noComment, NONE(), Absyn.dummyInfo);
 
+
 // Environments for the builtin types:
 public constant Env BUILTIN_REAL_ENV = {NFSCodeEnv.FRAME(SOME("Real"),
   NFSCodeEnv.NORMAL_SCOPE(),

--- a/Compiler/FrontEnd/NFSCodeLookup.mo
+++ b/Compiler/FrontEnd/NFSCodeLookup.mo
@@ -226,7 +226,6 @@ public constant SCode.Element BUILTIN_STATESELECT_ALWAYS = SCode.COMPONENT(
   "always", BUILTIN_PREFIXES, BUILTIN_CONST_ATTRIBUTES, BUILTIN_ENUMTYPE_SPEC,
   SCode.NOMOD(), SCode.noComment, NONE(), Absyn.dummyInfo);
 
-
 // Environments for the builtin types:
 public constant Env BUILTIN_REAL_ENV = {NFSCodeEnv.FRAME(SOME("Real"),
   NFSCodeEnv.NORMAL_SCOPE(),
@@ -352,16 +351,18 @@ public constant Item BUILTIN_STRING = NFSCodeEnv.CLASS(
       SCode.PARTS({}, {}, {}, {}, {}, {}, {}, NONE()),
       SCode.noComment, Absyn.dummyInfo), BUILTIN_STRING_ENV, NFSCodeEnv.BASIC_TYPE());
 
+public constant Item BUILTIN_ENUM = NFSCodeEnv.CLASS(
+  BUILTIN_ENUMTYPE, {}, NFSCodeEnv.BASIC_TYPE());
+
+protected constant list<SCode.Element> stateSelectEnumLst = {
+  BUILTIN_STATESELECT_NEVER, BUILTIN_STATESELECT_AVOID, BUILTIN_STATESELECT_DEFAULT,
+  BUILTIN_STATESELECT_PREFER, BUILTIN_STATESELECT_ALWAYS
+};
 public constant Item BUILTIN_STATESELECT = NFSCodeEnv.CLASS(
   SCode.CLASS("StateSelect",  SCode.defaultPrefixes,
-      SCode.NOT_ENCAPSULATED(), SCode.NOT_PARTIAL(), SCode.R_CLASS(),
-      SCode.ENUMERATION({
-        SCode.ENUM("never", SCode.noComment),
-        SCode.ENUM("avoid", SCode.noComment),
-        SCode.ENUM("default", SCode.noComment),
-        SCode.ENUM("prefer", SCode.noComment),
-        SCode.ENUM("always", SCode.noComment)}),
-      SCode.noComment, Absyn.dummyInfo), BUILTIN_STATESELECT_ENV, NFSCodeEnv.BASIC_TYPE());
+      SCode.NOT_ENCAPSULATED(), SCode.NOT_PARTIAL(), SCode.R_ENUMERATION(),
+      SCode.PARTS(stateSelectEnumLst, {}, {}, {}, {}, {}, {}, NONE()), SCode.noComment, Absyn.dummyInfo),
+      BUILTIN_STATESELECT_ENV, NFSCodeEnv.BASIC_TYPE());
 
 public constant Item BUILTIN_EXTERNALOBJECT = NFSCodeEnv.CLASS(
   SCode.CLASS("ExternalObject", SCode.defaultPrefixes,
@@ -1292,7 +1293,7 @@ algorithm
     case "$IntegerType" then BUILTIN_INTEGERTYPE_ITEM;
     case "$BooleanType" then BUILTIN_BOOLEANTYPE_ITEM;
     case "$StringType" then BUILTIN_STRINGTYPE_ITEM;
-    case "$EnumType" then BUILTIN_ENUMTYPE_ITEM;
+    case "$EnumType" then BUILTIN_ENUM;
   end match;
 end lookupBuiltinType;
 

--- a/Compiler/FrontEnd/SCode.mo
+++ b/Compiler/FrontEnd/SCode.mo
@@ -196,10 +196,6 @@ uniontype ClassDef
     Attributes attributes   "the element attributes";
   end DERIVED;
 
-  record ENUMERATION "an enumeration"
-    list<Enum> enumLst      "if the list is empty it means :, the supertype of all enumerations";
-  end ENUMERATION;
-
   record OVERLOAD "an overloaded function"
     list<Absyn.Path> pathLst "the path lists";
   end OVERLOAD;
@@ -1247,12 +1243,6 @@ protected function classDefEqual
        then
          true;
 
-     case (ENUMERATION(elst1),ENUMERATION(elst2))
-       equation
-         List.threadMapAllValue(elst1,elst2,enumEqual,true);
-       then
-         true;
-
      case (CLASS_EXTENDS(bcName1,mod1,PARTS(elts1,eqns1,ieqns1,algs1,ialgs1,_,_,_)),
            CLASS_EXTENDS(bcName2,mod2,PARTS(elts2,eqns2,ieqns2,algs2,ialgs2,_,_,_)))
        equation
@@ -1897,7 +1887,7 @@ algorithm
   ENUM(literal = literal, comment = comment) := inEnum;
   NFSCodeCheck.checkValidEnumLiteral(literal, inInfo);
   outEnumType := COMPONENT(literal, defaultPrefixes, defaultConstAttr,
-    Absyn.TPATH(Absyn.IDENT("EnumType"), NONE()),
+    Absyn.TPATH(Absyn.IDENT("$EnumType"), NONE()),
     NOMOD(), comment, NONE(), inInfo);
 end makeEnumType;
 

--- a/Compiler/FrontEnd/SCode.mo
+++ b/Compiler/FrontEnd/SCode.mo
@@ -938,6 +938,16 @@ algorithm
   end match;
 end enumName;
 
+public function isEnumeration
+  input Element inEnum;
+  output Boolean outBoolean;
+algorithm
+  outBoolean := match(inEnum)
+    case CLASS(restriction = R_ENUMERATION()) then true;
+    else false;
+  end match;
+end isEnumeration;
+
 public function isRecord
 "Return true if Class is a record."
   input Element inClass;

--- a/Compiler/FrontEnd/SCodeDump.mo
+++ b/Compiler/FrontEnd/SCodeDump.mo
@@ -243,14 +243,6 @@ algorithm
       then
         res;
 
-    case SCode.CLASS(name = n, partialPrefix = pp, prefixes = SCode.PREFIXES(innerOuter = io, redeclarePrefix = rdp, replaceablePrefix = rpp),
-                     classDef = SCode.ENUMERATION())
-      equation
-        ioStr = Dump.unparseInnerouterStr(io) + redeclareStr(rdp) + replaceablePrefixStr(rpp) + partialStr(pp);
-        res = stringAppendList({ioStr, "class ",n," enumeration;"});
-      then
-        res;
-
     case SCode.CLASS(name = n, partialPrefix = pp, prefixes = SCode.PREFIXES(innerOuter = io, redeclarePrefix = rdp, replaceablePrefix = rpp))
       equation
         ioStr = Dump.unparseInnerouterStr(io) + redeclareStr(rdp) + replaceablePrefixStr(rpp) + partialStr(pp);
@@ -485,6 +477,17 @@ algorithm
 
   end match;
 end prefixesStr;
+
+public function printElements
+  input list<SCode.Element> elts;
+  input String sep = "\n";
+ protected
+  SCode.Element el;
+algorithm
+  for el in elts loop
+    print(unparseElementStr(el) + "\n");
+  end for;
+end printElements;
 
 public function filterElements
   input list<SCode.Element> elements;

--- a/Compiler/FrontEnd/SCodeSimplify.mo
+++ b/Compiler/FrontEnd/SCodeSimplify.mo
@@ -136,11 +136,6 @@ algorithm
       then
         inClassDef;
 
-    // handle enumeration, just return the same
-    case (SCode.ENUMERATION())
-      then
-        inClassDef;
-
     // handle overload
     case (SCode.OVERLOAD())
       then

--- a/Compiler/FrontEnd/SCodeUtil.mo
+++ b/Compiler/FrontEnd/SCodeUtil.mo
@@ -1192,7 +1192,6 @@ algorithm
       equation
         // fprintln(Flags.TRANSLATE, "translating local class: " + n);
         re_1 = translateRestriction(cl, re); // uniontype will not get translated!
-
         (de_1,cmt) = translateClassdef(de,i);
         (_, redecl) = translateRedeclarekeywords(repl);
         sRed = SCode.boolRedeclare(redecl);

--- a/Compiler/FrontEnd/SCodeUtil.mo
+++ b/Compiler/FrontEnd/SCodeUtil.mo
@@ -321,7 +321,8 @@ algorithm
 
     case (_,Absyn.R_OPERATOR()) then SCode.R_OPERATOR();
 
-    case (_,Absyn.R_TYPE()) then SCode.R_TYPE();
+    case (Absyn.CLASS(body=Absyn.ENUMERATION()), Absyn.R_TYPE()) then SCode.R_ENUMERATION();
+    case (_, Absyn.R_TYPE()) then SCode.R_TYPE();
     case (_,Absyn.R_PACKAGE()) then SCode.R_PACKAGE();
     case (_,Absyn.R_ENUMERATION()) then SCode.R_ENUMERATION();
     case (_,Absyn.R_PREDEFINED_INTEGER()) then SCode.R_PREDEFINED_INTEGER();
@@ -445,8 +446,7 @@ algorithm
       Option<SCode.ExternalDecl> decl;
       list<Absyn.ClassPart> parts;
       list<String> vars;
-      list<SCode.Enum> lst_1;
-      list<Absyn.EnumLiteral> lst;
+      list<Absyn.EnumLiteral> enumLiterals;
       SCode.Comment scodeCmt;
       String name;
       Absyn.Path path;
@@ -483,20 +483,13 @@ algorithm
       then
         (SCode.PARTS(els,eqs,initeqs,als,initals,cos,classAttrs,decl),scodeCmt);
 
-    case (Absyn.ENUMERATION(Absyn.ENUMLITERALS(enumLiterals = lst), cmt),_)
-      equation
-        // fprintln(Flags.TRANSLATE, "translating enumerations");
-        lst_1 = translateEnumlist(lst);
-        scodeCmt = translateComment(cmt);
+    case (Absyn.ENUMERATION(Absyn.ENUMLITERALS(enumLiterals = enumLiterals), cmt),_)
       then
-        (SCode.ENUMERATION(lst_1), scodeCmt);
+        translateEnum(enumLiterals, cmt, info);
 
     case (Absyn.ENUMERATION(Absyn.ENUM_COLON(), cmt),_)
-      equation
-        // fprintln(Flags.TRANSLATE, "translating enumeration of ':'");
-        scodeCmt = translateComment(cmt);
       then
-        (SCode.ENUMERATION({}),scodeCmt);
+        translateEnum({}, cmt, info);
 
     case (Absyn.OVERLOAD(pathLst,cmt),_)
       equation
@@ -535,6 +528,18 @@ algorithm
         fail();
   end match;
 end translateClassdef;
+
+public function translateEnum
+  input list<Absyn.EnumLiteral> enumLiterals;
+  input Option<Absyn.Comment> cmt;
+  input SourceInfo info;
+  output tuple<SCode.ClassDef, SCode.Comment> outClassDef;
+protected
+  list<SCode.Element> els;
+algorithm
+  els := translateEnumlist(enumLiterals, info);
+  outClassDef := (SCode.PARTS(els, {}, {}, {}, {}, {}, {}, NONE()), translateComment(cmt));
+end translateEnum;
 
 protected function translateAlternativeExternalAnnotation
 "first class annotation instead, since it is very common that an element
@@ -591,11 +596,12 @@ protected function translateEnumlist
 "Convert an EnumLiteral list to an Ident list.
   Comments are lost."
   input list<Absyn.EnumLiteral> inAbsynEnumLiteralLst;
-  output list<SCode.Enum> outEnumLst;
+  input SourceInfo info;
+  output list<SCode.Element> outEnumLst;
 algorithm
   outEnumLst := match (inAbsynEnumLiteralLst)
     local
-      list<SCode.Enum> res;
+      list<SCode.Element> res;
       String id;
       Option<Absyn.Comment> cmtOpt;
       SCode.Comment cmt;
@@ -605,9 +611,9 @@ algorithm
     case ((Absyn.ENUMLITERAL(id, cmtOpt) :: rest))
       equation
         cmt = translateComment(cmtOpt);
-        res = translateEnumlist(rest);
+        res = translateEnumlist(rest, info);
       then
-        (SCode.ENUM(id, cmt) :: res);
+        (SCode.makeEnumType(SCode.ENUM(id, cmt), info) :: res);
   end match;
 end translateEnumlist;
 
@@ -1186,6 +1192,7 @@ algorithm
       equation
         // fprintln(Flags.TRANSLATE, "translating local class: " + n);
         re_1 = translateRestriction(cl, re); // uniontype will not get translated!
+
         (de_1,cmt) = translateClassdef(de,i);
         (_, redecl) = translateRedeclarekeywords(repl);
         sRed = SCode.boolRedeclare(redecl);
@@ -2552,66 +2559,6 @@ algorithm
     else SCode.NOMOD();
   end match;
 end getConstrainedByModifiers;
-
-public function expandEnumerationClass
-"@author: PA, adrpo
- this function expands the enumeration from a list into a class with components
- if the class is not an enumeration is kept as it is"
-  input SCode.Element inElement;
-  output SCode.Element outElement;
-algorithm
-  outElement := match(inElement)
-    local
-      SCode.Ident n;
-      list<SCode.Enum> l;
-      SCode.Comment cmt;
-      SourceInfo info;
-      SCode.Element c;
-
-    case SCode.CLASS(name = n,restriction = SCode.R_TYPE(),
-                     classDef = SCode.ENUMERATION(enumLst=l),cmt=cmt,info = info)
-      equation
-        c = expandEnumeration(n, l, cmt, info);
-      then
-        c;
-
-    else inElement;
-
-  end match;
-end expandEnumerationClass;
-
-public function expandEnumeration
-"author: PA
-  This function takes an Ident and list of strings, and returns an enumeration class."
-  input SCode.Ident n;
-  input list<SCode.Enum> l;
-  input SCode.Comment cmt;
-  input SourceInfo info;
-  output SCode.Element outClass;
-protected
-  list<SCode.Element> comp;
-algorithm
-  comp := makeEnumComponents(l, info);
-  outClass :=
-    SCode.CLASS(
-     n,
-     SCode.defaultPrefixes,
-     SCode.NOT_ENCAPSULATED(),
-     SCode.NOT_PARTIAL(),
-     SCode.R_ENUMERATION(),
-     SCode.PARTS(comp,{},{},{},{},{},{},NONE()),
-     cmt,
-     info);
-end expandEnumeration;
-
-public function makeEnumComponents
-  "Translates a list of Enums to a list of elements of type EnumType."
-  input list<SCode.Enum> inEnumLst;
-  input SourceInfo info;
-  output list<SCode.Element> outSCodeElementLst;
-algorithm
-  outSCodeElementLst := List.map1(inEnumLst, SCode.makeEnumType, info);
-end makeEnumComponents;
 
 public function getElementWithPathCheckBuiltin
 "returns the element from the program having the name as the id.

--- a/Compiler/Template/SCodeDumpTpl.tpl
+++ b/Compiler/Template/SCodeDumpTpl.tpl
@@ -63,7 +63,11 @@ match element
     match visibility
       case PROTECTED(__) then (match options case OPTIONS(stripProtectedImports=true) then "" else dumpImport(element)) else dumpImport(element)
   case EXTENDS(__) then dumpExtends(element,options)
-  case CLASS(__) then dumpClass(element, each, options)
+  case CLASS(__) then
+    match restriction
+      case R_ENUMERATION() then dumpEnumeration(element, each, options)
+      else dumpClass(element, each, options)
+    end match
   case COMPONENT(__) then dumpComponent(element, each, options)
   case DEFINEUNIT(__) then dumpDefineUnit(element)
   else errorMsg("SCodeDump.dumpElement: Unknown element.")
@@ -118,15 +122,37 @@ match extends
     '<%visibility_str%>extends <%bc_str%><%mod_str%><%ann_str%>'
 end dumpExtends;
 
+template dumpClassPrefixes(SCode.Prefixes prefixes, String each, SCode.Encapsulated enc, SCode.Partial part)
+::=
+  let prefix_str = dumpPrefixes(prefixes, each)
+  let enc_str = dumpEncapsulated(enc)
+  let partial_str = dumpPartial(part)
+  '<%prefix_str%><%enc_str%><%partial_str%>'
+end dumpClassPrefixes;
+
+template dumpEnumeration(SCode.Element class, String each, SCodeDumpOptions options)
+::=
+match class
+  case CLASS(__) then
+    let prefix_str = dumpClassPrefixes(prefixes, each, encapsulatedPrefix, partialPrefix)
+    let cmt_str = dumpClassComment(cmt, options)
+    let ann_str = dumpClassAnnotation(cmt, options)
+    let cc_str = dumpReplaceableConstrainClass(prefixes, options)
+    let ann_str1 = if ann_str then ' <%ann_str%>' else ''
+    let literals_str = match classDef
+      case PARTS(__) then
+        (elementLst |> elt => '<%dumpEnumClassLiteral(elt, options)%>'; separator=", ")
+    end match
+    '<%prefix_str%>type <%name%> = enumeration(<%literals_str%>) <%cmt_str%><%ann_str1%>'
+end match
+end dumpEnumeration;
+
 template dumpClass(SCode.Element class, String each, SCodeDumpOptions options)
 ::=
 match class
   case CLASS(__) then
-    let prefix_str = dumpPrefixes(prefixes, each)
-    let enc_str = dumpEncapsulated(encapsulatedPrefix)
-    let partial_str = dumpPartial(partialPrefix)
+    let prefixes_str = dumpClassPrefixes(prefixes, each, encapsulatedPrefix, partialPrefix)
     let res_str = dumpRestriction(restriction)
-    let prefixes_str = '<%prefix_str%><%enc_str%><%partial_str%><%res_str%>'
     let cdef_str = dumpClassDef(classDef, options)
     let cmt_str = dumpClassComment(cmt, options)
     let ann_str = dumpClassAnnotation(cmt, options)
@@ -134,7 +160,7 @@ match class
     let header_str = dumpClassHeader(classDef, name, cmt_str, options)
     let footer_str = dumpClassFooter(classDef, cdef_str, name, cmt_str, ann_str, cc_str)
     <<
-    <%prefixes_str%> <%header_str%> <%footer_str%>
+    <%prefixes_str%><%res_str%> <%header_str%> <%footer_str%>
     >>
 end dumpClass;
 
@@ -148,6 +174,13 @@ match classDef
   case PARTS(__) then '<%name%> <%cmt%>'
   else '<%name%>'
 end dumpClassHeader;
+
+template dumpEnumClassLiteral(SCode.Element literals, SCodeDumpOptions options)
+::=
+match literals
+  case COMPONENT(__)
+    then '<%name%><%dumpComment(comment, options)%>'
+end dumpEnumClassLiteral;
 
 template dumpClassDef(SCode.ClassDef classDef, SCodeDumpOptions options)
 ::=

--- a/Compiler/Template/SCodeDumpTpl.tpl
+++ b/Compiler/Template/SCodeDumpTpl.tpl
@@ -180,12 +180,6 @@ match classDef
     let mod_str = dumpModifier(modifications,options)
     let attr_str = dumpAttributes(attributes)
     '= <%attr_str%><%type_str%><%mod_str%>'
-  case ENUMERATION(__) then
-    let enum_str = if enumLst then
-        (enumLst |> enum => dumpEnumLiteral(enum, options) ;separator=", ")
-      else
-        ':'
-    '= enumeration(<%enum_str%>)'
   case PDER(__) then
     let func_str = AbsynDumpTpl.dumpPath(functionPath)
     '= der(<%func_str%>, <%derivedVariables ;separator=", "%>)'
@@ -198,7 +192,6 @@ template dumpClassFooter(SCode.ClassDef classDef, String cdefStr, String name, S
 ::=
 match classDef
   case DERIVED(__) then '<%cdefStr%><%cmt%><%ann%><%cc_str%>'
-  case ENUMERATION(__) then '<%cdefStr%><%cmt%><%ann%><%cc_str%>'
   case PDER(__) then cdefStr
   case _ then
     let annstr = if ann then '<%ann%>; ' else ''

--- a/Compiler/Template/SCodeTV.mo
+++ b/Compiler/Template/SCodeTV.mo
@@ -785,6 +785,12 @@ package SCode
     record INITIAL end INITIAL;
     record NON_INITIAL end NON_INITIAL;
   end Initial;
+
+  function isEnumeration
+    input Element inEnum;
+    output Boolean outBoolean;
+  end isEnumeration;
+
 end SCode;
 
 package SCodeDump

--- a/Compiler/Template/SCodeTV.mo
+++ b/Compiler/Template/SCodeTV.mo
@@ -429,10 +429,6 @@ package SCode
       Attributes attributes;
     end DERIVED;
 
-    record ENUMERATION
-      list<Enum> enumLst;
-    end ENUMERATION;
-
     record OVERLOAD
       list<Absyn.Path> pathLst;
     end OVERLOAD;


### PR DESCRIPTION
Patch replaces transformation Absyn.ENUMERATION --> SCode.ENUMERATION --> SCode.CLASS to Absyn.ENUMERATION --> SCode.CLASS and fix bug https://trac.openmodelica.org/OpenModelica/ticket/3327.
Also SCodeDumpTpl is improved to reduce trailing and double whitespaces in its output.