### PR TITLE
Improve usability of back end optimization phases

### DIFF
--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -7157,12 +7157,12 @@ protected function allPostOptimizationModules
     (SymbolicJacobian.generateSymbolicJacobianPast, "generateSymbolicJacobian"),
     (SymbolicJacobian.generateSymbolicLinearizationPast, "generateSymbolicLinearization"),
     (BackendDAEOptimize.removeConstants, "removeConstants"),
+    (ExpressionSolve.solveSimpleEquations, "solveSimpleEquations"),
     (BackendDAEOptimize.simplifyTimeIndepFuncCalls, "simplifyTimeIndepFuncCalls"),
     (BackendDAEOptimize.simplifyAllExpressions, "simplifyAllExpressions"),
     // TODO: move the following modules to the correct position
     (BackendDump.dumpComponentsGraphStr, "dumpComponentsGraphStr"),
     (BackendDump.dumpDAE, "dumpDAE"),
-    (ExpressionSolve.solveSimpleEquations, "solveSimpleEquations"),
     (XMLDump.dumpDAEXML, "dumpDAEXML")
   };
 end allPostOptimizationModules;

--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -6596,6 +6596,7 @@ algorithm
   SimCodeFunctionUtil.execStat("prepare preOptimizeDAE");
   for preOptModule in inPreOptModules loop
     (optModule, moduleStr) := preOptModule;
+    moduleStr := moduleStr + " (" + BackendDump.printBackendDAEType2String(inDAE.shared.backendDAEType) + ")";
     try
       BackendDAE.DAE(systs, shared) := optModule(outDAE);
       (systs, shared) := filterEmptySystems(systs, shared);

--- a/Compiler/BackEnd/Initialization.mo
+++ b/Compiler/BackEnd/Initialization.mo
@@ -94,7 +94,7 @@ protected
   HashSet.HashSet clkHS "contains all clocked variables";
   list<BackendDAE.Equation> removedEqns;
   list<BackendDAE.Var> dumpVars, dumpVars2;
-  list<tuple<BackendDAEFunc.optimizationModule, String, Boolean>> initOptModules;
+  list<tuple<BackendDAEFunc.optimizationModule, String>> initOptModules;
   tuple<BackendDAEFunc.StructurallySingularSystemHandlerFunc, String, BackendDAEFunc.stateDeselectionFunc, String> daeHandler;
   tuple<BackendDAEFunc.matchingAlgorithmFunc, String> matchingAlgorithm;
 algorithm

--- a/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/Compiler/BackEnd/SymbolicJacobian.mo
@@ -1830,20 +1830,20 @@ algorithm
           end if;
 
           backendDAE2 = BackendDAEUtil.getSolvedSystemforJacobians(backendDAE,
-                                                                   SOME({"simplifyAllExpressions",
+                                                                   SOME({"removeEqualFunctionCalls",
+                                                                         "removeSimpleEquations",
                                                                          "evalFunc",
-                                                                         "removeEqualFunctionCalls",
-                                                                         "removeSimpleEquations"}),
+                                                                         "simplifyAllExpressions"}),
                                                                    NONE(),
                                                                    NONE(),
                                                                    SOME({"inlineArrayEqn",
                                                                          "constantLinearSystem",
                                                                          "removeSimpleEquations",
-                                                                         "removeConstants",
                                                                          "tearingSystem",
+                                                                         "calculateStrongComponentJacobians",
+                                                                         "removeConstants",
                                                                          "solveSimpleEquations",
                                                                          "simplifyTimeIndepFuncCalls",
-                                                                         "calculateStrongComponentJacobians",
                                                                          "simplifyAllExpressions"}));
           _ = Flags.set(Flags.EXEC_STAT, b);
           if Flags.isSet(Flags.JAC_DUMP) then

--- a/Compiler/BackEnd/Uncertainties.mo
+++ b/Compiler/BackEnd/Uncertainties.mo
@@ -130,6 +130,8 @@ algorithm
       String outStringA,outStringB,outString,description;
       list<Option<DAE.Distribution>> distributions;
 
