### PR TITLE
Fix for #3382.

### DIFF
--- a/Compiler/FrontEnd/Types.mo
+++ b/Compiler/FrontEnd/Types.mo
@@ -8874,6 +8874,19 @@ algorithm
   end for;
 end lookupAttributeValue;
 
+public function lookupAttributeExp
+  input list<DAE.Var> inAttributes;
+  input String inName;
+  output Option<DAE.Exp> outExp = NONE();
+algorithm
+  for attr in inAttributes loop
+    if inName == varName(attr) then
+      outExp := DAEUtil.bindingExp(varBinding(attr));
+      break;
+    end if;
+  end for;
+end lookupAttributeExp;
+
 protected function unboxedTypeTraverseHelper<T>
   input DAE.Type ty;
   input T dummy;

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -1108,6 +1108,10 @@ constant ConfigFlag RTEARING = CONFIG_FLAG(74, "recursiveTearing",
     })),
     Util.gettext("inline and repeat tearing."));
 
+constant ConfigFlag FLOW_THRESHOLD = CONFIG_FLAG(75, "flowThreshold",
+  NONE(), EXTERNAL(), REAL_FLAG(1e-7), NONE(),
+  Util.gettext("Sets the minium threshold for stream flow rates"));
+
 
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
@@ -1187,7 +1191,8 @@ constant list<ConfigFlag> allConfigFlags = {
   LOOP2CON,
   FORCE_TEARING,
   SIMPLIFY_LOOPS,
-  RTEARING
+  RTEARING,
+  FLOW_THRESHOLD
 };
 
 public function new


### PR DESCRIPTION
- Use 1e-7 as default flow threshold when generating stream connect
  equations instead of 1e-15.
- Use a flow variables nominal value (if any) to calculate a better
  flow threshold as 1e-7 * nominal.
- Allow the flow threshold to be set with --flowThreshold.