### PR TITLE
Fix for return in try-block

### DIFF
--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1909,20 +1909,16 @@ protected function collateArrExpStmt "author: Frenkel TUD 2010-07
   wbraun: added as workaround for when condition.
   As long as we don't support fully array helpVars,
   we can't collate the expression of a when condition."
-  input tuple<DAE.Exp, DAE.Statement, Option<DAE.FunctionTree>> itpl;
-  output tuple<DAE.Exp, Option<DAE.FunctionTree>> otpl;
+  input DAE.Exp inExp;
+  input DAE.Statement inStmt;
+  input Option<DAE.FunctionTree> funcs;
+  output DAE.Exp outExp = inExp;
+  output Option<DAE.FunctionTree> oarg = funcs;
 algorithm
-  otpl := matchcontinue itpl
-    local
-      DAE.Exp e;
-      DAE.Statement x;
-      Option<DAE.FunctionTree> funcs;
-    case ((e, x, funcs))
-      equation
-       (e, (_, _)) = Expression.traverseExpBottomUp(e, traversingcollateArrExpStmt, (x, funcs));
-      then ((e,funcs));
-    case ((e, _, funcs)) then ((e,funcs));
-  end matchcontinue;
+  try
+    outExp := Expression.traverseExpBottomUp(outExp, traversingcollateArrExpStmt, (inStmt, funcs));
+  else
+  end try;
 end collateArrExpStmt;
 
 protected function traversingcollateArrExpStmt "wbraun: added as workaround for when condition.

--- a/Compiler/SimCode/SimCode.mo
+++ b/Compiler/SimCode/SimCode.mo
@@ -256,7 +256,7 @@ uniontype Function
     list<Variable> outVars;
     list<Variable> functionArguments;
     list<Variable> variableDeclarations;
-    list<Statement> body;
+    list<DAE.Statement> body;
     SCode.Visibility visibility;
     SourceInfo info;
   end FUNCTION;
@@ -266,7 +266,7 @@ uniontype Function
     list<Variable> outVars;
     list<Variable> functionArguments;
     list<Variable> variableDeclarations;
-    list<Statement> body;
+    list<DAE.Statement> body;
     SourceInfo info;
   end PARALLEL_FUNCTION;
 
@@ -275,7 +275,7 @@ uniontype Function
     list<Variable> outVars;
     list<Variable> functionArguments;
     list<Variable> variableDeclarations;
-    list<Statement> body;
+    list<DAE.Statement> body;
     SourceInfo info;
   end KERNEL_FUNCTION;
 
@@ -364,13 +364,6 @@ uniontype Variable
     Option<DAE.Exp> defaultValue "default value";
   end FUNCTION_PTR;
 end Variable;
-
-// TODO: Replace Statement with just list<DAE.Statement>?
-uniontype Statement
-  record ALGORITHM
-    list<DAE.Statement> statementLst; // in functions
-  end ALGORITHM;
-end Statement;
 
 uniontype SimEqSystem
   "Represents a single equation or a system of equations that must be solved together."

--- a/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -673,7 +673,7 @@ algorithm
       DAE.ExternalDecl extdecl;
       list<SimCode.Variable> outVars, inVars, biVars, funArgs, varDecls;
       list<SimCode.RecordDeclaration> recordDecls;
-      list<SimCode.Statement> bodyStmts;
+      list<DAE.Statement> bodyStmts;
       list<DAE.Element> daeElts;
       Absyn.Path name;
       DAE.ElementSource source;
@@ -699,8 +699,7 @@ algorithm
         (recordDecls, rt_1) = elaborateRecordDeclarations(daeElts, recordDecls, rt);
         vars = List.filter(daeElts, isVarQ);
         varDecls = List.map(vars, daeInOutSimVar);
