### PR TITLE
Fix for attribute propagation with redeclares.

### DIFF
--- a/Compiler/FrontEnd/Lookup.mo
+++ b/Compiler/FrontEnd/Lookup.mo
@@ -3220,5 +3220,39 @@ algorithm
   end match;
 end prefixSplicedExp;
 
+public function isArrayType
+  input FCore.Cache inCache;
+  input FCore.Graph inEnv;
+  input Absyn.Path inPath;
+  output FCore.Cache outCache;
+  output Boolean outIsArray;
+protected
+  SCode.Element el;
+  Absyn.Path p;
+  FCore.Graph env;
+algorithm
+  try
+    (outCache, el, env) := lookupClass(inCache, inEnv, inPath, false);
+
+    outIsArray := match el
+      case SCode.CLASS(classDef = SCode.DERIVED(typeSpec = Absyn.TPATH(arrayDim = SOME(_))))
+        then true;
+
+      case SCode.CLASS(classDef = SCode.DERIVED(attributes = SCode.ATTR(arrayDims = _ :: _)))
+        then true;
+
+      case SCode.CLASS(classDef = SCode.DERIVED(typeSpec = Absyn.TPATH(path = p)))
+        algorithm
+          (outCache, outIsArray) := isArrayType(outCache, env, p);
+        then
+          outIsArray;
+
+      else false;
+    end match;
+  else
+    outIsArray := false;
+  end try;
+end isArrayType;
+
 annotation(__OpenModelica_Interface="frontend");
 end Lookup;


### PR DESCRIPTION
- Treat (redeclare Real3 x) with type Real3 = Real[3] the same as
  (redeclare Real x[3]).