### PR TITLE
MetaUtil cleanup and fixes.

### DIFF
--- a/Compiler/FrontEnd/Absyn.mo
+++ b/Compiler/FrontEnd/Absyn.mo
@@ -1029,6 +1029,7 @@ uniontype Restriction "These constructors each correspond to a different kind of
     Path name; //Name of the uniontype
     Integer index; //Index in the uniontype
     Boolean singleton;
+    Boolean moved; // true if moved outside uniontype, otherwise false.
   end R_METARECORD;
   record R_UNKNOWN "Helper restriction" end R_UNKNOWN; /* added by simbj */
 end Restriction;

--- a/Compiler/FrontEnd/ClassInf.mo
+++ b/Compiler/FrontEnd/ClassInf.mo
@@ -790,7 +790,7 @@ algorithm
     case TYPE_ENUM(p) then (SCode.R_PREDEFINED_ENUMERATION(),p);
      /* Meta Modelica extensions */
     case META_UNIONTYPE(p) then (SCode.R_UNIONTYPE(),p);
-    case  META_RECORD(p) then (SCode.R_METARECORD(p, 0, false),p);
+    case  META_RECORD(p) then (SCode.R_METARECORD(p, 0, false, false),p);
   end match;
 end stateToSCodeRestriction;
 

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -2319,7 +2319,7 @@ algorithm
         eqConstraint = InstUtil.equalityConstraint(env5, els, info);
         ci_state6 = if Util.isSome(ed) then ClassInf.assertTrans(ci_state6,ClassInf.FOUND_EXT_DECL(),info) else ci_state6;
       then
