### PR TITLE
Fixes for listFile

### DIFF
--- a/Compiler/FrontEnd/Absyn.mo
+++ b/Compiler/FrontEnd/Absyn.mo
@@ -2410,6 +2410,16 @@ algorithm
   end match;
 end elementSpecName;
 
+public function isClassdef
+  input Element inElement;
+  output Boolean b;
+algorithm
+  b := match inElement
+    case ELEMENT(specification=CLASSDEF()) then true;
+    else false;
+  end match;
+end isClassdef;
+
 public function printImportString
   "This function takes a Import and prints it as a flat-string."
   input Import imp;

--- a/Compiler/Template/AbsynDumpTV.mo
+++ b/Compiler/Template/AbsynDumpTV.mo
@@ -7,6 +7,23 @@ package builtin
     replaceable type T subtypeof Any;
   end listReverse;
 
+  function boolAnd
+    input Boolean b1;
+    input Boolean b2;
+    output Boolean b;
+  end boolAnd;
+
+  function boolOr
+    input Boolean a;
+    input Boolean b;
+    output Boolean c;
+  end boolOr;
+
+  function boolNot
+    input Boolean b;
+    output Boolean nb;
+  end boolNot;
+
   uniontype SourceInfo
     record SOURCEINFO
       String fileName;
@@ -828,6 +845,12 @@ package Absyn
       Option<Annotation> annotation_;
     end EXTERNALDECL;
   end ExternalDecl;
+
+  function isClassdef
+    input Element inElement;
+    output Boolean b;
+  end isClassdef;
+
 end Absyn;
 
 package Config

--- a/Compiler/Template/AbsynDumpTpl.tpl
+++ b/Compiler/Template/AbsynDumpTpl.tpl
@@ -267,7 +267,7 @@ template dumpElement(Absyn.Element elem, DumpOptions options)
 ::=
 match elem
   case ELEMENT(__) then
-    if boolUnparseFileFromInfo(info, options) then
+    if boolOr(boolUnparseFileFromInfo(info, options), boolNot(isClassdef(elem))) then
     let final_str = dumpFinal(finalPrefix)
     let redecl_str = match redeclareKeywords case SOME(re) then dumpRedeclare(re)
     let repl_str = match redeclareKeywords case SOME(re) then dumpReplaceable(re)


### PR DESCRIPTION
listFile now lists non-class elements with a different source file
than the given class. The reason is that components always need to be
part of the same file.