### PR TITLE
 Fixes to run parmodelica tests cleanly

### DIFF
--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -4918,7 +4918,7 @@ template simulationParModelicaKernelsFile(String filePrefix, list<Function> func
   let()= System.tmpTickResetIndex(0,20) /* parfor index */
 
   <<
-  #include "OCLRuntimeUtil.cl"
+  #include <ParModelica/explicit/openclrt/OCLRuntimeUtil.cl>
 
   // ParModelica Parallel Function headers.
   <%functionHeadersParModelica(filePrefix, functions)%>

--- a/Compiler/Template/CodegenCFunctions.tpl
+++ b/Compiler/Template/CodegenCFunctions.tpl
@@ -3254,7 +3254,7 @@ template functionsParModelicaKernelsFile(String filePrefix, Option<Function> mai
   let()= System.tmpTickResetIndex(0,20) /* parfor index */
 
   <<
-  #include "OCLRuntimeUtil.cl"
+  #include <ParModelica/explicit/openclrt/OCLRuntimeUtil.cl>
 
   // ParModelica Parallel Function headers.
   <%functionHeadersParModelica(filePrefix, functions)%>

--- a/SimulationRuntime/ParModelica/explicit/openclrt/Makefile.in
+++ b/SimulationRuntime/ParModelica/explicit/openclrt/Makefile.in
@@ -3,6 +3,7 @@ HOST_SHORT = @host_short@
 
 OPENMODELICA_INC=$(TOP_BUILDDIR)/include/omc/c/
 PARMODELICAEXPOCL_INC=$(OPENMODELICA_INC)/ParModelica/explicit/openclrt/
+OPENMODELICA_BUILTIN_DIR=$(TOP_BUILDDIR)/lib/omc
 OPENMODELICA_LIB=$(TOP_BUILDDIR)/lib/$(HOST_SHORT)/omc
 OPENMODELICA_BIN=$(TOP_BUILDDIR)/bin/
 
@@ -24,7 +25,7 @@ transfer: libOMOCLRuntime.a
 	$(COPY) omc_ocl_common_header.h $(PARMODELICAEXPOCL_INC)
 	$(COPY) omc_ocl_memory_ops.h $(PARMODELICAEXPOCL_INC)
 	$(COPY) libOMOCLRuntime.a $(OPENMODELICA_LIB)
-	$(COPY) ParModelicaBuiltin.mo $(OPENMODELICA_LIB)
+	$(COPY) ParModelicaBuiltin.mo $(OPENMODELICA_BUILTIN_DIR)
 	$(COPY) OCLRuntimeUtil.cl $(PARMODELICAEXPOCL_INC)
 
 Makefile: Makefile.in

--- a/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_util.cpp
+++ b/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_util.cpp
@@ -213,9 +213,12 @@ void ocl_initialize(){
     }
 
     gettimeofday(&t2, NULL);
+
+#if BE_OCL_VERBOSE
     elapsedTime = (t2.tv_sec - t1.tv_sec) * 1000.0;      // sec to ms
     elapsedTime += (t2.tv_usec - t1.tv_usec) / 1000.0;   // us to ms
     printf ("\tOpenCL initialization :        %lf ms\n", elapsedTime);
+#endif
 
     setenv("CUDA_CACHE_DISABLE", "1", 1);
 }
@@ -465,9 +468,12 @@ void ocl_execute_kernel(cl_kernel kernel){
 
 
     gettimeofday(&t2, NULL);
+#if BE_OCL_VERBOSE
     elapsedTime = (t2.tv_sec - t1.tv_sec) * 1000.0;      // sec to ms
     elapsedTime += (t2.tv_usec - t1.tv_usec) / 1000.0;   // us to ms
     printf ("\tKernel Execution      :        %lf ms\n", elapsedTime);
+#endif
+
 
     if(err) exit(1);
 


### PR DESCRIPTION
- Fix inculde path for Intel OpenCL 
- Fix include directory for build
- Disable extra timing outputs