### PR TITLE
Synchronous improvements

### DIFF
--- a/Compiler/BackEnd/BackendDAE.mo
+++ b/Compiler/BackEnd/BackendDAE.mo
@@ -70,13 +70,15 @@ type EqSystems = list<EqSystem>;
 public
 uniontype EqSystem "An independent system of equations (and their corresponding variables)"
   record EQSYSTEM
-    Variables orderedVars "ordered Variables, only states and alg. vars";
-    EquationArray orderedEqs "ordered Equations";
+    Variables orderedVars                   "ordered Variables, only states and alg. vars";
+    EquationArray orderedEqs                "ordered Equations";
     Option<IncidenceMatrix> m;
     Option<IncidenceMatrixT> mT;
     Matching matching;
-    StateSets stateSets "the state sets of the system";
+    StateSets stateSets                    "the state sets of the system";
     BaseClockPartitionKind partitionKind;
+    EquationArray removedEqs               "these are equations that cannot solve for a variable.
+                                            e.g. assertions, external function calls, algorithm sections without effect";
   end EQSYSTEM;
 end EqSystem;
 
@@ -115,7 +117,6 @@ uniontype Shared "Data shared for all equation-systems"
                                              data about variables' names, comments, units, etc. is preserved as well as
                                              pointer to their values (trajectories).";
     EquationArray initialEqs                "Initial equations";
-    EquationArray removedEqs                "these are equations that cannot solve for a variable. for example assertions, external function calls, algorithm sections without effect";
     list< .DAE.Constraint> constraints     "constraints (Optimica extension)";
     list< .DAE.ClassAttributes> classAttrs "class attributes (Optimica extension)";
     FCore.Cache cache;

--- a/Compiler/BackEnd/BackendDAECreate.mo
+++ b/Compiler/BackEnd/BackendDAECreate.mo
@@ -135,12 +135,11 @@ algorithm
   ieqnarr := BackendEquation.listEquation(ieqns);
   einfo := BackendDAE.EVENT_INFO(timeEvents, whenclauses_1, {}, {}, {}, 0);
   symjacs := {(NONE(), ({}, {}, ({}, {})), {}), (NONE(), ({}, {}, ({}, {})), {}), (NONE(), ({}, {}, ({}, {})), {}), (NONE(), ({}, {}, ({}, {})), {})};
