### PR TITLE
Do not override the user's --std choice

### DIFF
--- a/Compiler/FrontEnd/ClassLoader.mo
+++ b/Compiler/FrontEnd/ClassLoader.mo
@@ -385,7 +385,7 @@ algorithm
   end if;
   s1 := Absyn.withinString(w1);
   s2 := Absyn.withinString(w2);
-  if not (Absyn.withinEqual(w1,w2) or Config.languageStandardAtMost(Config.MODELICA_2_X())) then
+  if not (Absyn.withinEqual(w1,w2) or Config.languageStandardAtMost(Config.LanguageStandard.'2.x')) then
     Error.addSourceMessage(Error.LIBRARY_UNEXPECTED_WITHIN, {s1,s2}, info);
     fail();
   elseif expectPackage and not Absyn.isParts(body) then

--- a/Compiler/FrontEnd/ConnectUtil.mo
+++ b/Compiler/FrontEnd/ConnectUtil.mo
@@ -3574,7 +3574,7 @@ algorithm
     case (_, _, _, _, _)
       equation
         true = intEq(inPotentialVars, inFlowVars) or
-          Config.languageStandardAtMost(Config.MODELICA_2_X());
+          Config.languageStandardAtMost(Config.LanguageStandard.'2.x');
         true = if intEq(inStreamVars, 0) then true else intEq(inFlowVars, 1);
       then
         true;

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -7838,7 +7838,7 @@ algorithm
         isBuiltin = if SCode.hasBooleanNamedAnnotationInClass(cl,"__OpenModelica_BuiltinPtr") then DAE.FUNCTION_BUILTIN_PTR() else DAE.FUNCTION_NOT_BUILTIN();
         isOpenModelicaPure = not SCode.hasBooleanNamedAnnotationInClass(cl,"__OpenModelica_Impure");
         // In Modelica 3.2 and before, external functions with side-effects are not marked
-        isImpure = SCode.isRestrictionImpure(restriction,hasOutVars or Config.languageStandardAtLeast(Config.MODELICA_3_3()));
+        isImpure = SCode.isRestrictionImpure(restriction,hasOutVars or Config.languageStandardAtLeast(Config.LanguageStandard.'3.3'));
       then DAE.FUNCTION_ATTRIBUTES(inlineType,isOpenModelicaPure,isImpure,false,isBuiltin,DAE.FP_NON_PARALLEL());
   end matchcontinue;
 end getFunctionAttributes;


### PR DESCRIPTION
This solves ticket #3481, where the language standard is reset to 3.2
when loading MSL after loading Modelica_Synchronous (which requires
Modelica language 3.3).

Also changed the implementation from uniontypes to Modelica arrays
(since it should speed up lookup).