### PR TITLE
Do partitioning for removed equations

### DIFF
--- a/Compiler/BackEnd/BackendDAE.mo
+++ b/Compiler/BackEnd/BackendDAE.mo
@@ -70,13 +70,15 @@ type EqSystems = list<EqSystem>;
 public
 uniontype EqSystem "An independent system of equations (and their corresponding variables)"
   record EQSYSTEM
-    Variables orderedVars "ordered Variables, only states and alg. vars";
-    EquationArray orderedEqs "ordered Equations";
+    Variables orderedVars                   "ordered Variables, only states and alg. vars";
+    EquationArray orderedEqs                "ordered Equations";
     Option<IncidenceMatrix> m;
     Option<IncidenceMatrixT> mT;
     Matching matching;
-    StateSets stateSets "the state sets of the system";
+    StateSets stateSets                    "the state sets of the system";
     BaseClockPartitionKind partitionKind;
+    EquationArray removedEqs               "these are equations that cannot solve for a variable.
+                                            e.g. assertions, external function calls, algorithm sections without effect";
   end EQSYSTEM;
 end EqSystem;
 

--- a/Compiler/BackEnd/BackendDAECreate.mo
+++ b/Compiler/BackEnd/BackendDAECreate.mo
@@ -135,12 +135,12 @@ algorithm
   ieqnarr := BackendEquation.listEquation(ieqns);
   einfo := BackendDAE.EVENT_INFO(timeEvents, whenclauses_1, {}, {}, {}, 0);
   symjacs := {(NONE(), ({}, {}, ({}, {})), {}), (NONE(), ({}, {}, ({}, {})), {}), (NONE(), ({}, {}, ({}, {})), {}), (NONE(), ({}, {}, ({}, {})), {})};
