### PR TITLE
Improve sanity check by checking all commits

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -410,5 +410,6 @@ git-clean:
 
 git-sanity-check: git-clean
 	test "./Compiler/boot/bootstrap-sources.tar.xz" = `find . -type f -size +684k | grep -v 3rdParty`
-	test ! -e SimulationRuntime/cpp/Doc
-	! find . -name "*.html" -o -name "*.png" | grep -v 3rdParty
+	for commit in `git rev-list origin/master..HEAD`; do \
+	  (! git ls-tree --name-only -r $$commit | egrep "(.*[.](html|png|o|so|a|dll|exe|log|db|zip|DS_Store)$$)|SimulationRuntime/cpp/Doc" || exit 1) \
+	done


### PR DESCRIPTION
This compares this commit to the master, looking for bad files.