-  outBackendDAE := BackendDAE.DAE(BackendDAEUtil.createEqSystem(vars_1, eqnarr)::{},
+  outBackendDAE := BackendDAE.DAE(BackendDAEUtil.createEqSystem(vars_1, eqnarr, {}, BackendDAE.UNKNOWN_PARTITION(), reqnarr)::{},
                                   BackendDAE.SHARED(knvars,
                                                     extVars,
                                                     aliasVars,
                                                     ieqnarr,
-                                                    reqnarr,
                                                     constrs,
                                                     clsAttrs,
                                                     inCache,

--- a/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -1632,8 +1632,8 @@ public function partitionIndependentBlocksHelper
 algorithm
   (systs,oshared) := matchcontinue (isyst,ishared,numErrorMessages,throwNoError)
     local
-      BackendDAE.IncidenceMatrix m,mT;
-      array<Integer> ixs;
+      BackendDAE.IncidenceMatrix m, mT, rm, rmT;
+      array<Integer> ixs, rixs;
       Boolean b;
       Integer i;
       BackendDAE.Shared shared;
@@ -1641,17 +1641,18 @@ algorithm
       DAE.FunctionTree funcs;
     case (syst,shared,_,_)
       equation
-        // print("partitionIndependentBlocks: TODO: Implement me\n");
         funcs = BackendDAEUtil.getFunctions(ishared);
-        (syst,m,mT) = BackendDAEUtil.getIncidenceMatrixfromOption(syst,BackendDAE.NORMAL(),SOME(funcs));
-        ixs = arrayCreate(arrayLength(m),0);
+        (syst, m, mT) = BackendDAEUtil.getIncidenceMatrixfromOption(syst, BackendDAE.NORMAL(), SOME(funcs));
+        (rm, rmT) = BackendDAEUtil.removedIncidenceMatrix(syst, BackendDAE.NORMAL(), SOME(funcs));
+        ixs = arrayCreate(arrayLength(m), 0);
+        rixs = arrayCreate(arrayLength(m), 0);
         // ixsT = arrayCreate(arrayLength(mT),0);
-        i = SynchronousFeatures.partitionIndependentBlocks0(m,mT,ixs);
+        i = SynchronousFeatures.partitionIndependentBlocks0(m, mT, rm, rmT, ixs, rixs);
         // i2 = SynchronousFeatures.partitionIndependentBlocks0(mT,m,ixsT);
         b = i > 1;
         // bcall2(b,BackendDump.dumpBackendDAE,BackendDAE.DAE({syst},shared), "partitionIndependentBlocksHelper");
         // printPartition(b,ixs);
-        systs = if b then SynchronousFeatures.partitionIndependentBlocksSplitBlocks(i,syst,ixs,mT,throwNoError) else {syst};
+        systs = if b then SynchronousFeatures.partitionIndependentBlocksSplitBlocks(i, syst, ixs, rixs, mT, throwNoError) else {syst};
         // print("Number of partitioned systems: " + intString(listLength(systs)) + "\n");
         // List.map1_0(systs, BackendDump.dumpEqSystem, "System");
       then (systs,shared);

--- a/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -109,16 +109,18 @@ protected function simplifyTimeIndepFuncCalls0 "author: Frenkel TUD 2012-06"
 algorithm
   (osyst, outShared, outChanged) := matchcontinue (isyst, inShared)
     local
-      BackendDAE.Variables orderedVars, knvars, aliasvars;
-      BackendDAE.EquationArray orderedEqs;
       BackendDAE.Shared shared;
       BackendDAE.EqSystem syst;
 
-    case (BackendDAE.EQSYSTEM(orderedEqs=orderedEqs), BackendDAE.SHARED(knownVars=knvars, aliasVars=aliasvars))
+    case (syst, shared)
       algorithm
         ((_, (_, _, true))) := BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate (
-            orderedEqs, Expression.traverseSubexpressionsHelper, (traverserExpsimplifyTimeIndepFuncCalls,
-            (knvars, aliasvars, false))
+            syst.orderedEqs, Expression.traverseSubexpressionsHelper, (traverserExpsimplifyTimeIndepFuncCalls,
+            (shared.knownVars, shared.aliasVars, false))
+        );
+        ((_, (_, _, true))) := BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate (
+            syst.removedEqs, Expression.traverseSubexpressionsHelper, (traverserExpsimplifyTimeIndepFuncCalls,
+            (shared.knownVars, shared.aliasVars, false))
         );
     then (isyst, inShared, true);
 
@@ -223,7 +225,6 @@ algorithm
   shared := inDAE.shared;
   BackendDAEUtil.traverseBackendDAEExpsVarsWithUpdate(shared.knownVars, Expression.traverseSubexpressionsHelper, (traverserExpsimplifyTimeIndepFuncCalls, (shared.knownVars, shared.aliasVars, false)));
   BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate(shared.initialEqs, Expression.traverseSubexpressionsHelper, (traverserExpsimplifyTimeIndepFuncCalls, (shared.knownVars, shared.aliasVars, false)));
-  BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate(shared.removedEqs, Expression.traverseSubexpressionsHelper, (traverserExpsimplifyTimeIndepFuncCalls, (shared.knownVars, shared.aliasVars, false)));
   (shared.eventInfo, _) := traverseEventInfoExps(shared.eventInfo, Expression.traverseSubexpressionsHelper, (traverserExpsimplifyTimeIndepFuncCalls, (shared.knownVars, shared.aliasVars, false)));
   outDAE := BackendDAE.DAE(inDAE.eqs, shared);
 end simplifyTimeIndepFuncCallsShared;
@@ -1146,25 +1147,20 @@ public function removeUnusedParameter
 algorithm
   outDlow := match inDlow
     local
-      BackendDAE.Variables knvars, knvars1, aliasVars;
-      BackendDAE.EquationArray remeqns, inieqns;
-      list<BackendDAE.WhenClause> whenClauseLst;
-      BackendDAE.ExternalObjectClasses eoc;
+      BackendDAE.Variables knvars, knvars1;
       BackendDAE.EqSystems eqs;
       BackendDAE.Shared shared;
 
-    case BackendDAE.DAE(eqs,shared as BackendDAE.SHARED (
-            knownVars=knvars, aliasVars=aliasVars, initialEqs=inieqns, removedEqs=remeqns,
-            eventInfo=BackendDAE.EVENT_INFO(whenClauseLst=whenClauseLst) ))
+    case BackendDAE.DAE(eqs, shared)
       algorithm
         knvars1 := BackendVariable.emptyVars();
+        knvars := shared.knownVars;
         ((knvars, knvars1)) := BackendVariable.traverseBackendDAEVars(knvars, copyNonParamVariables, (knvars,knvars1));
-        ((_, knvars1)) := List.fold1(eqs,BackendDAEUtil.traverseBackendDAEExpsEqSystem, checkUnusedVariables, (knvars,knvars1));
+        ((_, knvars1)) := List.fold1(eqs, BackendDAEUtil.traverseBackendDAEExpsEqSystem, checkUnusedVariables, (knvars,knvars1));
         ((_, knvars1)) := BackendDAEUtil.traverseBackendDAEExpsVars(knvars, checkUnusedParameter, (knvars,knvars1));
-        ((_, knvars1)) := BackendDAEUtil.traverseBackendDAEExpsVars(aliasVars, checkUnusedParameter, (knvars,knvars1));
-        ((_, knvars1)) := BackendDAEUtil.traverseBackendDAEExpsEqns(remeqns, checkUnusedParameter, (knvars,knvars1));
-        ((_, knvars1)) := BackendDAEUtil.traverseBackendDAEExpsEqns(inieqns, checkUnusedParameter, (knvars,knvars1));
-        (_, (_,knvars1)) := BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(whenClauseLst, checkUnusedParameter, (knvars,knvars1));
+        ((_, knvars1)) := BackendDAEUtil.traverseBackendDAEExpsVars(shared.aliasVars, checkUnusedParameter, (knvars,knvars1));
+        ((_, knvars1)) := BackendDAEUtil.traverseBackendDAEExpsEqns(shared.initialEqs, checkUnusedParameter, (knvars,knvars1));
+        (_, (_,knvars1)) := BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(shared.eventInfo.whenClauseLst, checkUnusedParameter, (knvars,knvars1));
         shared.knownVars := knvars1;
       then
         BackendDAE.DAE(eqs, shared);
@@ -1277,23 +1273,19 @@ public function removeUnusedVariables
 algorithm
   outDlow := match inDlow
     local
-      BackendDAE.Variables knvars, knvars1, aliasVars;
-      BackendDAE.EquationArray remeqns, inieqns;
-      list<BackendDAE.WhenClause> whenClauseLst;
+      BackendDAE.Variables knvars, knvars1;
       BackendDAE.EqSystems eqs;
       BackendDAE.Shared shared;
 
-    case BackendDAE.DAE(eqs, shared as BackendDAE.SHARED (
-            knownVars=knvars, aliasVars=aliasVars, initialEqs=inieqns, removedEqs=remeqns,
-            eventInfo=BackendDAE.EVENT_INFO(whenClauseLst=whenClauseLst) ))
+    case BackendDAE.DAE(eqs, shared)
       algorithm
         knvars1 := BackendVariable.emptyVars();
-        ((_, knvars1)) := List.fold1(eqs,BackendDAEUtil.traverseBackendDAEExpsEqSystem, checkUnusedVariables, (knvars,knvars1));
+        knvars := shared.knownVars;
+        ((_, knvars1)) := List.fold1(eqs, BackendDAEUtil.traverseBackendDAEExpsEqSystem, checkUnusedVariables, (knvars,knvars1));
         ((_, knvars1)) := BackendDAEUtil.traverseBackendDAEExpsVars(knvars, checkUnusedVariables, (knvars,knvars1));
-        ((_, knvars1)) := BackendDAEUtil.traverseBackendDAEExpsVars(aliasVars, checkUnusedVariables, (knvars,knvars1));
-        ((_, knvars1)) := BackendDAEUtil.traverseBackendDAEExpsEqns(remeqns, checkUnusedVariables, (knvars,knvars1));
-        ((_, knvars1)) := BackendDAEUtil.traverseBackendDAEExpsEqns(inieqns, checkUnusedVariables, (knvars,knvars1));
-        (_, (_,knvars1)) := BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(whenClauseLst, checkUnusedVariables, (knvars,knvars1));
+        ((_, knvars1)) := BackendDAEUtil.traverseBackendDAEExpsVars(shared.aliasVars, checkUnusedVariables, (knvars,knvars1));
+        ((_, knvars1)) := BackendDAEUtil.traverseBackendDAEExpsEqns(shared.initialEqs, checkUnusedVariables, (knvars,knvars1));
+       (_, (_,knvars1)) := BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(shared.eventInfo.whenClauseLst, checkUnusedVariables, (knvars,knvars1));
         shared.knownVars := knvars1;
       then
         BackendDAE.DAE(eqs, shared);
@@ -1394,30 +1386,22 @@ protected
 algorithm
   outDlow := match inDlow
     local
-      BackendDAE.Variables knvars, aliasVars, exobj;
-      BackendDAE.EquationArray remeqns, inieqns;
-      list<BackendDAE.WhenClause> whenClauseLst;
-      BackendDAE.SymbolicJacobians symjacs;
       BackendDAE.Shared shared;
       BackendDAE.EqSystems eqs;
       DAE.FunctionTree funcs, usedfuncs;
-    case BackendDAE.DAE(eqs, shared as BackendDAE.SHARED (
-            knownVars=knvars, aliasVars=aliasVars, initialEqs=inieqns, removedEqs=remeqns, externalObjects=exobj,
-            eventInfo=BackendDAE.EVENT_INFO(whenClauseLst=whenClauseLst), functionTree=funcs, symjacs=symjacs ))
+    case BackendDAE.DAE(eqs, shared)
       algorithm
+        funcs := shared.functionTree;
         usedfuncs := copyRecordConstructorAndExternalObjConstructorDestructor(funcs);
         func := function checkUnusedFunctions(inFunctions = funcs);
         usedfuncs := List.fold1(eqs, BackendDAEUtil.traverseBackendDAEExpsEqSystem, func, usedfuncs);
         usedfuncs := List.fold1(eqs, BackendDAEUtil.traverseBackendDAEExpsEqSystemJacobians, func, usedfuncs);
-        usedfuncs := BackendDAEUtil.traverseBackendDAEExpsVars(knvars, func, usedfuncs);
-        usedfuncs := BackendDAEUtil.traverseBackendDAEExpsVars(exobj, func, usedfuncs);
-        usedfuncs := BackendDAEUtil.traverseBackendDAEExpsVars(aliasVars, func, usedfuncs);
-        usedfuncs := BackendDAEUtil.traverseBackendDAEExpsEqns(remeqns, func, usedfuncs);
-        usedfuncs := BackendDAEUtil.traverseBackendDAEExpsEqns(inieqns, func, usedfuncs);
-        (_, usedfuncs) := BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(whenClauseLst, func, usedfuncs);
-
-        //traverse Symbolic jacobians
-        usedfuncs := removeUnusedFunctionsSymJacs(symjacs, funcs, usedfuncs);
+        usedfuncs := BackendDAEUtil.traverseBackendDAEExpsVars(shared.knownVars, func, usedfuncs);
+        usedfuncs := BackendDAEUtil.traverseBackendDAEExpsVars(shared.externalObjects, func, usedfuncs);
+        usedfuncs := BackendDAEUtil.traverseBackendDAEExpsVars(shared.aliasVars, func, usedfuncs);
+        usedfuncs := BackendDAEUtil.traverseBackendDAEExpsEqns(shared.initialEqs, func, usedfuncs);
+        (_, usedfuncs) := BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(shared.eventInfo.whenClauseLst, func, usedfuncs);
+        usedfuncs := removeUnusedFunctionsSymJacs(shared.symjacs, funcs, usedfuncs);
         shared.functionTree := usedfuncs;
       then
         BackendDAE.DAE(eqs, shared);
@@ -1603,16 +1587,15 @@ protected function mergeIndependentBlocks
   input BackendDAE.EqSystem syst2;
   output BackendDAE.EqSystem syst;
 protected
-  BackendDAE.Variables vars, vars1, vars2;
-  BackendDAE.EquationArray eqs, eqs1, eqs2;
-  BackendDAE.StateSets stateSets, statSets1;
+  BackendDAE.Variables vars;
+  BackendDAE.EquationArray eqs, removedEqs;
+  BackendDAE.StateSets stateSets;
 algorithm
-  BackendDAE.EQSYSTEM(orderedVars=vars1, orderedEqs=eqs1, stateSets=stateSets) := syst1;
-  BackendDAE.EQSYSTEM(orderedVars=vars2, orderedEqs=eqs2, stateSets=statSets1) := syst2;
-  vars := BackendVariable.mergeVariables(vars2, vars1);
-  eqs := BackendEquation.addEquations(BackendEquation.equationList(eqs2), eqs1);
-  stateSets := listAppend(stateSets, statSets1);
-  syst := BackendDAEUtil.createEqSystem(vars, eqs, stateSets, BackendDAE.UNKNOWN_PARTITION());
+  vars := BackendVariable.mergeVariables(syst2.orderedVars, syst1.orderedVars);
+  eqs := BackendEquation.addEquations(BackendEquation.equationList(syst2.orderedEqs), syst1.orderedEqs);
+  removedEqs := BackendEquation.addEquations(BackendEquation.equationList(syst2.removedEqs), syst1.removedEqs);
+  stateSets := listAppend(syst2.stateSets, syst1.stateSets);
+  syst := BackendDAEUtil.createEqSystem(vars, eqs, stateSets, BackendDAE.UNKNOWN_PARTITION(), removedEqs);
 end mergeIndependentBlocks;
 
 public function partitionIndependentBlocks
@@ -2235,7 +2218,7 @@ algorithm
         ((eqnslst,asserts,true)) := List.fold1(listReverse(eqnslst), simplifyIfEquationsFinder, knvars, ({},{},false));
         syst.orderedEqs := BackendEquation.listEquation(eqnslst);
         syst := BackendDAEUtil.clearEqSyst(syst);
-        shared := BackendEquation.requationsAddDAE(asserts, shared);
+        syst := BackendEquation.requationsAddDAE(asserts, syst);
       then (syst, shared);
 
     else
@@ -3425,22 +3408,22 @@ algorithm
       BackendDAE.Shared shared;
       list<BackendDAE.Equation> lsteqns;
       Boolean b;
-    case BackendDAE.DAE(systs, shared as BackendDAE.SHARED(knownVars=knvars, initialEqs=inieqns, removedEqs=remeqns))
+    case BackendDAE.DAE(systs, shared as BackendDAE.SHARED(knownVars=knvars, initialEqs=inieqns))
       algorithm
         repl := BackendVarTransform.emptyReplacements();
         repl := BackendVariable.traverseBackendDAEVars(knvars, removeConstantsFinder, repl);
         if Flags.isSet(Flags.DUMP_CONST_REPL) then
           BackendVarTransform.dumpReplacements(repl);
         end if;
+
         (knvars, (repl, _)) := BackendVariable.traverseBackendDAEVarsWithUpdate(knvars, replaceFinalVarTraverser, (repl, 0));
-        lsteqns := BackendEquation.equationList(remeqns);
-        (lsteqns, b) := BackendVarTransform.replaceEquations(lsteqns, repl, NONE());
-        remeqns := if b then BackendEquation.listEquation(lsteqns) else remeqns;
+
         lsteqns := BackendEquation.equationList(inieqns);
         (lsteqns, b) := BackendVarTransform.replaceEquations(lsteqns, repl, NONE());
-        inieqns := if b then BackendEquation.listEquation(lsteqns) else inieqns;
+        shared.initialEqs := if b then BackendEquation.listEquation(lsteqns) else inieqns;
+
         systs := List.map1(systs, removeConstantsWork, repl);
-        shared.removedEqs := remeqns; shared.initialEqs := inieqns;
+
       then BackendDAE.DAE(systs, shared);
   end match;
 end removeConstants;
@@ -3460,11 +3443,18 @@ algorithm
     case syst as BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns)
       algorithm
         BackendVariable.traverseBackendDAEVarsWithUpdate(vars, replaceFinalVarTraverser, (repl, 0));
-        (lsteqns, b) := BackendVarTransform.replaceEquations(BackendEquation.equationList(eqns), repl, NONE());
+
+        (lsteqns, b) := BackendVarTransform.replaceEquations(BackendEquation.equationList(syst.orderedEqs), repl, NONE());
         if b then
           syst.orderedEqs := BackendEquation.listEquation(lsteqns);
           syst := BackendDAEUtil.clearEqSyst(syst);
         end if;
+
+        (lsteqns, b) := BackendVarTransform.replaceEquations(BackendEquation.equationList(syst.removedEqs), repl, NONE());
+        if b then
+          syst.removedEqs := BackendEquation.listEquation(lsteqns);
+        end if;
+
       then syst;
   end match;
 end removeConstantsWork;
@@ -3504,7 +3494,6 @@ public function replaceEdgeChange "author: Frenkel TUD 2012-11
   output BackendDAE.BackendDAE outDAE;
 algorithm
   (outDAE,_) := BackendDAEUtil.mapEqSystemAndFold(inDAE, replaceEdgeChange0, false);
-  outDAE := replaceEdgeChangeShared(outDAE);
 end replaceEdgeChange;
 
 protected function replaceEdgeChange0 "author: Frenkel TUD 2012-11"
@@ -3517,11 +3506,12 @@ protected function replaceEdgeChange0 "author: Frenkel TUD 2012-11"
 algorithm
   (osyst, outChanged) := matchcontinue isyst
     local
-      BackendDAE.EquationArray orderedEqs;
+      BackendDAE.EquationArray orderedEqs, removedEqs;
 
-    case BackendDAE.EQSYSTEM(orderedEqs=orderedEqs)
+    case BackendDAE.EQSYSTEM(orderedEqs=orderedEqs, removedEqs=removedEqs)
     algorithm
       BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate(orderedEqs, traverserreplaceEdgeChange, false);
+      BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate(removedEqs, traverserreplaceEdgeChange, false);
     then (isyst, true);
 
     else (isyst, inChanged);
@@ -3563,22 +3553,6 @@ algorithm
     else (inExp,inB);
   end matchcontinue;
 end traverserExpreplaceEdgeChange;
-
-protected function replaceEdgeChangeShared "author: Frenkel TUD 2012-11"
-  input BackendDAE.BackendDAE inDAE;
-  output BackendDAE.BackendDAE outDAE;
-algorithm
-  outDAE := match inDAE
-    local
-      BackendDAE.EquationArray remeqns;
-      BackendDAE.EqSystems systs;
-      BackendDAE.Shared shared;
-    case BackendDAE.DAE(systs, shared as BackendDAE.SHARED(removedEqs=remeqns))
-      algorithm
-        BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate(remeqns, traverserreplaceEdgeChange, false);
-      then BackendDAE.DAE(systs, shared);
-  end match;
-end replaceEdgeChangeShared;
 
 // =============================================================================
 // section for postOptModule >>addInitialStmtsToAlgorithms<<
@@ -4249,15 +4223,12 @@ protected
   array<Integer> ass1 "eqn := ass1[var]";
   array<Integer> ass2 "var := ass2[eqn]";
   Integer n1, n2;
-  BackendDAE.BaseClockPartitionKind partitionKind;
-  BackendDAE.StateSets stateSets;
   BackendDAE.Matching matching;
   BackendDAE.StrongComponents comps;
 algorithm
   //print("\nStart simplifyLoopsUpdateMatching");
-
-  BackendDAE.EQSYSTEM(partitionKind=partitionKind, stateSets=stateSets,matching=matching) := inSyst;
-  BackendDAE.MATCHING(comps=comps, ass1 = ass1, ass2=ass2) := matching;
+  matching := inSyst.matching;
+  BackendDAE.MATCHING(comps=comps, ass1=ass1, ass2=ass2) := matching;
 
   n1 := listLength(ass1_);
   n2 := listLength(ass2_);
@@ -4274,8 +4245,10 @@ algorithm
 
   comps := simplifyLoopsUpdateComps(comps, ass1_, ass2_, compOrders);
 
-  matching := BackendDAE.MATCHING(ass1,ass2,comps);
-  outSyst :=  BackendDAE.EQSYSTEM(inVars, inEqns, NONE(), NONE(), matching, stateSets, partitionKind);
+  outSyst.matching := BackendDAE.MATCHING(ass1, ass2, comps);
+  outSyst.orderedEqs := inEqns;
+  outSyst.orderedVars := inVars;
+  outSyst := BackendDAEUtil.setEqSystMatrices(outSyst);
 
   //print("\nEnde simplifyLoopsUpdateMatching");
 end simplifyLoopsUpdateMatching;
@@ -4953,24 +4926,18 @@ protected function applyRewriteRulesBackend0
   input BackendDAE.EqSystem isyst;
   input BackendDAE.Shared inShared;
   input Boolean inChanged;
-  output BackendDAE.EqSystem osyst;
+  output BackendDAE.EqSystem osyst = isyst;
   output BackendDAE.Shared outShared = inShared;
   output Boolean outChanged;
 algorithm
-  (osyst, outChanged) := matchcontinue isyst
-    local
-      BackendDAE.Variables orderedVars;
-      BackendDAE.EquationArray orderedEqs;
-      BackendDAE.EqSystem syst;
-
-    case BackendDAE.EQSYSTEM(orderedVars=orderedVars, orderedEqs=orderedEqs)
-      algorithm
-        BackendDAEUtil.traverseBackendDAEExpsVarsWithUpdate(orderedVars, traverserapplyRewriteRulesBackend, false);
-        BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate(orderedEqs, traverserapplyRewriteRulesBackend, false);
-      then (isyst, true);
-
-    else (isyst, inChanged);
-  end matchcontinue;
+  try
+    BackendDAEUtil.traverseBackendDAEExpsVarsWithUpdate(isyst.orderedVars, traverserapplyRewriteRulesBackend, false);
+    BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate(isyst.orderedEqs, traverserapplyRewriteRulesBackend, false);
+    BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate(isyst.removedEqs, traverserapplyRewriteRulesBackend, false);
+    outChanged := true;
+  else
+    outChanged := false;
+  end try;
 end applyRewriteRulesBackend0;
 
 protected function traverserapplyRewriteRulesBackend
@@ -5014,7 +4981,6 @@ algorithm
   shared := inDAE.shared;
   BackendDAEUtil.traverseBackendDAEExpsVarsWithUpdate(shared.knownVars, traverserapplyRewriteRulesBackend, false);
   BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate(shared.initialEqs, traverserapplyRewriteRulesBackend, false);
-  BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate(shared.removedEqs, traverserapplyRewriteRulesBackend, false);
   // not sure if we should apply the rules on the event info!
   // (ei, _) := traverseEventInfoExps(eventInfo, traverserapplyRewriteRulesBackend, false);
   outDAE := BackendDAE.DAE(inDAE.eqs, shared);

--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -262,31 +262,30 @@ public function checkBackendDAE "author: Frenkel TUD
   output list<tuple<DAE.Exp,list<DAE.ComponentRef>>> outExpCrefs;
   output list<BackendDAE.Equation> outWrongEqns;
 algorithm
-  (outExpCrefs,outWrongEqns) := matchcontinue (inBackendDAE)
+  (outExpCrefs,outWrongEqns) := matchcontinue inBackendDAE
     local
-      BackendDAE.Variables vars1,vars2,allvars;
-      BackendDAE.EquationArray eqns,reqns,ieqns;
-      list<BackendDAE.WhenClause> whenClauseLst;
-      list<BackendDAE.Var> varlst1,varlst2,allvarslst;
-      list<tuple<DAE.Exp,list<DAE.ComponentRef>>> expcrefs,expcrefs1,expcrefs2,expcrefs3,expcrefs4,expcrefs5;
-      list<BackendDAE.Equation> wrongEqns,wrongEqns1,wrongEqns2;
+      BackendDAE.EqSystem syst;
+      BackendDAE.Shared shared;
+      BackendDAE.Variables allvars;
+      list<tuple<DAE.Exp,list<DAE.ComponentRef>>> expcrefs;
+      list<BackendDAE.Equation> wrongEqns;
 
 
-    case (BackendDAE.DAE(eqs=BackendDAE.EQSYSTEM(orderedVars = vars1,orderedEqs = eqns)::{},shared=BackendDAE.SHARED(knownVars = vars2,initialEqs = ieqns,removedEqs = reqns,
-          eventInfo = BackendDAE.EVENT_INFO(whenClauseLst=whenClauseLst))))
+    case BackendDAE.DAE(syst::{}, shared)
       equation
-        allvars = BackendVariable.mergeVariables(vars1, vars2);
-        ((_,expcrefs)) = traverseBackendDAEExpsVars(vars1,checkBackendDAEExp,(allvars,{}));
-        ((_,expcrefs1)) = traverseBackendDAEExpsVars(vars2,checkBackendDAEExp,(allvars,expcrefs));
-        ((_,expcrefs2)) = traverseBackendDAEExpsEqns(eqns,checkBackendDAEExp,(allvars,expcrefs1));
-        ((_,expcrefs3)) = traverseBackendDAEExpsEqns(reqns,checkBackendDAEExp,(allvars,expcrefs2));
-        ((_,expcrefs4)) = traverseBackendDAEExpsEqns(ieqns,checkBackendDAEExp,(allvars,expcrefs3));
-        (_,(_,expcrefs5)) = BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(whenClauseLst,checkBackendDAEExp,(allvars,expcrefs4));
-        wrongEqns = BackendEquation.traverseEquationArray(eqns,checkEquationSize,{});
-        wrongEqns1 = BackendEquation.traverseEquationArray(reqns,checkEquationSize,wrongEqns);
-        wrongEqns2 = BackendEquation.traverseEquationArray(ieqns,checkEquationSize,wrongEqns1);
+        allvars = BackendVariable.mergeVariables(syst.orderedVars, shared.knownVars);
+        ((_, expcrefs)) = traverseBackendDAEExpsVars(syst.orderedVars, checkBackendDAEExp, (allvars, {}));
+        ((_, expcrefs)) = traverseBackendDAEExpsVars(shared.knownVars, checkBackendDAEExp, (allvars, expcrefs));
+        ((_, expcrefs)) = traverseBackendDAEExpsEqns(syst.orderedEqs, checkBackendDAEExp, (allvars, expcrefs));
+        ((_, expcrefs)) = traverseBackendDAEExpsEqns(syst.removedEqs, checkBackendDAEExp, (allvars, expcrefs));
+        ((_, expcrefs)) = traverseBackendDAEExpsEqns(shared.initialEqs, checkBackendDAEExp, (allvars, expcrefs));
+        (_, (_, expcrefs)) = BackendDAETransform.traverseBackendDAEExpsWhenClauseLst( shared.eventInfo.whenClauseLst, checkBackendDAEExp,
+                                                                                      (allvars, expcrefs) );
+        wrongEqns = BackendEquation.traverseEquationArray(syst.orderedEqs, checkEquationSize, {});
+        wrongEqns = BackendEquation.traverseEquationArray(syst.removedEqs, checkEquationSize, wrongEqns);
+        wrongEqns = BackendEquation.traverseEquationArray(shared.initialEqs, checkEquationSize, wrongEqns);
       then
-        (expcrefs5,wrongEqns2);
+        (expcrefs, wrongEqns);
 
     else
       equation
@@ -485,22 +484,18 @@ public function copyEqSystem
   input BackendDAE.EqSystem inSystem;
   output BackendDAE.EqSystem outSystem;
 protected
-  BackendDAE.Variables ordvars, ordvars1;
-  BackendDAE.EquationArray eqns, eqns1;
-  Option<BackendDAE.IncidenceMatrix> m, mT, m1, mT1;
-  BackendDAE.Matching matching, matching1;
-  BackendDAE.StateSets stateSets;
-  BackendDAE.BaseClockPartitionKind partitionKind;
+  BackendDAE.Variables vars;
+  BackendDAE.EquationArray eqns, removedEqs;
+  Option<BackendDAE.IncidenceMatrix> m, mt;
+  BackendDAE.Matching matching;
 algorithm
-  BackendDAE.EQSYSTEM(ordvars, eqns, m, mT, matching, stateSets, partitionKind) := inSystem;
-
-  ordvars1 := BackendVariable.copyVariables(ordvars);
-  eqns1 := BackendEquation.copyEquationArray(eqns);
-  m1 := copyIncidenceMatrix(m);
-  mT1 := copyIncidenceMatrix(mT);
-  matching1 := copyMatching(matching);
-
-  outSystem := BackendDAE.EQSYSTEM(ordvars1, eqns1, m1, mT1, matching1, stateSets, partitionKind);
+  vars := BackendVariable.copyVariables(inSystem.orderedVars);
+  eqns := BackendEquation.copyEquationArray(inSystem.orderedEqs);
+  removedEqs := BackendEquation.copyEquationArray(inSystem.removedEqs);
+  m := copyIncidenceMatrix(inSystem.m);
+  mt := copyIncidenceMatrix(inSystem.mT);
+  matching := copyMatching(inSystem.matching);
+  outSystem := BackendDAE.EQSYSTEM(vars, eqns, m, mt, matching, inSystem.stateSets, inSystem.partitionKind, removedEqs);
 end copyEqSystem;
 
 public function copyBackendDAEShared
@@ -520,7 +515,6 @@ algorithm
         shared.knownVars = BackendVariable.copyVariables(shared.knownVars);
         shared.externalObjects = BackendVariable.copyVariables(shared.externalObjects);
         shared.initialEqs = BackendEquation.copyEquationArray(shared.initialEqs);
-        shared.removedEqs = BackendEquation.copyEquationArray(shared.removedEqs);
       then
         shared;
   end match;
@@ -561,17 +555,12 @@ public function numberOfZeroCrossings "author: lochel"
   output Integer outNumRelations;
   output Integer outNumMathEventFunctions;
 protected
-  list<BackendDAE.TimeEvent> timeEvents;
-  list<ZeroCrossing> zeroCrossingLst, relationsLst;
+  BackendDAE.EventInfo eventInfo = inBackendDAE.shared.eventInfo;
 algorithm
-  BackendDAE.SHARED(eventInfo=BackendDAE.EVENT_INFO(timeEvents=timeEvents,
-                                                    zeroCrossingLst=zeroCrossingLst,
-                                                    relationsLst=relationsLst,
-                                                    numberMathEvents=outNumMathEventFunctions)) := inBackendDAE.shared;
-
-  outNumZeroCrossings := listLength(zeroCrossingLst);
-  outNumTimeEvents := listLength(timeEvents);
-  outNumRelations := listLength(relationsLst);
+  outNumZeroCrossings := listLength(eventInfo.zeroCrossingLst);
+  outNumTimeEvents := listLength(eventInfo.timeEvents);
+  outNumRelations := listLength(eventInfo.relationsLst);
+  outNumMathEventFunctions := eventInfo.numberMathEvents;
 end numberOfZeroCrossings;
 
 public function numberOfDiscreteVars "author: lochel"
@@ -1784,20 +1773,13 @@ public function whenClauseAddDAE
 "author: Frenkel TUD 2011-05"
   input list<BackendDAE.WhenClause> inWcLst;
   input BackendDAE.Shared inShared;
-  output BackendDAE.Shared outShared;
+  output BackendDAE.Shared outShared = inShared;
+protected
+  BackendDAE.EventInfo eventInfo;
 algorithm
-  outShared := match inShared
-    local
-      BackendDAE.Shared shared;
-      BackendDAE.EventInfo eventInfo;
-      list<BackendDAE.WhenClause> wclst;
-
-    case shared as BackendDAE.SHARED(eventInfo=eventInfo as BackendDAE.EVENT_INFO(whenClauseLst=wclst))
-      equation
-        eventInfo.whenClauseLst = listAppend(wclst, inWcLst);
-        shared.eventInfo = eventInfo;
-      then shared;
-  end match;
+  eventInfo := outShared.eventInfo;
+  eventInfo.whenClauseLst := listAppend(inShared.eventInfo.whenClauseLst, inWcLst);
+  outShared.eventInfo := eventInfo;
 end whenClauseAddDAE;
 
 public function getStrongComponents
@@ -5709,26 +5691,20 @@ public function traverseBackendDAEExps "author: Frenkel TUD
     output Type_a outA;
   end FuncExpType;
 algorithm
-  outTypeA:=
-  matchcontinue (inBackendDAE,func,inTypeA)
+  outTypeA := matchcontinue inBackendDAE
     local
-      BackendDAE.Variables vars2;
-      BackendDAE.EquationArray reqns,ieqns;
-      list<BackendDAE.WhenClause> whenClauseLst;
-      Type_a ext_arg_1,ext_arg_2,ext_arg_4,ext_arg_5,ext_arg_6;
+      BackendDAE.Shared shared;
       list<BackendDAE.EqSystem> systs;
       String name;
 
-    case (BackendDAE.DAE( eqs=systs, shared=BackendDAE.SHARED(knownVars=vars2, initialEqs=ieqns, removedEqs=reqns,
-                          eventInfo = BackendDAE.EVENT_INFO(whenClauseLst=whenClauseLst) )), _, _)
+    case BackendDAE.DAE(systs, shared)
       equation
-        ext_arg_1 = List.fold1(systs,traverseBackendDAEExpsEqSystem,func,inTypeA);
-        ext_arg_2 = traverseBackendDAEExpsVars(vars2,func,ext_arg_1);
-        ext_arg_4 = traverseBackendDAEExpsEqns(reqns,func,ext_arg_2);
-        ext_arg_5 = traverseBackendDAEExpsEqns(ieqns,func,ext_arg_4);
-        (_,ext_arg_6) = BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(whenClauseLst,func,ext_arg_5);
+        outTypeA = List.fold1(systs, traverseBackendDAEExpsEqSystem, func, inTypeA);
+        outTypeA = traverseBackendDAEExpsVars(shared.knownVars, func, outTypeA);
+        outTypeA = traverseBackendDAEExpsEqns(shared.initialEqs, func, outTypeA);
+        (_, outTypeA) = BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(shared.eventInfo.whenClauseLst, func, outTypeA);
       then
-        ext_arg_6;
+        outTypeA;
 
     else equation
       (_, _, name) = System.dladdr(func);
@@ -5888,25 +5864,20 @@ public function traverseBackendDAEExpsNoCopyWithUpdate "
     output Type_a outA;
   end FuncExpType;
 algorithm
-  outTypeA:=
-  matchcontinue (inBackendDAE,func,inTypeA)
+  outTypeA := matchcontinue inBackendDAE
     local
-      BackendDAE.Variables vars2;
-      BackendDAE.EquationArray reqns,ieqns;
-      Type_a ext_arg_1,ext_arg_2,ext_arg_4,ext_arg_5,ext_arg_6;
       list<BackendDAE.EqSystem> systs;
-      list<BackendDAE.WhenClause> wc;
+      BackendDAE.Shared shared;
       String name;
 
-    case (BackendDAE.DAE(eqs=systs,shared=BackendDAE.SHARED(knownVars = vars2,initialEqs = ieqns,removedEqs = reqns,eventInfo=BackendDAE.EVENT_INFO(whenClauseLst=wc))),_,_)
+    case BackendDAE.DAE(systs, shared)
       equation
-        ext_arg_1 = List.fold1(systs,traverseBackendDAEExpsEqSystemWithUpdate,func,inTypeA);
-        ext_arg_2 = traverseBackendDAEExpsVarsWithUpdate(vars2,func,ext_arg_1);
-        ext_arg_4 = traverseBackendDAEExpsEqnsWithUpdate(reqns,func,ext_arg_2);
-        ext_arg_5 = traverseBackendDAEExpsEqnsWithUpdate(ieqns,func,ext_arg_4);
-        (_,ext_arg_6) = BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(wc,func,ext_arg_5);
+        outTypeA = List.fold1(systs, traverseBackendDAEExpsEqSystemWithUpdate, func, inTypeA);
+        outTypeA = traverseBackendDAEExpsVarsWithUpdate(shared.knownVars, func, outTypeA);
+        outTypeA = traverseBackendDAEExpsEqnsWithUpdate(shared.initialEqs, func, outTypeA);
+        (_, outTypeA) = BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(shared.eventInfo.whenClauseLst, func, outTypeA);
       then
-        ext_arg_6;
+        outTypeA;
 
     else equation
       (_, _, name) = System.dladdr(func);
@@ -5930,13 +5901,10 @@ public function traverseBackendDAEExpsEqSystem "This function goes through the B
     output DAE.Exp outExp;
     output Type_a outA;
   end FuncExpType;
-protected
-  BackendDAE.Variables vars;
-  BackendDAE.EquationArray eqns;
 algorithm
-  BackendDAE.EQSYSTEM(orderedVars = vars,orderedEqs = eqns) := syst;
-  outTypeA := traverseBackendDAEExpsVars(vars,func,inTypeA);
-  outTypeA := traverseBackendDAEExpsEqns(eqns,func,outTypeA);
+  outTypeA := traverseBackendDAEExpsVars(syst.orderedVars, func, inTypeA);
+  outTypeA := traverseBackendDAEExpsEqns(syst.orderedEqs, func, outTypeA);
+  outTypeA := traverseBackendDAEExpsEqns(syst.removedEqs, func, outTypeA);
 end traverseBackendDAEExpsEqSystem;
 
 public function traverseBackendDAEExpsEqSystemWithUpdate "This function goes through the BackendDAE structure and finds all the
@@ -5953,13 +5921,10 @@ public function traverseBackendDAEExpsEqSystemWithUpdate "This function goes thr
     output DAE.Exp outExp;
     output Type_a outA;
   end FuncExpType;
-protected
-  BackendDAE.Variables vars;
-  BackendDAE.EquationArray eqns;
 algorithm
-  BackendDAE.EQSYSTEM(orderedVars = vars,orderedEqs = eqns) := syst;
-  outTypeA := traverseBackendDAEExpsVarsWithUpdate(vars,func,inTypeA);
-  outTypeA := traverseBackendDAEExpsEqnsWithUpdate(eqns,func,outTypeA);
+  outTypeA := traverseBackendDAEExpsVarsWithUpdate(syst.orderedVars, func, inTypeA);
+  outTypeA := traverseBackendDAEExpsEqnsWithUpdate(syst.orderedEqs, func, outTypeA);
+  outTypeA := traverseBackendDAEExpsEqnsWithUpdate(syst.removedEqs, func, outTypeA);
 end traverseBackendDAEExpsEqSystemWithUpdate;
 
 public function traverseBackendDAEExpsVars "Helper for traverseBackendDAEExps"
@@ -7928,10 +7893,11 @@ public function createEqSystem
   input BackendDAE.EquationArray inEqs;
   input BackendDAE.StateSets inStateSets = {};
   input BackendDAE.BaseClockPartitionKind inPartitionKind = BackendDAE.UNKNOWN_PARTITION();
+  input BackendDAE.EquationArray removedEqs = BackendEquation.emptyEqns();
   output BackendDAE.EqSystem outSyst;
 algorithm
   outSyst := BackendDAE.EQSYSTEM( inVars, inEqs, NONE(), NONE(), BackendDAE.NO_MATCHING(),
-                                  inStateSets, inPartitionKind );
+                                  inStateSets, inPartitionKind, removedEqs );
 end createEqSystem;
 
 public function createEmptyShared
@@ -7945,8 +7911,8 @@ protected
   BackendDAE.EquationArray emptyEqs = BackendEquation.emptyEqns();
   DAE.FunctionTree functions = DAEUtil.avlTreeNew();
 algorithm
-  shared := BackendDAE.SHARED( emptyVars, emptyVars, emptyVars, emptyEqs, emptyEqs, {}, {}, cache, graph,
-                               DAEUtil.avlTreeNew(), BackendDAEUtil.emptyEventInfo(), {}, backendDAEType, {}, ei,
+  shared := BackendDAE.SHARED( emptyVars, emptyVars, emptyVars, emptyEqs, {}, {}, cache, graph,
+                               DAEUtil.avlTreeNew(), emptyEventInfo(), {}, backendDAEType, {}, ei,
                                BackendDAE.PARTITIONS_INFO(emptyClocks()) );
 end createEmptyShared;
 
@@ -8082,12 +8048,13 @@ public function clearEqSyst
   output BackendDAE.EqSystem outSyst;
 protected
   BackendDAE.Variables vars;
-  BackendDAE.EquationArray eqs;
+  BackendDAE.EquationArray eqs, removedEqs;
   BackendDAE.StateSets stateSets;
   BackendDAE.BaseClockPartitionKind partitionKind;
 algorithm
-  BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqs, stateSets=stateSets, partitionKind=partitionKind) := inSyst;
-  outSyst := BackendDAE.EQSYSTEM( orderedVars=vars, orderedEqs=eqs, m=NONE(), mT=NONE(),
+  BackendDAE.EQSYSTEM( orderedVars=vars, orderedEqs=eqs, stateSets=stateSets, partitionKind=partitionKind,
+                       removedEqs=removedEqs ) := inSyst;
+  outSyst := BackendDAE.EQSYSTEM( orderedVars=vars, orderedEqs=eqs, m=NONE(), mT=NONE(), removedEqs=removedEqs,
                                   matching=BackendDAE.NO_MATCHING(), stateSets=stateSets, partitionKind=partitionKind );
 end clearEqSyst;
 
@@ -8105,19 +8072,13 @@ algorithm
   end match;
 end setEqSystMatching;
 
-public function setSharedRemovedEqns
-  input BackendDAE.Shared inShared;
+public function setEqSystRemovedEqns
+  input BackendDAE.EqSystem inSyst;
   input BackendDAE.EquationArray removedEqs;
-  output BackendDAE.Shared outShared;
+  output BackendDAE.EqSystem outSyst = inSyst;
 algorithm
-  outShared := match inShared
-    local
-      BackendDAE.Shared shared;
-    case shared as BackendDAE.SHARED()
-      algorithm shared.removedEqs := removedEqs;
-      then shared;
-  end match;
-end setSharedRemovedEqns;
+  outSyst.removedEqs := removedEqs;
+end setEqSystRemovedEqns;
 
 public function setSharedInitialEqns
   input BackendDAE.Shared inShared;
@@ -8164,15 +8125,9 @@ end setSharedFunctionTree;
 public function setSharedEventInfo
   input BackendDAE.Shared inShared;
   input BackendDAE.EventInfo eventInfo;
-  output BackendDAE.Shared outShared;
+  output BackendDAE.Shared outShared = inShared;
 algorithm
-  outShared := match inShared
-    local
-      BackendDAE.Shared shared;
-    case shared as BackendDAE.SHARED()
-      algorithm shared.eventInfo := eventInfo;
-      then shared;
-  end match;
+  outShared.eventInfo := eventInfo;
 end setSharedEventInfo;
 
 public function setSharedKnVars
@@ -8219,6 +8174,24 @@ algorithm
       then shared;
   end match;
 end setSharedOptimica;
+
+public function collapseRemovedEqs
+  input BackendDAE.EqSystems inSysts;
+  output BackendDAE.EquationArray outEqns;
+protected
+  list<BackendDAE.Equation> eqsLst;
+algorithm
+  eqsLst := List.fold(inSysts, collapseRemovedEqs1, {});
+  outEqns := BackendEquation.listEquation(eqsLst);
+end collapseRemovedEqs;
+
+protected function collapseRemovedEqs1
+  input BackendDAE.EqSystem inSyst;
+  input list<BackendDAE.Equation> inEqns;
+  output list<BackendDAE.Equation> outEqns;
+algorithm
+  outEqns := listAppend(BackendEquation.equationList(inSyst.removedEqs), inEqns);
+end collapseRemovedEqs1;
 
 public function emptyEventInfo
   output BackendDAE.EventInfo info;

--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -3610,6 +3610,15 @@ algorithm
   osyst := BackendDAEUtil.setEqSystMatrices(syst, SOME(outM), SOME(outMT));
 end getIncidenceMatrixScalar;
 
+public function removedIncidenceMatrix
+  input BackendDAE.EqSystem inSyst;
+  input BackendDAE.IndexType inIndxType;
+  input Option<DAE.FunctionTree> inFunctionTree;
+  output BackendDAE.IncidenceMatrix outM;
+  output BackendDAE.IncidenceMatrix outMT;
+algorithm
+  (outM, outMT) := incidenceMatrixDispatch(inSyst.orderedVars, inSyst.removedEqs, inIndxType, inFunctionTree);
+end removedIncidenceMatrix;
 
 protected function traverseStmts "Author: Frenkel TUD 2012-06
   traverese DAE.Statement without change possibility."
@@ -7587,13 +7596,8 @@ end mapEqSystem;
 public function nonEmptySystem
   input BackendDAE.EqSystem syst;
   output Boolean nonEmpty;
-protected
-  Integer num;
-  BackendDAE.Variables vars;
 algorithm
-  BackendDAE.EQSYSTEM(orderedVars=vars) := syst;
-  num := BackendVariable.varsSize(vars);
-  nonEmpty := num <> 0;
+  nonEmpty := BackendVariable.varsSize(syst.orderedVars) <> 0 or BackendDAEUtil.equationArraySize(syst.removedEqs) <> 0;
 end nonEmptySystem;
 
 public function filterEmptySystems
@@ -8182,7 +8186,7 @@ protected
   list<BackendDAE.Equation> eqsLst;
 algorithm
   eqsLst := List.fold(inSysts, collapseRemovedEqs1, {});
-  outEqns := BackendEquation.listEquation(eqsLst);
+  outEqns := BackendEquation.listEquation(listReverse(eqsLst));
 end collapseRemovedEqs;
 
 protected function collapseRemovedEqs1

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -104,7 +104,7 @@ algorithm
   BackendDAE.DAE(eqs, shared) := inBackendDAE;
   List.map_0(eqs, printEqSystem);
   print("\n");
-  printShared(shared);
+  printShared(eqs, shared);
 end printBackendDAE;
 
 public function printEqSystem "This function prints the BackendDAE.EqSystem representation to stdout."
@@ -256,6 +256,7 @@ public function printClassAttributes "This unction print the  Optimica ClassAttr
 end printClassAttributes;
 
 public function printShared "This function dumps the BackendDAE.Shared representation to stdout."
+  input BackendDAE.EqSystems inSysts "for backward compatibility";
   input BackendDAE.Shared inShared;
 protected
   BackendDAE.Variables knownVars, externalObjects, aliasVars;
@@ -272,17 +273,16 @@ algorithm
                     externalObjects=externalObjects,
                     aliasVars=aliasVars,
                     initialEqs=initialEqs,
-                    removedEqs=removedEqs,
                     constraints=constraints,
                     eventInfo=BackendDAE.EVENT_INFO( timeEvents=timeEvents, relationsLst=relationsLst, zeroCrossingLst=zeroCrossingLst,
                                                      sampleLst=sampleLst, whenClauseLst=whenClauseLst ),
                     extObjClasses=extObjClasses,
                     backendDAEType=backendDAEType,
                     symjacs=symjacs) := inShared;
+  removedEqs := BackendDAEUtil.collapseRemovedEqs(inSysts);
   print("\nBackendDAEType: ");
   printBackendDAEType(backendDAEType);
   print("\n\n");
-
 
   dumpVariables(knownVars, "Known Variables (constants)");
   dumpVariables(externalObjects, "External Objects");
@@ -3268,7 +3268,7 @@ algorithm
       print(headerline + ":\n");
       List.map_0(eqs, printEqSystem);
       print("\n");
-      printShared(shared);
+      printShared(eqs, shared);
     then ();
   end matchcontinue;
 end bltdump;
@@ -3309,7 +3309,8 @@ protected
   DumpCompShortTornTpl tornTpl;
   BackendDAE.BackendDAEType backendDAEType;
 algorithm
-  BackendDAE.DAE(systs, BackendDAE.SHARED(removedEqs=removedEqs, backendDAEType=backendDAEType)) := inDAE;
+  BackendDAE.DAE(systs, BackendDAE.SHARED(backendDAEType=backendDAEType)) := inDAE;
+  removedEqs := BackendDAEUtil.collapseRemovedEqs(systs);
   daeType := printBackendDAEType2String(backendDAEType);
 
   HS := HashSet.emptyHashSet();

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -104,11 +104,11 @@ algorithm
   BackendDAE.DAE(eqs, shared) := inBackendDAE;
   List.map_0(eqs, printEqSystem);
   print("\n");
-  printShared(eqs, shared);
+  printShared(shared);
 end printBackendDAE;
 
 public function printEqSystem "This function prints the BackendDAE.EqSystem representation to stdout."
-  input BackendDAE.EqSystem inEqSystem;
+  input BackendDAE.EqSystem inSyst;
 protected
   BackendDAE.Variables orderedVars;
   BackendDAE.EquationArray orderedEqs;
@@ -118,23 +118,16 @@ protected
   BackendDAE.StateSets stateSets;
   BackendDAE.BaseClockPartitionKind partitionKind;
 algorithm
-  BackendDAE.EQSYSTEM(orderedVars=orderedVars,
-                      orderedEqs=orderedEqs,
-                      m=m,
-                      mT=mT,
-                      matching=matching,
-                      stateSets=stateSets,
-                      partitionKind=partitionKind) := inEqSystem;
-
-  print("\n" + partitionKindString(partitionKind) + "\n" + UNDERLINE + "\n");
-  dumpVariables(orderedVars, "Variables");
-  dumpEquationArray(orderedEqs, "Equations");
-  dumpStateSets(stateSets, "State Sets");
-  dumpOption(m, dumpIncidenceMatrix);
-  dumpOption(mT, dumpIncidenceMatrixT);
+  print("\n" + partitionKindString(inSyst.partitionKind) + "\n" + UNDERLINE + "\n");
+  dumpVariables(inSyst.orderedVars, "Variables");
+  dumpEquationArray(inSyst.orderedEqs, "Equations");
+  dumpEquationArray(inSyst.removedEqs, "Simple Equations");
+  dumpStateSets(inSyst.stateSets, "State Sets");
+  dumpOption(inSyst.m, dumpIncidenceMatrix);
+  dumpOption(inSyst.mT, dumpIncidenceMatrixT);
 
   print("\n");
-  dumpFullMatching(matching);
+  dumpFullMatching(inSyst.matching);
   print("\n");
 end printEqSystem;
 
@@ -256,7 +249,6 @@ public function printClassAttributes "This unction print the  Optimica ClassAttr
 end printClassAttributes;
 
 public function printShared "This function dumps the BackendDAE.Shared representation to stdout."
-  input BackendDAE.EqSystems inSysts "for backward compatibility";
   input BackendDAE.Shared inShared;
 protected
   BackendDAE.Variables knownVars, externalObjects, aliasVars;
@@ -279,7 +271,7 @@ algorithm
                     extObjClasses=extObjClasses,
                     backendDAEType=backendDAEType,
                     symjacs=symjacs) := inShared;
