### PR TITLE
Add failtrace flag to SimCodeUtil.createSimCode function

### DIFF
--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -473,7 +473,9 @@ algorithm
     then (simCode, (highestSimEqIndex, equationSccMapping));
 
     else equation
-      Error.addInternalError("function createSimCode failed [Transformation from optimised DAE to simulation code structure failed]", sourceInfo());
+      if Flags.isSet(Flags.FAILTRACE) then
+        Error.addInternalError("function createSimCode failed [Transformation from optimised DAE to simulation code structure failed]", sourceInfo());
+      end if;
     then fail();
   end matchcontinue;
 end createSimCode;


### PR DESCRIPTION
The error message contains source info for function createSimCode and appears in some tests,
so changes in SimCodeUtil.mo may cause changes in tests output.
This patch add failtrace flag to createSimCode error message to hide it.