### PR TITLE
Separation of back end transformations for simulation and initialization

### DIFF
--- a/Compiler/BackEnd/BackendDAE.mo
+++ b/Compiler/BackEnd/BackendDAE.mo
@@ -33,8 +33,6 @@ encapsulated package BackendDAE
 " file:        BackendDAE.mo
   package:     BackendDAE
   description: BackendDAE contains the data-types used by the back end.
-
-  RCS: $Id$
 "
 
 public import Absyn;

--- a/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -4340,7 +4340,8 @@ algorithm
   functionTree := shared.functionTree;
 
   simDAE := match shared
-            case BackendDAE.SHARED(backendDAEType = BackendDAE.SIMULATION()) then true;
+            case BackendDAE.SHARED(backendDAEType=BackendDAE.SIMULATION()) then true;
+            case BackendDAE.SHARED(backendDAEType=BackendDAE.INITIALSYSTEM()) then true;
             else false;
             end match;
 
@@ -4818,17 +4819,6 @@ public function symEuler
 algorithm
  outDAE := if Flags.getConfigBool(Flags.SYM_EULER) then symEulerWork(inDAE, true) else inDAE;
 end symEuler;
-public function symEulerInit
-"
-fix the difference quotient for initial equations[0/0]
-ToDo: remove me
-"
- input BackendDAE.BackendDAE inDAE;
- output BackendDAE.BackendDAE outDAE;
-algorithm
- outDAE := if Flags.getConfigBool(Flags.SYM_EULER) then symEulerWork(BackendDAEUtil.copyBackendDAE(inDAE), false) else inDAE;
-
-end symEulerInit;
 
 protected function symEulerWork
   input BackendDAE.BackendDAE inDAE;

--- a/Compiler/BackEnd/BackendEquation.mo
+++ b/Compiler/BackEnd/BackendEquation.mo
@@ -2479,6 +2479,7 @@ algorithm
        b := listEmpty(inputsKnVars);
     end if;
 
+    b := false "hack";
     if b then
       if noPara then
         oExp := ExpressionSimplify.simplify(iExp);

--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -2449,6 +2449,22 @@ algorithm
   end try;
 end existsVar;
 
+public function existsAnyVar
+"author: PA
+  Return true if a variable exists in the vector"
+  input list<DAE.ComponentRef> inComponentRefs;
+  input BackendDAE.Variables inVariables;
+  input Boolean skipDiscrete = false;
+  output Boolean outExists = false;
+algorithm
+  for cref in inComponentRefs loop
+    if existsVar(cref, inVariables, skipDiscrete) and not isState(cref, inVariables) then
+      outExists := true;
+      break;
+    end if;
+  end for;
+end existsAnyVar;
+
 public function makeVar
  input DAE.ComponentRef cr;
  output BackendDAE.Var v = BackendDAE.VAR(cr, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);

--- a/Compiler/Main/Main.mo
+++ b/Compiler/Main/Main.mo
@@ -593,18 +593,28 @@ protected function optimizeDae
 protected
   BackendDAE.ExtraInfo info;
   BackendDAE.BackendDAE dlow;
+  BackendDAE.BackendDAE initDAE;
+  Boolean useHomotopy "true if homotopy(...) is used during initialization";
+  list<BackendDAE.Equation> removedInitialEquationLst;
+  list<BackendDAE.Var> primaryParameters "already sorted";
+  list<BackendDAE.Var> allPrimaryParameters "already sorted";
 algorithm
   if Config.simulationCg() then
     info := BackendDAE.EXTRA_INFO(DAEUtil.daeDescription(dae), Absyn.pathString(inClassName));
     dlow := BackendDAECreate.lower(dae, inCache, inEnv, info);
-    dlow := BackendDAEUtil.getSolvedSystem(dlow, "");
-    simcodegen(dlow, inClassName, ap);
+    (dlow, initDAE, useHomotopy, removedInitialEquationLst, primaryParameters, allPrimaryParameters) := BackendDAEUtil.getSolvedSystem(dlow, "");
+    simcodegen(dlow, initDAE, useHomotopy, removedInitialEquationLst, primaryParameters, allPrimaryParameters, inClassName, ap);
   end if;
 end optimizeDae;
 
 protected function simcodegen "
   Genereates simulation code using the SimCode module"
   input BackendDAE.BackendDAE inBackendDAE;
+  input BackendDAE.BackendDAE inInitDAE;
+  input Boolean inUseHomotopy "true if homotopy(...) is used during initialization";
+  input list<BackendDAE.Equation> inRemovedInitialEquationLst;
+  input list<BackendDAE.Var> inPrimaryParameters "already sorted";
+  input list<BackendDAE.Var> inAllPrimaryParameters "already sorted";
   input Absyn.Path inClassName;
   input Absyn.Program inProgram;
 protected
@@ -624,7 +634,8 @@ algorithm
       SimCodeMain.createSimulationSettings(0.0, 1.0, 500, 1e-6, "dassl", "", "mat", ".*", "");
 
     System.realtimeTock(ClockIndexes.RT_CLOCK_BACKEND); // Is this necessary?