-  removedEqs := BackendDAEUtil.collapseRemovedEqs(inSysts);
+
   print("\nBackendDAEType: ");
   printBackendDAEType(backendDAEType);
   print("\n\n");
@@ -288,7 +280,6 @@ algorithm
   dumpVariables(externalObjects, "External Objects");
   dumpExternalObjectClasses(extObjClasses, "Classes of External Objects");
   dumpVariables(aliasVars, "Alias Variables");
-  dumpEquationArray(removedEqs, "Simple Equations");
   dumpEquationArray(initialEqs, "Initial Equations");
   dumpZeroCrossingList(zeroCrossingLst, "Zero Crossings");
   dumpZeroCrossingList(relationsLst, "Relations");
@@ -3268,7 +3259,7 @@ algorithm
       print(headerline + ":\n");
       List.map_0(eqs, printEqSystem);
       print("\n");
-      printShared(eqs, shared);
+      printShared(shared);
     then ();
   end matchcontinue;
 end bltdump;

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -587,7 +587,6 @@ algorithm
   print("\n");
 end dumpClocks;
 
-
 public function dumpVariables "function dumpVariables"
   input BackendDAE.Variables inVars;
   input String heading;

--- a/Compiler/BackEnd/BackendEquation.mo
+++ b/Compiler/BackEnd/BackendEquation.mo
@@ -1250,41 +1250,42 @@ public function equationAddDAE "author: Frenkel TUD 2011-05"
   output BackendDAE.EqSystem outEqSystem;
 algorithm
   outEqSystem := BackendDAEUtil.setEqSystEqs(inEqSystem, addEquation(inEquation, inEqSystem.orderedEqs));
