### PR TITLE
Use va_copy when re-using a va_list

### DIFF
--- a/SimulationRuntime/c/util/modelica_string.c
+++ b/SimulationRuntime/c/util/modelica_string.c
@@ -298,9 +298,11 @@ extern char* omc__escapedString(const char* str, int nl)
 
 int GC_vasprintf(char **strp, const char *fmt, va_list ap) {
   int len;
+  va_list ap2;
+  va_copy(ap2, ap);
   len = vsnprintf(NULL, 0, fmt, ap);
   *strp = omc_alloc_interface.malloc_atomic(len+1);
-  len = vsnprintf(*strp, len+1, fmt, ap);
+  len = vsnprintf(*strp, len+1, fmt, ap2);
   return len;
 }
 


### PR DESCRIPTION
This fixes a bug in GC_asprintf, which is now used more often than
earlier. This should fix simulation of models on OSX.