### PR TITLE
Fixed alias default and initial equation sub expression tag

### DIFF
--- a/Compiler/Template/CodegenXML.tpl
+++ b/Compiler/Template/CodegenXML.tpl
@@ -218,7 +218,7 @@ template getAliasVarXml(AliasVariable aliasvar)
  "Returns the alias Attribute of ScalarVariable."
 ::=
 match aliasvar
-  case NOALIAS(__) then ""
+  case NOALIAS(__) then "noAlias"
   case ALIAS(__) then '<%crefStrXml(varName)%>'
   case NEGATEDALIAS(__) then '-<%crefStrXml(varName)%>'
   else ""
@@ -668,10 +668,10 @@ end initialEquationsXml;
       let &preExp = buffer "" /*BUFD*/
          <<
          <equ:Equation>
-           <equ:Sub>
+           <exp:Sub>
              <%identName%>
              <%daeExpXml(exp, contextOther, &preExp, &varDecls)%>
-           </equ:Sub>
+           </exp:Sub>
          </equ:Equation><%\n%>
          >>
 end initialEquationXml;


### PR DESCRIPTION
Fixes two differences between exported XML files and the format standard (what JModelica and casadi produce/expect).

The first is that when there are no alias' a blank string was used instead of "noAlias" :
https://svn.jmodelica.org/trunk/XML/jmodelicaScalarVariable.xsd

The second was that the InitialEquations section was using the tag of <equ:Sub> instead of <exp:Sub>.

After making these changes the casadi xml parser can now load an exported OM XML file without throwing an exception.

I'm not sure if any of the unit tests need to be modified because of this change.  This is my first pull request for this project so I'm not sure how to initiate the Hudson testing on the branch.