+      Boolean forceOrdering = Flags.getConfigBool(Flags.FORCE_RECOMMENDED_ORDERING);
+
     case (cache,graph,_,(st as GlobalScript.SYMBOLTABLE(ast = p)),outputFile,_)
       equation
         //print("Initiating\n");
@@ -140,7 +142,9 @@ algorithm
         //print("- Flatten ok\n");
         dlow = BackendDAECreate.lower(dae,cache,graph,BackendDAE.EXTRA_INFO(description,outputFile));
         //(dlow_1,funcs1) = BackendDAEUtil.getSolvedSystem(dlow, funcs,SOME({"removeSimpleEquations","removeFinalParameters", "removeEqualFunctionCalls", "expandDerOperator"}), NONE(), NONE(),NONE());
-        (dlow_1) = BackendDAEUtil.getSolvedSystem(dlow,"", SOME({"removeSimpleEquations","removeUnusedVariables","removeEqualFunctionCalls","expandDerOperator"}), NONE(), NONE(), SOME({}));
+        Flags.setConfigBool(Flags.FORCE_RECOMMENDED_ORDERING, false);
+        (dlow_1) = BackendDAEUtil.getSolvedSystem(dlow, "", SOME({"removeSimpleEquations","removeUnusedVariables","removeEqualFunctionCalls","expandDerOperator"}), NONE(), NONE(), SOME({}));
+        Flags.setConfigBool(Flags.FORCE_RECOMMENDED_ORDERING, forceOrdering);
         //print("* Lowered Ok \n");
 
         dlow_1 = removeSimpleEquationsUC(dlow_1);

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -687,10 +687,9 @@ constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG(12, "preOptModules",
     "expandDerOperator",
     "removeEqualFunctionCalls",
     "clockPartitioning",
-    //"CSE_EachCall",
     "findStateOrder",
     "introduceDerAlias",
-    "inputDerivativesForDynOpt", // only for dyn. opt.
+    "inputDerivativesForDynOpt",
     "replaceEdgeChange",
     "inlineArrayEqn",
     "removeSimpleEquations",
@@ -793,8 +792,8 @@ constant ConfigFlag POST_OPT_MODULES = CONFIG_FLAG(16, "postOptModules",
     "simplifyComplexFunction",
     "symEuler",
     "reshufflePost",
-    "reduceDynamicOptimization", // before tearing
-    "tearingSystem", // must be the last one, otherwise the torn systems are lost when throw away the matching information
+    "reduceDynamicOptimization",
+    "tearingSystem",
     "simplifyLoops",
     "recursiveTearing",
     "partlintornsystem",
@@ -1159,17 +1158,13 @@ constant ConfigFlag PARTLINTORN = CONFIG_FLAG(77, "partlintorn",
 
 constant ConfigFlag INIT_OPT_MODULES = CONFIG_FLAG(78, "initOptModules",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({
-    //"constantLinearSystem",
     "simplifyComplexFunction",
-      //"reduceDynamicOptimization", // before tearing
     "tearingSystem",
     "simplifyLoops",
     "recursiveTearing",
     "calculateStrongComponentJacobians",
     "solveSimpleEquations",
     "simplifyAllExpressions"
-      //"inputDerivativesUsed",
-      //"extendDynamicOptimization"
     }),
   SOME(STRING_DESC_OPTION({
     ("calculateStrongComponentJacobians", Util.gettext("Generates analytical Jacobian for non-linear strong components.")),
@@ -1193,6 +1188,9 @@ constant ConfigFlag MAX_MIXED_DETERMINED_INDEX = CONFIG_FLAG(79, "maxMixedDeterm
 constant ConfigFlag USE_LOCAL_DIRECTION = CONFIG_FLAG(80, "useLocalDirection",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Keeps the input/output prefix for all variables in the flat model, not only top-level ones."));
+constant ConfigFlag FORCE_RECOMMENDED_ORDERING = CONFIG_FLAG(81, "forceRecommendedOrdering",
+  NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
+  Util.gettext("If this is activated, then the specified pre-/post-/init-optimization modules will be rearranged to the recommended ordering."));
 
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
@@ -1278,7 +1276,8 @@ constant list<ConfigFlag> allConfigFlags = {
   PARTLINTORN,
   INIT_OPT_MODULES,
   MAX_MIXED_DETERMINED_INDEX,
-  USE_LOCAL_DIRECTION
+  USE_LOCAL_DIRECTION,
+  FORCE_RECOMMENDED_ORDERING
 };
 
 public function new

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -1191,6 +1191,24 @@ constant ConfigFlag USE_LOCAL_DIRECTION = CONFIG_FLAG(80, "useLocalDirection",
 constant ConfigFlag FORCE_RECOMMENDED_ORDERING = CONFIG_FLAG(81, "forceRecommendedOrdering",
   NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
   Util.gettext("If this is activated, then the specified pre-/post-/init-optimization modules will be rearranged to the recommended ordering."));
+constant ConfigFlag PRE_OPT_MODULES_ADD = CONFIG_FLAG(82, "preOptModules+",
+  NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
+  Util.gettext("Sets additional pre-optimization modules to use in the back end. See --help=optmodules for more info."));
+constant ConfigFlag PRE_OPT_MODULES_SUB = CONFIG_FLAG(83, "preOptModules-",
+  NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
+  Util.gettext("Disables a list of pre-optimization modules. See --help=optmodules for more info."));
+constant ConfigFlag POST_OPT_MODULES_ADD = CONFIG_FLAG(84, "postOptModules+",
+  NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
+  Util.gettext("Sets additional post-optimization modules to use in the back end. See --help=optmodules for more info."));
+constant ConfigFlag POST_OPT_MODULES_SUB = CONFIG_FLAG(85, "postOptModules-",
+  NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
+  Util.gettext("Disables a list of post-optimization modules. See --help=optmodules for more info."));
+constant ConfigFlag INIT_OPT_MODULES_ADD = CONFIG_FLAG(86, "initOptModules+",
+  NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
+  Util.gettext("Sets additional init-optimization modules to use in the back end. See --help=optmodules for more info."));
+constant ConfigFlag INIT_OPT_MODULES_SUB = CONFIG_FLAG(87, "initOptModules-",
+  NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
+  Util.gettext("Disables a list of init-optimization modules. See --help=optmodules for more info."));
 
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
@@ -1277,7 +1295,13 @@ constant list<ConfigFlag> allConfigFlags = {
   INIT_OPT_MODULES,
   MAX_MIXED_DETERMINED_INDEX,
   USE_LOCAL_DIRECTION,
-  FORCE_RECOMMENDED_ORDERING
+  FORCE_RECOMMENDED_ORDERING,
+  PRE_OPT_MODULES_ADD,
+  PRE_OPT_MODULES_SUB,
+  POST_OPT_MODULES_ADD,
+  POST_OPT_MODULES_SUB,
+  INIT_OPT_MODULES_ADD,
+  INIT_OPT_MODULES_SUB
 };
 
 public function new

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -2637,6 +2637,14 @@ algorithm
   DEBUG_FLAG(name = name) := inFlag;
 end debugFlagName;
 
+public function configFlagName
+  "Prints out name of a debug flag."
+  input ConfigFlag inFlag;
+  output String name;
+algorithm
+  CONFIG_FLAG(name = name) := inFlag;
+end configFlagName;
+
 protected function getValidStringOptions
   input ValidOptions inOptions;
   output list<String> validOptions;


### PR DESCRIPTION
This pull request introduces a couple of new flags:

`--forceRecommendedOrdering`: This is a Boolean flag with default true. This flag means that the specified pre-/post-/init-optimization modules will be automatically arranged in the recommended order. This flag can be set to false to achieve the old behaviour.

`--preOptModules+=module1,module2` / `-–preOptModules-=module3,module4`: This activates/deactivates certain pre-optimization modules. Since the back end takes care of arranging all pre-optimization module properly, this cannot be used in combination with `--forceRecommendedOrdering=false`.
The same is implemented for post-/init-optimization phase. Therefore, the flags are called `--postOptModules+=module1,module2` / `-–postOptModules-=module3,module4` and `--initOptModules+=module1,module2` / `-–initOptModules-=module3,module4`.