### PR TITLE
Fix for #3421.

### DIFF
--- a/Compiler/FrontEnd/Types.mo
+++ b/Compiler/FrontEnd/Types.mo
@@ -8071,11 +8071,13 @@ algorithm
       DAE.Dimensions dims;
       ClassInf.State state;
       EqualityConstraint ec;
+      list<DAE.Type> tys;
 
     case DAE.T_INTEGER(vars, src) then (DAE.T_INTEGER({}, src), vars);
     case DAE.T_REAL(vars, src)    then (DAE.T_REAL({}, src), vars);
     case DAE.T_STRING(vars, src)  then (DAE.T_STRING({}, src), vars);
     case DAE.T_BOOL(vars, src)    then (DAE.T_BOOL({}, src), vars);
+    case DAE.T_TUPLE(tys, _, src) then (DAE.T_TUPLE(tys, NONE(), src), {});
 
     case DAE.T_ARRAY(ty, dims, src)
       equation


### PR DESCRIPTION
- When checking if the rhs is a function call in an tuple assignment,
  check the unelaborated expression since the elaborated one might no
  longer be a function call.
- Changed Types.stripTypeVars to also strip tuple element names
  (for less confusing error messages).