-  outEqSystem := BackendDAEUtil.setEqSystMatching(outEqSystem, BackendDAE.NO_MATCHING());
+  outEqSystem.matching := BackendDAE.NO_MATCHING();
 end equationAddDAE;
 
 public function equationsAddDAE "author: Frenkel TUD 2011-05"
   input list<BackendDAE.Equation> inEquations;
   input BackendDAE.EqSystem inEqSystem;
-  output BackendDAE.EqSystem outEqSystem;
+  output BackendDAE.EqSystem outEqSystem = inEqSystem;
 algorithm
-  outEqSystem := BackendDAEUtil.setEqSystEqs(inEqSystem, List.fold(inEquations, addEquation, inEqSystem.orderedEqs));
-  outEqSystem := BackendDAEUtil.setEqSystMatching(outEqSystem, BackendDAE.NO_MATCHING());
+  outEqSystem.orderedEqs := addEquations(inEquations, outEqSystem.orderedEqs);
+  outEqSystem.matching := BackendDAE.NO_MATCHING();
 end equationsAddDAE;
 
 public function requationsAddDAE "author: Frenkel TUD 2012-10
   Add a list of equations to removed equations of a BackendDAE.
   If the variable already exists, the function updates the variable."
   input list<BackendDAE.Equation> inEquations;