-  outBackendDAE := BackendDAE.DAE(BackendDAEUtil.createEqSystem(vars_1, eqnarr)::{},
+  outBackendDAE := BackendDAE.DAE(BackendDAEUtil.createEqSystem(vars_1, eqnarr, {}, BackendDAE.UNKNOWN_PARTITION(), reqnarr)::{},
                                   BackendDAE.SHARED(knvars,
                                                     extVars,
                                                     aliasVars,
                                                     ieqnarr,
-                                                    reqnarr,
+                                                    BackendEquation.emptyEqns(),
                                                     constrs,
                                                     clsAttrs,
                                                     inCache,

--- a/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -1636,8 +1636,8 @@ public function partitionIndependentBlocksHelper
 algorithm
   (systs,oshared) := matchcontinue (isyst,ishared,numErrorMessages,throwNoError)
     local
-      BackendDAE.IncidenceMatrix m,mT;
-      array<Integer> ixs;
+      BackendDAE.IncidenceMatrix m, mT, rm, rmT;
+      array<Integer> ixs, rixs;
       Boolean b;
       Integer i;
       BackendDAE.Shared shared;
@@ -1645,17 +1645,18 @@ algorithm
       DAE.FunctionTree funcs;
     case (syst,shared,_,_)
       equation
-        // print("partitionIndependentBlocks: TODO: Implement me\n");
         funcs = BackendDAEUtil.getFunctions(ishared);
-        (syst,m,mT) = BackendDAEUtil.getIncidenceMatrixfromOption(syst,BackendDAE.NORMAL(),SOME(funcs));
-        ixs = arrayCreate(arrayLength(m),0);
+        (syst, m, mT) = BackendDAEUtil.getIncidenceMatrixfromOption(syst, BackendDAE.NORMAL(), SOME(funcs));
+        (rm, rmT) = BackendDAEUtil.removedIncidenceMatrix(syst, BackendDAE.NORMAL(), SOME(funcs));
+        ixs = arrayCreate(arrayLength(m), 0);
+        rixs = arrayCreate(arrayLength(m), 0);
         // ixsT = arrayCreate(arrayLength(mT),0);
-        i = SynchronousFeatures.partitionIndependentBlocks0(m,mT,ixs);
+        i = SynchronousFeatures.partitionIndependentBlocks0(m, mT, rm, rmT, ixs, rixs);
         // i2 = SynchronousFeatures.partitionIndependentBlocks0(mT,m,ixsT);
         b = i > 1;
         // bcall2(b,BackendDump.dumpBackendDAE,BackendDAE.DAE({syst},shared), "partitionIndependentBlocksHelper");
         // printPartition(b,ixs);
-        systs = if b then SynchronousFeatures.partitionIndependentBlocksSplitBlocks(i,syst,ixs,mT,throwNoError) else {syst};
+        systs = if b then SynchronousFeatures.partitionIndependentBlocksSplitBlocks(i, syst, ixs, rixs, mT, throwNoError) else {syst};
         // print("Number of partitioned systems: " + intString(listLength(systs)) + "\n");
         // List.map1_0(systs, BackendDump.dumpEqSystem, "System");
       then (systs,shared);

--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -7636,9 +7636,10 @@ protected
   BackendDAE.EqSystems systs;
 algorithm
   (reqs, systs) := inTpl;
-  outTpl := if BackendVariable.varsSize(inSyst.orderedVars) == 0
-            then (listAppend(BackendEquation.equationList(inSyst.removedEqs), reqs), systs)
-            else (reqs, inSyst::systs);
+  outTpl := if BackendVariable.varsSize(inSyst.orderedVars) <> 0
+               or (isClockedSyst(inSyst) and BackendDAEUtil.equationArraySize(inSyst.removedEqs) <> 0)
+            then (reqs, inSyst::systs)
+            else (listAppend(BackendEquation.equationList(inSyst.removedEqs), reqs), systs);
 end filterEmptySystem;
 
 public function getAllVarLst "retrieve all variables of the dae by collecting them from each equation system and combining with known vars"
@@ -7651,6 +7652,16 @@ algorithm
   BackendDAE.DAE(eqs=eqs,shared = BackendDAE.SHARED(knownVars=knvars)) := dae;
   varLst := List.flatten(List.map(listAppend({knvars}, List.map(eqs, BackendVariable.daeVars)), BackendVariable.varList));
 end getAllVarLst;
+
+public function isClockedSyst
+  input BackendDAE.EqSystem inSyst;
+  output Boolean out;
+algorithm
+  out := match inSyst
+    case BackendDAE.EQSYSTEM(partitionKind=BackendDAE.CLOCKED_PARTITION()) then true;
+    else false;
+  end match;
+end isClockedSyst;
 
 public function getAlgorithms
   input BackendDAE.BackendDAE dae;

--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -262,31 +262,32 @@ public function checkBackendDAE "author: Frenkel TUD
   output list<tuple<DAE.Exp,list<DAE.ComponentRef>>> outExpCrefs;
   output list<BackendDAE.Equation> outWrongEqns;
 algorithm
-  (outExpCrefs,outWrongEqns) := matchcontinue (inBackendDAE)
+  (outExpCrefs,outWrongEqns) := matchcontinue inBackendDAE
     local
-      BackendDAE.Variables vars1,vars2,allvars;
-      BackendDAE.EquationArray eqns,reqns,ieqns;
-      list<BackendDAE.WhenClause> whenClauseLst;
-      list<BackendDAE.Var> varlst1,varlst2,allvarslst;
-      list<tuple<DAE.Exp,list<DAE.ComponentRef>>> expcrefs,expcrefs1,expcrefs2,expcrefs3,expcrefs4,expcrefs5;
-      list<BackendDAE.Equation> wrongEqns,wrongEqns1,wrongEqns2;
+      BackendDAE.EqSystem syst;
+      BackendDAE.Shared shared;
+      BackendDAE.Variables allvars;
+      list<tuple<DAE.Exp,list<DAE.ComponentRef>>> expcrefs;
+      list<BackendDAE.Equation> wrongEqns;
 
 
-    case (BackendDAE.DAE(eqs=BackendDAE.EQSYSTEM(orderedVars = vars1,orderedEqs = eqns)::{},shared=BackendDAE.SHARED(knownVars = vars2,initialEqs = ieqns,removedEqs = reqns,
-          eventInfo = BackendDAE.EVENT_INFO(whenClauseLst=whenClauseLst))))
+    case BackendDAE.DAE(syst::{}, shared)
       equation
-        allvars = BackendVariable.mergeVariables(vars1, vars2);
-        ((_,expcrefs)) = traverseBackendDAEExpsVars(vars1,checkBackendDAEExp,(allvars,{}));
-        ((_,expcrefs1)) = traverseBackendDAEExpsVars(vars2,checkBackendDAEExp,(allvars,expcrefs));
-        ((_,expcrefs2)) = traverseBackendDAEExpsEqns(eqns,checkBackendDAEExp,(allvars,expcrefs1));
-        ((_,expcrefs3)) = traverseBackendDAEExpsEqns(reqns,checkBackendDAEExp,(allvars,expcrefs2));
-        ((_,expcrefs4)) = traverseBackendDAEExpsEqns(ieqns,checkBackendDAEExp,(allvars,expcrefs3));
-        (_,(_,expcrefs5)) = BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(whenClauseLst,checkBackendDAEExp,(allvars,expcrefs4));
-        wrongEqns = BackendEquation.traverseEquationArray(eqns,checkEquationSize,{});
-        wrongEqns1 = BackendEquation.traverseEquationArray(reqns,checkEquationSize,wrongEqns);
-        wrongEqns2 = BackendEquation.traverseEquationArray(ieqns,checkEquationSize,wrongEqns1);
+        allvars = BackendVariable.mergeVariables(syst.orderedVars, shared.knownVars);
+        ((_, expcrefs)) = traverseBackendDAEExpsVars(syst.orderedVars, checkBackendDAEExp, (allvars, {}));
+       ((_, expcrefs)) = traverseBackendDAEExpsEqns(shared.removedEqs, checkBackendDAEExp, (allvars, expcrefs));
+        ((_, expcrefs)) = traverseBackendDAEExpsVars(shared.knownVars, checkBackendDAEExp, (allvars, expcrefs));
+        ((_, expcrefs)) = traverseBackendDAEExpsEqns(syst.orderedEqs, checkBackendDAEExp, (allvars, expcrefs));
+        ((_, expcrefs)) = traverseBackendDAEExpsEqns(syst.removedEqs, checkBackendDAEExp, (allvars, expcrefs));
+        ((_, expcrefs)) = traverseBackendDAEExpsEqns(shared.initialEqs, checkBackendDAEExp, (allvars, expcrefs));
+        (_, (_, expcrefs)) = BackendDAETransform.traverseBackendDAEExpsWhenClauseLst( shared.eventInfo.whenClauseLst, checkBackendDAEExp,
+                                                                                      (allvars, expcrefs) );
+        wrongEqns = BackendEquation.traverseEquationArray(syst.orderedEqs, checkEquationSize, {});
+        wrongEqns = BackendEquation.traverseEquationArray(shared.removedEqs, checkEquationSize, wrongEqns);
+        wrongEqns = BackendEquation.traverseEquationArray(syst.removedEqs, checkEquationSize, wrongEqns);
+        wrongEqns = BackendEquation.traverseEquationArray(shared.initialEqs, checkEquationSize, wrongEqns);
       then
-        (expcrefs5,wrongEqns2);
+        (expcrefs, wrongEqns);
 
     else
       equation
@@ -485,22 +486,18 @@ public function copyEqSystem
   input BackendDAE.EqSystem inSystem;
   output BackendDAE.EqSystem outSystem;
 protected
-  BackendDAE.Variables ordvars, ordvars1;
-  BackendDAE.EquationArray eqns, eqns1;
-  Option<BackendDAE.IncidenceMatrix> m, mT, m1, mT1;
-  BackendDAE.Matching matching, matching1;
-  BackendDAE.StateSets stateSets;
-  BackendDAE.BaseClockPartitionKind partitionKind;
+  BackendDAE.Variables vars;
+  BackendDAE.EquationArray eqns, removedEqs;
+  Option<BackendDAE.IncidenceMatrix> m, mt;
+  BackendDAE.Matching matching;
 algorithm
-  BackendDAE.EQSYSTEM(ordvars, eqns, m, mT, matching, stateSets, partitionKind) := inSystem;
-
-  ordvars1 := BackendVariable.copyVariables(ordvars);
-  eqns1 := BackendEquation.copyEquationArray(eqns);
-  m1 := copyIncidenceMatrix(m);
-  mT1 := copyIncidenceMatrix(mT);
-  matching1 := copyMatching(matching);
-
-  outSystem := BackendDAE.EQSYSTEM(ordvars1, eqns1, m1, mT1, matching1, stateSets, partitionKind);
+  vars := BackendVariable.copyVariables(inSystem.orderedVars);
+  eqns := BackendEquation.copyEquationArray(inSystem.orderedEqs);
+  removedEqs := BackendEquation.copyEquationArray(inSystem.removedEqs);
+  m := copyIncidenceMatrix(inSystem.m);
+  mt := copyIncidenceMatrix(inSystem.mT);
+  matching := copyMatching(inSystem.matching);
+  outSystem := BackendDAE.EQSYSTEM(vars, eqns, m, mt, matching, inSystem.stateSets, inSystem.partitionKind, removedEqs);
 end copyEqSystem;
 
 public function copyBackendDAEShared
@@ -561,17 +558,12 @@ public function numberOfZeroCrossings "author: lochel"
   output Integer outNumRelations;
   output Integer outNumMathEventFunctions;
 protected
-  list<BackendDAE.TimeEvent> timeEvents;
-  list<ZeroCrossing> zeroCrossingLst, relationsLst;
+  BackendDAE.EventInfo eventInfo = inBackendDAE.shared.eventInfo;
 algorithm
-  BackendDAE.SHARED(eventInfo=BackendDAE.EVENT_INFO(timeEvents=timeEvents,
-                                                    zeroCrossingLst=zeroCrossingLst,
-                                                    relationsLst=relationsLst,
-                                                    numberMathEvents=outNumMathEventFunctions)) := inBackendDAE.shared;
-
-  outNumZeroCrossings := listLength(zeroCrossingLst);
-  outNumTimeEvents := listLength(timeEvents);
-  outNumRelations := listLength(relationsLst);
+  outNumZeroCrossings := listLength(eventInfo.zeroCrossingLst);
+  outNumTimeEvents := listLength(eventInfo.timeEvents);
+  outNumRelations := listLength(eventInfo.relationsLst);
+  outNumMathEventFunctions := eventInfo.numberMathEvents;
 end numberOfZeroCrossings;
 
 public function numberOfDiscreteVars "author: lochel"
@@ -1784,20 +1776,13 @@ public function whenClauseAddDAE
 "author: Frenkel TUD 2011-05"
   input list<BackendDAE.WhenClause> inWcLst;
   input BackendDAE.Shared inShared;
-  output BackendDAE.Shared outShared;
+  output BackendDAE.Shared outShared = inShared;
+protected
+  BackendDAE.EventInfo eventInfo;
 algorithm
-  outShared := match inShared
-    local
-      BackendDAE.Shared shared;
-      BackendDAE.EventInfo eventInfo;
-      list<BackendDAE.WhenClause> wclst;
-
-    case shared as BackendDAE.SHARED(eventInfo=eventInfo as BackendDAE.EVENT_INFO(whenClauseLst=wclst))
-      equation
-        eventInfo.whenClauseLst = listAppend(wclst, inWcLst);
-        shared.eventInfo = eventInfo;
-      then shared;
-  end match;
+  eventInfo := outShared.eventInfo;
+  eventInfo.whenClauseLst := listAppend(inShared.eventInfo.whenClauseLst, inWcLst);
+  outShared.eventInfo := eventInfo;
 end whenClauseAddDAE;
 
 public function getStrongComponents
@@ -5709,26 +5694,21 @@ public function traverseBackendDAEExps "author: Frenkel TUD
     output Type_a outA;
   end FuncExpType;
 algorithm
-  outTypeA:=
-  matchcontinue (inBackendDAE,func,inTypeA)
+  outTypeA := matchcontinue inBackendDAE
     local
-      BackendDAE.Variables vars2;
-      BackendDAE.EquationArray reqns,ieqns;
-      list<BackendDAE.WhenClause> whenClauseLst;
-      Type_a ext_arg_1,ext_arg_2,ext_arg_4,ext_arg_5,ext_arg_6;
+      BackendDAE.Shared shared;
       list<BackendDAE.EqSystem> systs;
       String name;
 
-    case (BackendDAE.DAE( eqs=systs, shared=BackendDAE.SHARED(knownVars=vars2, initialEqs=ieqns, removedEqs=reqns,
-                          eventInfo = BackendDAE.EVENT_INFO(whenClauseLst=whenClauseLst) )), _, _)
+    case BackendDAE.DAE(systs, shared)
       equation
-        ext_arg_1 = List.fold1(systs,traverseBackendDAEExpsEqSystem,func,inTypeA);
-        ext_arg_2 = traverseBackendDAEExpsVars(vars2,func,ext_arg_1);
-        ext_arg_4 = traverseBackendDAEExpsEqns(reqns,func,ext_arg_2);
-        ext_arg_5 = traverseBackendDAEExpsEqns(ieqns,func,ext_arg_4);
-        (_,ext_arg_6) = BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(whenClauseLst,func,ext_arg_5);
+        outTypeA = List.fold1(systs, traverseBackendDAEExpsEqSystem, func, inTypeA);
+        outTypeA = traverseBackendDAEExpsVars(shared.knownVars, func, outTypeA);
+        outTypeA = traverseBackendDAEExpsEqns(shared.initialEqs, func, outTypeA);
+        outTypeA = traverseBackendDAEExpsEqns(shared.removedEqs, func, outTypeA);
+        (_, outTypeA) = BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(shared.eventInfo.whenClauseLst, func, outTypeA);
       then
-        ext_arg_6;
+        outTypeA;
 
     else equation
       (_, _, name) = System.dladdr(func);
@@ -5888,25 +5868,21 @@ public function traverseBackendDAEExpsNoCopyWithUpdate "
     output Type_a outA;
   end FuncExpType;
 algorithm
-  outTypeA:=
-  matchcontinue (inBackendDAE,func,inTypeA)
+  outTypeA := matchcontinue inBackendDAE
     local
-      BackendDAE.Variables vars2;
-      BackendDAE.EquationArray reqns,ieqns;
-      Type_a ext_arg_1,ext_arg_2,ext_arg_4,ext_arg_5,ext_arg_6;
       list<BackendDAE.EqSystem> systs;
-      list<BackendDAE.WhenClause> wc;
+      BackendDAE.Shared shared;
       String name;
 
-    case (BackendDAE.DAE(eqs=systs,shared=BackendDAE.SHARED(knownVars = vars2,initialEqs = ieqns,removedEqs = reqns,eventInfo=BackendDAE.EVENT_INFO(whenClauseLst=wc))),_,_)
+    case BackendDAE.DAE(systs, shared)
       equation
-        ext_arg_1 = List.fold1(systs,traverseBackendDAEExpsEqSystemWithUpdate,func,inTypeA);
-        ext_arg_2 = traverseBackendDAEExpsVarsWithUpdate(vars2,func,ext_arg_1);
-        ext_arg_4 = traverseBackendDAEExpsEqnsWithUpdate(reqns,func,ext_arg_2);
-        ext_arg_5 = traverseBackendDAEExpsEqnsWithUpdate(ieqns,func,ext_arg_4);
-        (_,ext_arg_6) = BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(wc,func,ext_arg_5);
+        outTypeA = List.fold1(systs, traverseBackendDAEExpsEqSystemWithUpdate, func, inTypeA);
+        outTypeA = traverseBackendDAEExpsVarsWithUpdate(shared.knownVars, func, outTypeA);
+        outTypeA = traverseBackendDAEExpsEqnsWithUpdate(shared.initialEqs, func, outTypeA);
+        outTypeA = traverseBackendDAEExpsEqnsWithUpdate(shared.removedEqs, func, outTypeA);
+        (_, outTypeA) = BackendDAETransform.traverseBackendDAEExpsWhenClauseLst(shared.eventInfo.whenClauseLst, func, outTypeA);
       then
-        ext_arg_6;
+        outTypeA;
 
     else equation
       (_, _, name) = System.dladdr(func);
@@ -5930,13 +5906,10 @@ public function traverseBackendDAEExpsEqSystem "This function goes through the B
     output DAE.Exp outExp;
     output Type_a outA;
   end FuncExpType;
-protected
-  BackendDAE.Variables vars;
-  BackendDAE.EquationArray eqns;
 algorithm
-  BackendDAE.EQSYSTEM(orderedVars = vars,orderedEqs = eqns) := syst;
-  outTypeA := traverseBackendDAEExpsVars(vars,func,inTypeA);
-  outTypeA := traverseBackendDAEExpsEqns(eqns,func,outTypeA);
+  outTypeA := traverseBackendDAEExpsVars(syst.orderedVars, func, inTypeA);
+  outTypeA := traverseBackendDAEExpsEqns(syst.orderedEqs, func, outTypeA);
+  outTypeA := traverseBackendDAEExpsEqns(syst.removedEqs, func, outTypeA);
 end traverseBackendDAEExpsEqSystem;
 
 public function traverseBackendDAEExpsEqSystemWithUpdate "This function goes through the BackendDAE structure and finds all the
@@ -5953,13 +5926,10 @@ public function traverseBackendDAEExpsEqSystemWithUpdate "This function goes thr
     output DAE.Exp outExp;
     output Type_a outA;
   end FuncExpType;
-protected
-  BackendDAE.Variables vars;
-  BackendDAE.EquationArray eqns;
 algorithm
-  BackendDAE.EQSYSTEM(orderedVars = vars,orderedEqs = eqns) := syst;
-  outTypeA := traverseBackendDAEExpsVarsWithUpdate(vars,func,inTypeA);
-  outTypeA := traverseBackendDAEExpsEqnsWithUpdate(eqns,func,outTypeA);
+  outTypeA := traverseBackendDAEExpsVarsWithUpdate(syst.orderedVars, func, inTypeA);
+  outTypeA := traverseBackendDAEExpsEqnsWithUpdate(syst.orderedEqs, func, outTypeA);
+  outTypeA := traverseBackendDAEExpsEqnsWithUpdate(syst.removedEqs, func, outTypeA);
 end traverseBackendDAEExpsEqSystemWithUpdate;
 
 public function traverseBackendDAEExpsVars "Helper for traverseBackendDAEExps"
@@ -7928,10 +7898,11 @@ public function createEqSystem
   input BackendDAE.EquationArray inEqs;
   input BackendDAE.StateSets inStateSets = {};
   input BackendDAE.BaseClockPartitionKind inPartitionKind = BackendDAE.UNKNOWN_PARTITION();
+  input BackendDAE.EquationArray removedEqs = BackendEquation.emptyEqns();
   output BackendDAE.EqSystem outSyst;
 algorithm
   outSyst := BackendDAE.EQSYSTEM( inVars, inEqs, NONE(), NONE(), BackendDAE.NO_MATCHING(),
-                                  inStateSets, inPartitionKind );
+                                  inStateSets, inPartitionKind, removedEqs );
 end createEqSystem;
 
 public function createEmptyShared
@@ -7946,7 +7917,7 @@ protected
   DAE.FunctionTree functions = DAEUtil.avlTreeNew();
 algorithm
   shared := BackendDAE.SHARED( emptyVars, emptyVars, emptyVars, emptyEqs, emptyEqs, {}, {}, cache, graph,
-                               DAEUtil.avlTreeNew(), BackendDAEUtil.emptyEventInfo(), {}, backendDAEType, {}, ei,
+                               DAEUtil.avlTreeNew(), emptyEventInfo(), {}, backendDAEType, {}, ei,
                                BackendDAE.PARTITIONS_INFO(emptyClocks()) );
 end createEmptyShared;
 
@@ -8082,12 +8053,13 @@ public function clearEqSyst
   output BackendDAE.EqSystem outSyst;
 protected
   BackendDAE.Variables vars;
-  BackendDAE.EquationArray eqs;
+  BackendDAE.EquationArray eqs, removedEqs;
   BackendDAE.StateSets stateSets;
   BackendDAE.BaseClockPartitionKind partitionKind;
 algorithm
-  BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqs, stateSets=stateSets, partitionKind=partitionKind) := inSyst;
-  outSyst := BackendDAE.EQSYSTEM( orderedVars=vars, orderedEqs=eqs, m=NONE(), mT=NONE(),
+  BackendDAE.EQSYSTEM( orderedVars=vars, orderedEqs=eqs, stateSets=stateSets, partitionKind=partitionKind,
+                       removedEqs=removedEqs ) := inSyst;
+  outSyst := BackendDAE.EQSYSTEM( orderedVars=vars, orderedEqs=eqs, m=NONE(), mT=NONE(), removedEqs=removedEqs,
                                   matching=BackendDAE.NO_MATCHING(), stateSets=stateSets, partitionKind=partitionKind );
 end clearEqSyst;
 
@@ -8105,19 +8077,13 @@ algorithm
   end match;
 end setEqSystMatching;
 
-public function setSharedRemovedEqns
-  input BackendDAE.Shared inShared;
+public function setEqSystRemovedEqns
+  input BackendDAE.EqSystem inSyst;
   input BackendDAE.EquationArray removedEqs;
-  output BackendDAE.Shared outShared;
+  output BackendDAE.EqSystem outSyst = inSyst;
 algorithm
-  outShared := match inShared
-    local
-      BackendDAE.Shared shared;
-    case shared as BackendDAE.SHARED()
-      algorithm shared.removedEqs := removedEqs;
-      then shared;
-  end match;
-end setSharedRemovedEqns;
+  outSyst.removedEqs := removedEqs;
+end setEqSystRemovedEqns;
 
 public function setSharedInitialEqns
   input BackendDAE.Shared inShared;
@@ -8164,15 +8130,9 @@ end setSharedFunctionTree;
 public function setSharedEventInfo
   input BackendDAE.Shared inShared;
   input BackendDAE.EventInfo eventInfo;
-  output BackendDAE.Shared outShared;
+  output BackendDAE.Shared outShared = inShared;
 algorithm
-  outShared := match inShared
-    local
-      BackendDAE.Shared shared;
-    case shared as BackendDAE.SHARED()
-      algorithm shared.eventInfo := eventInfo;
-      then shared;
-  end match;
+  outShared.eventInfo := eventInfo;
 end setSharedEventInfo;
 
 public function setSharedKnVars
@@ -8219,6 +8179,24 @@ algorithm
       then shared;
   end match;
 end setSharedOptimica;
+
+public function collapseRemovedEqs
+  input BackendDAE.BackendDAE inDAE;
+  output BackendDAE.EquationArray outEqns;
+protected
+  list<BackendDAE.Equation> eqsLst;
+algorithm
+  eqsLst := List.fold(inDAE.eqs, collapseRemovedEqs1, {});
+  outEqns := BackendEquation.listEquation(listAppend(eqsLst, BackendEquation.equationList(inDAE.shared.removedEqs)));
+end collapseRemovedEqs;
+
+protected function collapseRemovedEqs1
+  input BackendDAE.EqSystem inSyst;
+  input list<BackendDAE.Equation> inEqns;
+  output list<BackendDAE.Equation> outEqns;
+algorithm
+  outEqns := listAppend(BackendEquation.equationList(inSyst.removedEqs), inEqns);
+end collapseRemovedEqs1;
 
 public function emptyEventInfo
   output BackendDAE.EventInfo info;

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -596,7 +596,6 @@ algorithm
   print("\n");
 end dumpClocks;
 
-
 public function dumpVariables "function dumpVariables"
   input BackendDAE.Variables inVars;
   input String heading;

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -104,7 +104,7 @@ algorithm
   BackendDAE.DAE(eqs, shared) := inBackendDAE;
   List.map_0(eqs, printEqSystem);
   print("\n");
-  printShared(shared);
+  printShared(eqs, shared);
 end printBackendDAE;
 
 public function printEqSystem "This function prints the BackendDAE.EqSystem representation to stdout."
@@ -256,6 +256,7 @@ public function printClassAttributes "This unction print the  Optimica ClassAttr
 end printClassAttributes;
 
 public function printShared "This function dumps the BackendDAE.Shared representation to stdout."
+  input BackendDAE.EqSystems inSysts "for backward compatibility";
   input BackendDAE.Shared inShared;
 protected
   BackendDAE.Variables knownVars, externalObjects, aliasVars;
@@ -272,17 +273,16 @@ algorithm
                     externalObjects=externalObjects,
                     aliasVars=aliasVars,
                     initialEqs=initialEqs,
-                    removedEqs=removedEqs,
                     constraints=constraints,
                     eventInfo=BackendDAE.EVENT_INFO( timeEvents=timeEvents, relationsLst=relationsLst, zeroCrossingLst=zeroCrossingLst,
                                                      sampleLst=sampleLst, whenClauseLst=whenClauseLst ),
                     extObjClasses=extObjClasses,
                     backendDAEType=backendDAEType,
                     symjacs=symjacs) := inShared;
+  removedEqs := BackendDAEUtil.collapseRemovedEqs(BackendDAE.DAE(inSysts, inShared));
   print("\nBackendDAEType: ");
   printBackendDAEType(backendDAEType);
   print("\n\n");
-
 
   dumpVariables(knownVars, "Known Variables (constants)");
   dumpVariables(externalObjects, "External Objects");
@@ -3267,7 +3267,7 @@ algorithm
       print(headerline + ":\n");
       List.map_0(eqs, printEqSystem);
       print("\n");
-      printShared(shared);
+      printShared(eqs, shared);
     then ();
   end matchcontinue;
 end bltdump;
@@ -3308,7 +3308,8 @@ protected
   DumpCompShortTornTpl tornTpl;
   BackendDAE.BackendDAEType backendDAEType;
 algorithm
-  BackendDAE.DAE(systs, BackendDAE.SHARED(removedEqs=removedEqs, backendDAEType=backendDAEType)) := inDAE;
+  BackendDAE.DAE(systs, BackendDAE.SHARED(backendDAEType=backendDAEType)) := inDAE;
+  removedEqs := BackendDAEUtil.collapseRemovedEqs(inDAE);
   daeType := printBackendDAEType2String(backendDAEType);
 
   HS := HashSet.emptyHashSet();

--- a/Compiler/BackEnd/BackendEquation.mo
+++ b/Compiler/BackEnd/BackendEquation.mo
@@ -1250,41 +1250,42 @@ public function equationAddDAE "author: Frenkel TUD 2011-05"
   output BackendDAE.EqSystem outEqSystem;
 algorithm
   outEqSystem := BackendDAEUtil.setEqSystEqs(inEqSystem, addEquation(inEquation, inEqSystem.orderedEqs));
-  outEqSystem := BackendDAEUtil.setEqSystMatching(outEqSystem, BackendDAE.NO_MATCHING());
+  outEqSystem.matching := BackendDAE.NO_MATCHING();
 end equationAddDAE;
 
 public function equationsAddDAE "author: Frenkel TUD 2011-05"
   input list<BackendDAE.Equation> inEquations;
   input BackendDAE.EqSystem inEqSystem;
-  output BackendDAE.EqSystem outEqSystem;
+  output BackendDAE.EqSystem outEqSystem = inEqSystem;
 algorithm
-  outEqSystem := BackendDAEUtil.setEqSystEqs(inEqSystem, List.fold(inEquations, addEquation, inEqSystem.orderedEqs));
-  outEqSystem := BackendDAEUtil.setEqSystMatching(outEqSystem, BackendDAE.NO_MATCHING());
+  outEqSystem.orderedEqs := addEquations(inEquations, outEqSystem.orderedEqs);
+  outEqSystem.matching := BackendDAE.NO_MATCHING();
 end equationsAddDAE;
 
 public function requationsAddDAE "author: Frenkel TUD 2012-10
   Add a list of equations to removed equations of a BackendDAE.
   If the variable already exists, the function updates the variable."
   input list<BackendDAE.Equation> inEquations;
-  input BackendDAE.Shared inShared;
-  output BackendDAE.Shared outShared;
+  input BackendDAE.EqSystem inSyst;
+  output BackendDAE.EqSystem outSyst;
 algorithm
-  outShared := match inEquations
-    case {} then inShared;
-    else  then BackendDAEUtil.setSharedRemovedEqns(inShared, List.fold(inEquations, addEquation, inShared.removedEqs));
+  outSyst := match inEquations
+    case {} then inSyst;
+    else  then BackendDAEUtil.setEqSystRemovedEqns(inSyst, List.fold(inEquations, addEquation, inSyst.removedEqs));
   end match;
 end requationsAddDAE;
 
 public function removeRemovedEqs "remove removedEqs"
-  input BackendDAE.Shared inShared;
-  output BackendDAE.Shared outShared;
+  input BackendDAE.EqSystem inSyst;
+  output BackendDAE.EqSystem outSyst = inSyst;
 protected
-  BackendDAE.EquationArray removedEqs = inShared.removedEqs;
+  BackendDAE.EquationArray removedEqs = inSyst.removedEqs;
+  Integer N;
 algorithm
   for i in 1:removedEqs.numberOfElement loop
     removedEqs := equationRemove(i, removedEqs);
   end for;
-  outShared := BackendDAEUtil.setSharedRemovedEqns(inShared, removedEqs);
+  outSyst.removedEqs := removedEqs;
 end removeRemovedEqs;
 
 public function setAtIndex "author: lochel

--- a/Compiler/BackEnd/BackendEquation.mo
+++ b/Compiler/BackEnd/BackendEquation.mo
@@ -350,6 +350,16 @@ algorithm
   end matchcontinue;
 end traversingStateRefFinder;
 
+public function assertWithCondTrue "author: Frenkel TUD 2012-12"
+  input BackendDAE.Equation inEqn;
+  output Boolean b;
+algorithm
+  b := match inEqn
+    case BackendDAE.ALGORITHM(alg=DAE.ALGORITHM_STMTS({DAE.STMT_ASSERT(cond=DAE.BCONST(true))})) then false;
+    else true;
+  end match;
+end assertWithCondTrue;
+
 public function equationsParams "author: marcusw
   From a list of equations return all occurring parameter variables. Duplicates are removed."
   input list<BackendDAE.Equation> inEquationLst;

--- a/Compiler/BackEnd/BackendInline.mo
+++ b/Compiler/BackEnd/BackendInline.mo
@@ -80,7 +80,7 @@ algorithm
       BackendDAE.EqSystems eqs;
       BackendDAE.Shared shared;
 
-    case BackendDAE.DAE(eqs, shared as BackendDAE.SHARED())
+    case BackendDAE.DAE(eqs, shared)
       algorithm
         tpl := (SOME(shared.functionTree), inITLst);
         eqs := List.map1(eqs, inlineEquationSystem, tpl);
@@ -104,21 +104,11 @@ end inlineCalls;
 protected function inlineEquationSystem
   input BackendDAE.EqSystem eqs;
   input Inline.Functiontuple tpl;
-  output BackendDAE.EqSystem oeqs;
+  output BackendDAE.EqSystem oeqs = eqs;
 algorithm
-  oeqs := match eqs
-    local
-      BackendDAE.EqSystem syst;
-      BackendDAE.Variables orderedVars;
-      BackendDAE.EquationArray orderedEqs;
-
-    case syst as BackendDAE.EQSYSTEM(orderedVars=orderedVars, orderedEqs=orderedEqs)
-      equation
-        _ = inlineVariables(orderedVars, tpl);
-        _ = inlineEquationArray(orderedEqs, tpl);
-      then
-        syst;
-  end match;
+  inlineVariables(oeqs.orderedVars, tpl);
+  inlineEquationArray(oeqs.orderedEqs, tpl);
+  inlineEquationArray(oeqs.removedEqs, tpl);
 end inlineEquationSystem;
 
 protected function inlineEquationArray "

--- a/Compiler/BackEnd/DAEQuery.mo
+++ b/Compiler/BackEnd/DAEQuery.mo
@@ -85,24 +85,14 @@ public function getEquations
   This function returns the equations"
   input BackendDAE.BackendDAE inBackendDAE;
   output String strEqs;
+protected
+  BackendDAE.Shared shared;
+  BackendDAE.EqSystem syst;
+  list<String> ls1;
 algorithm
-  strEqs := match (inBackendDAE)
-    local
-      String s,s1;
-      list<String> ls1;
-      list<BackendDAE.Equation> eqnsl;
-      BackendDAE.EquationArray eqns;
-      list<BackendDAE.WhenClause> wcLst;
-
-    case (BackendDAE.DAE(eqs=BackendDAE.EQSYSTEM(orderedEqs = eqns)::{}, shared=BackendDAE.SHARED(eventInfo = BackendDAE.EVENT_INFO(whenClauseLst = wcLst))))
-      equation
-        eqnsl = BackendEquation.equationList(eqns);
-        ls1 = List.map1(eqnsl, equationStr, wcLst);
-        s1 = stringDelimitList(ls1, ",");
-        s = "EqStr = {" + s1 + "};";
-      then
-        s;
-  end match;
+    BackendDAE.DAE({syst}, shared) := inBackendDAE;
+    ls1 := List.map1(BackendEquation.equationList(syst.orderedEqs), equationStr, shared.eventInfo.whenClauseLst);
+    strEqs := "EqStr = {" + stringDelimitList(ls1, ",") + "};";
 end getEquations;
 
 public function equationStr

--- a/Compiler/BackEnd/DynamicOptimization.mo
+++ b/Compiler/BackEnd/DynamicOptimization.mo
@@ -903,10 +903,11 @@ algorithm
     //BackendDump.bltdump("START:reduceDynamicOptimization", inDAE);
     BackendDAE.DAE(systlst, shared) := inDAE;
     // ToDo
-    shared := BackendEquation.removeRemovedEqs(shared);
     shared := BackendVariable.removeAliasVars(shared);
 
     for syst in systlst loop
+
+      syst := BackendEquation.removeRemovedEqs(syst);
 
       BackendDAE.EQSYSTEM(orderedVars = v) := syst;
       varlst := BackendVariable.varList(v);

--- a/Compiler/BackEnd/EvaluateParameter.mo
+++ b/Compiler/BackEnd/EvaluateParameter.mo
@@ -1064,26 +1064,24 @@ protected function replaceEvaluatedParametersEqns "author Frenkel TUD"
   input BackendVarTransform.VariableReplacements inRepl;
   output BackendDAE.BackendDAE outDAE;
 protected
-  BackendDAE.EquationArray remeqns, inieqns;
-  list<BackendDAE.Equation> eqnslst;
+  list<BackendDAE.Equation> lsteqns;
   BackendDAE.EqSystems systs;
   Boolean b;
   BackendDAE.Shared shared;
 algorithm
-  BackendDAE.DAE(systs, shared as BackendDAE.SHARED(initialEqs=inieqns, removedEqs=remeqns)) := inDAE;
+  BackendDAE.DAE(systs, shared) := inDAE;
 
   // do replacements in initial equations
-  eqnslst := BackendEquation.equationList(inieqns);
-  (eqnslst, b) := BackendVarTransform.replaceEquations(eqnslst, inRepl, NONE());
+  lsteqns := BackendEquation.equationList(shared.initialEqs);
+  (lsteqns, b) := BackendVarTransform.replaceEquations(lsteqns, inRepl, NONE());
   if b then
-    shared := BackendDAEUtil.setSharedInitialEqns(shared, BackendEquation.listEquation(eqnslst));
+    shared.initialEqs :=  BackendEquation.listEquation(lsteqns);
   end if;
 
-  // do replacements in simple equations
-  eqnslst := BackendEquation.equationList(remeqns);
-  (eqnslst, b) := BackendVarTransform.replaceEquations(eqnslst, inRepl, NONE());
+  lsteqns := BackendEquation.equationList(shared.removedEqs);
+  (lsteqns, b) := BackendVarTransform.replaceEquations(lsteqns, inRepl, NONE());
   if b then
-    shared := BackendDAEUtil.setSharedRemovedEqns(shared, BackendEquation.listEquation(eqnslst));
+    shared.initialEqs :=  BackendEquation.listEquation(lsteqns);
   end if;
 
   // do replacements in systems
@@ -1096,18 +1094,26 @@ protected function replaceEvaluatedParametersSystemEqns
 "author Frenkel TUD
   replace the evaluated parameters in the equationsystems"
   input BackendDAE.EqSystem isyst;
-  input BackendVarTransform.VariableReplacements repl;
-  output BackendDAE.EqSystem osyst;
+  input BackendVarTransform.VariableReplacements inRepl;
+  output BackendDAE.EqSystem osyst = isyst;
 protected
-  BackendDAE.EquationArray eqns, eqns1;
   list<BackendDAE.Equation> lsteqns;
   Boolean b;
 algorithm
-  BackendDAE.EQSYSTEM(orderedEqs=eqns) := isyst;
-  lsteqns := BackendEquation.equationList(eqns);
-  (lsteqns, b) := BackendVarTransform.replaceEquations(lsteqns, repl, NONE());
-  eqns1 := if b then BackendEquation.listEquation(lsteqns) else eqns;
-  osyst := if b then BackendDAEUtil.clearEqSyst(BackendDAEUtil.setEqSystEqs(isyst, eqns1)) else isyst;
+  lsteqns := BackendEquation.equationList(osyst.orderedEqs);
+  (lsteqns, b) := BackendVarTransform.replaceEquations(lsteqns, inRepl, NONE());
+  if b then
+    osyst.orderedEqs := BackendEquation.listEquation(lsteqns);
+    osyst := BackendDAEUtil.clearEqSyst(osyst);
+  end if;
+
+  // do replacements in simple equations
+  lsteqns := BackendEquation.equationList(osyst.removedEqs);
+  (lsteqns, b) := BackendVarTransform.replaceEquations(lsteqns, inRepl, NONE());
+  if b then
+    osyst.removedEqs := BackendEquation.listEquation(lsteqns);
+  end if;
+
 end replaceEvaluatedParametersSystemEqns;
 
 annotation(__OpenModelica_Interface="backend");

--- a/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/Compiler/BackEnd/FindZeroCrossings.mo
@@ -72,59 +72,29 @@ public function encapsulateWhenConditions "author: lochel"
 protected
   BackendDAE.EqSystems systs;
   BackendDAE.Shared shared;
-  BackendDAE.EquationArray removedEqs;
-
-  list<BackendDAE.TimeEvent> timeEvents;
-  list<BackendDAE.WhenClause> whenClauseLst;
-  list<BackendDAE.ZeroCrossing> zeroCrossingLst;
-  list<BackendDAE.ZeroCrossing> sampleLst;
-  list<BackendDAE.ZeroCrossing> relationsLst;
-  Integer numberMathEvents;
-
+  BackendDAE.EventInfo eventInfo;
+  list<BackendDAE.WhenClause> wcl;
   Integer index;
   HashTableExpToIndex.HashTable ht "is used to avoid redundant condition-variables";
   list<BackendDAE.Var> vars;
   list<BackendDAE.Equation> eqns;
   BackendDAE.Variables vars_;
   BackendDAE.EquationArray eqns_;
-  BackendDAE.ExtraInfo info;
-  BackendDAE.EventInfo eventInfo;
 
 algorithm
   BackendDAE.DAE(systs, shared) := inDAE;
-  BackendDAE.SHARED(removedEqs=removedEqs, eventInfo=eventInfo) := shared;
-  BackendDAE.EVENT_INFO( timeEvents=timeEvents,
-                         whenClauseLst=whenClauseLst,
-                         zeroCrossingLst=zeroCrossingLst,
-                         sampleLst=sampleLst,
-                         relationsLst=relationsLst,
-                         numberMathEvents=numberMathEvents ) := eventInfo;
 
   ht := HashTableExpToIndex.emptyHashTable();
-
-  // equation system
   (systs, index, ht) := List.mapFold2(systs, encapsulateWhenConditions_EqSystem, 1, ht);
 
   // when clauses
-  (whenClauseLst, vars, eqns, ht, index) := encapsulateWhenConditions_WhenClause(whenClauseLst, {}, {}, {}, ht, index);
-
-  // removed equations
-  ((removedEqs, vars, eqns, index, ht)) :=
-      BackendEquation.traverseEquationArray( removedEqs, encapsulateWhenConditions_Equation,
-                                             (BackendEquation.emptyEqns(), vars, eqns, index, ht) );
+  eventInfo := shared.eventInfo;
+  (wcl, vars, eqns, ht, index) := encapsulateWhenConditions_WhenClause(eventInfo.whenClauseLst, {}, {}, {}, ht, index);
+  eventInfo.whenClauseLst := wcl;
+  shared.eventInfo := eventInfo;
   vars_ := BackendVariable.listVar(vars);
   eqns_ := BackendEquation.listEquation(eqns);
   systs := listAppend(systs, {BackendDAEUtil.createEqSystem(vars_, eqns_)});
-
-  eventInfo := BackendDAE.EVENT_INFO(timeEvents,
-                                     whenClauseLst,
-                                     zeroCrossingLst,
-                                     sampleLst,
-                                     relationsLst,
-                                     numberMathEvents);
-
-  shared := BackendDAEUtil.setSharedEventInfo(shared, eventInfo);
-  shared := BackendDAEUtil.setSharedRemovedEqns(shared, removedEqs);
 
   outDAE := if intGt(index, 1) then BackendDAE.DAE(systs, shared) else inDAE;
   if Flags.isSet(Flags.DUMP_ENCAPSULATECONDITIONS) then
@@ -182,7 +152,7 @@ algorithm
   outEqSystem := match inEqSystem
     local
       BackendDAE.Variables orderedVars;
-      BackendDAE.EquationArray orderedEqs;
+      BackendDAE.EquationArray orderedEqs, removedEqs;
       BackendDAE.EqSystem syst;
       list<BackendDAE.Var> varLst;
       list<BackendDAE.Equation> eqnLst;
@@ -191,6 +161,13 @@ algorithm
         ((orderedEqs, varLst, eqnLst, outIndex, outHT)) :=
             BackendEquation.traverseEquationArray( orderedEqs, encapsulateWhenConditions_Equation,
                                                    (BackendEquation.emptyEqns(), {}, {}, inIndex, inHT) );
+
+        // removed equations
+        ((removedEqs, varLst, eqnLst, outIndex, outHT)) :=
+            BackendEquation.traverseEquationArray( syst.removedEqs, encapsulateWhenConditions_Equation,
+                                                   (BackendEquation.emptyEqns(), varLst, eqnLst, outIndex, outHT) );
+        syst.removedEqs := removedEqs;
+
         syst.orderedVars := BackendVariable.addVars(varLst, orderedVars);
         syst.orderedEqs := BackendEquation.addEquations(eqnLst, orderedEqs);
       then BackendDAEUtil.clearEqSyst(syst);

--- a/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/Compiler/BackEnd/FindZeroCrossings.mo
@@ -59,33 +59,6 @@ protected import List;
 protected import Util;
 
 // =============================================================================
-// section for some public util functions
-//
-// =============================================================================
-
-public function getZeroCrossings
-  input BackendDAE.BackendDAE inBackendDAE;
-  output list<BackendDAE.ZeroCrossing> outZeroCrossingList;
-algorithm
-  BackendDAE.DAE(shared=BackendDAE.SHARED(eventInfo=BackendDAE.EVENT_INFO(zeroCrossingLst=outZeroCrossingList))) := inBackendDAE;
-end getZeroCrossings;
-
-public function getRelations
-  input BackendDAE.BackendDAE inBackendDAE;
-  output list<BackendDAE.ZeroCrossing> outZeroCrossingList;
-algorithm
-  BackendDAE.DAE(shared=BackendDAE.SHARED(eventInfo=BackendDAE.EVENT_INFO(relationsLst=outZeroCrossingList))) := inBackendDAE;
-end getRelations;
-
-public function getSamples "deprecated - use EVENT_INFO.timeEvents instead"
-  input BackendDAE.BackendDAE inBackendDAE;
-  output list<BackendDAE.ZeroCrossing> outZeroCrossingList;
-algorithm
-  BackendDAE.DAE(shared=BackendDAE.SHARED(eventInfo=BackendDAE.EVENT_INFO(sampleLst=outZeroCrossingList))) := inBackendDAE;
-end getSamples;
-
-
-// =============================================================================
 // section for preOptModule >>encapsulateWhenConditions<<
 //
 // This module encapsulates each when-condition in a boolean-variable

--- a/Compiler/BackEnd/HpcOmTaskGraph.mo
+++ b/Compiler/BackEnd/HpcOmTaskGraph.mo
@@ -5943,6 +5943,7 @@ algorithm
       array<tuple<Integer,Integer,Integer>> varCompMap;
       TaskGraph graph;
       TaskGraphMeta graphData;
+      BackendDAE.EqSystems systs;
       BackendDAE.EquationArray remEqs;
       BackendDAE.Shared shared;
       list<BackendDAE.Equation> eqLst;
@@ -5960,8 +5961,8 @@ algorithm
       array<ComponentInfo> compInformations1, compInformations2;
   case(_,_,_)
     equation
-      BackendDAE.DAE(shared = shared) = dae;
-      BackendDAE.SHARED(removedEqs=remEqs) = shared;
+      BackendDAE.DAE(eqs = systs, shared = shared) = dae;
+      remEqs = BackendDAEUtil.collapseRemovedEqs(dae);
       TASKGRAPHMETA(varCompMapping=varCompMap) = graphDataIn;
       eqLst = BackendEquation.equationList(remEqs);
       numNewComps = listLength(eqLst);

--- a/Compiler/BackEnd/RemoveSimpleEquations.mo
+++ b/Compiler/BackEnd/RemoveSimpleEquations.mo
@@ -3571,9 +3571,9 @@ algorithm
         ((_, eqnslst, b1)) = BackendEquation.traverseEquationArray(shared.initialEqs, replaceEquationTraverser, (repl, {}, false));
         shared.initialEqs = if b1 then BackendEquation.listEquation(eqnslst) else shared.initialEqs;
 
-        ((_, eqnslst, b1)) = BackendEquation.traverseEquationArray(shared.removedEqs, replaceEquationTraverser, (repl, {}, false));
-        eqnslst = List.select(eqnslst, assertWithCondTrue);
-        shared.removedEqs = if b1 then BackendEquation.listEquation(eqnslst) else shared.removedEqs;
+        ((_, eqnslst, _)) = BackendEquation.traverseEquationArray(shared.removedEqs, replaceEquationTraverser, (repl, {}, false));
+        eqnslst = List.select(eqnslst, BackendEquation.assertWithCondTrue);
+        shared.removedEqs = BackendEquation.listEquation(eqnslst);
 
         (eventInfo.whenClauseLst, _) =
             BackendVarTransform.replaceWhenClauses(eventInfo.whenClauseLst, repl, SOME(BackendVarTransform.skipPreChangeEdgeOperator));
@@ -3672,16 +3672,6 @@ algorithm
   end matchcontinue;
 end replaceVarTraverser;
 
-protected function assertWithCondTrue "author: Frenkel TUD 2012-12"
-  input BackendDAE.Equation inEqn;
-  output Boolean b;
-algorithm
-  b := match inEqn
-    case BackendDAE.ALGORITHM(alg=DAE.ALGORITHM_STMTS({DAE.STMT_ASSERT(cond=DAE.BCONST(true))})) then false;
-    else true;
-  end match;
-end assertWithCondTrue;
-
 protected function removeSimpleEquationsShared1 "author: Frenkel TUD 2012-12"
   input BackendDAE.EqSystems inSysts;
   input BackendDAE.EqSystems inSysts1;
@@ -3715,7 +3705,7 @@ algorithm
 
         ((_, eqnslst, _)) := BackendEquation.traverseEquationArray(syst.removedEqs, replaceEquationTraverser, (repl, {}, false));
         // remove asserts with condition=true from removed equations
-        eqnslst := List.select(eqnslst, assertWithCondTrue);
+        eqnslst := List.select(eqnslst, BackendEquation.assertWithCondTrue);
         syst.removedEqs := BackendEquation.listEquation(eqnslst);
       then
         removeSimpleEquationsShared1(rest, syst::inSysts1, repl, statesetrepl1, aliasVars);
@@ -4421,12 +4411,12 @@ algorithm
       remEqList = BackendEquation.equationList(syst.removedEqs);
       (remEqList,_) = BackendEquation.traverseExpsOfEquationList(remEqList, traverseExpTopDown, HTCrToExp);
       //remove asserts with condition=true from removed equations
-      syst.removedEqs = BackendEquation.listEquation(List.select(remEqList, assertWithCondTrue));
+      syst.removedEqs = BackendEquation.listEquation(List.select(remEqList, BackendEquation.assertWithCondTrue));
 
       remEqList = BackendEquation.equationList(shared.removedEqs);
       (remEqList,_) = BackendEquation.traverseExpsOfEquationList(remEqList, traverseExpTopDown, HTCrToExp);
       //remove asserts with condition=true from removed equations
-      shared.removedEqs = BackendEquation.listEquation(List.select(remEqList, assertWithCondTrue));
+      shared.removedEqs = BackendEquation.listEquation(List.select(remEqList, BackendEquation.assertWithCondTrue));
 
 
       // BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB

--- a/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/Compiler/BackEnd/SynchronousFeatures.mo
@@ -115,6 +115,7 @@ algorithm
 
   if Flags.isSet(Flags.DUMP_SYNCHRONOUS) then
     BackendDump.dumpEqSystems(systs, "base-clock partitioning");
+    BackendDump.dumpClocks(baseClocks, "Base clocks");
   end if;
 end clockPartitioning1;
 

--- a/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/Compiler/BackEnd/SynchronousFeatures.mo
@@ -98,11 +98,12 @@ protected
   BackendDAE.Shared shared;
   list<BackendDAE.EqSystem> systs;
   BackendDAE.Variables vars;
-  BackendDAE.EquationArray eqs;
+  BackendDAE.EquationArray eqs, removedEqs;
   BackendDAE.BaseClockPartitionKind partitionKind;
   list<DAE.ComponentRef> holdComps;
   array<Integer> varsPartition;
 algorithm
+  removedEqs := inSyst.removedEqs;
   syst := substituteParitionOpExps(inSyst);
 
   (contSysts, clockedSysts) := baseClockPartitioning(syst, inShared);
@@ -111,6 +112,12 @@ algorithm
 
   //Continuous system always first in equation systems list
   systs := listAppend(contSysts, clockedSysts);
+  (syst, systs) := match systs
+    case {} then (BackendDAEUtil.createEqSystem(BackendVariable.emptyVars(), BackendEquation.emptyEqns()), {});
+    case syst::systs then (syst, systs);
+  end match;
+  syst.removedEqs := removedEqs;
+  systs := syst::systs;
   outDAE := BackendDAE.DAE(systs, setClocks(inShared, baseClocks));
 
   if Flags.isSet(Flags.DUMP_SYNCHRONOUS) then

--- a/Compiler/BackEnd/Vectorization.mo
+++ b/Compiler/BackEnd/Vectorization.mo
@@ -1433,6 +1433,7 @@ algorithm
         syst.orderedVars := BackendVariable.listVar1(varLst);
         shared.aliasVars := BackendVariable.listVar1(aliasLst);
         shared.knownVars := BackendVariable.listVar1(knownLst);
+        syst.removedEqs := BackendEquation.listEquation({});
         shared.removedEqs := BackendEquation.listEquation({});
         syst.orderedEqs := BackendEquation.listEquation(eqLst);
         //BackendDump.dumpEquationList(eqLst,"eqsOut");

--- a/Compiler/BackEnd/XMLDump.mo
+++ b/Compiler/BackEnd/XMLDump.mo
@@ -1030,14 +1030,15 @@ algorithm
                  vars_knownVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_knownVars),
                  vars_externalObject as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_externalObject),
                  vars_aliasVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_aliasVars),
