### PR TITLE
Fix for Buildings library, #3506:

### DIFF
--- a/Compiler/Util/List.mo
+++ b/Compiler/Util/List.mo
@@ -1756,6 +1756,21 @@ algorithm
   outUnion := listReverseInPlace(outUnion);
 end unionOnTrue;
 
+public function unionAppendListOnTrue<T>
+  input list<T> inList;
+  input list<T> inUnion;
+  input CompFunc inCompFunc;
+  output list<T> outUnion;
+
+  partial function CompFunc
+    input T inElement1;
+    input T inElement2;
+    output Boolean outIsEqual;
+  end CompFunc;
+algorithm
+  outUnion := fold(inList, function unionEltOnTrue(inCompFunc = inCompFunc), inUnion);
+end unionAppendListOnTrue;
+
 public function unionList<T>
   "Takes a list of lists and returns the union of the sublists.
      Example: unionList({1}, {1, 2}, {3, 4}, {5}}) => {1, 2, 3, 4, 5}"


### PR DESCRIPTION
- Fix InstExtends.fixModifications so that it uses fixClassdef instead
  of fixElement on class names in redeclares, since fixElement will
  always fully qualify them even when it shouldn't.
- Some cleanup.