-  input BackendDAE.Shared inShared;
-  output BackendDAE.Shared outShared;
+  input BackendDAE.EqSystem inSyst;
+  output BackendDAE.EqSystem outSyst;
 algorithm
-  outShared := match inEquations
-    case {} then inShared;
-    else  then BackendDAEUtil.setSharedRemovedEqns(inShared, List.fold(inEquations, addEquation, inShared.removedEqs));
+  outSyst := match inEquations
+    case {} then inSyst;
+    else  then BackendDAEUtil.setEqSystRemovedEqns(inSyst, List.fold(inEquations, addEquation, inSyst.removedEqs));
   end match;
 end requationsAddDAE;
 
 public function removeRemovedEqs "remove removedEqs"
-  input BackendDAE.Shared inShared;
-  output BackendDAE.Shared outShared;
+  input BackendDAE.EqSystem inSyst;
+  output BackendDAE.EqSystem outSyst = inSyst;
 protected
-  BackendDAE.EquationArray removedEqs = inShared.removedEqs;
+  BackendDAE.EquationArray removedEqs = inSyst.removedEqs;
+  Integer N;
 algorithm
   for i in 1:removedEqs.numberOfElement loop
     removedEqs := equationRemove(i, removedEqs);
   end for;
-  outShared := BackendDAEUtil.setSharedRemovedEqns(inShared, removedEqs);
+  outSyst.removedEqs := removedEqs;
 end removeRemovedEqs;
 
 public function setAtIndex "author: lochel

--- a/Compiler/BackEnd/BackendInline.mo
+++ b/Compiler/BackEnd/BackendInline.mo
@@ -80,14 +80,13 @@ algorithm
       BackendDAE.EqSystems eqs;
       BackendDAE.Shared shared;
 
-    case BackendDAE.DAE(eqs, shared as BackendDAE.SHARED())
+    case BackendDAE.DAE(eqs, shared)
       algorithm
         tpl := (SOME(shared.functionTree), inITLst);
         eqs := List.map1(eqs, inlineEquationSystem, tpl);
         shared.knownVars := inlineVariables(shared.knownVars, tpl);
         shared.externalObjects := inlineVariables(shared.externalObjects, tpl);
         shared.initialEqs := inlineEquationArray(shared.initialEqs, tpl);
-        shared.removedEqs := inlineEquationArray(shared.removedEqs, tpl);
         shared.eventInfo := inlineEventInfo(shared.eventInfo, tpl);
       then
         BackendDAE.DAE(eqs, shared);
@@ -104,21 +103,11 @@ end inlineCalls;
 protected function inlineEquationSystem
   input BackendDAE.EqSystem eqs;
   input Inline.Functiontuple tpl;
-  output BackendDAE.EqSystem oeqs;
+  output BackendDAE.EqSystem oeqs = eqs;
 algorithm
-  oeqs := match eqs
-    local
-      BackendDAE.EqSystem syst;
-      BackendDAE.Variables orderedVars;
-      BackendDAE.EquationArray orderedEqs;
-
-    case syst as BackendDAE.EQSYSTEM(orderedVars=orderedVars, orderedEqs=orderedEqs)
-      equation
-        _ = inlineVariables(orderedVars, tpl);
-        _ = inlineEquationArray(orderedEqs, tpl);
-      then
-        syst;
-  end match;
+  inlineVariables(oeqs.orderedVars, tpl);
+  inlineEquationArray(oeqs.orderedEqs, tpl);
+  inlineEquationArray(oeqs.removedEqs, tpl);
 end inlineEquationSystem;
 
 protected function inlineEquationArray "

--- a/Compiler/BackEnd/DAEQuery.mo
+++ b/Compiler/BackEnd/DAEQuery.mo
@@ -85,24 +85,14 @@ public function getEquations
   This function returns the equations"
   input BackendDAE.BackendDAE inBackendDAE;
   output String strEqs;
+protected
+  BackendDAE.Shared shared;
+  BackendDAE.EqSystem syst;
+  list<String> ls1;
 algorithm
-  strEqs := match (inBackendDAE)
-    local
-      String s,s1;
-      list<String> ls1;
-      list<BackendDAE.Equation> eqnsl;
-      BackendDAE.EquationArray eqns;
-      list<BackendDAE.WhenClause> wcLst;
-
-    case (BackendDAE.DAE(eqs=BackendDAE.EQSYSTEM(orderedEqs = eqns)::{}, shared=BackendDAE.SHARED(eventInfo = BackendDAE.EVENT_INFO(whenClauseLst = wcLst))))
-      equation
-        eqnsl = BackendEquation.equationList(eqns);
-        ls1 = List.map1(eqnsl, equationStr, wcLst);
-        s1 = stringDelimitList(ls1, ",");
-        s = "EqStr = {" + s1 + "};";
-      then
-        s;
-  end match;
+    BackendDAE.DAE({syst}, shared) := inBackendDAE;
+    ls1 := List.map1(BackendEquation.equationList(syst.orderedEqs), equationStr, shared.eventInfo.whenClauseLst);
+    strEqs := "EqStr = {" + stringDelimitList(ls1, ",") + "};";
 end getEquations;
 
 public function equationStr

--- a/Compiler/BackEnd/DynamicOptimization.mo
+++ b/Compiler/BackEnd/DynamicOptimization.mo
@@ -903,10 +903,11 @@ algorithm
     //BackendDump.bltdump("START:reduceDynamicOptimization", inDAE);
     BackendDAE.DAE(systlst, shared) := inDAE;
     // ToDo
-    shared := BackendEquation.removeRemovedEqs(shared);
     shared := BackendVariable.removeAliasVars(shared);
 
     for syst in systlst loop
+
+      syst := BackendEquation.removeRemovedEqs(syst);
 
       BackendDAE.EQSYSTEM(orderedVars = v) := syst;
       varlst := BackendVariable.varList(v);

--- a/Compiler/BackEnd/EvaluateParameter.mo
+++ b/Compiler/BackEnd/EvaluateParameter.mo
@@ -1064,26 +1064,18 @@ protected function replaceEvaluatedParametersEqns "author Frenkel TUD"
   input BackendVarTransform.VariableReplacements inRepl;
   output BackendDAE.BackendDAE outDAE;
 protected
-  BackendDAE.EquationArray remeqns, inieqns;
-  list<BackendDAE.Equation> eqnslst;
+  list<BackendDAE.Equation> lsteqns;
   BackendDAE.EqSystems systs;
   Boolean b;
   BackendDAE.Shared shared;
 algorithm
-  BackendDAE.DAE(systs, shared as BackendDAE.SHARED(initialEqs=inieqns, removedEqs=remeqns)) := inDAE;
+  BackendDAE.DAE(systs, shared) := inDAE;
 
   // do replacements in initial equations
-  eqnslst := BackendEquation.equationList(inieqns);
-  (eqnslst, b) := BackendVarTransform.replaceEquations(eqnslst, inRepl, NONE());
+  lsteqns := BackendEquation.equationList(shared.initialEqs);
+  (lsteqns, b) := BackendVarTransform.replaceEquations(lsteqns, inRepl, NONE());
   if b then
-    shared := BackendDAEUtil.setSharedInitialEqns(shared, BackendEquation.listEquation(eqnslst));
-  end if;
-
-  // do replacements in simple equations
-  eqnslst := BackendEquation.equationList(remeqns);
-  (eqnslst, b) := BackendVarTransform.replaceEquations(eqnslst, inRepl, NONE());
-  if b then
-    shared := BackendDAEUtil.setSharedRemovedEqns(shared, BackendEquation.listEquation(eqnslst));
+    shared.initialEqs :=  BackendEquation.listEquation(lsteqns);
   end if;
 
   // do replacements in systems
@@ -1096,18 +1088,26 @@ protected function replaceEvaluatedParametersSystemEqns
 "author Frenkel TUD
   replace the evaluated parameters in the equationsystems"
   input BackendDAE.EqSystem isyst;
-  input BackendVarTransform.VariableReplacements repl;
-  output BackendDAE.EqSystem osyst;
+  input BackendVarTransform.VariableReplacements inRepl;
+  output BackendDAE.EqSystem osyst = isyst;
 protected
-  BackendDAE.EquationArray eqns, eqns1;
   list<BackendDAE.Equation> lsteqns;
   Boolean b;
 algorithm
-  BackendDAE.EQSYSTEM(orderedEqs=eqns) := isyst;
-  lsteqns := BackendEquation.equationList(eqns);
-  (lsteqns, b) := BackendVarTransform.replaceEquations(lsteqns, repl, NONE());
-  eqns1 := if b then BackendEquation.listEquation(lsteqns) else eqns;
-  osyst := if b then BackendDAEUtil.clearEqSyst(BackendDAEUtil.setEqSystEqs(isyst, eqns1)) else isyst;
+  lsteqns := BackendEquation.equationList(osyst.orderedEqs);
+  (lsteqns, b) := BackendVarTransform.replaceEquations(lsteqns, inRepl, NONE());
+  if b then
+    osyst.orderedEqs := BackendEquation.listEquation(lsteqns);
+    osyst := BackendDAEUtil.clearEqSyst(osyst);
+  end if;
+
+  // do replacements in simple equations
+  lsteqns := BackendEquation.equationList(osyst.removedEqs);
+  (lsteqns, b) := BackendVarTransform.replaceEquations(lsteqns, inRepl, NONE());
+  if b then
+    osyst.removedEqs := BackendEquation.listEquation(lsteqns);
+  end if;
+
 end replaceEvaluatedParametersSystemEqns;
 
 annotation(__OpenModelica_Interface="backend");

--- a/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/Compiler/BackEnd/FindZeroCrossings.mo
@@ -72,59 +72,29 @@ public function encapsulateWhenConditions "author: lochel"
 protected
   BackendDAE.EqSystems systs;
   BackendDAE.Shared shared;
-  BackendDAE.EquationArray removedEqs;
-
-  list<BackendDAE.TimeEvent> timeEvents;
-  list<BackendDAE.WhenClause> whenClauseLst;
-  list<BackendDAE.ZeroCrossing> zeroCrossingLst;
-  list<BackendDAE.ZeroCrossing> sampleLst;
-  list<BackendDAE.ZeroCrossing> relationsLst;
-  Integer numberMathEvents;
-
+  BackendDAE.EventInfo eventInfo;
+  list<BackendDAE.WhenClause> wcl;
   Integer index;
   HashTableExpToIndex.HashTable ht "is used to avoid redundant condition-variables";
   list<BackendDAE.Var> vars;
   list<BackendDAE.Equation> eqns;
   BackendDAE.Variables vars_;
   BackendDAE.EquationArray eqns_;