-        algs = List.filterOnTrue(daeElts, DAEUtil.isAlgorithm);
-        bodyStmts = List.map(algs, elaborateStatement);
+        bodyStmts = listAppend(elaborateStatement(e) for e guard DAEUtil.isAlgorithm(e) in daeElts);
         info = DAEUtil.getElementSourceFileInfo(source);
       then
         (SimCode.FUNCTION(fpath, outVars, funArgs, varDecls, bodyStmts, visibility, info), rt_1, recordDecls, includes, includeDirs, libs,libPaths);
@@ -719,8 +718,7 @@ algorithm
         (recordDecls, rt_1) = elaborateRecordDeclarations(daeElts, recordDecls, rt);
         vars = List.filter(daeElts, isVarNotInputNotOutput);
         varDecls = List.map(vars, daeInOutSimVar);
-        algs = List.filterOnTrue(daeElts, DAEUtil.isAlgorithm);
-        bodyStmts = List.map(algs, elaborateStatement);
+        bodyStmts = listAppend(elaborateStatement(e) for e guard DAEUtil.isAlgorithm(e) in daeElts);
         info = DAEUtil.getElementSourceFileInfo(source);
       then
         (SimCode.KERNEL_FUNCTION(fpath, outVars, funArgs, varDecls, bodyStmts, info), rt_1, recordDecls, includes, includeDirs, libs,libPaths);
@@ -739,8 +737,7 @@ algorithm
         (recordDecls, rt_1) = elaborateRecordDeclarations(daeElts, recordDecls, rt);
         vars = List.filter(daeElts, isVarQ);
         varDecls = List.map(vars, daeInOutSimVar);
-        algs = List.filterOnTrue(daeElts, DAEUtil.isAlgorithm);
-        bodyStmts = List.map(algs, elaborateStatement);
+        bodyStmts = listAppend(elaborateStatement(e) for e guard DAEUtil.isAlgorithm(e) in daeElts);
         info = DAEUtil.getElementSourceFileInfo(source);
       then
         (SimCode.PARALLEL_FUNCTION(fpath, outVars, funArgs, varDecls, bodyStmts, info), rt_1, recordDecls, includes, includeDirs, libs,libPaths);
@@ -1012,22 +1009,9 @@ end findIndexInList;
 
 protected function elaborateStatement
   input DAE.Element inElement;
-  output SimCode.Statement outStatement;
+  output list<DAE.Statement> stmts;
 algorithm
-  (outStatement):=
-  matchcontinue (inElement)
-    local
-      list<DAE.Statement> stmts;
-    case (DAE.ALGORITHM(algorithm_ = DAE.ALGORITHM_STMTS(statementLst = stmts)))
-    then
-      SimCode.ALGORITHM(stmts);
-    else
-      equation
-        true = Flags.isSet(Flags.FAILTRACE);
-        Debug.trace("# SimCode.elaborateStatement failed\n");
-      then
-        fail();
-  end matchcontinue;
+  DAE.ALGORITHM(algorithm_ = DAE.ALGORITHM_STMTS(statementLst = stmts)) := inElement;
 end elaborateStatement;
 
 

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -4234,21 +4234,21 @@ protected
   list<BackendDAE.Equation> eqs;
 algorithm
   try
