### PR TITLE
Changed number of event indicators for c++ based FMU export

### DIFF
--- a/Compiler/Template/CodegenCppInit.tpl
+++ b/Compiler/Template/CodegenCppInit.tpl
@@ -63,7 +63,7 @@ template fmiModelDescriptionAttributes(SimCode simCode, String guid)
       let generationDateAndTime = CodegenFMUCommon.xsdateTime(getCurrentDateTime())
       let variableNamingConvention = 'structured'
       let numberOfContinuousStates = vi.numStateVars
-      let numberOfEventIndicators = eventIndicatorsLength(simCode)
+      let numberOfEventIndicators = CodegenFMUCommon.getNumberOfEventIndicators(simCode)
       <<
       fmiVersion="<%fmiVersion%>"
       modelName="<%modelName%>"
@@ -230,16 +230,6 @@ template timeEventLength(SimCode simCode)
       <%vi.numTimeEvents%>
       >>
 end timeEventLength;
-
-template eventIndicatorsLength(SimCode simCode)
-::=
-  match simCode
-    case SIMCODE(modelInfo = MODELINFO(varInfo = vi as VARINFO(__))) then
-      let size = listLength(zeroCrossings)
-      <<
-      <%listLength(zeroCrossings)%>
-      >>
-end eventIndicatorsLength;
 
 annotation(__OpenModelica_Interface="backend");
 end CodegenCppInit;

--- a/Compiler/Template/CodegenFMU1.tpl
+++ b/Compiler/Template/CodegenFMU1.tpl
@@ -83,7 +83,7 @@ case SIMCODE(modelInfo = MODELINFO(varInfo = vi as VARINFO(__), vars = SIMVARS(s
   let generationDateAndTime = xsdateTime(getCurrentDateTime())
   let variableNamingConvention = 'structured'
   let numberOfContinuousStates = if intEq(vi.numStateVars,1) then statesnumwithDummy(listStates) else vi.numStateVars
-  let numberOfEventIndicators = vi.numZeroCrossings
+  let numberOfEventIndicators = getNumberOfEventIndicators(simCode)
   <<
   fmiVersion="<%fmiVersion%>"
   modelName="<%modelName%>"

--- a/Compiler/Template/CodegenFMU2.tpl
+++ b/Compiler/Template/CodegenFMU2.tpl
@@ -95,7 +95,7 @@ case SIMCODE(modelInfo = MODELINFO(varInfo = vi as VARINFO(__), vars = SIMVARS(s
   let generationTool= 'OpenModelica Compiler <%getVersionNr()%>'
   let generationDateAndTime = xsdateTime(getCurrentDateTime())
   let variableNamingConvention = 'structured'
-  let numberOfEventIndicators = vi.numZeroCrossings
+  let numberOfEventIndicators = getNumberOfEventIndicators(simCode)
   <<
   fmiVersion="<%fmiVersion%>"
   modelName="<%modelName%>"

--- a/Compiler/Template/CodegenFMUCommon.tpl
+++ b/Compiler/Template/CodegenFMUCommon.tpl
@@ -435,6 +435,18 @@ match varKind
   else "local"
 end getCausality2Helper;
 
+template getNumberOfEventIndicators(SimCode simCode)
+ "Get the number of event indicators, which depends on the selected code target (c or cpp)."
+::=
+match simCode
+  case SIMCODE(zeroCrossings = zeroCrossings, modelInfo = MODELINFO(varInfo = vi as VARINFO(__))) then
+    match Config.simCodeTarget()
+      case "Cpp" then listLength(zeroCrossings)
+      else vi.numZeroCrossings
+    end match
+  else ""
+end getNumberOfEventIndicators;
+
 template getInitialType(VarKind varKind, Option<DAE.Exp> initialValue, Causality c, Boolean isValueChangeable)
  "Returns the Initial Attribute of ScalarVariable."
 ::=

--- a/Compiler/Template/CodegenFMUCpp.tpl
+++ b/Compiler/Template/CodegenFMUCpp.tpl
@@ -238,7 +238,7 @@ case SIMCODE(modelInfo=MODELINFO(__)) then
   #define MODEL_GUID "{<%guid%>}"
 
   <%ModelDefineData(modelInfo)%>
-  #define NUMBER_OF_EVENT_INDICATORS <%CodegenCppInit.eventIndicatorsLength(simCode)%>
+  #define NUMBER_OF_EVENT_INDICATORS <%CodegenFMUCommon.getNumberOfEventIndicators(simCode)%>
 
   <%if isFMIVersion20(FMUVersion) then
     '#include "FMU2/FMU2Wrapper.cpp"'


### PR DESCRIPTION
Because the c++-runtime handles events different than the c-runtime, the number of event indicators created by FMUCommon.tpl was not correct for both runtimes. Therefore i've added a switch inside the new function "getNumberOfEventIndicators()".

This fixes a segfault, that occurs when the CoupledClutches model is translated to FMU and simulated in OpenModelica. 

@rfranke  Can you please take a look at the request and test if these changes will also fix your local segfault?