-  BackendDAE.ExtraInfo info;
-  BackendDAE.EventInfo eventInfo;
 
 algorithm
   BackendDAE.DAE(systs, shared) := inDAE;
-  BackendDAE.SHARED(removedEqs=removedEqs, eventInfo=eventInfo) := shared;
-  BackendDAE.EVENT_INFO( timeEvents=timeEvents,
-                         whenClauseLst=whenClauseLst,
-                         zeroCrossingLst=zeroCrossingLst,
-                         sampleLst=sampleLst,
-                         relationsLst=relationsLst,
-                         numberMathEvents=numberMathEvents ) := eventInfo;
 
   ht := HashTableExpToIndex.emptyHashTable();
-
-  // equation system
   (systs, index, ht) := List.mapFold2(systs, encapsulateWhenConditions_EqSystem, 1, ht);
 
   // when clauses
-  (whenClauseLst, vars, eqns, ht, index) := encapsulateWhenConditions_WhenClause(whenClauseLst, {}, {}, {}, ht, index);
-
-  // removed equations
-  ((removedEqs, vars, eqns, index, ht)) :=
-      BackendEquation.traverseEquationArray( removedEqs, encapsulateWhenConditions_Equation,
-                                             (BackendEquation.emptyEqns(), vars, eqns, index, ht) );
+  eventInfo := shared.eventInfo;
+  (wcl, vars, eqns, ht, index) := encapsulateWhenConditions_WhenClause(eventInfo.whenClauseLst, {}, {}, {}, ht, index);
+  eventInfo.whenClauseLst := wcl;
+  shared.eventInfo := eventInfo;
   vars_ := BackendVariable.listVar(vars);
   eqns_ := BackendEquation.listEquation(eqns);
   systs := listAppend(systs, {BackendDAEUtil.createEqSystem(vars_, eqns_)});
-
-  eventInfo := BackendDAE.EVENT_INFO(timeEvents,
-                                     whenClauseLst,
-                                     zeroCrossingLst,
-                                     sampleLst,
-                                     relationsLst,
-                                     numberMathEvents);
-
-  shared := BackendDAEUtil.setSharedEventInfo(shared, eventInfo);
-  shared := BackendDAEUtil.setSharedRemovedEqns(shared, removedEqs);
 
   outDAE := if intGt(index, 1) then BackendDAE.DAE(systs, shared) else inDAE;
   if Flags.isSet(Flags.DUMP_ENCAPSULATECONDITIONS) then
@@ -182,7 +152,7 @@ algorithm
   outEqSystem := match inEqSystem
     local
       BackendDAE.Variables orderedVars;
-      BackendDAE.EquationArray orderedEqs;
+      BackendDAE.EquationArray orderedEqs, removedEqs;
       BackendDAE.EqSystem syst;
       list<BackendDAE.Var> varLst;
       list<BackendDAE.Equation> eqnLst;
@@ -191,6 +161,13 @@ algorithm
         ((orderedEqs, varLst, eqnLst, outIndex, outHT)) :=
             BackendEquation.traverseEquationArray( orderedEqs, encapsulateWhenConditions_Equation,
                                                    (BackendEquation.emptyEqns(), {}, {}, inIndex, inHT) );
+
+        // removed equations
+        ((removedEqs, varLst, eqnLst, outIndex, outHT)) :=
+            BackendEquation.traverseEquationArray( syst.removedEqs, encapsulateWhenConditions_Equation,
+                                                   (BackendEquation.emptyEqns(), varLst, eqnLst, outIndex, outHT) );
+        syst.removedEqs := removedEqs;
+
         syst.orderedVars := BackendVariable.addVars(varLst, orderedVars);
         syst.orderedEqs := BackendEquation.addEquations(eqnLst, orderedEqs);
       then BackendDAEUtil.clearEqSyst(syst);

--- a/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/Compiler/BackEnd/FindZeroCrossings.mo
@@ -59,33 +59,6 @@ protected import List;
 protected import Util;
 
 // =============================================================================
-// section for some public util functions
-//
-// =============================================================================
-
-public function getZeroCrossings
-  input BackendDAE.BackendDAE inBackendDAE;
-  output list<BackendDAE.ZeroCrossing> outZeroCrossingList;
-algorithm
-  BackendDAE.DAE(shared=BackendDAE.SHARED(eventInfo=BackendDAE.EVENT_INFO(zeroCrossingLst=outZeroCrossingList))) := inBackendDAE;
-end getZeroCrossings;
-
-public function getRelations
-  input BackendDAE.BackendDAE inBackendDAE;
-  output list<BackendDAE.ZeroCrossing> outZeroCrossingList;
-algorithm
-  BackendDAE.DAE(shared=BackendDAE.SHARED(eventInfo=BackendDAE.EVENT_INFO(relationsLst=outZeroCrossingList))) := inBackendDAE;
-end getRelations;
-
-public function getSamples "deprecated - use EVENT_INFO.timeEvents instead"
-  input BackendDAE.BackendDAE inBackendDAE;
-  output list<BackendDAE.ZeroCrossing> outZeroCrossingList;
-algorithm
-  BackendDAE.DAE(shared=BackendDAE.SHARED(eventInfo=BackendDAE.EVENT_INFO(sampleLst=outZeroCrossingList))) := inBackendDAE;
-end getSamples;
-
-
-// =============================================================================
 // section for preOptModule >>encapsulateWhenConditions<<
 //
 // This module encapsulates each when-condition in a boolean-variable

--- a/Compiler/BackEnd/HpcOmTaskGraph.mo
+++ b/Compiler/BackEnd/HpcOmTaskGraph.mo
@@ -5943,6 +5943,7 @@ algorithm
       array<tuple<Integer,Integer,Integer>> varCompMap;
       TaskGraph graph;
       TaskGraphMeta graphData;
+      BackendDAE.EqSystems systs;
       BackendDAE.EquationArray remEqs;
       BackendDAE.Shared shared;
       list<BackendDAE.Equation> eqLst;
@@ -5960,8 +5961,8 @@ algorithm
       array<ComponentInfo> compInformations1, compInformations2;
   case(_,_,_)
     equation
-      BackendDAE.DAE(shared = shared) = dae;
-      BackendDAE.SHARED(removedEqs=remEqs) = shared;
+      BackendDAE.DAE(eqs = systs, shared = shared) = dae;
+      remEqs = BackendDAEUtil.collapseRemovedEqs(systs);
       TASKGRAPHMETA(varCompMapping=varCompMap) = graphDataIn;
       eqLst = BackendEquation.equationList(remEqs);
       numNewComps = listLength(eqLst);

--- a/Compiler/BackEnd/IndexReduction.mo
+++ b/Compiler/BackEnd/IndexReduction.mo
@@ -1248,7 +1248,9 @@ algorithm
   // do state selection
   ht := HashTableCrIntToExp.emptyHashTable();
   (systs, shared, ht) := mapdynamicStateSelection(systs, shared, inArgs, 1, ht);
-  shared := if intGt(BaseHashTable.hashTableCurrentSize(ht), 0) then replaceDummyDerivativesShared(shared, ht) else shared;
+  if intGt(BaseHashTable.hashTableCurrentSize(ht), 0) then
+    (systs, shared) :=  List.map1Fold(systs, replaceDummyDerivatives, ht, shared);
+  end if;
   outDAE := BackendDAE.DAE(systs, shared);
 end dynamicStateSelection;
 
@@ -3818,37 +3820,30 @@ algorithm
   end matchcontinue;
 end replaceDummyDerivativesExp;
 
-protected function replaceDummyDerivativesShared
+protected function replaceDummyDerivatives
 "author Frenkel TUD 2012-08"
-  input BackendDAE.Shared inShared;
+  input BackendDAE.EqSystem inSyst;
   input HashTableCrIntToExp.HashTable ht;
-  output BackendDAE.Shared oshared;
+  input BackendDAE.Shared inShared;
+  output BackendDAE.EqSystem outSyst = inSyst;
+  output BackendDAE.Shared outShared = inShared;
+protected
+  list<BackendDAE.WhenClause> wcl;
+  BackendDAE.EventInfo eventInfo;
 algorithm
-  oshared:= match inShared
-    local
-      list<BackendDAE.WhenClause> whenClauseLst;
-      BackendDAE.Shared shared;
-      BackendDAE.EventInfo eventInfo;
+  BackendVariable.traverseBackendDAEVarsWithUpdate(outShared.aliasVars, replaceDummyDerivativesVar, ht);
+  BackendVariable.traverseBackendDAEVarsWithUpdate(outShared.knownVars, replaceDummyDerivativesVar, ht);
+  BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate( outShared.initialEqs, Expression.traverseSubexpressionsHelper,
+                                                       (replaceDummyDerivativesExp, ht) );
+  BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate( outSyst.removedEqs, Expression.traverseSubexpressionsHelper,
+                                                       (replaceDummyDerivativesExp, ht) );
 
-    case shared as BackendDAE.SHARED(eventInfo=eventInfo as BackendDAE.EVENT_INFO())
-      equation
-        // replace dummy_derivatives in knvars,aliases,ineqns,remeqns
-        _ = BackendVariable.traverseBackendDAEVarsWithUpdate(shared.aliasVars, replaceDummyDerivativesVar, ht);
-        _ = BackendVariable.traverseBackendDAEVarsWithUpdate(shared.knownVars, replaceDummyDerivativesVar, ht);
-        _ = BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate( shared.initialEqs, Expression.traverseSubexpressionsHelper,
-                                                                 (replaceDummyDerivativesExp, ht) );
-        _ = BackendDAEUtil.traverseBackendDAEExpsEqnsWithUpdate( shared.removedEqs, Expression.traverseSubexpressionsHelper,
-                                                                 (replaceDummyDerivativesExp, ht) );
-        (whenClauseLst, _) =
-            BackendDAETransform.traverseBackendDAEExpsWhenClauseLst (
-                eventInfo.whenClauseLst, Expression.traverseSubexpressionsHelper, (replaceDummyDerivativesExp, ht) );
-        eventInfo.whenClauseLst = whenClauseLst;
-        shared.eventInfo = eventInfo;
-      then
-        shared;
-
-  end match;
-end replaceDummyDerivativesShared;
+  eventInfo := outShared.eventInfo;
+  (wcl, _) := BackendDAETransform.traverseBackendDAEExpsWhenClauseLst (
+      outShared.eventInfo.whenClauseLst, Expression.traverseSubexpressionsHelper, (replaceDummyDerivativesExp, ht) );
+  eventInfo.whenClauseLst := wcl;
+  outShared.eventInfo := eventInfo;
+end replaceDummyDerivatives;
 
 protected function replaceDummyDerivativesVar
 "author: Frenkel TUD 2012-08"

--- a/Compiler/BackEnd/Initialization.mo
+++ b/Compiler/BackEnd/Initialization.mo
@@ -134,11 +134,11 @@ algorithm
     shared := BackendDAEUtil.createEmptyShared(BackendDAE.INITIALSYSTEM(), dae.shared.info, dae.shared.cache, dae.shared.graph);
     shared := BackendDAEUtil.setSharedKnVars(shared, fixvars);
     shared := BackendDAEUtil.setSharedOptimica(shared, dae.shared.constraints, dae.shared.classAttrs);
-    shared := BackendDAEUtil.setSharedRemovedEqns(shared, reeqns);
     shared := BackendDAEUtil.setSharedFunctionTree(shared, dae.shared.functionTree);
 
     // generate initial system and pre-balance it
     initsyst := BackendDAEUtil.createEqSystem(vars, eqns);
+    initsyst := BackendDAEUtil.setEqSystRemovedEqns(initsyst, reeqns);
     (initsyst, dumpVars) := preBalanceInitialSystem(initsyst);
     SimCodeFunctionUtil.execStat("created initial system");
 
@@ -466,22 +466,23 @@ protected
   //list<DAE.ComponentRef> crefs;
 algorithm
   //BackendDump.dumpBackendDAE(inDAE, "inDAE");
-  outHS := HashSet.emptyHashSet();
-  outHS := List.fold(inDAE.eqs, collectPreVariablesEqSystem, outHS);
-  ((_, outHS)) := BackendDAEUtil.traverseBackendDAEExpsEqns(inDAE.shared.removedEqs, Expression.traverseSubexpressionsHelper, (collectPreVariablesTraverseExp, outHS)); // ???
-  ((_, outHS)) := BackendDAEUtil.traverseBackendDAEExpsEqns(inDAE.shared.initialEqs, Expression.traverseSubexpressionsHelper, (collectPreVariablesTraverseExp, outHS));
-
+  outHS := List.fold(inDAE.eqs, collectPreVariablesEqSystem, HashSet.emptyHashSet());
+  ((_, outHS)) := BackendDAEUtil.traverseBackendDAEExpsEqns( inDAE.shared.initialEqs, Expression.traverseSubexpressionsHelper,
+                                                             (collectPreVariablesTraverseExp, outHS) );
   //print("collectPreVariables:\n");
   //crefs := BaseHashSet.hashSetList(outHS);
   //BackendDump.debuglst(crefs, ComponentReference.printComponentRefStr, "\n", "\n");
 end collectPreVariables;
 
 public function collectPreVariablesEqSystem
-  input BackendDAE.EqSystem inEqSystem;
+  input BackendDAE.EqSystem inSyst;
   input HashSet.HashSet inHS;
   output HashSet.HashSet outHS;
 algorithm
-  ((_, outHS)) := BackendDAEUtil.traverseBackendDAEExpsEqns(inEqSystem.orderedEqs, Expression.traverseSubexpressionsHelper, (collectPreVariablesTraverseExp, inHS));
+  ((_, outHS)) := BackendDAEUtil.traverseBackendDAEExpsEqns( inSyst.orderedEqs, Expression.traverseSubexpressionsHelper,
+                                                             (collectPreVariablesTraverseExp, inHS) );
+  ((_, outHS)) := BackendDAEUtil.traverseBackendDAEExpsEqns( inSyst.removedEqs, Expression.traverseSubexpressionsHelper,
+                                                             (collectPreVariablesTraverseExp, outHS) );
 end collectPreVariablesEqSystem;
 
 public function collectPreVariablesTraverseExp

