### PR TITLE
Run without OPENMODELICAHOME on Windows

### DIFF
--- a/Compiler/Main/Main.mo
+++ b/Compiler/Main/Main.mo
@@ -735,7 +735,7 @@ algorithm
     // check if we have OMDEV set
     case (omHome)
       equation
-        _ = System.setEnv("OPENMODELICAHOME",omHome,true);
+        System.setEnv("OPENMODELICAHOME",omHome,true);
         omdevPath = Util.makeValueOrDefault(System.readEnv,"OMDEV","");
         // we have something!
         false = stringEq(omdevPath, "");
@@ -749,13 +749,12 @@ algorithm
                                     omdevPath,"\\tools\\mingw\\bin;",
                                     omdevPath,"\\tools\\mingw\\libexec\\gcc\\mingw32\\4.4.0\\;",
                                     oldPath});
-        _ = System.setEnv("PATH",newPath,true);
-      then
-        ();
+        System.setEnv("PATH",newPath,true);
+      then ();
 
     case (omHome)
       equation
-        _ = System.setEnv("OPENMODELICAHOME",omHome,true);
+        System.setEnv("OPENMODELICAHOME",omHome,true);
         oldPath = System.readEnv("PATH");
         // do we have bin?
         true = System.directoryExists(omHome + "\\mingw\\bin");
@@ -766,24 +765,21 @@ algorithm
                                     omHome,"\\mingw\\bin;",
                                     omHome,"\\mingw\\libexec\\gcc\\mingw32\\4.4.0\\;",
                                     oldPath});
-        _ = System.setEnv("PATH",newPath,true);
-      then
-        ();
+        System.setEnv("PATH",newPath,true);
+      then ();
 
     // do not display anything if +d=disableWindowsPathCheckWarning
     case (_)
       equation
         true = Flags.isSet(Flags.DISABLE_WINDOWS_PATH_CHECK_WARNING);
-      then
-        ();
+      then ();
 
     else
       equation
         print("We could not find any of:\n");
-        print("\t$OPENMODELICAHOME/MinGW/bin and $OPENMODELICAHOME/MinGW/libexec/gcc/mingw32/4.4.0\n");
+        print("\t"+inOMHome+"/MinGW/bin and "+inOMHome+"/MinGW/libexec/gcc/mingw32/4.4.0\n");
         print("\t$OMDEV/tools/MinGW/bin and $OMDEV/tools/MinGW/libexec/gcc/mingw32/4.4.0\n");
-      then
-        ();
+      then ();
 
   end matchcontinue;
 end setWindowsPaths;

--- a/Compiler/runtime/config.unix.h.in
+++ b/Compiler/runtime/config.unix.h.in
@@ -27,11 +27,7 @@
 #endif
 
 #define DEFAULT_CFLAGS "@RUNTIMECFLAGS@ ${MODELICAUSERCFLAGS}"
-#ifdef __APPLE_CC__
-  #define CONFIG_OS "OSX"
-#else
-  #define CONFIG_OS "linux"
-#endif
+#define CONFIG_OS "@CONFIG_OS@"
 
 #define CONFIG_LPSOLVEINC "@LPSOLVEINC@"
 @NO_LPLIB@

--- a/Compiler/runtime/settingsimpl.c
+++ b/Compiler/runtime/settingsimpl.c
@@ -155,12 +155,21 @@ const char* SettingsImpl__getInstallationDirectoryPath(void) {
 }
 #endif /* dylib */
 