-        (cache,env5,ih,store,dae,csets5,ci_state6,vars,MetaUtil.fixUniontype(ci_state6,NONE()/* no basictype bc*/,inClassDef6),NONE(),eqConstraint,graph);
+        (cache,env5,ih,store,dae,csets5,ci_state6,vars,MetaUtil.fixUniontype(ci_state6,inClassDef6),NONE(),eqConstraint,graph);
 
     // This rule describes how to instantiate class definition derived from an enumeration
     case (cache,env,ih,store,mods,pre,_,_,

--- a/Compiler/FrontEnd/InstFunction.mo
+++ b/Compiler/FrontEnd/InstFunction.mo
@@ -54,7 +54,6 @@ public import SCode;
 public import UnitAbsyn;
 
 protected import Lookup;
-protected import MetaUtil;
 protected import Inst;
 protected import InstBinding;
 protected import InstVar;

--- a/Compiler/FrontEnd/InstSection.mo
+++ b/Compiler/FrontEnd/InstSection.mo
@@ -71,7 +71,6 @@ protected import InstTypes;
 protected import NFInstUtil;
 protected import List;
 protected import Lookup;
-protected import MetaUtil;
 protected import Patternm;
 protected import PrefixUtil;
 protected import Static;
@@ -5015,7 +5014,7 @@ algorithm
     // (v1,v2,..,vn) := func(...)
     case (cache,env,ih,pre,Absyn.TUPLE(expressions = expl),e_1,eprop,_,source,_,impl,_,_)
       equation
-        true = MetaUtil.onlyCrefExpressions(expl);
+        true = List.all(expl, Absyn.isCref);
         (cache, e_1 as DAE.CALL(), eprop) = Ceval.cevalIfConstant(cache, env, e_1, eprop, impl, info);
         (cache,e_2) = PrefixUtil.prefixExp(cache, env, ih, e_1, pre);
         (cache,expl_1,cprops,attrs,_) = Static.elabExpCrefNoEvalList(cache, env, expl, impl, NONE(), false, pre, info);
@@ -5030,7 +5029,7 @@ algorithm
     case (cache,env,ih,pre,Absyn.TUPLE(expressions = expl),e_1,eprop,_,source,_,impl,_,_)
       equation
         true = Config.acceptMetaModelicaGrammar();
-        true = MetaUtil.onlyCrefExpressions(expl);
+        true = List.all(expl, Absyn.isCref);
         true = Types.isTuple(Types.getPropType(eprop));
         (cache, e_1 as DAE.MATCHEXPRESSION(), eprop) = Ceval.cevalIfConstant(cache, env, e_1, eprop, impl, info);
         (cache,e_2) = PrefixUtil.prefixExp(cache, env, ih, e_1, pre);

--- a/Compiler/FrontEnd/MetaUtil.mo
+++ b/Compiler/FrontEnd/MetaUtil.mo
@@ -243,13 +243,19 @@ protected
   Integer index = 0;
   Boolean singleton = listLength(inElementItems) == 1;
   Absyn.Class c;
+  Absyn.Restriction r;
 algorithm
   outElementItems := list(match e
     case Absyn.ELEMENTITEM(element = Absyn.ELEMENT(specification =
         Absyn.CLASSDEF(class_ = c as Absyn.CLASS(restriction = Absyn.R_RECORD()))))
       algorithm
-        c.restriction := Absyn.R_METARECORD(Absyn.IDENT(inName), index, singleton);
+        // Change the record into a metarecord and add it to the list of metaclasses.
+        r := Absyn.R_METARECORD(Absyn.IDENT(inName), index, singleton, true);
+        c.restriction := r;
         outMetaClasses := c :: outMetaClasses;
+        // Change the record into a metarecord and update the original class.
+        r := Absyn.R_METARECORD(Absyn.IDENT(inName), index, singleton, false);
+        c.restriction := r;
         index := index + 1;
       then
         setElementItemClass(e, c);

--- a/Compiler/FrontEnd/MetaUtil.mo
+++ b/Compiler/FrontEnd/MetaUtil.mo
@@ -33,594 +33,278 @@ encapsulated package MetaUtil
 " file:        MetaUtil.mo
   package:     MetaUtil
   description: Different MetaModelica extension functions.
-
-  RCS: $Id$
-
-  "
+"
 
 public import Absyn;
 public import ClassInf;
 public import DAE;
 public import SCode;
-public import SCodeUtil;
 
 protected import Config;
-protected import Dump;
-protected import Error;
 protected import Flags;
 protected import List;
 protected import Types;
 
-public function transformArrayNodesToListNodes "function: transformArrayNodesToListNodes"
-  input list<Absyn.Exp> inList;
-  input list<Absyn.Exp> accList;
-  output list<Absyn.Exp> outList;
+public function createMetaClassesInProgram
+  "This function goes through a program and changes all records inside of
+   uniontype into metarecords. It also makes a copy of them outside of the
+   uniontype where they are found so that they can be used without prefixing
+   with the uniontype name."
+  input Absyn.Program inProgram;
+  output Absyn.Program outProgram = inProgram;
+protected
+  list<Absyn.Class> classes = {}, meta_classes;
 algorithm
-  outList := matchcontinue (inList,accList)
-    local
-      list<Absyn.Exp> localAccList,es,restList;
-      Absyn.Exp firstExp;
-    case ({},localAccList) then listReverse(localAccList);
-    case (Absyn.ARRAY({}) :: restList,localAccList)
-      equation
-        localAccList = Absyn.LIST({})::localAccList;
-        localAccList = transformArrayNodesToListNodes(restList,localAccList);
-      then localAccList;
-    case (Absyn.ARRAY(es) :: restList,localAccList)
-      equation
-        es = transformArrayNodesToListNodes(es,{});
-        localAccList = Absyn.LIST(es)::localAccList;
-        localAccList = transformArrayNodesToListNodes(restList,localAccList);
-      then localAccList;
-    case (firstExp :: restList,localAccList)
-      equation
-        localAccList = firstExp::localAccList;
-        localAccList = transformArrayNodesToListNodes(restList,localAccList);
-      then localAccList;
-  end matchcontinue;
-end transformArrayNodesToListNodes;
+  if not Config.acceptMetaModelicaGrammar() then
+    return;
+  end if;
 
-public function createListType "function: createListType"
-  input DAE.Type inType;
-  input Integer numLists;
-  output DAE.Type outType;
-algorithm
-  outType :=
-  matchcontinue (inType,numLists)
-    local
-      DAE.Type localT;
-      Integer n;
-      DAE.Type t;
-    case (localT,0) then localT;
-    case (localT,n)
-      equation
-        t = DAE.T_METALIST(localT, DAE.emptyTypeSource);
-        t = createListType(t,n-1);
-      then t;
-  end matchcontinue;
-end createListType;
+  _ := match outProgram
+    case Absyn.PROGRAM()
+      algorithm
+        for c in outProgram.classes loop
+          (c, meta_classes) := createMetaClasses(c);
+          classes := c :: listAppend(meta_classes, classes);
+        end for;
 
-public function getTypeFromProp "function: getTypeFromProp"
-  input DAE.Properties inProp;
-  output DAE.Type outType;
-algorithm
-  outType :=
-  match (inProp)
-    local
-      DAE.Type t;
-    case (DAE.PROP(t,_)) equation then t;
-  end match;
-end getTypeFromProp;
-
-public function getListOfStrings
-  input list<SCode.Element> els;
-  output list<String> outStrings;
-algorithm
-  outStrings := match(els)
-    local
-      list<SCode.Element> rest;
-      list<String> slst;
-      String n;
-
-    case({}) then {};
-
-    case(SCode.CLASS(name = n)::rest)
-      equation
-        slst = getListOfStrings(rest);
+        outProgram.classes := listReverse(classes);
       then
-        n::slst;
+        ();
 
-  end match;
-end getListOfStrings;
-
-//Check if a class has a certain restriction, added by simbj
-public function classHasMetaRestriction
-  input SCode.Element cl;
-  output Boolean outBoolean;
-algorithm
-  outBoolean := match(cl)
-    case(SCode.CLASS(restriction = SCode.R_METARECORD())) then true;
-    else false;
-  end match;
-end classHasMetaRestriction;
-
-//Check if a class has a certain restriction, added by simbj
-public function classHasRestriction
-  input SCode.Element cl;
-  input SCode.Restriction re;
-  output Boolean outBoolean;
-algorithm
-  outBoolean := matchcontinue(cl,re)
-    local
-      SCode.Restriction re1,re2;
-
-    case(SCode.CLASS(restriction = re1),re2)
-      equation
-        equality(re1 = re2);
-      then true;
-
-    else false;
-  end matchcontinue;
-end classHasRestriction;
-
-public function createMetaClassesInProgram "Adds metarecord classes to the AST. This function handles a whole program,
-  including packages."
-  input Absyn.Program program;
-  output Absyn.Program out;
-algorithm
-  out :=  match (program)
-    local
-      list<Absyn.Class> classes, metaClassesFlat;
-      list<list<Absyn.Class>> metaClasses;
-      Absyn.Program p;
-
-    case p as Absyn.PROGRAM() guard Config.acceptMetaModelicaGrammar()
-      equation
-        metaClasses = List.map(p.classes, createMetaClasses);
-        metaClassesFlat = List.flatten(metaClasses);
-        classes = List.map(p.classes, createMetaClassesFromPackage);
-        p.classes = listAppend(classes, metaClassesFlat);
-      then p;
-    else program;
+    else ();
   end match;
 end createMetaClassesInProgram;
 
-protected function createMetaClassesFromPackage "Helper function to createMetaClassesInProgram"
-  input Absyn.Class cl;
-  output Absyn.Class out;
+protected function createMetaClasses
+  "Takes a class, and if it's a uniontype it converts all records inside it into
+   metarecords and returns the updated uniontype and a list of all metarecords.
+   It then recursively applies the same operation to all subclasses."
+  input Absyn.Class inClass;
+  output Absyn.Class outClass = inClass;
+  output list<Absyn.Class> outMetaClasses = {};
+protected
+  Absyn.ClassDef body;
+  list<Absyn.ClassPart> parts;
 algorithm
-  out := matchcontinue(cl)
-    local
-      String name;
-      Boolean     partialPrefix;
-      Boolean     finalPrefix;
-      Boolean     encapsulatedPrefix;
-      Absyn.Restriction restriction;
-      Absyn.ClassDef    body;
-      SourceInfo        info;
-      list<Absyn.ClassPart> classParts;
-      Option<String>  comment;
-      list<String> typeVars;
-      list<Absyn.NamedArg> classAttrs;
-      list<Absyn.Annotation> ann;
+  _ := match outClass
+    case Absyn.CLASS(restriction = Absyn.R_UNIONTYPE(),
+        body = body as Absyn.PARTS(classParts = parts))
+      algorithm
+        (parts, outMetaClasses) := fixClassParts(parts, outClass.name);
+        body.classParts := parts;
+        outClass.body := body;
+      then
+        ();
 
-    case (Absyn.CLASS(body=Absyn.PARTS(typeVars=typeVars,classAttrs=classAttrs,classParts=classParts,ann=ann,comment=comment),name=name,partialPrefix=partialPrefix,finalPrefix=finalPrefix,encapsulatedPrefix=encapsulatedPrefix,restriction=restriction,info=info))
-      equation
-        classParts = List.map(classParts,createMetaClassesFromClassParts);
-        body = Absyn.PARTS(typeVars,classAttrs,classParts,ann,comment);
-      then Absyn.CLASS(name,partialPrefix,finalPrefix,encapsulatedPrefix,restriction,body,info);
+    case Absyn.CLASS(restriction = Absyn.R_UNIONTYPE(),
+        body = body as Absyn.CLASS_EXTENDS(parts = parts))
+      algorithm
+        (parts, outMetaClasses) := fixClassParts(parts, outClass.name);
+        body.parts := parts;
+        outClass.body := body;
+      then
+        ();
 
-    else cl;
-  end matchcontinue;
-end createMetaClassesFromPackage;
+    else ();
+  end match;
+
+  _ := match outClass
+    case Absyn.CLASS(body = body as Absyn.PARTS())
+      algorithm
+        body.classParts := createMetaClassesFromClassParts(body.classParts);
+        outClass.body := body;
+      then
+        ();
+
+    case Absyn.CLASS(body = body as Absyn.CLASS_EXTENDS())
+      algorithm
+        body.parts := createMetaClassesFromClassParts(body.parts);
+        outClass.body := body;
+      then
+        ();
+
+    else ();
+  end match;
+end createMetaClasses;
 
 protected function createMetaClassesFromClassParts
-  input Absyn.ClassPart classPart;
-  output Absyn.ClassPart out;
+  input list<Absyn.ClassPart> inClassParts;
+  output list<Absyn.ClassPart> outClassParts;
 algorithm
-  out := matchcontinue (classPart)
-    local
-      list<Absyn.ElementItem> els;
-      list<list<Absyn.ElementItem>> lels;
+  outClassParts := list(match p
+    case Absyn.PUBLIC()
+      algorithm
+        p.contents := createMetaClassesFromElementItems(p.contents);
+      then
+        p;
 
-    case (Absyn.PUBLIC(els))
-      equation
-        lels = List.map(els, createMetaClassesFromElementItem);
-        els = List.flatten(lels);
-      then Absyn.PUBLIC(els);
+    case Absyn.PROTECTED()
+      algorithm
+        p.contents := createMetaClassesFromElementItems(p.contents);
+      then
+        p;
 
-    case (Absyn.PROTECTED(els))
-      equation
-        lels = List.map(els, createMetaClassesFromElementItem);
-        els = List.flatten(lels);
-      then Absyn.PROTECTED(els);
-
-    else classPart;
-  end matchcontinue;
+    else p;
+  end match for p in inClassParts);
 end createMetaClassesFromClassParts;
 
-protected function createMetaClassesFromElementItem
-  input Absyn.ElementItem elementItem;
-  output list<Absyn.ElementItem> out;
+protected function createMetaClassesFromElementItems
+  input list<Absyn.ElementItem> inElementItems;
+  output list<Absyn.ElementItem> outElementItems = {};
+protected
+  Absyn.Class cls;
+  list<Absyn.Class> meta_classes;
+  list<Absyn.ElementItem> els;
 algorithm
-  out := matchcontinue(elementItem)
-    local
-      SourceInfo info;
-      Boolean replaceable_;
-      Absyn.Class class_, cl2;
-      list<Absyn.Class> metaClasses, classes;
-      list<Absyn.ElementItem> elementItems;
-    case (Absyn.ELEMENTITEM(Absyn.ELEMENT(specification=Absyn.CLASSDEF(class_=class_))))
-      equation
-        metaClasses = createMetaClasses(class_);
-        cl2 = createMetaClassesFromPackage(class_);
-        classes = cl2 :: metaClasses;
-        elementItems = List.map1r(classes,setElementItemClass,elementItem);
-      then elementItems;
-    else {elementItem};
-  end matchcontinue;
-end createMetaClassesFromElementItem;
+  for e in listReverse(inElementItems) loop
+    e := match e
+      case Absyn.ELEMENTITEM(element = Absyn.ELEMENT(specification =
+          Absyn.CLASSDEF(class_ = cls)))
+        algorithm
+          (cls, meta_classes) := createMetaClasses(cls);
+          els := list(setElementItemClass(e, c) for c in meta_classes);
+          outElementItems := listAppend(els, outElementItems);
+        then
+          setElementItemClass(e, cls);
+
+      else e;
+    end match;
+
+    outElementItems := e :: outElementItems;
+  end for;
+end createMetaClassesFromElementItems;
 
 protected function setElementItemClass
-  input Absyn.ElementItem elementItem;
-  input Absyn.Class class_;
-  output Absyn.ElementItem out;
+  input Absyn.ElementItem inElementItem;
+  input Absyn.Class inClass;
+  output Absyn.ElementItem outElementItem = inElementItem;
 algorithm
-  out := match (elementItem,class_)
-      local
-      Boolean finalPrefix;
-      Option<Absyn.RedeclareKeywords> redeclareKeywords;
-      Absyn.InnerOuter innerOuter;
-      SourceInfo info;
-      Option<Absyn.ConstrainClass> constrainClass;
-      Boolean replaceable_;
-    case (Absyn.ELEMENTITEM(Absyn.ELEMENT(specification=Absyn.CLASSDEF(replaceable_=replaceable_),finalPrefix=finalPrefix,redeclareKeywords=redeclareKeywords,innerOuter=innerOuter,info=info,constrainClass=constrainClass)),_)
-      then Absyn.ELEMENTITEM(Absyn.ELEMENT(finalPrefix,redeclareKeywords,innerOuter,Absyn.CLASSDEF(replaceable_,class_),info,constrainClass));
-    /* Annotations, comments */
-    else elementItem;
+  outElementItem := match outElementItem
+    local
+      Absyn.Element e;
+      Absyn.ElementSpec es;
+
+    case Absyn.ELEMENTITEM(element = e as Absyn.ELEMENT(specification = es as Absyn.CLASSDEF()))
+      algorithm
+        es.class_ := inClass;
+        e.specification := es;
+        outElementItem.element := e;
+      then
+        outElementItem;
+
+    else outElementItem;
   end match;
 end setElementItemClass;
 
-//Added by simbj
-//Analyze the AST, find union type and extend the AST with metarecords
-public function createMetaClasses
-input Absyn.Class cl;
-output list<Absyn.Class> clstout;
+protected function convertElementToClass
+  input Absyn.ElementItem inElementItem;
+  output Absyn.Class outClass;
 algorithm
-  clstout := matchcontinue(cl)
-    local
-      list<Absyn.ClassPart> cls;
-      list<Absyn.ElementItem> els;
-      list<Absyn.Class> cllst;
-      SCode.Restriction r_1;
-      Absyn.Class c;
-      String n;
-      Boolean p,f,e;
-      Absyn.Restriction r;
-      Absyn.ClassDef d;
-      SourceInfo file_info;
+  Absyn.ELEMENTITEM(element = Absyn.ELEMENT(
+    specification = Absyn.CLASSDEF(class_ = outClass))) := inElementItem;
+end convertElementToClass;
 
-    case(c as Absyn.CLASS(name = n,restriction = r,
-         body = Absyn.PARTS(classParts = {Absyn.PUBLIC(contents = els)})))
-      equation
-        r_1 = SCodeUtil.translateRestriction(c, r); // uniontype will not get elaborated!
-        SCode.R_UNIONTYPE() = r_1;
-        els = fixElementItems(els,n,0,listLength(els)==1);
-        cllst = convertElementsToClasses(els);
-      then cllst;
-    else {};
-  end matchcontinue;
-end createMetaClasses;
-
-//Added by simbj
-//Helper function
-function convertElementsToClasses
-  input list<Absyn.ElementItem> els;
-  output list<Absyn.Class> outcls;
+protected function fixClassParts
+  input list<Absyn.ClassPart> inClassParts;
+  input Absyn.Ident inClassName;
+  output list<Absyn.ClassPart> outClassParts = {};
+  output list<Absyn.Class> outMetaClasses = {};
+protected
+  list<Absyn.Class> meta_classes;
+  list<Absyn.ElementItem> els;
 algorithm
-  outcls := match(els)
-    local
-      list<Absyn.ElementItem> rest;
-      Absyn.Class c;
-      list<Absyn.Class> clst;
-
-    case({}) then {};
-
-    case(Absyn.ELEMENTITEM(element = Absyn.ELEMENT(specification = Absyn.CLASSDEF(class_ = c)))::rest)
-      equation
-        clst = convertElementsToClasses(rest);
+  outClassParts := list(match p
+    case Absyn.PUBLIC()
+      algorithm
+        (els, meta_classes) := fixElementItems(p.contents, inClassName);
+        p.contents := els;
+        outMetaClasses := listAppend(meta_classes, outMetaClasses);
       then
-        c::clst;
+        p;
 
-    /* Strip annotation, comment */
-    case(_::rest)
-      then convertElementsToClasses(rest);
-  end match;
-end convertElementsToClasses;
+    case Absyn.PROTECTED()
+      algorithm
+        (els, meta_classes) := fixElementItems(p.contents, inClassName);
+        p.contents := els;
+        outMetaClasses := listAppend(meta_classes, outMetaClasses);
+      then
+        p;
 
-//Added by simbj
-//Reparses type and returns the real type
-//NOTE: This is probably a bad way to do this, should be moved, maybe to the parser?
-function reparseType
-  input Absyn.Path path;
-  output DAE.Type outType;
+    else p;
+  end match for p in inClassParts);
+end fixClassParts;
+
+protected function fixElementItems
+  input list<Absyn.ElementItem> inElementItems;
+  input String inName;
+  output list<Absyn.ElementItem> outElementItems;
+  output list<Absyn.Class> outMetaClasses = {};
+protected
+  Integer index = 0;
+  Boolean singleton = listLength(inElementItems) == 1;
+  Absyn.Class c;
 algorithm
-  outType := match(path)
-    local
-      DAE.Type t;
-    case(Absyn.IDENT("Integer")) then DAE.T_INTEGER_DEFAULT;
-    case(Absyn.IDENT("Real")) then DAE.T_REAL_DEFAULT;
-    case(Absyn.IDENT("String")) then DAE.T_STRING_DEFAULT;
-    case(Absyn.IDENT("Boolean")) then DAE.T_BOOL_DEFAULT;
-    // BTH
-    case(Absyn.IDENT("Clock"))
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then DAE.T_CLOCK_DEFAULT;
-  end match;
-end reparseType;
+  outElementItems := list(match e
+    case Absyn.ELEMENTITEM(element = Absyn.ELEMENT(specification =
+        Absyn.CLASSDEF(class_ = c as Absyn.CLASS(restriction = Absyn.R_RECORD()))))
+      algorithm
+        c.restriction := Absyn.R_METARECORD(Absyn.IDENT(inName), index, singleton);
+        outMetaClasses := c :: outMetaClasses;
+        index := index + 1;
+      then
+        setElementItemClass(e, c);
 
-/* These functions are helper functions for the Uniontypes, added by simbj */
-public function getRestriction
-  input Absyn.Element el;
-  output Absyn.Restriction res;
-algorithm
-  res := match(el)
-    local
-      Absyn.ElementSpec spec;
-      Absyn.Class cl;
-      Absyn.Restriction r;
-    case(Absyn.ELEMENT(specification=Absyn.CLASSDEF(class_=Absyn.CLASS(restriction=r))))
-      then r;
-    else Absyn.R_UNKNOWN();
-  end match;
-end getRestriction;
-
-function fixRestriction
-  input Absyn.Restriction resin;
-  input String name;
-  input Integer index;
-  input Boolean singleton;
-  output Absyn.Restriction resout;
-algorithm
-  resout := match(resin,name,index,singleton)
-    local
-      Absyn.Ident ident;
-      Absyn.Path path;
-    case(Absyn.R_RECORD(),_,_,_)
-      equation
-        ident = name;
-        path = Absyn.IDENT(ident);
-      then Absyn.R_METARECORD(path,index,singleton);
-    else resin;
-  end match;
-end fixRestriction;
-
-
-function fixClass
-  input Absyn.Class classin;
-  input String name;
-  input Integer index;
-  input Boolean singleton;
-  output Absyn.Class classout;
-algorithm
-  classout := match(classin,name,index,singleton)
-    local
-      Absyn.Ident n;
-      Boolean p;
-      Boolean f;
-      Boolean e;
-      Absyn.Restriction res;
-      Absyn.ClassDef b;
-      SourceInfo i;
-
-    case(Absyn.CLASS(n,p,f,e,res,b,i),_,_,_)
-      equation
-        res = fixRestriction(res,name,index,singleton);
-      then Absyn.CLASS(n,p,f,e,res,b,i);
-    else classin;
-  end match;
-end fixClass;
-
-
-function fixElementSpecification
-  input Absyn.ElementSpec specin;
-  input String name;
-  input Integer index;
-  input Boolean singleton;
-  output Absyn.ElementSpec specout;
-algorithm
-  specout := match(specin,name,index,singleton)
-    local
-      Boolean rep;
-      Absyn.Class c;
-    case(Absyn.CLASSDEF(rep,c),_,_,_)
-      equation
-        c = fixClass(c,name,index,singleton);
-      then Absyn.CLASSDEF(rep,c);
-    else specin;
-  end match;
-end fixElementSpecification;
-
-function fixElement
-  input Absyn.Element elementin;
-  input String name;
-  input Integer index;
-  input Boolean singleton;
-  output Absyn.Element elementout;
-
-algorithm
-  elementout := match(elementin,name,index,singleton)
-    local
-      Boolean f;
-      Option<Absyn.RedeclareKeywords> r;
-      Absyn.InnerOuter i;
-      Absyn.ElementSpec spec;
-      SourceInfo inf;
-      Option<Absyn.ConstrainClass> con;
-    case(Absyn.ELEMENT(finalPrefix = f, redeclareKeywords = r, innerOuter=i, specification=spec, info=inf, constrainClass=con),_,_,_)
-      equation
-        spec = fixElementSpecification(spec,name,index,singleton);
-      then Absyn.ELEMENT(f,r,i,spec,inf,con);
-  end match;
-end fixElement;
-
-
-
-function fixElementItems
-  input list<Absyn.ElementItem> elementItemsin;
-  input String name;
-  input Integer index;
-  input Boolean singleton;
-  output list<Absyn.ElementItem> elementItemsout;
-algorithm
-  elementItemsout := match (elementItemsin,name,index,singleton)
-    local
-      Absyn.Element element;
-      Absyn.ElementItem elementitem;
-      list<Absyn.ElementItem> rest;
-    case({},_,_,_) then {};
-    case(Absyn.ELEMENTITEM(element)::rest,_,_,_)
-      equation
-        element = fixElement(element,name,index,singleton);
-        rest = fixElementItems(rest,name,index+1,singleton);
-      then (Absyn.ELEMENTITEM(element)::rest);
-    case (_::rest,_,_,_) then fixElementItems(rest,name,index,singleton);
-  end match;
+    else e;
+  end match for e in inElementItems);
 end fixElementItems;
 
-/* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^END^OF^HELPERFUNCTIONS^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ */
-
-public function constructorCallTypeToNamesAndTypes "Fetches the field names
-and types from a record call or metarecord call"
-  input DAE.Type inType;
-  output list<String> varNames;
-  output list<DAE.Type> outTypes;
-algorithm
-  (varNames,outTypes) := match (inType)
-    local
-      list<String> names;
-      list<DAE.Type> types;
-      list<DAE.FuncArg> fargs;
-      list<DAE.Var> fields;
-
-    case (DAE.T_METARECORD(fields = fields))
-      equation
-        names = List.map(fields, Types.getVarName);
-        types = List.map(fields, Types.getVarType);
-      then (names,types);
-
-    case (DAE.T_FUNCTION(funcArg = fargs,funcResultType = DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(_))))
-      equation
-        names = List.map(fargs, Types.funcArgName);
-        types = List.map(fargs, Types.funcArgType);
-      then (names,types);
-  end match;
-end constructorCallTypeToNamesAndTypes;
-
 public function fixUniontype
-  input ClassInf.State st;
-  input Option<DAE.Type> t;
-  input SCode.ClassDef c;
+  input ClassInf.State inState;
+  input SCode.ClassDef inClassDef;
   output Option<DAE.Type> outType;
 algorithm
-  outType := matchcontinue (st,t,c)
+  outType := matchcontinue(inState, inClassDef)
     local
-      list<SCode.Element> els;
-      list<String> slst;
-      list<Absyn.Path> paths;
       Absyn.Path p;
-      Boolean b;
+      list<Absyn.Path> paths;
+      list<String> names;
       DAE.TypeSource ts;
 
-    case (ClassInf.META_UNIONTYPE(p),_,SCode.PARTS(elementLst = els))
-      equation
-        p = Absyn.makeFullyQualified(p);
-        slst = getListOfStrings(els);
-        paths = List.map1r(slst, Absyn.pathReplaceIdent, p);
-        b = listLength(paths)==1;
-        ts = Types.mkTypeSource(SOME(p));
+    case (ClassInf.META_UNIONTYPE(), SCode.PARTS())
+      algorithm
+        p := Absyn.makeFullyQualified(inState.path);
+        names := SCode.elementNames(inClassDef.elementLst);
+        paths := list(Absyn.pathReplaceIdent(p, n) for n in names);
+        ts := Types.mkTypeSource(SOME(p));
       then
-        SOME(DAE.T_METAUNIONTYPE(paths,b,ts));
+        SOME(DAE.T_METAUNIONTYPE(paths, listLength(paths) == 1, ts));
 
-    else t;
+    else NONE();
   end matchcontinue;
 end fixUniontype;
 
-public function createLhsExp "function: createLhsExp"
+public function checkArrayType
+  "Checks that an array type is valid."
+  input DAE.Type inType;
+protected
+  DAE.Type el_ty;
+algorithm
+  el_ty := Types.arrayElementType(inType);
+  false := (not Types.isString(el_ty) and Types.isBoxedType(el_ty)) or
+    Flags.isSet(Flags.RML);
+end checkArrayType;
+
+public function transformArrayNodesToListNodes
   input list<Absyn.Exp> inList;
-  output Absyn.Exp outExp;
-algorithm
-  outExp := matchcontinue (inList)
-    local
-      list<Absyn.Exp> lst;
-      Absyn.Exp firstExp;
-    case (firstExp :: {}) then firstExp;
-    case (lst) then Absyn.TUPLE(lst);
-  end matchcontinue;
-end createLhsExp;
-
-public function onlyCrefExpressions "function: onlyCrefExpressions"
-  input list<Absyn.Exp> expList;
-  output Boolean boolVal;
-algorithm
-  boolVal :=
-  matchcontinue (expList)
-    local
-      list<Absyn.Exp> restList;
-    case ({}) then true;
-    case (Absyn.CREF(_) :: restList) then onlyCrefExpressions(restList);
-    else false;
-  end matchcontinue;
-end onlyCrefExpressions;
-
-public function isTupleExp
-  input Absyn.Exp inExp;
-  output Boolean b;
-algorithm
-  b := match (inExp)
-    case Absyn.TUPLE(_) then true;
-    else false;
-  end match;
-end isTupleExp;
-
-public function extractListFromTuple "author: KS
- Given an Absyn.Exp, this function will extract the list of expressions if the
- expression is a tuple, otherwise a list of length one is created"
-  input Absyn.Exp inExp;
-  input Integer numOfExps;
   output list<Absyn.Exp> outList;
 algorithm
-  outList :=
-  match (inExp,numOfExps)
-    local
-      list<Absyn.Exp> l;
-      Absyn.Exp exp;
-    case (Absyn.TUPLE(l),1) then {Absyn.TUPLE(l)};
-    case (Absyn.TUPLE(l),_) then l;
-    else {inExp};
-  end match;
-end extractListFromTuple;
-
-public function tryToConvertArrayToList
-"Convert an array, T[:], of a MetaModelica type into list (done by a different function).
-MetaModelica types can only be of array<T> type, not T[:].
-This is mainly to produce better error messages."
-  input DAE.Exp exp;
-  input DAE.Type ty;
-  output DAE.Exp outExp;
-  output DAE.Type outTy;
-algorithm
-  (outExp,outTy) := match (exp,ty)
-    local
-      DAE.Type flatType;
-    case (_,_)
-      equation
-        (flatType,_) = Types.flattenArrayType(ty);
-        false = (not Types.isString(flatType) and Types.isBoxedType(flatType)) or Flags.isSet(Flags.RML) "debug flag to produce better error messages by converting all arrays into lists; the compiler does not use Modelica-style arrays anyway";
-      then (exp,ty);
-  end match;
-end tryToConvertArrayToList;
+  outList := list(match e
+    case Absyn.ARRAY({}) then Absyn.LIST({});
+    case Absyn.ARRAY()
+      then Absyn.LIST(transformArrayNodesToListNodes(e.arrayExp));
+    else e;
+  end match for e in inList);
+end transformArrayNodesToListNodes;
 
 annotation(__OpenModelica_Interface="frontend");
 end MetaUtil;

--- a/Compiler/FrontEnd/Patternm.mo
+++ b/Compiler/FrontEnd/Patternm.mo
@@ -706,7 +706,7 @@ algorithm
     case (cache,env,Absyn.MATCHEXP(matchTy=matchTy,inputExp=inExp,localDecls=decls,cases=cases),_,st,_,pre,_,_)
       equation
         // First do inputs
-        inExps = MetaUtil.extractListFromTuple(inExp, 0);
+        inExps = convertExpToPatterns(inExp);
         (inExps,inputAliases,inputAliasesAndCrefs) = List.map_3(inExps,getInputAsBinding);
         (cache,elabExps,elabProps,st) = Static.elabExpList(cache,env,inExps,impl,st,performVectorization,pre,info);
         // Then add locals
@@ -2011,7 +2011,7 @@ algorithm
     case (cache,env,Absyn.CASE(pattern=pattern,patternGuard=patternGuard,patternInfo=patternInfo,localDecls=decls,classPart=cp,result=result,resultInfo=resultInfo,info=info),_,_,_,_,st,_,_)
       equation
         (cache,SOME((env,DAE.DAE(caseDecls),caseLocalTree))) = addLocalDecls(cache,env,decls,FCore.caseScopeName,impl,info);
-        patterns = MetaUtil.extractListFromTuple(pattern, 0);
+        patterns = convertExpToPatterns(pattern);
         patterns = if listLength(tys)==1 then {pattern} else patterns;
         (cache,elabPatterns) = elabPatternTuple(cache, env, patterns, tys, patternInfo, pattern);
         // open a pattern type scope
@@ -2944,6 +2944,19 @@ algorithm
     else (inExp,inType);
   end match;
 end makeTupleFromMetaTuple;
+
+protected function convertExpToPatterns
+  "Converts an expression to a list of patterns. If the expression is a tuple
+   then the contents of the tuple are returned, otherwise the expression itself
+   is returned as a list."
+  input Absyn.Exp inExp;
+  output list<Absyn.Exp> outInputs;
+algorithm
+  outInputs := match inExp
+    case Absyn.TUPLE() then inExp.expressions;
+    else {inExp};
+  end match;
+end convertExpToPatterns;
 
 annotation(__OpenModelica_Interface="frontend");
 end Patternm;

--- a/Compiler/FrontEnd/SCode.mo
+++ b/Compiler/FrontEnd/SCode.mo
@@ -88,6 +88,7 @@ uniontype Restriction
     Absyn.Path name; //Name of the uniontype
     Integer index; //Index in the uniontype
     Boolean singleton;
+    Boolean moved; // true if moved outside uniontype, otherwise false.
   end R_METARECORD; /* added by x07simbj */
 
   record R_UNIONTYPE "Metamodelica extension"

--- a/Compiler/FrontEnd/SCodeDump.mo
+++ b/Compiler/FrontEnd/SCodeDump.mo
@@ -503,7 +503,7 @@ algorithm
     case (SCode.IMPORT(visibility=SCode.PROTECTED()),OPTIONS(stripProtectedImports=true)) then false;
     case (SCode.CLASS(prefixes=SCode.PREFIXES(visibility=SCode.PROTECTED())),OPTIONS(stripProtectedClasses=true)) then false;
     case (SCode.COMPONENT(prefixes=SCode.PREFIXES(visibility=SCode.PROTECTED())),OPTIONS(stripProtectedComponents=true)) then false;
-    case (SCode.CLASS(restriction=SCode.R_METARECORD()),OPTIONS(stripMetaRecords=true)) then false;
+    case (SCode.CLASS(restriction=SCode.R_METARECORD(moved = true)),OPTIONS(stripMetaRecords=true)) then false;
     else true;
   end match;
 end filterElement;

--- a/Compiler/FrontEnd/SCodeUtil.mo
+++ b/Compiler/FrontEnd/SCodeUtil.mo
@@ -293,7 +293,7 @@ algorithm
       Absyn.Class d;
       Absyn.Path name;
       Integer index;
-      Boolean singleton, isImpure;
+      Boolean singleton, isImpure, moved;
       Absyn.FunctionPurity purity;
 
     // ?? Only normal functions can have 'external'
@@ -332,8 +332,8 @@ algorithm
     case (_,Absyn.R_PREDEFINED_CLOCK()) then SCode.R_PREDEFINED_CLOCK();
     case (_,Absyn.R_PREDEFINED_ENUMERATION()) then SCode.R_PREDEFINED_ENUMERATION();
 
-    case (_,Absyn.R_METARECORD(name,index,singleton)) //MetaModelica extension, added by x07simbj
-      then SCode.R_METARECORD(name,index,singleton);
+    case (_,Absyn.R_METARECORD(name,index,singleton,moved)) //MetaModelica extension, added by x07simbj
+      then SCode.R_METARECORD(name,index,singleton,moved);
     case (_,Absyn.R_UNIONTYPE()) then SCode.R_UNIONTYPE(); /*MetaModelica extension added by x07simbj */
 
   end match;

--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -718,7 +718,7 @@ algorithm
         (expl, DAE.PROP(ty, c)) := elabArray(expl, props, inPrefix, inInfo); // type-checking the array
         arr_ty := DAE.T_ARRAY(ty, {DAE.DIM_INTEGER(listLength(expl))}, DAE.emptyTypeSource);
         exp := DAE.ARRAY(Types.simplifyType(arr_ty), not Types.isArray(ty), expl);
-        (exp, arr_ty) := MetaUtil.tryToConvertArrayToList(exp, arr_ty) "converts types that cannot be arrays in ot lists.";
+        MetaUtil.checkArrayType(ty);
         exp := elabMatrixToMatrixExp(exp);
       then
         (exp, DAE.PROP(arr_ty, c));
@@ -797,7 +797,7 @@ protected
   String exp_str, ty1_str, ty2_str;
 algorithm
   Absyn.CONS(e1, e2) := inExp;
-  {e1, e2} := MetaUtil.transformArrayNodesToListNodes({e1, e2}, {});
+  {e1, e2} := MetaUtil.transformArrayNodesToListNodes({e1, e2});
 
   // Elaborate both sides of the cons expression.
   (outCache, exp1, prop1) := elabExpInExpression(outCache, inEnv, e1,

--- a/Compiler/OpenModelicaBootstrappingHeader.h
+++ b/Compiler/OpenModelicaBootstrappingHeader.h
@@ -3995,7 +3995,7 @@ static void *Absyn__R_5fUNIONTYPE = MMC_REFSTRUCTLIT(Absyn__R_5fUNIONTYPE__struc
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef Absyn_Restriction_R__METARECORD__desc_added
 #define Absyn_Restriction_R__METARECORD__desc_added
-ADD_METARECORD_DEFINITIONS const char* Absyn_Restriction_R__METARECORD__desc__fields[3] = {"name","index","singleton"};
+ADD_METARECORD_DEFINITIONS const char* Absyn_Restriction_R__METARECORD__desc__fields[4] = {"name","index","singleton","moved"};
 ADD_METARECORD_DEFINITIONS struct record_description Absyn_Restriction_R__METARECORD__desc = {
   "Absyn_Restriction_R__METARECORD",
   "Absyn.Restriction.R_METARECORD",
@@ -4005,8 +4005,8 @@ ADD_METARECORD_DEFINITIONS struct record_description Absyn_Restriction_R__METARE
 #else /* Only use the file as a header */
 extern struct record_description Absyn_Restriction_R__METARECORD__desc;
 #endif
-#define Absyn__R_5fMETARECORD_3dBOX3 23
-#define Absyn__R_5fMETARECORD(name,index,singleton) (mmc_mk_box4(23,&Absyn_Restriction_R__METARECORD__desc,name,index,singleton))
+#define Absyn__R_5fMETARECORD_3dBOX4 23
+#define Absyn__R_5fMETARECORD(name,index,singleton,moved) (mmc_mk_box5(23,&Absyn_Restriction_R__METARECORD__desc,name,index,singleton,moved))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef Absyn_Restriction_R__UNKNOWN__desc_added
 #define Absyn_Restriction_R__UNKNOWN__desc_added

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -2195,6 +2195,7 @@ uniontype Restriction
   record R_METARECORD "Metamodelica extension"
     Absyn.Path name; //Name of the uniontype
     Integer index; //Index in the uniontype
+    Boolean moved;
   end R_METARECORD; /* added by x07simbj */
 
   record R_UNIONTYPE "Metamodelica extension"

--- a/Compiler/Template/Unparsing.tpl
+++ b/Compiler/Template/Unparsing.tpl
@@ -51,7 +51,7 @@ end metaHelperBoxStart;
 template elementExternalHeader(SCode.Element elt, String pack)
 ::=
 match elt
-  case c as SCode.CLASS(restriction=r as SCode.R_METARECORD(__),classDef=p as SCode.PARTS(__))
+  case c as SCode.CLASS(restriction=r as SCode.R_METARECORD(moved = true),classDef=p as SCode.PARTS(__))
     then
       let fields=(p.elementLst |> SCode.COMPONENT(__) => name; separator=",")
       let fieldsStr=(p.elementLst |> SCode.COMPONENT(__) => '"<%name%>"'; separator=",")


### PR DESCRIPTION
- Update uniontypes when converting records to metarecords, to make
  functions inside uniontypes work.
- Cleaned up a lot of code and removed unused code.