### PR TITLE
Handle delete+whitespace+add better

### DIFF
--- a/Compiler/Lexers/Makefile.in
+++ b/Compiler/Lexers/Makefile.in
@@ -12,7 +12,6 @@ OMCC/OMCC:
 	cd OMCC && git fetch && git pull --ff-only
 	$(MAKE) -C OMCC omcc OMC="@OMBUILDDIR@/bin/omc"
 flex:
-	$(MAKE) -C ../../3rdParty/flex-2.5.35
-	cp ../../3rdParty/flex-2.5.35/flex "@OMBUILDDIR@/bin/flex"
+	cd ../../3rdParty/flex-2.5.35 && ./autogen.sh && ./configure && $(MAKE) && cp ./flex "@OMBUILDDIR@/bin/flex"
 Makefile: Makefile.in
 	cd @top_builddir@ && ./config.status

--- a/Compiler/Lexers/lexerModelicaDiff.l
+++ b/Compiler/Lexers/lexerModelicaDiff.l
@@ -274,10 +274,43 @@ algorithm
     (lastIsNewline,simpleDiff,tmp) := match simpleDiff
       local
         tuple<Diff, Token> e,e1,e2;
-        Token t,t1,t2;
+        Token t,t1,t2,tk3,tk4,tk5;
+        TokenId t3,t4,t5;
+        Diff d1,d2,d3,d4,d5;
       // Do not delete whitespace in-between two tokens
       case (e1 as (Diff.Equal,_))::(Diff.Delete,t1 as TOKEN(id=TokenId.NEWLINE))::(Diff.Delete,t2 as TOKEN(id=TokenId.WHITESPACE))::(e2 as (Diff.Equal,_))::rest then (false,e1::(Diff.Equal,t1)::(Diff.Equal,t2)::e2::rest,tmp);
       case (e1 as (Diff.Equal,_))::(Diff.Delete,t as TOKEN(id=TokenId.WHITESPACE))::(e2 as (Diff.Equal,_))::rest then (false,e1::(Diff.Equal,t)::e2::rest,tmp);
+
+      // Do not delete+add the same token just because there is whitespace added
+      case (d1,t1)::(Diff.Add,TOKEN(id=t3))::(Diff.Add,TOKEN(id=t4))::(Diff.Add,TOKEN(id=t5))::(d2,t2)::rest
+        guard ((d1==Diff.Add and d2==Diff.Delete) or (d2==Diff.Add and d1==Diff.Delete)) and modelicaDiffTokenEq(t1,t2)
+               and (t3==TokenId.NEWLINE or t3 == TokenId.WHITESPACE) and (t4==TokenId.NEWLINE or t4 == TokenId.WHITESPACE) and (t5==TokenId.NEWLINE or t5 == TokenId.WHITESPACE)
+        then (false,(Diff.Equal,t1)::rest,tmp);
+      case (d1,t1)::(Diff.Add,TOKEN(id=t3))::(Diff.Add,TOKEN(id=t4))::(d2,t2)::rest
+        guard ((d1==Diff.Add and d2==Diff.Delete) or (d2==Diff.Add and d1==Diff.Delete)) and modelicaDiffTokenEq(t1,t2)
+               and (t3==TokenId.NEWLINE or t3 == TokenId.WHITESPACE) and (t4==TokenId.NEWLINE or t4 == TokenId.WHITESPACE)
+        then (false,(Diff.Equal,t1)::rest,tmp);
+      case (d1,t1)::(Diff.Add,TOKEN(id=t3))::(d2,t2)::rest
+        guard ((d1==Diff.Add and d2==Diff.Delete) or (d2==Diff.Add and d1==Diff.Delete)) and modelicaDiffTokenEq(t1,t2)
+               and (t3==TokenId.NEWLINE or t3 == TokenId.WHITESPACE)
+        then (false,(Diff.Equal,t1)::rest,tmp);
+
+      // Odd case of Delete token + equals whitespace + Add token again... Do Equal token + equal whitespace
+      case (d1,t1)::(d3,tk3 as TOKEN(id=t3))::(d4,tk4 as TOKEN(id=t4))::(d5,tk5 as TOKEN(id=t5))::(d2,t2)::rest
+        guard ((d1==Diff.Add and d2==Diff.Delete) or (d2==Diff.Add and d1==Diff.Delete)) and modelicaDiffTokenEq(t1,t2)
+               and (d3==Diff.Equal or d3==Diff.Delete) and (d4==Diff.Equal or d4==Diff.Delete) and (d5==Diff.Equal or d5==Diff.Delete)
+               and (t3==TokenId.NEWLINE or t3 == TokenId.WHITESPACE) and (t4==TokenId.NEWLINE or t4 == TokenId.WHITESPACE) and (t5==TokenId.NEWLINE or t5 == TokenId.WHITESPACE)
+        then (false,(Diff.Equal,t1)::(Diff.Equal,tk3)::(Diff.Equal,tk4)::(Diff.Equal,tk5)::rest,tmp);
+      case (d1,t1)::(d3,tk3 as TOKEN(id=t3))::(d4,tk4 as TOKEN(id=t4))::(d2,t2)::rest
+        guard ((d1==Diff.Add and d2==Diff.Delete) or (d2==Diff.Add and d1==Diff.Delete)) and modelicaDiffTokenEq(t1,t2)
+               and (d3==Diff.Equal or d3==Diff.Delete) and (d4==Diff.Equal or d4==Diff.Delete)
+               and (t3==TokenId.NEWLINE or t3 == TokenId.WHITESPACE) and (t4==TokenId.NEWLINE or t4 == TokenId.WHITESPACE)
+        then (false,(Diff.Equal,t1)::(Diff.Equal,tk3)::(Diff.Equal,tk4)::rest,tmp);
+      case (d1,t1)::(d3,tk3 as TOKEN(id=t3))::(d2,t2)::rest
+        guard ((d1==Diff.Add and d2==Diff.Delete) or (d2==Diff.Add and d1==Diff.Delete)) and modelicaDiffTokenEq(t1,t2)
+               and (d3==Diff.Equal or d3==Diff.Delete)
+               and (t3==TokenId.NEWLINE or t3 == TokenId.WHITESPACE)
+        then (false,(Diff.Equal,t1)::(Diff.Equal,tk3)::rest,tmp);
 
       case (Diff.Add,TOKEN(id=TokenId.NEWLINE))::(Diff.Add,TOKEN(id=TokenId.WHITESPACE))::(rest as (_,TOKEN(id=TokenId.NEWLINE))::_)
         then (false,rest,tmp);


### PR DESCRIPTION
diffModelicaFileListings gives unexpected results when whitespace is
added and a token moves from one line to another. This is fixed by
these routines.