### PR TITLE
Add new flag --useLocalDirection.

### DIFF
--- a/Compiler/FrontEnd/InstVar.mo
+++ b/Compiler/FrontEnd/InstVar.mo
@@ -1167,7 +1167,9 @@ algorithm
         // Propagate the final prefix from the modifier.
         //fin = InstUtil.propagateModFinal(mod, fin);
 
-        attr = stripVarAttrDirection(cr, ih, inState, inPrefix, attr);
+        if not Flags.getConfigBool(Flags.USE_LOCAL_DIRECTION) then
+          attr = stripVarAttrDirection(cr, ih, inState, inPrefix, attr);
+        end if;
 
         // Propagate prefixes to any elements inside this components if it's a
         // structured component.

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -1189,6 +1189,9 @@ constant ConfigFlag INIT_OPT_MODULES = CONFIG_FLAG(78, "initOptModules",
 constant ConfigFlag MAX_MIXED_DETERMINED_INDEX = CONFIG_FLAG(79, "maxMixedDeterminedIndex",
   NONE(), EXTERNAL(), INT_FLAG(3), NONE(),
   Util.gettext("Sets the maximum mixed-determined index that is handled by the initialization."));
+constant ConfigFlag USE_LOCAL_DIRECTION = CONFIG_FLAG(80, "useLocalDirection",
+  NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
+  Util.gettext("Keeps the input/output prefix for all variables in the flat model, not only top-level ones."));
 
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
@@ -1273,7 +1276,8 @@ constant list<ConfigFlag> allConfigFlags = {
   MATRIX_FORMAT,
   PARTLINTORN,
   INIT_OPT_MODULES,
-  MAX_MIXED_DETERMINED_INDEX
+  MAX_MIXED_DETERMINED_INDEX,
+  USE_LOCAL_DIRECTION
 };
 
 public function new


### PR DESCRIPTION
- Used to revert back to the old behaviour of not stripping input/output
  from non-toplevel variables.