### PR TITLE
Fmu experimental jacobian

### DIFF
--- a/Compiler/SimCode/SimCodeMain.mo
+++ b/Compiler/SimCode/SimCodeMain.mo
@@ -258,7 +258,9 @@ algorithm
         fmi20 = FMI.isFMIVersion20(FMUVersion);
         symbolicJacActivated = Flags.getConfigBool(Flags.GENERATE_SYMBOLIC_LINEARIZATION);
         Flags.setConfigBool(Flags.GENERATE_SYMBOLIC_LINEARIZATION, fmi20);
-        flagValue = Flags.enableDebug(Flags.DIS_SYMJAC_FMI20);
+        if not Flags.isSet(Flags.FMU_EXPERIMENTAL) then
+            flagValue = Flags.enableDebug(Flags.DIS_SYMJAC_FMI20);
+        end if;
 
         _ = FCore.getFunctionTree(cache);
         dae = DAEUtil.transformationsBeforeBackend(cache,graph,dae);
@@ -272,7 +274,9 @@ algorithm
 
         //reset config flag
         Flags.setConfigBool(Flags.GENERATE_SYMBOLIC_LINEARIZATION, symbolicJacActivated);
-        Flags.set(Flags.DIS_SYMJAC_FMI20, flagValue);
+        if not Flags.isSet(Flags.FMU_EXPERIMENTAL) then
+            Flags.set(Flags.DIS_SYMJAC_FMI20, flagValue);
+        end if;
 
         resultValues =
         {("timeTemplates",Values.REAL(timeTemplates)),

--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -878,6 +878,32 @@ template simulationFile(SimCode simCode, String guid, Boolean isModelExchangeFMU
 
     #ifdef FMU_EXPERIMENTAL
     <% if Flags.isSet(Flags.FMU_EXPERIMENTAL) then functionODEPartial(odeEquations,(match simulationSettingsOpt case SOME(settings as SIMULATION_SETTINGS(__)) then settings.method else ""), hpcomData.schedules, modelNamePrefixStr, modelInfo)%>
+    <% if Flags.isSet(Flags.FMU_EXPERIMENTAL) then
+    <<
+    void <%symbolName(modelNamePrefixStr,"functionFMIJacobian")%>(DATA *data, threadData_t *threadData, const unsigned *unknown, int nUnk, const unsigned *ders, int nKnown, double *dvKnown, double *out) {
+        int i;
+        // TODO: Use the literal names instead of the data-> structure
+        // Beware! This code assumes that the FMI variables are sorted putting
+        // states first (0 to nStates-1) and state derivatives (nStates to 2*nStates-1) second.
+        for (int i=0;i<data->modelData.nStates; i++) {
+            // Clear out the seeds
+            data->simulationInfo.analyticJacobians[0].seedVars[i]=0;
+        }
+        for (int i=0;i<nUnk; i++) {
+            // Put the supplied value in the seeds
+            data->simulationInfo.analyticJacobians[0].seedVars[unknown[i]]=dvKnown[i];
+        }
+        // Call the Jacobian evaluation function. This function evaluates the whole column of the Jacobian.
+        // More efficient code could only evaluate the equations needed for the
+        // known variables only
+        <%symbolName(modelNamePrefixStr,"functionJacA_column")%>(data,threadData);
+
+        // Write the results back to the array
+        for (int i=0;i<nKnown; i++) {
+            out[ders[i]-data->modelData.nStates] = data->simulationInfo.analyticJacobians[0].resultVars[ders[i]-data->modelData.nStates];
+        }
+    }
+    >> %>
     #endif
     /* forward the main in the simulation runtime */
     extern int _main_SimulationRuntime(int argc, char**argv, DATA *data, threadData_t *threadData);
@@ -941,6 +967,7 @@ template simulationFile(SimCode simCode, String guid, Boolean isModelExchangeFMU
        <% if isModelExchangeFMU then symbolName(modelNamePrefixStr,"read_input_fmu") else "NULL" %>
        #ifdef FMU_EXPERIMENTAL
        ,<%symbolName(modelNamePrefixStr,"functionODE_Partial")%>
+       ,<%symbolName(modelNamePrefixStr,"functionFMIJacobian")%>
        #endif
 
     <%\n%>

--- a/Compiler/Template/CodegenFMUCommon.tpl
+++ b/Compiler/Template/CodegenFMUCommon.tpl
@@ -59,7 +59,7 @@ case SIMCODE(__) then
   let modelIdentifier = modelNamePrefix(simCode)
   <<
   <ModelExchange
-    modelIdentifier="<%modelIdentifier%>" <% if Flags.isSet(FMU_EXPERIMENTAL) then 'providesDirectionalDerivative="true"'%>>
+    modelIdentifier="<%modelIdentifier%>"<% if Flags.isSet(FMU_EXPERIMENTAL) then ' providesDirectionalDerivative="true"'%>>
   </ModelExchange>
   >>
 end ModelExchange;

--- a/Compiler/Template/CodegenFMUCommon.tpl
+++ b/Compiler/Template/CodegenFMUCommon.tpl
@@ -59,7 +59,7 @@ case SIMCODE(__) then
   let modelIdentifier = modelNamePrefix(simCode)
   <<
   <ModelExchange
-    modelIdentifier="<%modelIdentifier%>">
+    modelIdentifier="<%modelIdentifier%>" <% if Flags.isSet(FMU_EXPERIMENTAL) then 'providesDirectionalDerivative="true"'%>>
   </ModelExchange>
   >>
 end ModelExchange;

--- a/SimulationRuntime/c/openmodelica_func.h
+++ b/SimulationRuntime/c/openmodelica_func.h
@@ -315,6 +315,7 @@ void (*read_input_fmu)(MODEL_DATA* modelData, SIMULATION_INFO* simulationData);
 /* functionODEPartial contains those equations that are needed
  * to calculate the state derivative i-th */
 void (*functionODEPartial)(DATA *data, threadData_t*, int i);
+void (*functionFMIJacobian)(DATA *data, threadData_t*, const unsigned *unknown, int nUnk, const unsigned *ders, int nKnown, double *dvKnown, double *out);
 #endif
 };
 

--- a/SimulationRuntime/fmi/export/fmi2/fmu2_model_interface.c
+++ b/SimulationRuntime/fmi/export/fmi2/fmu2_model_interface.c
@@ -721,7 +721,7 @@ fmi2Status fmi2GetDirectionalDerivative(fmi2Component c, const fmi2ValueReferenc
         return fmi2Error;
   }
   for (i = 0; i < nKnown; i++) {
-    if (vKnown_ref[i]>2*NUMBER_OF_STATES) {
+    if (vKnown_ref[i]>=2*NUMBER_OF_STATES) {
         // We are only computing the A part of the Jacobian for now
         // so knowns can only be states derivatives
         return fmi2Error;

--- a/SimulationRuntime/fmi/export/fmi2/fmu2_model_interface.h
+++ b/SimulationRuntime/fmi/export/fmi2/fmu2_model_interface.h
@@ -83,6 +83,9 @@ typedef struct {
   fmi2Real stopTime;
 
   int _need_update;
+#ifdef FMU_EXPERIMENTAL
+  int _has_jacobian;
+#endif
 } ModelInstance;
 
 #ifdef __cplusplus


### PR DESCRIPTION
The following changes make use of the analytical Jacobian generated from OMC to use it to implement the fmi2GetDirectionalDerivative.
* Right now the code evaluates whole columns of the Jacobian and only the continuous part (the A matrix) is supported, i.e. derivatives of state derivatives w.r.t. states.
* The function is only activated with the fmuExperimental flag.

An extra callback function was included for the FMU to evaluate the columnos of A matrix. 