-                 ieqns,reqns,constrs,_,_,_,funcs,
-                 eventInfo,
+                 ieqns,_,constrs,_,_,_,funcs,eventInfo,
                  extObjCls,_,_,_)),addOrInMatrix,addSolInfo,addMML,dumpRes,false)
       equation
 
         knvars  = BackendVariable.varList(vars_knownVars);
         extvars = BackendVariable.varList(vars_externalObject);
         aliasvars = BackendVariable.varList(vars_aliasVars);
+
+        reqns = BackendDAEUtil.collapseRemovedEqs(inBackendDAE);
 
         Print.printBuf(HEADER);
         dumpStrOpenTag(DAE_OPEN);
@@ -1071,13 +1072,15 @@ algorithm
                  vars_knownVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_knownVars),
                  vars_externalObject as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_externalObject),
                  vars_aliasVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_aliasVars),
-                 ieqns,reqns,constrs,_,_,_,funcs,
-                 eventInfo,extObjCls,_,_,_)),addOrInMatrix,addSolInfo,addMML,dumpRes,true)
+                 ieqns,_,constrs,_,_,_,funcs,eventInfo,
+                 extObjCls,_,_,_,_)),addOrInMatrix,addSolInfo,addMML,dumpRes,true)
       equation
 
         knvars  = BackendVariable.varList(vars_knownVars);
         extvars = BackendVariable.varList(vars_externalObject);
         aliasvars = BackendVariable.varList(vars_aliasVars);