--- a/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/Compiler/BackEnd/SynchronousFeatures.mo
@@ -125,6 +125,7 @@ algorithm
 
   if Flags.isSet(Flags.DUMP_SYNCHRONOUS) then
     BackendDump.dumpEqSystems(systs, "base-clock partitioning");
+    BackendDump.dumpClocks(baseClocks, "Base clocks");
   end if;
 end clockPartitioning1;
 

--- a/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/Compiler/BackEnd/SynchronousFeatures.mo
@@ -98,11 +98,12 @@ protected
   BackendDAE.Shared shared;
   list<BackendDAE.EqSystem> systs;
   BackendDAE.Variables vars;
-  BackendDAE.EquationArray eqs;
+  BackendDAE.EquationArray eqs, removedEqs;
   BackendDAE.BaseClockPartitionKind partitionKind;
   list<DAE.ComponentRef> holdComps;
   array<Integer> varsPartition;
 algorithm
+  removedEqs := inSyst.removedEqs;
   syst := substituteParitionOpExps(inSyst);
 
   (contSysts, clockedSysts) := baseClockPartitioning(syst, inShared);
@@ -111,6 +112,12 @@ algorithm
 
   //Continuous system always first in equation systems list
   systs := listAppend(contSysts, clockedSysts);
+  (syst, systs) := match systs
+    case {} then (BackendDAEUtil.createEqSystem(BackendVariable.emptyVars(), BackendEquation.emptyEqns()), {});
+    case syst::systs then (syst, systs);
+  end match;
+  syst.removedEqs := removedEqs;
+  systs := syst::systs;
   outDAE := BackendDAE.DAE(systs, setClocks(inShared, baseClocks));
 
   if Flags.isSet(Flags.DUMP_SYNCHRONOUS) then

--- a/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/Compiler/BackEnd/SynchronousFeatures.mo
@@ -98,12 +98,11 @@ protected
   BackendDAE.Shared shared;
   list<BackendDAE.EqSystem> systs;
   BackendDAE.Variables vars;
-  BackendDAE.EquationArray eqs, removedEqs;
+  BackendDAE.EquationArray eqs;
   BackendDAE.BaseClockPartitionKind partitionKind;
   list<DAE.ComponentRef> holdComps;
   array<Integer> varsPartition;
 algorithm
-  removedEqs := inSyst.removedEqs;
   syst := substituteParitionOpExps(inSyst);
 
   (contSysts, clockedSysts) := baseClockPartitioning(syst, inShared);
@@ -112,12 +111,6 @@ algorithm
 
   //Continuous system always first in equation systems list
   systs := listAppend(contSysts, clockedSysts);
-  (syst, systs) := match systs
-    case {} then (BackendDAEUtil.createEqSystem(BackendVariable.emptyVars(), BackendEquation.emptyEqns()), {});
-    case syst::systs then (syst, systs);
-  end match;
-  syst.removedEqs := removedEqs;
-  systs := syst::systs;
   outDAE := BackendDAE.DAE(systs, setClocks(inShared, baseClocks));
 
   if Flags.isSet(Flags.DUMP_SYNCHRONOUS) then
@@ -284,9 +277,9 @@ protected
   BackendDAE.EquationArray eqs, clockEqs;
   BackendDAE.Variables vars, clockVars;
   BackendDAE.EqSystem syst, clockSyst;
-  BackendDAE.IncidenceMatrix m,mT;
+  BackendDAE.IncidenceMatrix m, mT, rm, rmT;
   Integer i, partitionsCnt;
-  array<Integer> partitions;
+  array<Integer> partitions, reqsPartitions;
   list<BackendDAE.Equation> newClockEqs;
   list<BackendDAE.Var> newClockVars;
   array<Option<Boolean>> contPartitions;
@@ -305,8 +298,10 @@ algorithm
   syst := BackendDAEUtil.createEqSystem(vars, eqs);
 
   (syst, m, mT) := BackendDAEUtil.getIncidenceMatrixfromOption(syst, BackendDAE.SUBCLOCK_IDX(), SOME(funcs));
+  (rm, rmT) := BackendDAEUtil.removedIncidenceMatrix(syst, BackendDAE.SUBCLOCK_IDX(), SOME(funcs));
   partitions := arrayCreate(arrayLength(m), 0);
-  partitionsCnt := partitionIndependentBlocks0(m, mT, partitions);
+  reqsPartitions := arrayCreate(arrayLength(rm), 0);
+  partitionsCnt := partitionIndependentBlocks0(m, mT, rm, rmT, partitions, reqsPartitions);
 
   //Detect clocked continuous partitions and create new subclock equations
   (eqs, newClockEqs, newClockVars, contPartitions, subclksCnt)
@@ -325,7 +320,7 @@ algorithm
   syst :=  BackendDAEUtil.createEqSystem(vars, eqs);
   systs :=
     if partitionsCnt > 1 then
-      partitionIndependentBlocksSplitBlocks(partitionsCnt, syst, partitions, mT, false)
+      partitionIndependentBlocksSplitBlocks(partitionsCnt, syst, partitions, reqsPartitions, mT, false)
     else
       {syst};
 
@@ -1218,14 +1213,14 @@ protected
   BackendDAE.Variables vars;
   BackendDAE.EquationArray eqs;
   DAE.FunctionTree funcs;
-  BackendDAE.IncidenceMatrix m,mT;
+  BackendDAE.IncidenceMatrix m, mT, rm, rmT;
   BackendDAE.EqSystem syst;
   BackendDAE.EqSystems systs;
   Integer partitionCnt, i, j, eqIdx;
   DAE.ComponentRef cr;
   list<Integer> varIxs;
   BackendDAE.EqSystem syst;
-  array<Integer> eqsPartition;
+  array<Integer> eqsPartition, reqsPartition;
   BackendDAE.Equation eq;
   list<tuple<DAE.ComponentRef, Boolean>> refsInfo;
   tuple<DAE.ComponentRef, Boolean> refInfo;
@@ -1237,14 +1232,18 @@ algorithm
   funcs := BackendDAEUtil.getFunctions(inShared);
 
   (syst, m, mT) := BackendDAEUtil.getIncidenceMatrixfromOption(inSyst, BackendDAE.BASECLOCK_IDX(), SOME(funcs));
+  (rm, rmT) := BackendDAEUtil.removedIncidenceMatrix(inSyst, BackendDAE.BASECLOCK_IDX(), SOME(funcs));
+
   BackendDAE.EQSYSTEM(orderedVars = vars, orderedEqs = eqs) := syst;
   eqsPartition := arrayCreate(arrayLength(m), 0);
-  partitionCnt := partitionIndependentBlocks0(m, mT, eqsPartition);
+  reqsPartition := arrayCreate(arrayLength(rm), 0);
+  partitionCnt := partitionIndependentBlocks0(m, mT, rm, rmT, eqsPartition, reqsPartition);
   systs :=
     if partitionCnt > 1 then
-      partitionIndependentBlocksSplitBlocks(partitionCnt, syst, eqsPartition, mT, false)
+      partitionIndependentBlocksSplitBlocks(partitionCnt, syst, eqsPartition, reqsPartition, mT, false)
     else
       {syst};
+
   //Partition finished
   clockedEqs := arrayCreate(BackendDAEUtil.equationArraySize(eqs), NONE());
   clockedVars := arrayCreate(BackendVariable.varsSize(vars), NONE());
@@ -1543,20 +1542,29 @@ end setClockedPartition;
 public function partitionIndependentBlocks0
   input BackendDAE.IncidenceMatrix m;
   input BackendDAE.IncidenceMatrixT mT;
+  input BackendDAE.IncidenceMatrix rm;
+  input BackendDAE.IncidenceMatrixT rmT;
   input array<Integer> ixs;
+  input array<Integer> rixs;
   output Integer on = 0;
 algorithm
   for i in arrayLength(m):-1:1 loop
-    on := if partitionIndependentBlocks1(i, on + 1, m, mT, ixs) then on + 1 else on;
+    on := if partitionIndependentBlocksEq(i, on + 1, m, mT, rm, rmT, ixs, rixs) then on + 1 else on;
+  end for;
+  for i in arrayLength(rm):-1:1 loop
+    on := if partitionIndependentBlocksReq(i, on + 1, m, mT, rm, rmT, ixs, rixs) then on + 1 else on;
   end for;
 end partitionIndependentBlocks0;
 
-protected function partitionIndependentBlocks1
+protected function partitionIndependentBlocksEq
   input Integer ix;
   input Integer n;
   input BackendDAE.IncidenceMatrix m;
   input BackendDAE.IncidenceMatrixT mT;
+  input BackendDAE.IncidenceMatrix rm;
+  input BackendDAE.IncidenceMatrixT rmT;
   input array<Integer> ixs;
+  input array<Integer> rixs;
   output Boolean ochange;
 algorithm
   ochange := arrayGet(ixs, ix) == 0;
@@ -1565,68 +1573,103 @@ algorithm
     arrayUpdate(ixs, ix, n);
     for i in arrayGet(m, ix) loop
       for j in arrayGet(mT, intAbs(i)) loop
-        partitionIndependentBlocks1(intAbs(j), n, m, mT, ixs);
+        partitionIndependentBlocksEq(intAbs(j), n, m, mT, rm, rmT, ixs, rixs);
+      end for;
+      for j in arrayGet(rmT, intAbs(i)) loop
+        partitionIndependentBlocksReq(intAbs(j), n, m, mT, rm, rmT, ixs, rixs);
       end for;
     end for;
   end if;
-end partitionIndependentBlocks1;
+end partitionIndependentBlocksEq;
+
+protected function partitionIndependentBlocksReq
+  input Integer ix;
+  input Integer n;
+  input BackendDAE.IncidenceMatrix m;
+  input BackendDAE.IncidenceMatrixT mT;
+  input BackendDAE.IncidenceMatrix rm;
+  input BackendDAE.IncidenceMatrixT rmT;
+  input array<Integer> ixs;
+  input array<Integer> rixs;
+  output Boolean ochange;
+algorithm
+  ochange := arrayGet(rixs, ix) == 0;
+  if ochange then
+    arrayUpdate(rixs, ix, n);
+    for i in arrayGet(rm, ix) loop
+      for j in arrayGet(mT, intAbs(i)) loop
+        partitionIndependentBlocksEq(intAbs(j), n, m, mT, rm, rmT, ixs, rixs);
+      end for;
+      for j in arrayGet(rmT, intAbs(i)) loop
+        partitionIndependentBlocksReq(intAbs(j), n, m, mT, rm, rmT, ixs, rixs);
+      end for;
+    end for;
+  end if;
+end partitionIndependentBlocksReq;
 
 public function partitionIndependentBlocksSplitBlocks
   "Partitions the independent blocks into list<array<...>> by first constructing
   an array<list<...>> structure for the algorithm complexity"
   input Integer n;
-  input BackendDAE.EqSystem syst;
+  input BackendDAE.EqSystem inSyst;
   input array<Integer> ixs;
+  input array<Integer> rixs;
   input BackendDAE.IncidenceMatrix mT;
   input Boolean throwNoError;
-  output list<BackendDAE.EqSystem> systs;
+  output list<BackendDAE.EqSystem> systs = {};
+protected
+  array<list<BackendDAE.Equation>> ea, rea;
+  array<list<BackendDAE.Var>> va;
+  Integer i1, i2;
+  String s1, s2;
+  Boolean b, b1 = true;
+  BackendDAE.EqSystem syst;
+  list<BackendDAE.Equation> rest;
 algorithm
-  systs := match (syst)
-    local
-      BackendDAE.Variables vars;
-      BackendDAE.EquationArray arr;
-      array<list<BackendDAE.Equation>> ea;
-      array<list<BackendDAE.Var>> va;
-      list<list<BackendDAE.Equation>> el;
-      list<list<BackendDAE.Var>> vl;
-      Integer i1, i2;
-      String s1, s2;
-      Boolean b;
+  ea := arrayCreate(n, {});
+  rea := arrayCreate(n, {});
+  va := arrayCreate(n, {});
+  i1 := BackendDAEUtil.equationSize(inSyst.orderedEqs);
+  i2 := BackendVariable.varsSize(inSyst.orderedVars);
 
-    case BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=arr)
-      equation
-        ea = arrayCreate(n, {});
-        va = arrayCreate(n, {});
-        i1 = BackendDAEUtil.equationSize(arr);
-        i2 = BackendVariable.varsSize(vars);
+  if i1 <> i2 and not throwNoError then
+  s1 := intString(i1);
+  s2 := intString(i2);
+  Error.addSourceMessage(if i1 > i2 then Error.OVERDET_EQN_SYSTEM else Error.UNDERDET_EQN_SYSTEM,
+    {s1, s2}, Absyn.dummyInfo);
+    fail();
+  end if;
 
-        if i1 <> i2 and not throwNoError then
-          s1 = intString(i1);
-          s2 = intString(i2);
-          Error.addSourceMessage(if i1 > i2 then Error.OVERDET_EQN_SYSTEM else Error.UNDERDET_EQN_SYSTEM,
-            {s1, s2}, Absyn.dummyInfo);
-          fail();
-        end if;
+  rest := partitionEquations(BackendDAEUtil.equationArraySize(inSyst.orderedEqs), inSyst.orderedEqs, ixs, ea);
+  assert(listLength(rest) == 0, "Equations partitioning failure in SynchronousFeatures.partitionIndependentBlocksSplitBlocks");
+  rest := partitionEquations(BackendDAEUtil.equationArraySize(inSyst.removedEqs), inSyst.removedEqs, rixs, rea);
+  partitionVars(i2, inSyst.orderedEqs, inSyst.orderedVars, ixs, mT, va);
 
