### PR TITLE
Clean up default preOptModules

### DIFF
--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -679,23 +679,16 @@ constant Util.TranslatableContent removeSimpleEquationDesc = Util.gettext("Perfo
 public
 constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG(12, "preOptModules",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({
-    "evaluateAllParameters",
     "evaluateReplaceProtectedFinalEvaluateParameters",
-    "stateMachineElab",
     "simplifyIfEquations",
     "expandDerOperator",
     "removeEqualFunctionCalls",
     "clockPartitioning",
     "findStateOrder",
-    "introduceDerAlias",
-    "inputDerivativesForDynOpt",
     "replaceEdgeChange",
     "inlineArrayEqn",
     "removeSimpleEquations",
     "comSubExp",
-    "resolveLoops",
-    "evalFunc",
-    "sortEqnsVars",
     "encapsulateWhenConditions"
     }),
   SOME(STRING_DESC_OPTION({


### PR DESCRIPTION
Modules that need to get activated using additional flags appear
no longer in the default preOptModule list.