+
+        reqns = BackendDAEUtil.collapseRemovedEqs(inBackendDAE);
 
         Print.printBuf(HEADER);
         dumpStrOpenTag(DAE_OPEN);

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -163,7 +163,6 @@ public function createSimCode "entry point to create SimCode from BackendDAE."
 protected
   BackendDAE.BackendDAE dlow;
   BackendDAE.BackendDAE initDAE;
-  BackendDAE.EqSystems systs;
   BackendDAE.EquationArray removedEqs;
   BackendDAE.Shared shared;
   BackendDAE.SymbolicJacobians symJacs;
@@ -215,6 +214,7 @@ protected
   list<list<SimCode.SimEqSystem>> odeEquations;         // --> functionODE
   list<tuple<Integer, tuple<DAE.Exp, DAE.Exp, DAE.Exp>>> delayedExps;
   list<tuple<Integer,Integer>> equationSccMapping, eqBackendSimCodeMapping;
+  BackendDAE.EventInfo eventInfo;
 algorithm
   try
     dlow := inBackendDAE;
@@ -258,19 +258,20 @@ algorithm
     dlow := BackendDAEOptimize.addInitialStmtsToAlgorithms(dlow);
 
     BackendDAE.DAE(shared=shared as BackendDAE.SHARED(knownVars=knownVars,
-                                                      removedEqs=removedEqs,
                                                       constraints=constraints,
                                                       classAttrs=classAttributes,
+                                                      removedEqs=removedEqs,
                                                       symjacs=symJacs,
                                                       partitionsInfo=BackendDAE.PARTITIONS_INFO(baseClocks),
-                                                      eventInfo=BackendDAE.EVENT_INFO(timeEvents=timeEvents))) := dlow;
+                                                      eventInfo=eventInfo)) := dlow;
 