-    SimCodeMain.generateModelCode(inBackendDAE, inProgram, inClassName, cname, SOME(sim_settings), Absyn.FUNCTIONARGS({}, {}));
+    SimCodeMain.generateModelCode(inBackendDAE, inInitDAE, inUseHomotopy, inRemovedInitialEquationLst, inPrimaryParameters, inAllPrimaryParameters, inProgram, inClassName, cname, SOME(sim_settings), Absyn.FUNCTIONARGS({}, {}));
+
     SimCodeFunctionUtil.execStat("Codegen Done");
   end if;
 end simcodegen;

--- a/Compiler/SimCode/HpcOmSimCodeMain.mo
+++ b/Compiler/SimCode/HpcOmSimCodeMain.mo
@@ -67,6 +67,11 @@ protected import Util;
 public function createSimCode "function createSimCode
   entry point to create SimCode from BackendDAE."
   input BackendDAE.BackendDAE inBackendDAE;
+  input BackendDAE.BackendDAE inInitDAE;
+  input Boolean inUseHomotopy "true if homotopy(...) is used during initialization";
+  input list<BackendDAE.Equation> inRemovedInitialEquationLst;
+  input list<BackendDAE.Var> inPrimaryParameters "already sorted";
+  input list<BackendDAE.Var> inAllPrimaryParameters "already sorted";
   input Absyn.Path inClassName;
   input String filenamePrefix;
   input String inString11;
@@ -87,7 +92,7 @@ algorithm
       Integer lastEqMappingIdx, maxDelayedExpIndex, uniqueEqIndex, numberofEqns, numberOfInitialEquations, numberOfInitialAlgorithms, numStateSets;
       Integer numberofLinearSys, numberofNonLinearSys, numberofMixedSys;
       BackendDAE.BackendDAE dlow, dlow2;
-      Option<BackendDAE.BackendDAE> initDAE;
+      BackendDAE.BackendDAE initDAE;
       BackendDAE.IncidenceMatrix incidenceMatrix;
       DAE.FunctionTree functionTree;
       BackendDAE.SymbolicJacobians symJacs;
@@ -182,15 +187,13 @@ algorithm
     case (BackendDAE.DAE(eqs=eqs), _, _, _, _,_, _, _, _, _, _, _, _) equation
       //Initial System
       //--------------
-      //(initDAE, _, _) = Initialization.solveInitialSystem(inBackendDAE);
-      //removedInitialEquations = {};
-      //createAndExportInitialSystemTaskGraph(initDAE, filenamePrefix);
+      //createAndExportInitialSystemTaskGraph(inInitDAE, filenamePrefix);
 
       //Setup
       //-----
       System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT_HPCOM_MODULES);
       (simCode,(lastEqMappingIdx,equationSccMapping)) =
-          SimCodeUtil.createSimCode( inBackendDAE, inClassName, filenamePrefix, inString11, functions,
+          SimCodeUtil.createSimCode( inBackendDAE, inInitDAE, inUseHomotopy, inRemovedInitialEquationLst, inPrimaryParameters, inAllPrimaryParameters, inClassName, filenamePrefix, inString11, functions,
                                      externalFunctionIncludes, includeDirs, libs,libPaths, simSettingsOpt, recordDecls, literals, args );
 
       simVarMapping = SimCodeUtil.getSimVarMappingOfBackendMapping(simCode.backendMapping);

--- a/Compiler/Stubs/BackendDAEUtil.mo
+++ b/Compiler/Stubs/BackendDAEUtil.mo
@@ -10,6 +10,11 @@ function getSolvedSystem<A>
   input Option<String> strdaeHandler = NONE();
   input Option<list<String>> strPostOptModules = NONE();
   output A outSODE;
+  output A outInitDAE;
+  output Boolean outUseHomotopy;
+  output list<BackendDAE.Equation> outRemovedInitialEquationLst;
+  output list<BackendDAE.Var> outPrimaryParameters;
+  output list<BackendDAE.Var> outAllPrimaryParameters;
 algorithm
   assert(false, getInstanceName());
 end getSolvedSystem;

--- a/Compiler/Stubs/SimCodeMain.mo
+++ b/Compiler/Stubs/SimCodeMain.mo
@@ -19,8 +19,13 @@ algorithm
   assert(false, getInstanceName());
 end createSimulationSettings;
 
-function generateModelCode<T,A,C,D,E>
+function generateModelCode<T,A,B,C,D,E>
   input T inBackendDAE;
+  input T inInitDAE;
+  input Boolean inUseHomotopy;
+  input list<BackendDAE.Equation> inRemovedInitialEquationLst;
+  input B inPrimaryParameters;
+  input B inAllPrimaryParameters;
   input A p;
   input C className;
   input String filenamePrefix;

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -683,7 +683,8 @@ constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG(12, "preOptModules",
     // "addInitialStmtsToAlgorithms",
     "resolveLoops",
     "evalFunc",
-    "sortEqnsVars"
+    "sortEqnsVars",
+    "encapsulateWhenConditions"
     }),
   SOME(STRING_DESC_OPTION({
     ("CSE_EachCall", Util.gettext("Common Function Call Elimination")),
@@ -716,7 +717,8 @@ constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG(12, "preOptModules",
     ("evalFunc", Util.gettext("evaluates functions partially")),
     ("comSubExp", Util.gettext("replaces common sub expressions")),
     ("dumpDAE", Util.gettext("dumps the DAE representation of the current transformation state")),
-    ("dumpDAEXML", Util.gettext("dumps the DAE as xml representation of the current transformation state"))
+    ("dumpDAEXML", Util.gettext("dumps the DAE as xml representation of the current transformation state")),
+    ("encapsulateWhenConditions", Util.gettext("This module replaces each when condition with a boolean variable."))
     })),
   Util.gettext("Sets the pre optimization modules to use in the back end. See --help=optmodules for more info."));
 