-	  (varsWithBind,varsWithoutBind) := List.separateOnTrue(varLstIn,BackendVariable.varHasBindExp);
-	  bindExps := List.map(varsWithBind,BackendVariable.varBindExp);
-	  eqs := List.threadMap2(List.map(varsWithBind,BackendVariable.varExp), bindExps, BackendEquation.generateEquation, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC);
-	  (m, mT) := BackendDAEUtil.incidenceMatrixDispatch(BackendVariable.listVar1(varsWithBind), BackendEquation.listEquation(eqs), BackendDAE.ABSOLUTE(), NONE());
-	  nVars := listLength(varsWithBind);
-	  nEqs := listLength(eqs);
-	  ass1 := arrayCreate(listLength(varsWithBind), -1);
-	  ass2 := arrayCreate(listLength(eqs), -1);
-	  Matching.matchingExternalsetIncidenceMatrix(nVars, nEqs, m);
-	  BackendDAEEXT.matching(nVars, nEqs, 5, -1, 0.0, 1);
-	  BackendDAEEXT.getAssignment(ass2, ass1);
-	  comps := Sorting.TarjanTransposed(mT, ass2);
-	  order := List.map1(List.flatten(comps),Array.getIndexFirst,ass1);
-	  varsWithBind := List.map1(order,List.getIndexFirst,varsWithBind);
-	  varLstOut := listAppend(varsWithoutBind,varsWithBind);
+    (varsWithBind,varsWithoutBind) := List.separateOnTrue(varLstIn,BackendVariable.varHasBindExp);
+    bindExps := List.map(varsWithBind,BackendVariable.varBindExp);
+    eqs := List.threadMap2(List.map(varsWithBind,BackendVariable.varExp), bindExps, BackendEquation.generateEquation, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC);
+    (m, mT) := BackendDAEUtil.incidenceMatrixDispatch(BackendVariable.listVar1(varsWithBind), BackendEquation.listEquation(eqs), BackendDAE.ABSOLUTE(), NONE());
+    nVars := listLength(varsWithBind);
+    nEqs := listLength(eqs);
+    ass1 := arrayCreate(listLength(varsWithBind), -1);
+    ass2 := arrayCreate(listLength(eqs), -1);
+    Matching.matchingExternalsetIncidenceMatrix(nVars, nEqs, m);
+    BackendDAEEXT.matching(nVars, nEqs, 5, -1, 0.0, 1);
+    BackendDAEEXT.getAssignment(ass2, ass1);
+    comps := Sorting.TarjanTransposed(mT, ass2);
+    order := List.map1(List.flatten(comps),Array.getIndexFirst,ass1);
+    varsWithBind := List.map1(order,List.getIndexFirst,varsWithBind);
+    varLstOut := listAppend(varsWithoutBind,varsWithBind);
   else
     varLstOut := varLstIn;
   end try;
@@ -6416,7 +6416,6 @@ algorithm
     Absyn.Path path;
     list<SimCode.Function> rest;
     list<SimCode.Variable> outVars,functionArguments,variableDeclarations,funArgs, locals;
-    list<SimCode.Statement> body;
   case({})
     equation
     then ();

--- a/Compiler/Template/CodegenAdevs.tpl
+++ b/Compiler/Template/CodegenAdevs.tpl
@@ -2264,7 +2264,7 @@ case FUNCTION(__) then
   let addRootsInputs = (functionArguments |> var => addRoots(var) ;separator="\n")
   let addRootsOutputs = (outVars |> var => addRoots(var) ;separator="\n")
   let funArgs = (functionArguments |> var => functionArg(var, &varInits) ;separator="\n")
-  let bodyPart = (body |> stmt  => funStatement(stmt, &varDecls /*BUFD*/) ;separator="\n")
+  let bodyPart = funStatement(body, &varDecls)
   let &outVarInits = buffer ""
   let &outVarCopy = buffer ""
   let &outVarAssign = buffer ""
@@ -3014,16 +3014,10 @@ template tempSizeVarName(ComponentRef c, DAE.Exp indices)
   else "tempSizeVarName:UNHANDLED_EXPRESSION"
 end tempSizeVarName;
 
-template funStatement(Statement stmt, Text &varDecls /*BUFP*/)
+template funStatement(list<DAE.Statement> statementLst, Text &varDecls /*BUFP*/)
  "Generates function statements."
 ::=
-  match stmt
-  case ALGORITHM(__) then
-    (statementLst |> stmt =>
-      algStatement(stmt, contextFunction, &varDecls /*BUFD*/)
-    ;separator="\n")
-  else
-    "NOT IMPLEMENTED FUN STATEMENT"
+  statementLst |> stmt => algStatement(stmt, contextFunction, &varDecls /*BUFD*/) ; separator="\n"
 end funStatement;
 
 template statementInfoString(DAE.Statement stmt)