-    // created event suff e.g. zeroCrossings, samples, ...
-    whenClauses := createSimWhenClauses(dlow);
-    zeroCrossings := if ifcpp then FindZeroCrossings.getRelations(dlow) else FindZeroCrossings.getZeroCrossings(dlow);
-    relations := FindZeroCrossings.getRelations(dlow);
-    sampleZC := FindZeroCrossings.getSamples(dlow);
-    zeroCrossings := if ifcpp then listAppend(zeroCrossings, sampleZC) else zeroCrossings;
+ // created event suff e.g. zeroCrossings, samples, ...
+      timeEvents := eventInfo.timeEvents;
+      whenClauses := createSimWhenClauses(dlow);
+      zeroCrossings := if ifcpp then eventInfo.relationsLst else eventInfo.zeroCrossingLst;
+      relations := eventInfo.relationsLst;
+      sampleZC := eventInfo.sampleLst;
+      zeroCrossings := if ifcpp then listAppend(zeroCrossings, sampleZC) else zeroCrossings;
 
     // equation generation for euler, dassl2, rungekutta
     ( uniqueEqIndex, odeEquations, algebraicEquations, allEquations, equationsForZeroCrossings, tempvars,

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -1143,6 +1143,7 @@ algorithm
     then (iuniqueEqIndex, inOdeEquations, inAlgebraicEquations, inAllEquations, inEquationsForZeroCrossings, itempvars, ieqSccMapping, ieqBackendSimCodeMapping, iBackendMapping);
 
     case ((syst as BackendDAE.EQSYSTEM(matching=BackendDAE.MATCHING(ass1=ass1, comps=comps)))::systs, _, _, _, _, _, _, _, _, _, _, _, _)
+    guard(BackendVariable.varsSize(syst.orderedVars) > 0)
       equation
         funcs = BackendDAEUtil.getFunctions(shared);
         (syst, _, _) = BackendDAEUtil.getIncidenceMatrixfromOption(syst, BackendDAE.ABSOLUTE(), SOME(funcs));
@@ -1159,6 +1160,9 @@ algorithm
         (uniqueEqIndex, odeEquations, algebraicEquations, allEquations, equationsForZeroCrossings, tempvars, eqSccMapping, tmpEqBackendSimCodeMapping, tmpBackendMapping) =
           createEquationsForSystems(systs, shared, uniqueEqIndex, odeEquations, algebraicEquations, allEquations, equationsForZeroCrossings, inAllZeroCrossings, tempvars, listLength(comps) + isccOffset, eqSccMapping, tmpEqBackendSimCodeMapping, tmpBackendMapping);
      then (uniqueEqIndex, odeEquations, algebraicEquations, allEquations, equationsForZeroCrossings, tempvars, eqSccMapping, tmpEqBackendSimCodeMapping, tmpBackendMapping);
+
+    else (iuniqueEqIndex, inOdeEquations, inAlgebraicEquations, inAllEquations, inEquationsForZeroCrossings, itempvars, ieqSccMapping, ieqBackendSimCodeMapping, iBackendMapping);
+
   end match;
 end createEquationsForSystems;
 


### PR DESCRIPTION
Each BackendDAE.EqSystem has its own removed equations section. Unpartitioned removed equations stay in BackendDAE.Shared. Output in BackendDump is changed as well.

Also  base clocks is added in synchronous dump info.