### PR TITLE
Some updates for mingw cross-compilation

### DIFF
--- a/Compiler/runtime/Makefile.omdev.mingw
+++ b/Compiler/runtime/Makefile.omdev.mingw
@@ -35,7 +35,7 @@ SHELL	= /bin/sh
 CC	= gcc
 CXX = g++
 IDL	= $(OMDEV)/bin/mico/idl
-override CFLAGS += -I. $(USE_CORBA) $(USE_METIS) -DBUILD_MICO_DLL -Wall -Wno-unused-variable -I../../ -I$(top_builddir) -I$(top_builddir)/SimulationRuntime/c -I$(top_builddir)/SimulationRuntime/c/simulation/results -I$(top_builddir)/SimulationRuntime/c/util -I$(top_builddir)/SimulationRuntime/c/meta -I$(top_builddir)/SimulationRuntime/c/meta/gc -I../ $(CORBAINCL) -I$(FMIINCLUDE) -I../../3rdParty/gc/include -I$(GRAPHSTREAMINCLUDE) -I$(CJSONINCLUDE) -I$(GRAPHINCLUDE)
+override CFLAGS += -I. $(USE_CORBA) $(USE_METIS) -DNO_AUTOCONF -DBUILD_MICO_DLL -Wall -Wno-unused-variable -I../../ -I$(top_builddir) -I$(top_builddir)/SimulationRuntime/c -I$(top_builddir)/SimulationRuntime/c/simulation/results -I$(top_builddir)/SimulationRuntime/c/util -I$(top_builddir)/SimulationRuntime/c/meta -I$(top_builddir)/SimulationRuntime/c/meta/gc -I../ $(CORBAINCL) -I$(FMIINCLUDE) -I../../3rdParty/gc/include -I$(GRAPHSTREAMINCLUDE) -I$(CJSONINCLUDE) -I$(GRAPHINCLUDE)
 CXXFLAGS = $(CFLAGS)
 
 include Makefile.common

--- a/Compiler/runtime/Print_omc.c
+++ b/Compiler/runtime/Print_omc.c
@@ -38,6 +38,7 @@
 #include "printimpl.h"
 #include "meta_modelica.h"
 
+#include "omc_config.h"
 #include "printimpl.c"
 #include "ModelicaUtilities.h"
 

--- a/Compiler/runtime/config.unix.h.in
+++ b/Compiler/runtime/config.unix.h.in
@@ -78,3 +78,4 @@
 #define USE_PATOH @USE_PATOH@
 #define USE_METIS @USE_METIS@
 #endif
+@HAVE_GETTEXT@

--- a/Compiler/runtime/omc_config.h
+++ b/Compiler/runtime/omc_config.h
@@ -31,7 +31,7 @@
 #ifndef OPENMODELICA_CONFIG_H
 #define OPENMODELICA_CONFIG_H
 
-#if defined(__MINGW32__) || defined(_MSC_VER) /* Windows */
+#if defined(NO_AUTOCONF) /* Windows */
 
 #define DEFAULT_CC "gcc"
 #define DEFAULT_CXX "g++"

--- a/Compiler/runtime/systemimpl.h
+++ b/Compiler/runtime/systemimpl.h
@@ -31,6 +31,7 @@
 #define __SYSTEMIMPL_H
 
 #include "openmodelica.h"
+#include "omc_config.h"
 
 char* _replace(const char* source_str,
                const char* search_str,
@@ -38,7 +39,7 @@ char* _replace(const char* source_str,
 
 typedef int (*function_t)(threadData_t*, type_description*, type_description*);
 
-#if defined(_MSC_VER) /* no gettext for VS! */
+#if defined(_MSC_VER) || defined(NO_GETTEXT) /* no gettext for VS! */
 #define gettext(str) str
 #else
 #include <locale.h>

--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,7 @@ AC_SUBST(with_paradiseo_lib)
 AC_SUBST(with_qwt)
 AC_SUBST(with_qwt_suffix)
 AC_SUBST(EXTRA_CFLAGS_GENERATED_CODE)
+AC_SUBST(HAVE_GETTEXT)
 AC_SUBST(LIBSOCKET)
 AC_SUBST(LIBNSL)
 AC_SUBST(LIBLPSOLVE55)
@@ -258,7 +259,7 @@ fi
 
 dnl Checks for libraries.
 
-if test ! "$DARWIN" = "1"; then
+if test ! "$DARWIN" = "1" && (! echo $host | grep -q mingw ); then
   LIBS=""
   AC_SEARCH_LIBS(clock_gettime,rt,[],[AC_MSG_ERROR([clock_gettime missing])])
   LIBRT="$LIBS"
@@ -302,7 +303,10 @@ fi
 
 dnl Misc. headers
 
-AC_CHECK_HEADER(expat.h,,AC_MSG_ERROR([expat missing]))
+AC_CHECK_HEADER(expat.h,,
+  CPPFLAGS="$CPPFLAGS -I \"$ac_top_srcdir/3rdParty/FMIL/Expat/lib\""
+  AC_MSG_RESULT([using local expat.h])
+)
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
@@ -409,6 +413,9 @@ LIBS=""
 CC="$CC_OLD"
 CFLAGS="$CFLAGS_OLD"
 
+if echo "$host" | grep -q "mingw"; then
+  true
+else
 dnl check for lpsolve55
 
 AC_ARG_WITH(lpsolve,  [  --with-lpsolve        (default searching for lpsolve; disable if only using omc to cross-compile)],[if test "$withval" = "no"; then NO_LPLIB="#define NO_LPLIB"; fi],[])
@@ -447,9 +454,10 @@ AC_CHECK_HEADER([lp_lib.h],[LPSOLVEINC=lp_lib.h],[
   AC_CHECK_HEADER([lpsolve/lp_lib.h],[LPSOLVEINC=lpsolve/lp_lib.h],[AC_MSG_ERROR([failed to find lpsolve55 headers])])
 ])
 
+fi
 fi # NO_LPLIB
 
-if test "$host" != "i586-pc-mingw32msvc"; then
+if ! (echo "$host" | grep -q "mingw"); then
   AC_CHECK_FUNC(socket,[LIBSOCKET=""],
    [AC_MSG_CHECKING([for libsocket]);
     AC_CHECK_LIB(socket, socket,[AC_MSG_RESULT([yes]); LIBSOCKET="-lsocket"],[AC_MSG_ERROR([neither socket nor libsocket.a found])])
@@ -530,8 +538,7 @@ fi
 
 LIBS=""
 
-AC_CHECK_HEADERS(locale.h libintl.h,[],[AC_MSG_ERROR([gettext headers not found])])
-
+AC_CHECK_HEADERS(locale.h libintl.h,[
 AC_MSG_CHECKING([gettext linking])
 AC_TRY_LINK([
 #include <libintl.h>
@@ -545,7 +552,14 @@ AC_TRY_LINK([
   ], [
       gettext("");
   ], [AC_MSG_RESULT([in intl]);RT_LDFLAGS_OPTIONAL="$RT_LDFLAGS_OPTIONAL $LIBS"],
-      [AC_MSG_ERROR([no])])
+      [
+        HAVE_GETTEXT="#define NO_GETTEXT 1"
+        AC_MSG_RESULT([no])
+      ])
+])
+],[
+  HAVE_GETTEXT="#define NO_GETTEXT 1"
+  AC_MSG_RESULT([gettext headers not found])
 ])
 
 LIBS=""


### PR DESCRIPTION
The autoconf now ignores some headers when mingw cross-compilation is
requested.