--- a/Compiler/Template/CodegenCSharp.tpl
+++ b/Compiler/Template/CodegenCSharp.tpl
@@ -260,7 +260,7 @@ case FUNCTION(__) then
                case (fv as VARIABLE(__)) :: _ then crefStr(fv.name,simCode)
   let varInits = variableDeclarations |> var => varInit(var, simCode)
                  ;separator="\n" //TODO:special end of line,see varInit
-  let bodyPart = (body |> stmt  => funStatement(stmt, simCode) ;separator="\n")
+  let bodyPart = funStatement(body, simCode)
   <<
   <%retType%> _<%fname%>(<%functionArguments |> var => funArgDefinition(var,simCode) ;separator=", "%>)
   {
@@ -364,16 +364,10 @@ template funArgDefinition(Variable var, SimCode simCode)
   else "UNSUPPORTED_VARIABLE_funArgDefinition"
 end funArgDefinition;
 
-template funStatement(Statement stmt, SimCode simCode)
+template funStatement(list<DAE.Statement> statementLst, SimCode simCode)
  "Generates function statements."
 ::=
-  match stmt
-  case ALGORITHM(__) then
-    (statementLst |> stmt =>
-      algStatement(stmt, contextFunction, simCode)
-    ;separator="\n")
-  else
-    "NOT IMPLEMENTED FUN STATEMENT"
+  statementLst |> stmt => algStatement(stmt, contextFunction, simCode)
 end funStatement;
 
 constant String localRepresentationArrayDefines =

--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -4625,7 +4625,7 @@ case FUNCTION(__) then
   //let addRootsInputs = (functionArguments |> var => addRoots(var) ;separator="\n")
   //let addRootsOutputs = (outVars |> var => addRoots(var) ;separator="\n")
   //let funArgs = (functionArguments |> var => functionArg(var, &varInits) ;separator="\n")
-  let bodyPart = (body |> stmt  => funStatement(stmt, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation) ;separator="\n")
+  let bodyPart = funStatement(body, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
   let &outVarInits = buffer ""
   let &outVarCopy = buffer ""
   let &outVarAssign = buffer ""
@@ -5665,16 +5665,10 @@ case var as VARIABLE(__) then
      end match
 end varType3;
 
-template funStatement(Statement stmt, Text &varDecls, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
+template funStatement(list<DAE.Statement> statementLst, Text &varDecls, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
  "Generates function statements."
 ::=
-  match stmt
-  case ALGORITHM(__) then
-    (statementLst |> stmt =>
-      algStatement(stmt, contextFunction, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
-    ;separator="\n")
-  else
-    "NOT IMPLEMENTED FUN STATEMENT"
+  statementLst |> stmt => algStatement(stmt, contextFunction, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation) ; separator="\n"
 end funStatement;
 
 template initExtVars(SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)

--- a/Compiler/Template/CodegenSparseFMI.tpl
+++ b/Compiler/Template/CodegenSparseFMI.tpl
@@ -1811,7 +1811,7 @@ case FUNCTION(__) then
   let addRootsInputs = (functionArguments |> var => addRoots(var) ;separator="\n")
   let addRootsOutputs = (outVars |> var => addRoots(var) ;separator="\n")
   let funArgs = (functionArguments |> var => functionArg(var, &varInits) ;separator="\n")
-  let bodyPart = (body |> stmt  => funStatement(stmt, &varDecls /*BUFD*/) ;separator="\n")
+  let bodyPart = funStatement(body, &varDecls)
   let &outVarInits = buffer ""
   let &outVarCopy = buffer ""
   let &outVarAssign = buffer ""
@@ -2561,16 +2561,10 @@ template tempSizeVarName(ComponentRef c, DAE.Exp indices)
   else "tempSizeVarName:UNHANDLED_EXPRESSION"
 end tempSizeVarName;
 
-template funStatement(Statement stmt, Text &varDecls /*BUFP*/)
+template funStatement(list<DAE.Statement> statementLst, Text &varDecls /*BUFP*/)
  "Generates function statements."
 ::=
-  match stmt
-  case ALGORITHM(__) then
-    (statementLst |> stmt =>
-      algStatement(stmt, contextFunction, &varDecls /*BUFD*/)
-    ;separator="\n")
-  else
-    "NOT IMPLEMENTED FUN STATEMENT"
+  statementLst |> stmt => algStatement(stmt, contextFunction, &varDecls)
 end funStatement;
 
 template statementInfoString(DAE.Statement stmt)

--- a/Compiler/Template/CodegenXML.tpl
+++ b/Compiler/Template/CodegenXML.tpl
@@ -1066,7 +1066,7 @@ case FUNCTION(__) then
   let fname = underscorePathXml(name)
   let &varDecls = buffer "" /*BUFD*/
   let &varInits = buffer "" /*BUFD*/
-  let bodyPart = (body |> stmt  => funStatementXml(stmt, &varDecls /*BUFD*/) ;separator="\n")
+  let bodyPart = funStatementXml(body, &varDecls)
   <<
   <fun:Function>
     <fun:Name>
@@ -1479,16 +1479,10 @@ end constraintXml;
  *         SECTION: GENERATE All Algorithm IN SIMULATION FILE
  *****************************************************************************/
 
-template funStatementXml(Statement stmt, Text &varDecls /*BUFP*/)
+template funStatementXml(list<DAE.Statement> statementLst, Text &varDecls /*BUFP*/)
  "Generates function statements."
 ::=
-  match stmt
-  case ALGORITHM(__) then
-    (statementLst |> stmt =>
-      algStatementXml(stmt, contextFunction, &varDecls /*BUFD*/)
-    ;separator="\n")
-  else
-    "NOT IMPLEMENTED FUN STATEMENT"
+  statementLst |> stmt => algStatementXml(stmt, contextFunction, &varDecls /*BUFD*/) ;separator="\n"
 end funStatementXml;
 
 template algStatementXml(DAE.Statement stmt, Context context, Text &varDecls /*BUFP*/)

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -417,12 +417,6 @@ package SimCode
     end FUNCTION_PTR;
   end Variable;
 
-  uniontype Statement
-    record ALGORITHM
-       list<DAE.Statement> statementLst;
-    end ALGORITHM;
-  end Statement;
-
   uniontype ExtObjInfo
     record EXTOBJINFO
       list<SimCodeVar.SimVar> vars;
@@ -603,7 +597,7 @@ package SimCode
       list<Variable> outVars;
       list<Variable> functionArguments;
       list<Variable> variableDeclarations;
-      list<Statement> body;
+      list<DAE.Statement> body;
       SCode.Visibility visibility;
       builtin.SourceInfo info;
     end FUNCTION;
@@ -612,7 +606,7 @@ package SimCode
       list<Variable> outVars;
       list<Variable> functionArguments;
       list<Variable> variableDeclarations;
-      list<Statement> body;
+      list<DAE.Statement> body;
       builtin.SourceInfo info;
     end PARALLEL_FUNCTION;
     record KERNEL_FUNCTION
@@ -620,7 +614,7 @@ package SimCode
       list<Variable> outVars;
       list<Variable> functionArguments;
       list<Variable> variableDeclarations;
-      list<Statement> body;
+      list<DAE.Statement> body;
       builtin.SourceInfo info;
     end KERNEL_FUNCTION;
     record EXTERNAL_FUNCTION
@@ -3252,6 +3246,17 @@ package DAEUtil
     input DAE.ElementSource source;
     output builtin.SourceInfo info;
   end getElementSourceFileInfo;
+
+  function statementsContainReturn
+    input list<DAE.Statement> stmts;
+    output Boolean b;
+  end statementsContainReturn;
+
+  function statementsContainTryBlock
+    input list<DAE.Statement> stmts;
+    output Boolean b;
+  end statementsContainTryBlock;
+
 end DAEUtil;
 
 package Types


### PR DESCRIPTION
This fixes bug #3240, where the jmp_buf is set to a deeper stack
frame after returning from the middle of a try block (the jmp_buf
needs to be restored after exiting the block).