-        partitionEquations(BackendDAEUtil.equationArraySize(arr), arr, ixs, ea);
-        partitionVars(i2, arr, vars, ixs, mT, va);
-        el = arrayList(ea);
-        vl = arrayList(va);
-        (systs, (b, _)) = List.threadMapFold(el, vl, createEqSystem, (true, throwNoError));
-        true = throwNoError or b;
-      then
-        systs;
-  end match;
+  for i in 1:n loop
+    (syst, (b, _)) := createEqSystem(ea[i], va[i], rea[i], (true, throwNoError));
+    systs := syst :: systs;
+    b1 := b1 and b;
+  end for;
+  true := throwNoError or b1;
+  systs := listReverse(systs);
+
+  if listLength(rest) <> 0 then
+    syst := BackendDAEUtil.createEqSystem( BackendVariable.emptyVars(), BackendEquation.emptyEqns(),
+                                            {}, BackendDAE.UNSPECIFIED_PARTITION(), BackendEquation.listEquation(rest) );
+    systs := syst::systs;
+  end if;
+
 end partitionIndependentBlocksSplitBlocks;
 
 protected function createEqSystem
   input list<BackendDAE.Equation> el;
   input list<BackendDAE.Var> vl;
+  input list<BackendDAE.Equation> rel;
   input tuple<Boolean, Boolean> iTpl;
   output BackendDAE.EqSystem syst;
   output tuple<Boolean, Boolean> oTpl;
 protected
-  BackendDAE.EquationArray arr;
+  BackendDAE.EquationArray arr, remArr;
   BackendDAE.Variables vars;
   Integer i1, i2;
   String s1, s2, s3, s4;
@@ -1636,6 +1679,7 @@ algorithm
   (success, throwNoError) := iTpl;
   vars := BackendVariable.listVar1(vl);
   arr := BackendEquation.listEquation(el);
+  remArr := BackendEquation.listEquation(rel);
   i1 := BackendDAEUtil.equationSize(arr);
   i2 := BackendVariable.varsSize(vars);
 
@@ -1650,7 +1694,7 @@ algorithm
     fail();
   end if;
 
-  syst := BackendDAEUtil.createEqSystem(vars, arr);
+  syst := BackendDAEUtil.createEqSystem(vars, arr, {}, BackendDAE.UNKNOWN_PARTITION(), remArr);
   success := success and i1==i2;
   oTpl := (success, throwNoError);
 end createEqSystem;
@@ -1660,6 +1704,7 @@ protected function partitionEquations
   input BackendDAE.EquationArray arr;
   input array<Integer> ixs;
   input array<list<BackendDAE.Equation>> ea;
+  output list<BackendDAE.Equation> restEqs = {};
 protected
   Integer ix;
   list<BackendDAE.Equation> lst;
@@ -1667,11 +1712,15 @@ protected
 algorithm
   for i in n:-1:1 loop
     ix := ixs[i];
-    lst := ea[ix];
     eq := BackendEquation.equationNth1(arr, i);
-    lst := eq::lst;
-    // print("adding eq " + intString(n) + " to group " + intString(ix) + "\n");
-    arrayUpdate(ea, ix, lst);
+    if ix == 0 then
+      restEqs := eq::restEqs;
+    else
+      lst := ea[ix];
+      lst := eq::lst;
+      // print("adding eq " + intString(n) + " to group " + intString(ix) + "\n");
+      arrayUpdate(ea, ix, lst);
+    end if;
   end for;
 end partitionEquations;
 

--- a/Compiler/BackEnd/Vectorization.mo
+++ b/Compiler/BackEnd/Vectorization.mo
@@ -1433,7 +1433,7 @@ algorithm
         syst.orderedVars := BackendVariable.listVar1(varLst);
         shared.aliasVars := BackendVariable.listVar1(aliasLst);
         shared.knownVars := BackendVariable.listVar1(knownLst);
-        shared.removedEqs := BackendEquation.listEquation({});
+        syst.removedEqs := BackendEquation.listEquation({});
         syst.orderedEqs := BackendEquation.listEquation(eqLst);
         //BackendDump.dumpEquationList(eqLst,"eqsOut");
         //BackendDump.dumpVariables(vars,"VARSOUT");

--- a/Compiler/BackEnd/XMLDump.mo
+++ b/Compiler/BackEnd/XMLDump.mo
@@ -1030,14 +1030,15 @@ algorithm
                  vars_knownVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_knownVars),
                  vars_externalObject as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_externalObject),
                  vars_aliasVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_aliasVars),
-                 ieqns,reqns,constrs,_,_,_,funcs,
-                 eventInfo,
+                 ieqns,constrs,_,_,_,funcs,eventInfo,
                  extObjCls,_,_,_)),addOrInMatrix,addSolInfo,addMML,dumpRes,false)
       equation
 
         knvars  = BackendVariable.varList(vars_knownVars);
         extvars = BackendVariable.varList(vars_externalObject);
         aliasvars = BackendVariable.varList(vars_aliasVars);
+
+        reqns = BackendDAEUtil.collapseRemovedEqs(systs);
 
         Print.printBuf(HEADER);
         dumpStrOpenTag(DAE_OPEN);
@@ -1071,13 +1072,15 @@ algorithm
                  vars_knownVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_knownVars),
                  vars_externalObject as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_externalObject),
                  vars_aliasVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_aliasVars),
-                 ieqns,reqns,constrs,_,_,_,funcs,
-                 eventInfo,extObjCls,_,_,_)),addOrInMatrix,addSolInfo,addMML,dumpRes,true)
+                 ieqns,constrs,_,_,_,funcs,eventInfo,
+                 extObjCls,_,_,_,_)),addOrInMatrix,addSolInfo,addMML,dumpRes,true)
       equation
 
         knvars  = BackendVariable.varList(vars_knownVars);
         extvars = BackendVariable.varList(vars_externalObject);
         aliasvars = BackendVariable.varList(vars_aliasVars);
+
+        reqns = BackendDAEUtil.collapseRemovedEqs(systs);
 
         Print.printBuf(HEADER);
         dumpStrOpenTag(DAE_OPEN);

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -163,7 +163,6 @@ public function createSimCode "entry point to create SimCode from BackendDAE."
 protected
   BackendDAE.BackendDAE dlow;
   BackendDAE.BackendDAE initDAE;
-  BackendDAE.EqSystems systs;
   BackendDAE.EquationArray removedEqs;
   BackendDAE.Shared shared;
   BackendDAE.SymbolicJacobians symJacs;
@@ -229,7 +228,6 @@ algorithm
       dlow := BackendDAEUtil.mapEqSystem(dlow, Vectorization.prepareVectorizedDAE0);
     end if;
 
-
     backendMapping := setUpBackendMapping(inBackendDAE);
     if Flags.isSet(Flags.VISUAL_XML) then
       VisualXML.visualizationInfoXML(dlow, filenamePrefix);
@@ -264,6 +262,7 @@ algorithm
                                                       symjacs=symJacs,
                                                       partitionsInfo=BackendDAE.PARTITIONS_INFO(baseClocks),
                                                       eventInfo=eventInfo)) := dlow;
+      removedEqs := BackendDAEUtil.collapseRemovedEqs(dlow.eqs);
 
  // created event suff e.g. zeroCrossings, samples, ...
       timeEvents := eventInfo.timeEvents;
@@ -1318,8 +1317,9 @@ algorithm
         (odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings, uniqueEqIndex, tempvars, tmpEqSccMapping, tmpEqBackendSimCodeMapping, tmpBackendMapping);
 
     // A single array equation
-    case (_, _, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns),
-          BackendDAE.SHARED(info = ei), BackendDAE.SINGLEARRAY(eqn=e), _, _, _, _, _, _, odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings)
+    case ( _, _, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns),
+           BackendDAE.SHARED(info = ei), BackendDAE.SINGLEARRAY(eqn=e), _, _, _, _, _, _, odeEquations,
+           algebraicEquations, allEquations, equationsforZeroCrossings )
       equation
         // block is dynamic, belong in dynamic section
         bdynamic = BackendDAEUtil.blockIsDynamic({e}, stateeqnsmark);
@@ -1343,7 +1343,8 @@ algorithm
         (odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings, uniqueEqIndex, tempvars, tmpEqSccMapping, tmpEqBackendSimCodeMapping, tmpBackendMapping);
 
     // A single algorithm section for several variables.
-    case (_, _, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns), _, BackendDAE.SINGLEALGORITHM(eqn=e), _, _, _, _, _, _, odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings)
+    case ( _, _, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns), _, BackendDAE.SINGLEALGORITHM(eqn=e), _, _, _,
+           _, _, _, odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings )
       equation
         // block is dynamic, belong in dynamic section
         bdynamic = BackendDAEUtil.blockIsDynamic({e}, stateeqnsmark);
@@ -1366,7 +1367,8 @@ algorithm
         (odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings, uniqueEqIndex, itempvars, tmpEqSccMapping, tmpEqBackendSimCodeMapping, tmpBackendMapping);
 
     // A single complex equation
-    case (_, _, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns), BackendDAE.SHARED(info = ei), BackendDAE.SINGLECOMPLEXEQUATION(eqn=e), _, _, _, _, _, _, odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings)
+    case ( _, _, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns), BackendDAE.SHARED(info = ei),
+           BackendDAE.SINGLECOMPLEXEQUATION(eqn=e), _, _, _, _, _, _, odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings )
       equation
         // block is dynamic, belong in dynamic section
         bdynamic = BackendDAEUtil.blockIsDynamic({e}, stateeqnsmark);
@@ -1390,7 +1392,8 @@ algorithm
         (odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings, uniqueEqIndex, tempvars, tmpEqSccMapping, tmpEqBackendSimCodeMapping, tmpBackendMapping);
 
     // A single when equation
-    case (_, _, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns), _, BackendDAE.SINGLEWHENEQUATION(eqn=e), _, _, _, _, _, _, odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings)
+    case ( _, _, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns),
+           _, BackendDAE.SINGLEWHENEQUATION(eqn=e), _, _, _, _, _, _, odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings )
       equation
         // block is dynamic, belong in dynamic section
         _ = BackendDAEUtil.blockIsDynamic({e}, stateeqnsmark);
@@ -1411,7 +1414,8 @@ algorithm
         (odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings, uniqueEqIndex, tempvars, tmpEqSccMapping, tmpEqBackendSimCodeMapping, tmpBackendMapping);
 
     // A single if equation
-    case (_, _, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns), _, BackendDAE.SINGLEIFEQUATION(eqn=e), _, _, _, _, _, _, odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings)
+    case ( _, _, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns), _, BackendDAE.SINGLEIFEQUATION(eqn=e), _, _, _, _, _, _,
+           odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings )
       equation
         // block is dynamic, belong in dynamic section
         bdynamic = BackendDAEUtil.blockIsDynamic({e}, stateeqnsmark);
@@ -1435,7 +1439,8 @@ algorithm
         (odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings, uniqueEqIndex, tempvars, tmpEqSccMapping, tmpEqBackendSimCodeMapping, tmpBackendMapping);
 
     // EQUATIONSYSTEM size 1 -> single equation
-    case (_, _, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns), _, (BackendDAE.EQUATIONSYSTEM(eqns={index}, vars={vindex})), _, _, _, _, _, _, odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings)
+    case ( _, _, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns), _, (BackendDAE.EQUATIONSYSTEM(eqns={index}, vars={vindex})),
+           _, _, _, _, _, _, odeEquations, algebraicEquations, allEquations, equationsforZeroCrossings )
       equation
         eqn = BackendEquation.equationNth1(eqns, index);
         // ignore when equations if we should not generate them
@@ -5192,11 +5197,13 @@ protected
   BackendDAE.Shared shared;
   BackendDAE.Variables knvars, aliasVars;
 algorithm
-  BackendDAE.DAE(systs, shared as BackendDAE.SHARED(knownVars=knvars, aliasVars=aliasVars, removedEqs=removedEqs)) := inInitDAE;
+  BackendDAE.DAE(systs, shared as BackendDAE.SHARED(knownVars=knvars, aliasVars=aliasVars)) := inInitDAE;
+  removedEqs := BackendDAEUtil.collapseRemovedEqs(systs);
   // generate equations from the known unfixed variables
   ((uniqueEqIndex, allEquations)) := BackendVariable.traverseBackendDAEVars(knvars, traverseKnVarsToSimEqSystem, (iuniqueEqIndex, {}));
   // generate equations from the solved systems
-  (uniqueEqIndex, _, _, solvedEquations, _, tempvars, _, _, _) := createEquationsForSystems(systs, shared, uniqueEqIndex, {}, {}, {}, {}, {}, itempvars, 0, {}, {}, SimCode.NO_MAPPING());
+  (uniqueEqIndex, _, _, solvedEquations, _, tempvars, _, _, _) :=
+      createEquationsForSystems(systs, shared, uniqueEqIndex, {}, {}, {}, {}, {}, itempvars, 0, {}, {}, SimCode.NO_MAPPING());
   allEquations := listAppend(allEquations, solvedEquations);
   // generate equations from the removed equations
   ((uniqueEqIndex, removedEquations)) := BackendEquation.traverseEquationArray(removedEqs, traversedlowEqToSimEqSystem, (uniqueEqIndex, {}));


### PR DESCRIPTION
* Collapse all continuous and unspecified partitions into single continuous-time partition;
* Print base clocks in synchronous dumps;
* Do partitioning for removed equations. We need that for handling such constructs:
```modelica
when Clock() then
  Modelica.Utilities.Streams.print("clock ticks at = " + String(sample(time)));
end when;
```
The equation ordering and output format is changed, so many tests are affected