-#else
+#else /* Not linux or Apple */
 const char* SettingsImpl__getInstallationDirectoryPath(void) {
   const char *path = getenv("OPENMODELICAHOME");
   int i = 0;
-  if (path == NULL)
-    return CONFIG_DEFAULT_OPENMODELICAHOME; // On Windows, this is NULL; on Unix it is the configured --prefix
+  if (path == NULL) {
+#if defined(__MINGW32__) || defined(_MSC_VER)
+    char filename[MAX_PATH];
+    if (0 != GetModuleFileName(NULL, filename, MAX_PATH)) {
+      path = filename;
+    } else
+#endif
+    {
+      return CONFIG_DEFAULT_OPENMODELICAHOME; // On Windows, this is NULL; on Unix it is the configured --prefix
+    }
+  }
 #if defined(__MINGW32__) || defined(_MSC_VER)
   /* adrpo: translate this to forward slashes! */
   /* already set, set it only once! */

--- a/Compiler/runtime/settingsimpl.c
+++ b/Compiler/runtime/settingsimpl.c
@@ -160,32 +160,35 @@ const char* SettingsImpl__getInstallationDirectoryPath(void) {
   const char *path = getenv("OPENMODELICAHOME");
   int i = 0;
   if (path == NULL) {
-#if defined(__MINGW32__) || defined(_MSC_VER)
+#if defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
     char filename[MAX_PATH];
     if (0 != GetModuleFileName(NULL, filename, MAX_PATH)) {
       path = filename;
+      *strrchr(path, '\\') = '\0';
+      *strrchr(path, '\\') = '\0';
     } else
 #endif
     {
       return CONFIG_DEFAULT_OPENMODELICAHOME; // On Windows, this is NULL; on Unix it is the configured --prefix
     }
   }
-#if defined(__MINGW32__) || defined(_MSC_VER)
+#if defined(__MINGW64__) || defined(__MINGW32__) || defined(_MSC_VER)
   /* adrpo: translate this to forward slashes! */
   /* already set, set it only once! */
-  if (winPath != NULL)
+  if (winPath != NULL) {
     return (const char*)winPath;
+  }
 
   /* duplicate the path */
   winPath = strdup(path);
 
   /* ?? not enough memory for duplication */
-  if (!winPath)
+  if (!winPath) {
     return path;
+  }
 
   /* convert \\ to / */
-  while(winPath[i] != '\0')
-  {
+  while(winPath[i] != '\0') {
     if (winPath[i] == '\\') winPath[i] = '/';
     i++;
   }

--- a/configure.ac
+++ b/configure.ac
@@ -656,6 +656,7 @@ AC_SUBST(CMAKE_LDFLAGS)
 AC_SUBST(CMAKE_EXTRA_DEFINES)
 AC_SUBST(DLLEXT)
 AC_SUBST(UMFPACK_SHARED)
+AC_SUBST(CONFIG_OS)
 if test "$DARWIN" = "1"; then
   APP=".app"
   EXE=".app"
@@ -688,6 +689,7 @@ if test "$DARWIN" = "1"; then
   BOOTSTRAP_STATIC=""
   CMAKE_LDFLAGS="-Wl,-undefined -Wl,dynamic_lookup"
   UMFPACK_SHARED=ON
+  CONFIG_OS=OSX
 elif echo "$host" | grep -iq "mingw"; then
   APP=".exe"
   EXE=".exe"
@@ -722,6 +724,7 @@ elif echo "$host" | grep -iq "mingw"; then
   CPPFLAGS="$CPPFLAGS -DMSYS2_AUTOCONF=1"
   OMC_LIBS="$OMC_LIBS -lwsock32 -Wl,-Bstatic -lstdc++ -ltre  -lintl -liconv -Wl,-Bdynamic -lshlwapi"
   UMFPACK_SHARED=OFF
+  CONFIG_OS=Windows_NT
 else
   APP=""
   EXE=""
@@ -752,6 +755,7 @@ else
   AR_SH="$AR -ru"
   BOOTSTRAP_STATIC=""
   UMFPACK_SHARED=ON
+  CONFIG_OS=`echo $host_os | sed s/-gnu//`
 fi
 
 AC_ARG_WITH(FMIL, [  --with-FMIL                 Link omc to FMIL (only disable when cross-compiling)],


### PR DESCRIPTION
Use GetModuleFileName on Windows if the environment variable is not
defined. This is similar to Linux and OSX, where the pidpath and
/proc/self are used to find out where OpenModelica was installed.

If OPENMODELICAHOME is set, the same behaviour as before applies.