### PR TITLE
Fix wrong parameter name for regex

### DIFF
--- a/Compiler/Util/System.mo
+++ b/Compiler/Util/System.mo
@@ -109,12 +109,12 @@ public function regex "Fails and sets Error.mo if the regex does not compile.
   input String str;
   input String re;
   input Integer maxMatches "The maximum number of matches that will be returned";
-  input Boolean extended "Use POSIX extended or regular syntax";
-  input Boolean sensitive;
+  input Boolean extended=false "Use POSIX extended or regular syntax";
+  input Boolean ignoreCase=false;
   output Integer numMatches "0 means no match, else returns a number 1..maxMatches (1 if maxMatches<0)";
   output list<String> strs "This list has length = maxMatches. Substrings that did not match are filled with the empty string";
 
-  external "C" strs=System_regex(str,re,maxMatches,extended,sensitive,numMatches) annotation(Library = "omcruntime");
+  external "C" strs=System_regex(str,re,maxMatches,extended,ignoreCase,numMatches) annotation(Library = "omcruntime");
 end regex;
 
 public function strncmp

--- a/SimulationRuntime/c/util/utility.c
+++ b/SimulationRuntime/c/util/utility.c
@@ -62,11 +62,11 @@ modelica_real real_int_pow(threadData_t *threadData, modelica_real base, modelic
   return m ? (1 / result) : result;
 }
 
-extern int OpenModelica_regexImpl(const char* str, const char* re, const int maxn, int extended, int sensitive, void*(*mystrdup)(const char*), void **outMatches)
+extern int OpenModelica_regexImpl(const char* str, const char* re, const int maxn, int extended, int ignoreCase, void*(*mystrdup)(const char*), void **outMatches)
 {
   regex_t myregex;
   int nmatch=0,i,rc,res;
-  int flags = (extended ? REG_EXTENDED : 0) | (sensitive ? REG_ICASE : 0) | (maxn ? 0 : REG_NOSUB);
+  int flags = (extended ? REG_EXTENDED : 0) | (ignoreCase ? REG_ICASE : 0) | (maxn ? 0 : REG_NOSUB);
 #if !defined(_MSC_VER)
   regmatch_t matches[maxn < 1 ? 1 : maxn];
 #else


### PR DESCRIPTION
Was behaviour of "ignore case"=true, but said insensitive=true.