@@ -763,6 +765,7 @@ constant ConfigFlag INDEX_REDUCTION_METHOD = CONFIG_FLAG(15, "indexReductionMeth
 
 constant ConfigFlag POST_OPT_MODULES = CONFIG_FLAG(16, "postOptModules",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({
+    "removeInitializationStuff",
     "lateInlineFunction",
     "simplifyConstraints",
     "CSE",
@@ -775,7 +778,6 @@ constant ConfigFlag POST_OPT_MODULES = CONFIG_FLAG(16, "postOptModules",
     "removeSimpleEquations",
     "simplifyComplexFunction",
     "symEuler",
-    "encapsulateWhenConditions",  // must called after remove simple equations
     "reshufflePost",
     "reduceDynamicOptimization", // before tearing
     "tearingSystem", // must be the last one, otherwise the torn systems are lost when throw away the matching information
@@ -798,7 +800,7 @@ constant ConfigFlag POST_OPT_MODULES = CONFIG_FLAG(16, "postOptModules",
     //"addInitialStmtsToAlgorithms",
     }),
   SOME(STRING_DESC_OPTION({
-    ("encapsulateWhenConditions", Util.gettext("Replace each condition/relation with a boolean variable.")),
+    ("removeInitializationStuff", Util.gettext("Does simplifications by removing initialization information like homotopy(..) and initial().")),
     ("lateInlineFunction", Util.gettext("Perform function inlining for function with annotation LateInline=true.")),
     ("removeSimpleEquations", removeSimpleEquationDesc),
     ("evaluateFinalParameters", Util.gettext("Structural parameters and parameters declared as final are removed and replaced with their value. They may no longer be changed in the init file.")),

--- a/SimulationRuntime/c/simulation/solver/initialization/initialization.c
+++ b/SimulationRuntime/c/simulation/solver/initialization/initialization.c
@@ -627,18 +627,17 @@ int initialization(DATA *data, threadData_t *threadData, const char* pInitMethod
   dumpInitialSolution(data);
   infoStreamPrint(LOG_INIT, 0, "### END INITIALIZATION ###");
 
-  data->simulationInfo.initial = 0;
-  /* initialization is done */
-
   overwriteOldSimulationData(data);     /* overwrite the whole ring-buffer with initialized values */
   storePreValues(data);                 /* save pre-values */
   updateDiscreteSystem(data, threadData);           /* evaluate discrete variables (event iteration) */
   saveZeroCrossings(data, threadData);
 
+  data->simulationInfo.initial = 0;
+  /* initialization is done */
+
   initSample(data, threadData, data->simulationInfo.startTime, data->simulationInfo.stopTime);
   data->callback->function_storeDelayed(data, threadData);
   data->callback->function_updateRelations(data, threadData, 1);
-
   initSynchronous(data, threadData, data->simulationInfo.startTime);
 
   printRelations(data, LOG_EVENTS);

--- a/SimulationRuntime/c/simulation/solver/model_help.h
+++ b/SimulationRuntime/c/simulation/solver/model_help.h
@@ -37,7 +37,8 @@ extern "C" {
 #include "simulation_data.h"
 
 /* lochel: I guess this is used for discrete relations */
-#define RELATION(res,exp1,exp2,index,op_w) { \
+#define RELATION(res,exp1,exp2,index,op_w) \
+{ \
   if(data->simulationInfo.initial) \
   { \
     res = ((op_w)((exp1),(exp2))); \
@@ -55,7 +56,8 @@ extern "C" {
 }
 
 /* lochel: I guess this is used for continuous relations */
-#define RELATIONHYSTERESIS(res,exp1,exp2,index,op_w) { \
+#define RELATIONHYSTERESIS(res,exp1,exp2,index,op_w) \
+{ \
   if(data->simulationInfo.initial) \
   { \
     res = ((op_w)((exp1),(exp2))); \


### PR DESCRIPTION
See [#3452] (https://trac.openmodelica.org/OpenModelica/ticket/3452).

This pull request will move the generation and optimization of the initialization problem from sim code to back end.
The initialization problem will be handled separately from the simulation problem right after index reduction. Therewith, both systems can be optimized independently during post-optimization.