### PR TITLE
Fix for #2959.

### DIFF
--- a/Compiler/FrontEnd/Ceval.mo
+++ b/Compiler/FrontEnd/Ceval.mo
@@ -1215,7 +1215,7 @@ protected
   list<Absyn.Exp> args;
   SCode.FunctionRestriction funcRest;
 algorithm
-  (outCache,cdef,env_1) := Lookup.lookupClass(inCache,env, funcpath, false);
+  (outCache,cdef,env_1) := Lookup.lookupClass(inCache,env, funcpath);
   SCode.CLASS(name=fid,restriction = SCode.R_FUNCTION(funcRest), classDef=SCode.PARTS(externalDecl=extdecl)) := cdef;
   SCode.FR_EXTERNAL_FUNCTION(_) := funcRest;
   SOME(SCode.EXTERNALDECL(oid,_,_,_,_)) := extdecl;

--- a/Compiler/FrontEnd/InstExtends.mo
+++ b/Compiler/FrontEnd/InstExtends.mo
@@ -294,7 +294,7 @@ algorithm
     case (_, _)
       equation
         path = Absyn.removePartialPrefix(Absyn.IDENT(inClassName), inPath);
-        (cache, elem, env) = Lookup.lookupClass(inCache, inEnv, path, false);
+        (cache, elem, env) = Lookup.lookupClass(inCache, inEnv, path);
       then
         (cache, SOME(elem), env);
 
@@ -655,7 +655,7 @@ algorithm
     case (cache,env,ih,mod,pre,SCode.CLASS( info = info, classDef = SCode.DERIVED(typeSpec = Absyn.TPATH(tp, _),modifications = dmod)),impl, _, false, _)
       equation
         // fprintln(Flags.INST_TRACE, "DERIVED: " + FGraph.printGraphPathStr(env) + " el: " + SCodeDump.unparseElementStr(inClass) + " mods: " + Mod.printModStr(mod));
-        (cache, c, cenv) = Lookup.lookupClass(cache, env, tp, true);
+        (cache, c, cenv) = Lookup.lookupClass(cache, env, tp, SOME(info));
         dmod = InstUtil.chainRedeclares(mod, dmod);
         // false = Absyn.pathEqual(FGraph.getGraphName(env),FGraph.getGraphName(cenv)) and SCode.elementEqual(c,inClass);
         // modifiers should be evaluated in the current scope for derived!
@@ -1613,7 +1613,7 @@ algorithm
     case (_, _, _)
       equation
         // see where the first ident from the path leads, if is outside the current env DO NOT strip!
-        (_, _, env) = Lookup.lookupClass(inCache, inEnv, Absyn.makeIdentPathFromString(Absyn.pathFirstIdent(inPath)), false);
+        (_, _, env) = Lookup.lookupClass(inCache, inEnv, Absyn.makeIdentPathFromString(Absyn.pathFirstIdent(inPath)));
         // if envClass is prefix of env then is outside scope
         yes = FGraph.graphPrefixOf(env, inEnv);
       then
@@ -1700,7 +1700,7 @@ algorithm
       equation
         id = Absyn.crefFirstIdent(cref);
         //print("Try lookupC " + id + "\n");
-        (_,c,denv) = Lookup.lookupClass(cache,env,Absyn.IDENT(id),false);
+        (_,c,denv) = Lookup.lookupClass(cache,env,Absyn.IDENT(id));
         // isOutside = FGraph.graphPrefixOf(denv, env);
         // id might come from named import, make sure you use the actual class name!
         id = SCode.getElementName(c);

--- a/Compiler/FrontEnd/InstSection.mo
+++ b/Compiler/FrontEnd/InstSection.mo
@@ -4291,7 +4291,7 @@ algorithm
 
         // deal with equalityConstraint function!
         // instantiate and add the equalityConstraint function to the dae function tree!
-        (cache,equalityConstraintFunction,env) = Lookup.lookupClass(cache,env,fpath1,false);
+        (cache,equalityConstraintFunction,env) = Lookup.lookupClass(cache,env,fpath1);
         (cache,fpath1) = Inst.makeFullyQualified(cache,env,fpath1);
         cache = FCore.addCachedInstFuncGuard(cache,fpath1);
         (cache,env,ih) =
@@ -4337,7 +4337,7 @@ algorithm
 
         // deal with equalityConstraint function!
         // instantiate and add the equalityConstraint function to the dae function tree!
-        (cache,equalityConstraintFunction,env) = Lookup.lookupClass(cache,env,fpath1,false);
+        (cache,equalityConstraintFunction,env) = Lookup.lookupClass(cache,env,fpath1);
         (cache,fpath1) = Inst.makeFullyQualified(cache,env,fpath1);
         cache = FCore.addCachedInstFuncGuard(cache,fpath1);
         (cache,env,ih) =

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -881,20 +881,20 @@ algorithm
     // we haven't found the class, do nothing
     case (_, _, _, _, {SCode.EXTENDS(baseClassPath=p)})
       equation
-        failure((_, _, _) = Lookup.lookupClass(inCache, inEnv, p, false));
+        failure((_, _, _) = Lookup.lookupClass(inCache, inEnv, p));
       then ();
 
     // we found te class, check the restriction
     case (_, _, _, r1, {SCode.EXTENDS(baseClassPath=p)})
       equation
-        (_,SCode.CLASS(restriction=r2),_) = Lookup.lookupClass(inCache,inEnv,p,false);
+        (_,SCode.CLASS(restriction=r2),_) = Lookup.lookupClass(inCache,inEnv,p);
         checkExtendsRestrictionMatch(r1, r2);
       then ();
 
     // make some waves that this is not correct
     case (_, _, _, r1, {SCode.EXTENDS(baseClassPath=p)})
       equation
-        (_,SCode.CLASS(restriction=r2),_) = Lookup.lookupClass(inCache, inEnv, p, false);
+        (_,SCode.CLASS(restriction=r2),_) = Lookup.lookupClass(inCache, inEnv, p);
         print("Error!: " + SCodeDump.restrString(r1) + " " + FGraph.printGraphPathStr(inEnv) +
               " cannot be extended by " + SCodeDump.restrString(r2) + " " + Absyn.pathString(p) + " due to derived/base class restrictions.\n");
       then fail();
@@ -3064,8 +3064,8 @@ algorithm
         equality(ad1 = ad2);
         equality(cond1 = cond2);
         // if we lookup tpath1 and tpath2 and reach the same class, we're fine!
-        (_, c1, env1) = Lookup.lookupClass(cache, env, tpath1, false);
-        (_, c2, env2) = Lookup.lookupClass(cache, env, tpath2, false);
+        (_, c1, env1) = Lookup.lookupClass(cache, env, tpath1);
+        (_, c2, env2) = Lookup.lookupClass(cache, env, tpath2);
         // the class has the same environment
         true = stringEq(FGraph.printGraphPathStr(env1), FGraph.printGraphPathStr(env2));
         // the classes are the same!
@@ -3093,8 +3093,8 @@ algorithm
         equality(ad1 = ad2);
         equality(cond1 = cond2);
         // if we lookup tpath1 and tpath2 and reach the same class, we're fine!
-        (_, c1, env1) = Lookup.lookupClass(cache, env, tpath1, false);
-        (_, c2, env2) = Lookup.lookupClass(cache, env, tpath2, false);
+        (_, c1, env1) = Lookup.lookupClass(cache, env, tpath1);
+        (_, c2, env2) = Lookup.lookupClass(cache, env, tpath2);
         // the class has the same environment
         true = stringEq(FGraph.printGraphPathStr(env1), FGraph.printGraphPathStr(env2));
         // the classes are the same!
@@ -3301,7 +3301,7 @@ algorithm
     case(NONE(),_,_) then {};
     case(SOME(SCode.CONSTRAINCLASS(constrainingClass = path)),_,_)
       equation
-        (_,SCode.CLASS(name = name, classDef = SCode.PARTS(elementLst=selems)), _) = Lookup.lookupClass(FCore.emptyCache(),env,path,false);
+        (_,SCode.CLASS(name = name, classDef = SCode.PARTS(elementLst=selems)), _) = Lookup.lookupClass(FCore.emptyCache(),env,path);
         (classes,classextendselts,extendselts,compelts) = splitElts(selems);
         (_,_,_,_,extcomps,_,_,_,_) = InstExtends.instExtendsAndClassExtendsList(FCore.emptyCache(), env, InnerOuter.emptyInstHierarchy, DAE.NOMOD(),  pre, extendselts, classextendselts, selems, ClassInf.UNKNOWN(Absyn.IDENT("")), name, true, false);
         extcompelts = List.map(extcomps,Util.tuple21);
@@ -3310,7 +3310,7 @@ algorithm
         compelts;
     case (SOME(SCode.CONSTRAINCLASS(path, mod, cmt)), _, _)
       equation
-        (_,SCode.CLASS(classDef = SCode.DERIVED(typeSpec = Absyn.TPATH(path = path))),_) = Lookup.lookupClass(FCore.emptyCache(),env,path,false);
+        (_,SCode.CLASS(classDef = SCode.DERIVED(typeSpec = Absyn.TPATH(path = path))),_) = Lookup.lookupClass(FCore.emptyCache(),env,path);
         compelts = extractConstrainingComps(SOME(SCode.CONSTRAINCLASS(path, mod, cmt)),env,pre);
       then
         compelts;
@@ -3693,7 +3693,7 @@ algorithm
                             classDef = SCode.DERIVED(Absyn.TPATH(path = cn, arrayDim = ad),modifications = mod)),
           dims, impl)
       equation
-        (cache,cl,cenv) = Lookup.lookupClass(cache, env, cn, true);
+        (cache,cl,cenv) = Lookup.lookupClass(cache, env, cn, SOME(info));
         owncref = Absyn.CREF_IDENT(id,{});
         ad_1 = getOptionArraydim(ad);
         env = addEnumerationLiteralsToEnv(env, cl);
@@ -3722,7 +3722,7 @@ algorithm
       equation
         (_,_,{SCode.EXTENDS(path, _, mod,_, info)},{}) = splitElts(els); // ONLY ONE extends!
         (cache,mod_1) = Mod.elabModForBasicType(cache, env, ih, pre, mod, impl, Mod.EXTENDS(path), info);
-        (cache,cl,_) = Lookup.lookupClass(cache, env, path, false);
+        (cache,cl,_) = Lookup.lookupClass(cache, env, path);
         (cache,res,cl,type_mods) = getUsertypeDimensions(cache,env,ih,pre,cl,{},impl);
         // type_mods = Mod.addEachIfNeeded(type_mods, res);
         type_mods = Mod.merge(mod_1, type_mods, env, pre);
@@ -3827,7 +3827,7 @@ algorithm
         false = FGraph.isTopScope(inNewEnv);
         id = FNode.refName(FGraph.lastScopeRef(inNewEnv));
         (rest, _) = FGraph.stripLastScopeRef(inNewEnv);
-        (_, cls, _) = Lookup.lookupClass(inCache, rest, Absyn.IDENT(id), false);
+        (_, cls, _) = Lookup.lookupClass(inCache, rest, Absyn.IDENT(id));
         ci_state = ClassInf.start(SCode.getClassRestriction(cls), FGraph.getGraphName(inNewEnv));
       then
         ci_state;
@@ -7654,18 +7654,19 @@ public function extractClassDefComment
   input FCore.Graph env;
   input SCode.ClassDef classDef;
   input SCode.Comment inComment;
+  input SourceInfo inInfo;
   output SCode.Comment comment;
 algorithm
-  comment := matchcontinue(cache, env, classDef, inComment)
+  comment := matchcontinue classDef
     local
       list<SCode.Annotation> al;
       Absyn.Path p;
       SCode.ClassDef cd;
       SCode.Comment cmt;
 
-    case (_, _, SCode.DERIVED(typeSpec = Absyn.TPATH(path = p)), _)
+    case SCode.DERIVED(typeSpec = Absyn.TPATH(path = p))
       equation
-        (_, SCode.CLASS(cmt=cmt), _) = Lookup.lookupClass(cache, env, p, true);
+        (_, SCode.CLASS(cmt=cmt), _) = Lookup.lookupClass(cache, env, p, SOME(inInfo));
         cmt = mergeClassComments(inComment, cmt);
       then cmt;
 

--- a/Compiler/FrontEnd/Mod.mo
+++ b/Compiler/FrontEnd/Mod.mo
@@ -3337,5 +3337,41 @@ algorithm
   outSubMods := listReverse(outSubMods);
 end stripSubModBindings;
 
+public function filterRedeclares
+  input DAE.Mod inMod;
+  output DAE.Mod outMod = inMod;
+algorithm
+  outMod := match outMod
+    case DAE.MOD()
+      algorithm
+        outMod.subModLst := filterRedeclaresSubMods(outMod.subModLst);
+        outMod.eqModOption := NONE();
+      then
+        if listEmpty(outMod.subModLst) then DAE.NOMOD() else outMod;
+
+    else outMod;
+  end match;
+end filterRedeclares;
+
+protected function filterRedeclaresSubMods
+  input list<DAE.SubMod> inSubMods;
+  output list<DAE.SubMod> outSubMods = {};
+protected
+  DAE.Ident id;
+  DAE.Mod mod;
+algorithm
+  for submod in inSubMods loop
+    DAE.NAMEMOD(id, mod) := submod;
+    mod := filterRedeclares(mod);
+
+    if isRedeclareMod(mod) then
+      outSubMods := DAE.NAMEMOD(id, mod) :: outSubMods;
+    end if;
+  end for;
+
+  outSubMods := listReverse(outSubMods);
+end filterRedeclaresSubMods;
+
+
 annotation(__OpenModelica_Interface="frontend");
 end Mod;

--- a/Compiler/FrontEnd/OperatorOverloading.mo
+++ b/Compiler/FrontEnd/OperatorOverloading.mo
@@ -217,12 +217,12 @@ algorithm
 
          path = getRecordPath(type1);
          path = Absyn.makeFullyQualified(path);
-         (cache,_,recordEnv) = Lookup.lookupClass(cache,env,path, false);
+         (cache,_,recordEnv) = Lookup.lookupClass(cache,env,path);
 
          str1 = "'" + Dump.opSymbolCompact(aboper) + "'";
          path = Absyn.joinPaths(path, Absyn.IDENT(str1));
 
-         (cache,operatorCl,operatorEnv) = Lookup.lookupClass(cache,recordEnv,path, false);
+         (cache,operatorCl,operatorEnv) = Lookup.lookupClass(cache,recordEnv,path);
          true = SCode.isOperator(operatorCl);
 
          operNames = SCodeUtil.getListofQualOperatorFuncsfromOperator(operatorCl);
@@ -277,12 +277,12 @@ algorithm
 
         path = getRecordPath(type1);
         path = Absyn.makeFullyQualified(path);
-        (cache,_,recordEnv) = Lookup.lookupClass(cache,env,path, false);
+        (cache,_,recordEnv) = Lookup.lookupClass(cache,env,path);
 
         str1 = "'String'";
         path = Absyn.joinPaths(path, Absyn.IDENT(str1));
 
-        (cache,operatorCl,operatorEnv) = Lookup.lookupClass(cache,recordEnv,path, false);
+        (cache,operatorCl,operatorEnv) = Lookup.lookupClass(cache,recordEnv,path);
         true = SCode.isOperator(operatorCl);
 
         operNames = SCodeUtil.getListofQualOperatorFuncsfromOperator(operatorCl);
@@ -1407,12 +1407,12 @@ algorithm
         scalarType = Types.arrayElementType(ty);
         path = getRecordPath(scalarType);
         path = Absyn.makeFullyQualified(path);
-        (cache,operatorCl,recordEnv) = Lookup.lookupClass(cache,env,path,false);
+        (cache,operatorCl,recordEnv) = Lookup.lookupClass(cache,env,path);
         (cache,path,recordEnv) = lookupOperatorBaseClass(cache,recordEnv,operatorCl);
         opNamePath = Absyn.IDENT(opName);
         path = Absyn.joinPaths(path, opNamePath);
         // check if the operator is defined. i.e overloaded
-        (cache,operatorCl,operEnv) = Lookup.lookupClass(cache,recordEnv,path,false);
+        (cache,operatorCl,operEnv) = Lookup.lookupClass(cache,recordEnv,path);
         true = SCode.isOperator(operatorCl);
         // get the list of functions in the operator. !! there can be multiple options
         paths = SCodeUtil.getListofQualOperatorFuncsfromOperator(operatorCl);
@@ -1451,7 +1451,7 @@ algorithm
       String name;
     case (cache,env,SCode.CLASS(classDef=SCode.DERIVED(typeSpec=Absyn.TPATH(path,NONE()))))
       equation
-        (cache,cl,env) = Lookup.lookupClass(cache,env,path,false);
+        (cache,cl,env) = Lookup.lookupClass(cache,env,path);
         (cache,path,env) = lookupOperatorBaseClass(cache,env,cl);
       then (cache,path,env);
 

--- a/Compiler/FrontEnd/Prefix.mo
+++ b/Compiler/FrontEnd/Prefix.mo
@@ -74,6 +74,7 @@ uniontype ComponentPrefix
     list<DAE.Subscript> subscripts "subscripts" ;
     ComponentPrefix next "next prefix" ;
     ClassInf.State ci_state "to be able to at least partially fill in type information properly for DAE.VAR";
+    SourceInfo info;
   end PRE;
 
   record NOCOMPPRE end NOCOMPPRE;

--- a/Compiler/FrontEnd/PrefixUtil.mo
+++ b/Compiler/FrontEnd/PrefixUtil.mo
@@ -81,21 +81,21 @@ algorithm
 
     case Prefix.NOPRE() then "<Prefix.NOPRE()>";
     case Prefix.PREFIX(Prefix.NOCOMPPRE(),_) then "<Prefix.PREFIX(Prefix.NOCOMPPRE())>";
-    case Prefix.PREFIX(Prefix.PRE(str,_,{},Prefix.NOCOMPPRE(),_),_) then str;
-    case Prefix.PREFIX(Prefix.PRE(str,_,ss,Prefix.NOCOMPPRE(),_),_)
+    case Prefix.PREFIX(Prefix.PRE(str,_,{},Prefix.NOCOMPPRE(),_,_),_) then str;
+    case Prefix.PREFIX(Prefix.PRE(str,_,ss,Prefix.NOCOMPPRE(),_,_),_)
       equation
         s = stringAppend(str, "[" + stringDelimitList(
           List.map(ss, ExpressionDump.subscriptString), ", ") + "]");
       then
         s;
-    case Prefix.PREFIX(Prefix.PRE(str,_,{},rest,_),cp)
+    case Prefix.PREFIX(Prefix.PRE(str,_,{},rest,_,_),cp)
       equation
         rest_1 = printPrefixStr(Prefix.PREFIX(rest,cp));
         s = stringAppend(rest_1, ".");
         s_1 = stringAppend(s, str);
       then
         s_1;
-    case Prefix.PREFIX(Prefix.PRE(str,_,ss,rest,_),cp)
+    case Prefix.PREFIX(Prefix.PRE(str,_,ss,rest,_,_),cp)
       equation
         rest_1 = printPrefixStr(Prefix.PREFIX(rest,cp));
         s = stringAppend(rest_1, ".");
@@ -166,6 +166,7 @@ public function prefixAdd "This function is used to extend a prefix with another
   input Prefix.Prefix inPrefix;
   input SCode.Variability vt;
   input ClassInf.State ci_state;
+  input SourceInfo inInfo;
   output Prefix.Prefix outPrefix;
 algorithm
   outPrefix := match (inIdent,inType,inIntegerLst,inPrefix,vt,ci_state)
@@ -175,10 +176,10 @@ algorithm
       Prefix.ComponentPrefix p;
 
     case (i,_,s,Prefix.PREFIX(p,_),_,_)
-      then Prefix.PREFIX(Prefix.PRE(i,inType,s,p,ci_state),Prefix.CLASSPRE(vt));
+      then Prefix.PREFIX(Prefix.PRE(i,inType,s,p,ci_state,inInfo),Prefix.CLASSPRE(vt));
 
     case(i,_,s,Prefix.NOPRE(),_,_)
-      then Prefix.PREFIX(Prefix.PRE(i,inType,s,Prefix.NOCOMPPRE(),ci_state),Prefix.CLASSPRE(vt));
+      then Prefix.PREFIX(Prefix.PRE(i,inType,s,Prefix.NOCOMPPRE(),ci_state,inInfo),Prefix.CLASSPRE(vt));
   end match;
 end prefixAdd;
 
@@ -194,8 +195,10 @@ algorithm
       Prefix.ComponentPrefix c;
       ClassInf.State ci_state;
       list<DAE.Dimension> pdims;
-    case (Prefix.PREFIX(Prefix.PRE(prefix = a, dimensions = pdims, subscripts = b,ci_state=ci_state),cp))
-      then Prefix.PREFIX(Prefix.PRE(a,pdims,b,Prefix.NOCOMPPRE(),ci_state),cp);
+      SourceInfo info;
+
+    case (Prefix.PREFIX(Prefix.PRE(prefix = a, dimensions = pdims, subscripts = b,ci_state=ci_state, info = info),cp))
+      then Prefix.PREFIX(Prefix.PRE(a,pdims,b,Prefix.NOCOMPPRE(),ci_state,info),cp);
   end match;
 end prefixFirst;
 
@@ -1417,6 +1420,16 @@ algorithm
 
   end match;
 end prefixClockKind;
+
+public function getPrefixInfo
+  input Prefix.Prefix inPrefix;
+  output SourceInfo outInfo;
+algorithm
+  outInfo := match inPrefix
+    case Prefix.PREFIX(compPre = Prefix.PRE(info = outInfo)) then outInfo;
+    else Absyn.dummyInfo;
+  end match;
+end getPrefixInfo;
 
 annotation(__OpenModelica_Interface="frontend");
 end PrefixUtil;

--- a/Compiler/FrontEnd/SCode.mo
+++ b/Compiler/FrontEnd/SCode.mo
@@ -1779,6 +1779,21 @@ algorithm
   end matchcontinue;
 end setClassName;
 
+public function makeClassPartial
+  input Element inClass;
+  output Element outClass = inClass;
+algorithm
+  outClass := match outClass
+    case CLASS(partialPrefix = NOT_PARTIAL())
+      algorithm
+        outClass.partialPrefix := PARTIAL();
+      then
+        outClass;
+
+    else outClass;
+  end match;
+end makeClassPartial;
+
 public function setClassPartialPrefix "Sets the partial prefix of a SCode Class"
   input Partial partialPrefix;
   input Element cl;

--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -7392,8 +7392,8 @@ algorithm
     case (cache,env,fn,args,nargs,impl,_,st,pre,_,_)
       equation
         (cache,cl as SCode.CLASS(restriction = SCode.R_PACKAGE()),_) =
-           Lookup.lookupClass(cache, env, Absyn.IDENT("GraphicalAnnotationsProgram____"), false);
-        (cache,cl as SCode.CLASS( restriction = SCode.R_RECORD(_)),env_1) = Lookup.lookupClass(cache, env, fn, false);
+           Lookup.lookupClass(cache, env, Absyn.IDENT("GraphicalAnnotationsProgram____"));
+        (cache,cl as SCode.CLASS( restriction = SCode.R_RECORD(_)),env_1) = Lookup.lookupClass(cache, env, fn);
         (cache,cl,env_2) = Lookup.lookupRecordConstructorClass(cache, env_1 /* env */, fn);
         (_,_::names) = SCode.getClassComponents(cl); // remove the fist one as it is the result!
         /*
@@ -7456,11 +7456,11 @@ algorithm
 
         false = Util.getStatefulBoolean(stopElab);
 
-        (cache,recordCl,recordEnv) = Lookup.lookupClass(cache,env,fn, false);
+        (cache,recordCl,recordEnv) = Lookup.lookupClass(cache,env,fn);
         true = SCode.isOperatorRecord(recordCl);
 
         fn_1 = Absyn.joinPaths(fn,Absyn.IDENT("'constructor'"));
-        (cache,recordCl,recordEnv) = Lookup.lookupClass(cache,recordEnv,fn_1, false);
+        (cache,recordCl,recordEnv) = Lookup.lookupClass(cache,recordEnv,fn_1);
         true = SCode.isOperator(recordCl);
 
         operNames = SCodeUtil.getListofQualOperatorFuncsfromOperator(recordCl);
@@ -7528,7 +7528,7 @@ algorithm
 
     case (cache,env,fn,_,_,_,_,_,_,_,_) /* class found; not function */
       equation
-        (cache,SCode.CLASS(restriction = re),_) = Lookup.lookupClass(cache,env,fn,false);
+        (cache,SCode.CLASS(restriction = re),_) = Lookup.lookupClass(cache,env,fn);
         false = SCode.isFunctionRestriction(re);
         fn_str = Absyn.pathString(fn);
         s = SCodeDump.restrString(re);
@@ -8194,12 +8194,12 @@ protected function lookupAndFullyQualify
 algorithm
   if Lookup.isFunctionCallViaComponent(inCache, inEnv, inFunctionName) then
     // do NOT qualify function calls via component instance!
-    (_, outClass, outEnv) := Lookup.lookupClass(inCache, inEnv, inFunctionName, false);
+    (_, outClass, outEnv) := Lookup.lookupClass(inCache, inEnv, inFunctionName);
     outFunctionName := FGraph.joinScopePath(outEnv, Absyn.makeIdentPathFromString(SCode.elementName(outClass)));
     outCache := inCache;
   else
     // qualify everything else
-    (outCache, outClass, outEnv) := Lookup.lookupClass(inCache, inEnv, inFunctionName, false);
+    (outCache, outClass, outEnv) := Lookup.lookupClass(inCache, inEnv, inFunctionName);
     outFunctionName := Absyn.makeFullyQualified(
       FGraph.joinScopePath(outEnv, Absyn.makeIdentPathFromString(SCode.elementName(outClass))));
   end if;
@@ -8449,7 +8449,7 @@ protected
 algorithm
   try
     (outCache, SCode.CLASS(classDef = SCode.PARTS(elementLst = els)), _) :=
-      Lookup.lookupClass(inCache, inEnv, inPath, false);
+      Lookup.lookupClass(inCache, inEnv, inPath);
     true := SCode.isExternalObject(els);
     outIsExt := true;
   else
@@ -10347,7 +10347,7 @@ algorithm
         c = replaceEnd(c);
         path = Absyn.crefToPath(c);
         (cache, cl as SCode.CLASS(restriction = SCode.R_ENUMERATION()), env) =
-          Lookup.lookupClass(cache, env, path, false);
+          Lookup.lookupClass(cache, env, path);
         typeStr = Absyn.pathLastIdent(path);
         path = FGraph.joinScopePath(env, Absyn.IDENT(typeStr));
         enum_lit_strs = SCode.componentNames(cl);
@@ -10408,7 +10408,7 @@ algorithm
                SOME((cl as SCode.COMPONENT(n, pref, SCode.ATTR(arrayDims = ad), Absyn.TPATH(tpath, _),m,comment,cond,info),cmod)),instStatus,_)
           = Lookup.lookupIdent(cache, env, id);
         print("Static: cref:" + Absyn.printComponentRefStr(c) + " component first ident:\n" + SCodeDump.unparseElementStr(cl) + "\n");
-        (cache, cl, env) = Lookup.lookupClass(cache, env, tpath, false);
+        (cache, cl, env) = Lookup.lookupClass(cache, env, tpath);
         print("Static: cref:" + Absyn.printComponentRefStr(c) + " class component first ident:\n" + SCodeDump.unparseElementStr(cl) + "\n");
       then
         (cache,NONE());*/
@@ -11573,7 +11573,7 @@ algorithm
         (cache,_,t,_,_,_,_,_,_) = Lookup.lookupVar(cache, crefEnv, cr);
         ty = Types.simplifyType(t);
         sl = Types.getDimensions(ty);
-        crefPrefix = PrefixUtil.prefixAdd(id,sl,{},crefPrefix,SCode.VAR(),ClassInf.UNKNOWN(Absyn.IDENT(""))); // variability doesn't matter
+        crefPrefix = PrefixUtil.prefixAdd(id,sl,{},crefPrefix,SCode.VAR(),ClassInf.UNKNOWN(Absyn.IDENT("")),info); // variability doesn't matter
         (cache,cr,const,hasZeroSizeDim) = elabCrefSubs(cache, crefEnv, crefSubs, restCref, topPrefix, crefPrefix, impl, hasZeroSizeDim, info);
       then
         (cache,ComponentReference.makeCrefQual(id,ty,{},cr),const,hasZeroSizeDim);
@@ -11581,7 +11581,7 @@ algorithm
     // QUAL,with no subscripts second case => look for class
     case (cache,crefEnv,crefSubs,Absyn.CREF_QUAL(name = id,subscripts = {},componentRef = restCref),topPrefix,crefPrefix,impl,hasZeroSizeDim,_)
       equation
-        crefPrefix = PrefixUtil.prefixAdd(id,{},{},crefPrefix,SCode.VAR(),ClassInf.UNKNOWN(Absyn.IDENT(""))); // variability doesn't matter
+        crefPrefix = PrefixUtil.prefixAdd(id,{},{},crefPrefix,SCode.VAR(),ClassInf.UNKNOWN(Absyn.IDENT("")),info); // variability doesn't matter
         (cache,cr,const,hasZeroSizeDim) = elabCrefSubs(cache, crefEnv, crefSubs, restCref, topPrefix, crefPrefix, impl, hasZeroSizeDim, info);
       then
         (cache,ComponentReference.makeCrefQual(id,DAE.T_COMPLEX_DEFAULT,{},cr),const,hasZeroSizeDim);
@@ -11597,7 +11597,7 @@ algorithm
         sl = Types.getDimensions(id_ty);
         (cache,ss_1,const1) = elabSubscriptsDims(cache, crefSubs, ss, sl, impl,
             topPrefix, inComponentRef, info);
-        crefPrefix = PrefixUtil.prefixAdd(id, sl, ss_1, crefPrefix, vt, ClassInf.UNKNOWN(Absyn.IDENT("")));
+        crefPrefix = PrefixUtil.prefixAdd(id, sl, ss_1, crefPrefix, vt, ClassInf.UNKNOWN(Absyn.IDENT("")),info);
         (cache,cr,const2,hasZeroSizeDim) = elabCrefSubs(cache, crefEnv, crefSubs, restCref, topPrefix, crefPrefix, impl, hasZeroSizeDim, info);
         const = Types.constAnd(const1, const2);
       then
@@ -12363,7 +12363,7 @@ algorithm
 
           case () // not a class or OpenModelica, continue
             equation
-              failure((_,_,_) = Lookup.lookupClass(cache, env, Absyn.IDENT(id), false));
+              failure((_,_,_) = Lookup.lookupClass(cache, env, Absyn.IDENT(id)));
               (_,dexp,prop,_) = elabExpInExpression(cache,env,exp,false,st,false,Prefix.NOPRE(),info);
             then
               ();
@@ -12521,7 +12521,7 @@ algorithm
     case (cache, _, _, Absyn.SUBSCRIPT(subscript = Absyn.CREF(cr)), _, _, _, _, _)
       equation
         type_path = Absyn.crefToPath(cr);
-        cache = Lookup.lookupClass(cache, inEnv, type_path, false);
+        cache = Lookup.lookupClass(cache, inEnv, type_path);
         (cache, t) = Lookup.lookupType(cache, inEnv, type_path, NONE());
         dim = match t
           case DAE.T_ENUMERATION(index=NONE())

--- a/Compiler/FrontEnd/UnitAbsynBuilder.mo
+++ b/Compiler/FrontEnd/UnitAbsynBuilder.mo
@@ -93,7 +93,7 @@ algorithm
        FCore.Ref r;
 
      case(_,_) equation
-       (_,_,env) = Lookup.lookupClass(Util.tuple21(tpl),Util.tuple22(tpl),p,false);
+       (_,_,env) = Lookup.lookupClass(Util.tuple21(tpl),Util.tuple22(tpl),p,NONE());
        r = FGraph.lastScopeRef(env);
        // get the defined units node
        r = FNode.child(r, FNode.duNodeName);

--- a/Compiler/Script/CevalScript.mo
+++ b/Compiler/Script/CevalScript.mo
@@ -192,7 +192,7 @@ algorithm
    // external functions are complete :)
    case (cache, env, fpath)
      equation
-       (_, SCode.CLASS(classDef = SCode.PARTS(externalDecl = SOME(_))), _) = Lookup.lookupClass(cache, env, fpath, false);
+       (_, SCode.CLASS(classDef = SCode.PARTS(externalDecl = SOME(_))), _) = Lookup.lookupClass(cache, env, fpath);
      then
        true;
 
@@ -206,7 +206,7 @@ algorithm
    // partial functions are not complete!
    case (cache, env, fpath)
      equation
-       (_, SCode.CLASS(partialPrefix = SCode.PARTIAL()), _) = Lookup.lookupClass(cache, env, fpath, false);
+       (_, SCode.CLASS(partialPrefix = SCode.PARTIAL()), _) = Lookup.lookupClass(cache, env, fpath);
      then
        false;
 
@@ -2311,7 +2311,7 @@ algorithm
         // bcall1(Flags.isSet(Flags.DYN_LOAD), print,"[dynload]: try constant evaluation: " + Absyn.pathString(funcpath) + "\n");
         (cache,
          sc as SCode.CLASS(partialPrefix = SCode.NOT_PARTIAL()),
-         env) = Lookup.lookupClass(cache, env, funcpath, false);
+         env) = Lookup.lookupClass(cache, env, funcpath);
         isCevaluableFunction(sc);
         (cache, env, _) = InstFunction.implicitFunctionInstantiation(
           cache,

--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -1563,7 +1563,7 @@ algorithm
         absynClass = Interactive.getPathedClassInProgram(classpath, p);
         (sp, st) = GlobalScriptUtil.symbolTableToSCode(st);
         (cache, env) = Inst.makeEnvFromProgram(FCore.emptyCache(), sp, Absyn.IDENT(""));
-        (cache,(cl as SCode.CLASS(name=name,encapsulatedPrefix=encflag,restriction=restr)),env) = Lookup.lookupClass(cache, env, classpath, false);
+        (cache,(cl as SCode.CLASS(name=name,encapsulatedPrefix=encflag,restriction=restr)),env) = Lookup.lookupClass(cache, env, classpath, NONE());
         env = FGraph.openScope(env, encflag, SOME(name), FGraph.restrictionToScopeType(restr));
         (_, env) = Inst.partialInstClassIn(cache, env, InnerOuter.emptyInstHierarchy, DAE.NOMOD(), Prefix.NOPRE(),
           ClassInf.start(restr, FGraph.getGraphName(env)), cl, SCode.PUBLIC(), {}, 0);
@@ -5239,7 +5239,7 @@ algorithm
         typename := matchcontinue ()
           case ()
             equation
-              (_,_,env) = Lookup.lookupClass(FCore.emptyCache(), inEnv, p, false);
+              (_,_,env) = Lookup.lookupClass(FCore.emptyCache(), inEnv, p, NONE());
               SOME(envpath) = FGraph.getScopePath(env);
               tpname = Absyn.pathLastIdent(p);
               p_1 = Absyn.joinPaths(envpath, Absyn.IDENT(tpname));

--- a/Compiler/Script/Interactive.mo
+++ b/Compiler/Script/Interactive.mo
@@ -3607,7 +3607,7 @@ algorithm
 
     case (pa,Absyn.COMPONENTS(typeSpec = Absyn.TPATH(path_1,_),components = comp_items),comps,env) /* the QUALIFIED path for the class */
       equation
-        (cache,SCode.CLASS(name=id),cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1, false);
+        (cache,SCode.CLASS(name=id),cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1);
         path_1 = Absyn.IDENT(id);
         (cache,path) = Inst.makeFullyQualified(cache, cenv, path_1);
         comps_1 = extractComponentsFromComponentitems(pa, path, comp_items, comps, env);
@@ -3615,7 +3615,7 @@ algorithm
         comps_1;
     case (pa,Absyn.EXTENDS(path = path_1,elementArg = elementargs),comps,env)
       equation
-        (cache,_,cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1, false)
+        (cache,_,cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1)
         "print \"extract_components_from_elementspec Absyn.EXTENDS(path,_) not implemented yet\"" ;
         (_,path) = Inst.makeFullyQualified(cache,cenv, path_1);
         comp = GlobalScript.EXTENDSITEM(pa,path);
@@ -3989,14 +3989,14 @@ algorithm
         p_1 = SCodeUtil.translateAbsyn2SCode(p);
         (cache,env) = Inst.makeEnvFromProgram(FCore.emptyCache(),p_1, Absyn.IDENT(""));
         (cache,(cl as SCode.CLASS(name=id,encapsulatedPrefix=encflag,restriction=restr,classDef=SCode.DERIVED(typeSpec=Absyn.TPATH(_,_)))),env_1) =
-        Lookup.lookupClass(cache,env, p_class, false);
+        Lookup.lookupClass(cache,env, p_class);
       then env_1;
 
     case (_,_)
       equation
         p_1 = SCodeUtil.translateAbsyn2SCode(p);
         (cache,env) = Inst.makeEnvFromProgram(FCore.emptyCache(),p_1, Absyn.IDENT(""));
-        (cache,(cl as SCode.CLASS(name=id,encapsulatedPrefix=encflag,restriction=restr)),env_1) = Lookup.lookupClass(cache,env, p_class, false);
+        (cache,(cl as SCode.CLASS(name=id,encapsulatedPrefix=encflag,restriction=restr)),env_1) = Lookup.lookupClass(cache,env, p_class);
         env2 = FGraph.openScope(env_1, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
         ci_state = ClassInf.start(restr, FGraph.getGraphName(env2));
         (_,env_2,_,_,_) =
@@ -6842,7 +6842,7 @@ algorithm
                       body = Absyn.DERIVED(typeSpec=Absyn.TPATH(path_1,subscripts),attributes = attrs,arguments = elementarg,comment = co),
                       info = file_info),old_comp,new_comp,env)
       equation
-        (cache,SCode.CLASS(name=name),cenv) = Lookup.lookupClass(FCore.emptyCache(), env, path_1, false);
+        (cache,SCode.CLASS(name=name),cenv) = Lookup.lookupClass(FCore.emptyCache(), env, path_1);
         path_1 = Absyn.IDENT(name);
         (_,path) = Inst.makeFullyQualified(cache, cenv, path_1);
         true = Absyn.pathEqual(path, old_comp);
@@ -6975,7 +6975,7 @@ algorithm
 
     case (Absyn.COMPONENTS(attributes = a,typeSpec = Absyn.TPATH(path_1,x),components = comp_items),old_comp,new_comp,env) /* the old name for the component signal if something in class have been changed rule */
       equation
-        (cache,SCode.CLASS(name=id),cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1, false);
+        (cache,SCode.CLASS(name=id),cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1);
         path_1 = Absyn.IDENT(id);
         (_,path) = Inst.makeFullyQualified(cache, cenv, path_1);
         true = Absyn.pathEqual(path, old_comp);
@@ -6984,7 +6984,7 @@ algorithm
         (Absyn.COMPONENTS(a,Absyn.TPATH(new_path,x),comp_items),true);
     case (Absyn.EXTENDS(path = path_1,elementArg = elargs, annotationOpt=annOpt),old_comp,new_comp,env)
       equation
-        (cache,_,cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1, false) "print \"rename_class_in_element_spec Absyn.EXTENDS(path,_) not implemented yet\"" ;
+        (cache,_,cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1) "print \"rename_class_in_element_spec Absyn.EXTENDS(path,_) not implemented yet\"" ;
         (_,path) = Inst.makeFullyQualified(cache,cenv, path_1);
         true = Absyn.pathEqual(path, old_comp);
         new_path = changeLastIdent(path_1, new_comp);
@@ -7020,7 +7020,7 @@ algorithm
 
     case (Absyn.NAMED_IMPORT(name = id,path = path_1),old_comp,new_comp,env) /* the old name for the component signal if something in class have been changed */
       equation
-        (cache,_,cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1, false);
+        (cache,_,cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1);
         (_,path) = Inst.makeFullyQualified(cache,cenv, path_1);
         true = Absyn.pathEqual(path, old_comp);
         new_path = changeLastIdent(path_1, new_comp);
@@ -7028,7 +7028,7 @@ algorithm
         (Absyn.NAMED_IMPORT(id,new_path),true);
     case (Absyn.QUAL_IMPORT(path = path_1),old_comp,new_comp,env)
       equation
-        (cache,_,cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1, false);
+        (cache,_,cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1);
         (_,path) = Inst.makeFullyQualified(cache,cenv, path_1);
         true = Absyn.pathEqual(path, old_comp);
         new_path = changeLastIdent(path_1, new_comp);
@@ -7036,7 +7036,7 @@ algorithm
         (Absyn.QUAL_IMPORT(new_path),true);
     case (Absyn.NAMED_IMPORT(path = path_1),old_comp,new_comp,env)
       equation
-        (cache,_,cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1, false);
+        (cache,_,cenv) = Lookup.lookupClass(FCore.emptyCache(),env, path_1);
         (_,path) = Inst.makeFullyQualified(cache,cenv, path_1);
         true = Absyn.pathEqual(path, old_comp);
         new_path = changeLastIdent(path_1, new_comp);
@@ -9279,7 +9279,7 @@ algorithm
         cdef = getPathedClassInProgram(modelpath, p);
         (p_1,st) = GlobalScriptUtil.symbolTableToSCode(st);
         (cache,env) = Inst.makeEnvFromProgram(FCore.emptyCache(),p_1, Absyn.IDENT(""));
-        (_,(c as SCode.CLASS()),env_1) = Lookup.lookupClass(cache,env, modelpath, false);
+        (_,(c as SCode.CLASS()),env_1) = Lookup.lookupClass(cache,env, modelpath);
         lst = getInheritedClassesHelper(c, cdef, env_1);
         failure({} = lst);
         paths = List.map(lst, Absyn.crefToPath);
@@ -9354,7 +9354,7 @@ algorithm
         cdef = getPathedClassInProgram(modelpath, p);
         (p_1,st) = GlobalScriptUtil.symbolTableToSCode(st);
         (cache,env) = Inst.makeEnvFromProgram(FCore.emptyCache(),p_1, Absyn.IDENT(""));
-        (_,(c as SCode.CLASS()),env_1) = Lookup.lookupClass(cache,env, modelpath, false);
+        (_,(c as SCode.CLASS()),env_1) = Lookup.lookupClass(cache,env, modelpath);
         str = getNthInheritedClass2(c, cdef, n, env_1);
       then
         (str,st);
@@ -9397,7 +9397,7 @@ algorithm
         cdef = inClass;
         p_1 = SCodeUtil.translateAbsyn2SCode(p);
         (cache,env) = Inst.makeEnvFromProgram(FCore.emptyCache(),p_1, Absyn.IDENT(""));
-        (_,(c as SCode.CLASS(id,_,encflag,restr,_)),env_1) = Lookup.lookupClass(cache, env, modelpath, false);
+        (_,(c as SCode.CLASS(id,_,encflag,restr,_)),env_1) = Lookup.lookupClass(cache, env, modelpath);
         str = getNthInheritedClass2(c, cdef, n, env_1);
       then
         (str, annOpt);
@@ -9780,7 +9780,7 @@ algorithm
         modelpath = Absyn.crefToPath(model_);
         p_1 = SCodeUtil.translateAbsyn2SCode(p);
         (cache,env) = Inst.makeEnvFromProgram(FCore.emptyCache(),p_1, Absyn.IDENT(""));
-        (_,(c as SCode.CLASS()),env_1) = Lookup.lookupClass(cache,env, modelpath, false);
+        (_,(c as SCode.CLASS()),env_1) = Lookup.lookupClass(cache,env, modelpath);
         cdef = getPathedClassInProgram(modelpath, p);
         str = getNthComponent2(c, cdef, n, env_1);
       then
@@ -9912,7 +9912,7 @@ algorithm
         cdef = getPathedClassInProgram(modelpath, p);
         (p_1,st) = GlobalScriptUtil.symbolTableToSCode(st);
         (cache,env) = Inst.makeEnvFromProgram(FCore.emptyCache(),p_1, Absyn.IDENT(""));
-        (cache,(c as SCode.CLASS(name=id,encapsulatedPrefix=encflag,restriction=restr)),env_1) = Lookup.lookupClass(cache,env, modelpath, false);
+        (cache,(c as SCode.CLASS(name=id,encapsulatedPrefix=encflag,restriction=restr)),env_1) = Lookup.lookupClass(cache,env, modelpath);
         env2 = FGraph.openScope(env_1, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
         ci_state = ClassInf.start(restr, FGraph.getGraphName(env2));
         (_,env_2,_,_,_) =
@@ -11610,7 +11610,7 @@ algorithm
     // adrpo: handle the case for model extends baseClassName end baseClassName;
     case (Absyn.CLASS(body = Absyn.CLASS_EXTENDS(baseClassName, _, _, parts = parts)),env)
       equation
-        (_,_,cenv) = Lookup.lookupClass(FCore.emptyCache(), env, Absyn.IDENT(baseClassName), true);
+        (_,_,cenv) = Lookup.lookupClass(FCore.emptyCache(), env, Absyn.IDENT(baseClassName), SOME(inClass.info));
         SOME(envpath) = FGraph.getScopePath(cenv);
         p1 = Absyn.joinPaths(envpath, Absyn.IDENT(baseClassName));
         cref = Absyn.pathToCref(p1);
@@ -11619,7 +11619,7 @@ algorithm
 
     case (Absyn.CLASS(body = Absyn.DERIVED(typeSpec = Absyn.TPATH(tp,_))),env)
       equation
-        (_,_,cenv) = Lookup.lookupClass(FCore.emptyCache(), env, tp, true);
+        (_,_,cenv) = Lookup.lookupClass(FCore.emptyCache(), env, tp, SOME(inClass.info));
         SOME(envpath) = FGraph.getScopePath(cenv);
         tpname = Absyn.pathLastIdent(tp);
         p1 = Absyn.joinPaths(envpath, Absyn.IDENT(tpname));
@@ -11629,7 +11629,7 @@ algorithm
 
     case (Absyn.CLASS(body = Absyn.DERIVED(typeSpec=Absyn.TPATH(tp,_))),env)
       equation
-        (_,_,cenv) = Lookup.lookupClass(FCore.emptyCache(), env, tp, true);
+        (_,_,cenv) = Lookup.lookupClass(FCore.emptyCache(), env, tp, SOME(inClass.info));
         NONE() = FGraph.getScopePath(cenv);
         cref = Absyn.pathToCref(tp);
         then {cref};
@@ -11694,13 +11694,14 @@ algorithm
       String tpname;
       Absyn.ComponentRef cref;
       list<Absyn.ElementItem> rest;
+      Absyn.Element e;
 
     case ({},_) then {};
 
-    case ((Absyn.ELEMENTITEM(element = Absyn.ELEMENT(specification = Absyn.EXTENDS(path = path))) :: rest),env)
+    case ((Absyn.ELEMENTITEM(element = e as Absyn.ELEMENT(specification = Absyn.EXTENDS(path = path))) :: rest),env)
       equation
         cl = getBaseClassesFromElts(rest, env) "Inherited class is defined inside package" ;
-        (_,_,env_1) = Lookup.lookupClass(FCore.emptyCache(),env, path, true);
+        (_,_,env_1) = Lookup.lookupClass(FCore.emptyCache(),env, path, SOME(e.info));
         SOME(envpath) = FGraph.getScopePath(env_1);
         tpname = Absyn.pathLastIdent(path);
         p_1 = Absyn.joinPaths(envpath, Absyn.IDENT(tpname));
@@ -11708,10 +11709,10 @@ algorithm
       then
         (cref :: cl);
 
-    case ((Absyn.ELEMENTITEM(element = Absyn.ELEMENT(specification = Absyn.EXTENDS(path = path))) :: rest),env)
+    case ((Absyn.ELEMENTITEM(element = e as Absyn.ELEMENT(specification = Absyn.EXTENDS(path = path))) :: rest),env)
       equation
         cl = getBaseClassesFromElts(rest, env) "Inherited class defined on top level scope" ;
-        (_,_,env_1) = Lookup.lookupClass(FCore.emptyCache(),env, path, true);
+        (_,_,env_1) = Lookup.lookupClass(FCore.emptyCache(),env, path, SOME(e.info));
         NONE() = FGraph.getScopePath(env_1);
         cref = Absyn.pathToCref(path);
       then
@@ -12925,7 +12926,7 @@ algorithm
       equation
         (cache, env_2, _) = buildEnvForGraphicProgram(inFullProgram, inModelPath, mod, annName);
 
-        (cache,c,env_1) = Lookup.lookupClass(cache, env, Absyn.IDENT(annName), false);
+        (cache,c,env_1) = Lookup.lookupClass(cache, env, Absyn.IDENT(annName));
         mod_1 = SCodeUtil.translateMod(SOME(Absyn.CLASSMOD(mod,Absyn.NOMOD())), SCode.NOT_FINAL(), SCode.NOT_EACH(), info);
         (cache,mod_2) = Mod.elabMod(cache, env_2, InnerOuter.emptyInstHierarchy, Prefix.NOPRE(), mod_1, false, Mod.COMPONENT(annName), Absyn.dummyInfo);
         c_1 = SCode.classSetPartial(c, SCode.NOT_PARTIAL());
@@ -12954,7 +12955,7 @@ algorithm
       equation
         (cache,_, _) = buildEnvForGraphicProgram(inFullProgram, inModelPath, {}, annName);
 
-        (cache,c,env_1) = Lookup.lookupClass(cache, env, Absyn.IDENT(annName), false);
+        (cache,c,env_1) = Lookup.lookupClass(cache, env, Absyn.IDENT(annName));
         mod_2 = DAE.NOMOD();
         c_1 = SCode.classSetPartial(c, SCode.NOT_PARTIAL());
         (_,_,_,_,dae,_,_,_,_,_) =
@@ -13933,7 +13934,7 @@ algorithm
         typename = matchcontinue ()
           case ()
             equation
-              (_,_,env_1) = Lookup.lookupClass(FCore.emptyCache(),env, p, false);
+              (_,_,env_1) = Lookup.lookupClass(FCore.emptyCache(),env, p);
               SOME(envpath) = FGraph.getScopePath(env_1);
               tpname = Absyn.pathLastIdent(p);
               p_1 = Absyn.joinPaths(envpath, Absyn.IDENT(tpname));
@@ -14092,7 +14093,7 @@ algorithm
                         specification = Absyn.COMPONENTS(typeSpec = Absyn.TPATH(p, _),components = lst)),
           env)
       equation
-        (_,_,env_1) = Lookup.lookupClass(FCore.emptyCache(),env, p, true);
+        (_,_,env_1) = Lookup.lookupClass(FCore.emptyCache(),env, p, SOME(inElement.info));
         SOME(envpath) = FGraph.getScopePath(env_1);
         tpname = Absyn.pathLastIdent(p);
         p_1 = Absyn.joinPaths(envpath, Absyn.IDENT(tpname));
@@ -18024,7 +18025,7 @@ protected
   FCore.Cache cache;
 algorithm
   (cache, (cl as SCode.CLASS(name = id, encapsulatedPrefix = encflag, restriction = restr)), env) :=
-    Lookup.lookupClass(FCore.emptyCache(), inEnv, inClassPath, false);
+    Lookup.lookupClass(FCore.emptyCache(), inEnv, inClassPath);
   env := FGraph.openScope(env, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
   ci_state := ClassInf.start(restr, FGraph.getGraphName(env));
 

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -690,10 +690,12 @@ public constant Message RETURN_OUTSIDE_FUNCTION = MESSAGE(281, TRANSLATION(), ER
   Util.gettext("'return' may not be used outside function."));
 public constant Message EXT_LIBRARY_NOT_FOUND = MESSAGE(282, TRANSLATION(), WARNING(),
   Util.gettext("Could not find library %s in either of:%s"));
-public constant Message EXT_LIBRARY_NOT_FOUND_DESPITE_COMPILATION_SUCCESS = MESSAGE(258, TRANSLATION(), WARNING(),
+public constant Message EXT_LIBRARY_NOT_FOUND_DESPITE_COMPILATION_SUCCESS = MESSAGE(283, TRANSLATION(), WARNING(),
   Util.gettext("Could not find library %s despite compilation command %s in directory %s returning success."));
-public constant Message GENERATE_SEPARATE_CODE_DEPENDENCIES_FAILED_UNKNOWN_PACKAGE = MESSAGE(283, SCRIPTING(), ERROR(),
+public constant Message GENERATE_SEPARATE_CODE_DEPENDENCIES_FAILED_UNKNOWN_PACKAGE = MESSAGE(284, SCRIPTING(), ERROR(),
   Util.gettext("Failed to get dependencies for package %s. %s contains an import to non-existing package %s."));
+public constant Message USE_OF_PARTIAL_CLASS = MESSAGE(285, TRANSLATION(), ERROR(),
+  Util.gettext("component %s contains the definition of a partial class %s.\nPlease redeclare it to any package compatible with %s."));
 
 public constant Message UNBOUND_PARAMETER_WITH_START_VALUE_WARNING = MESSAGE(499, TRANSLATION(), WARNING(),
   Util.gettext("Parameter %s has no value, and is fixed during initialization (fixed=true), using available start value (start=%s) as default value."));


### PR DESCRIPTION
- Propagate partial attribute to environment scope elements.
- Add SourceInfo to Prefix.ComponentPrefix.
- Replace Boolean message argument to Lookup.lookupClass with
  Option<SourceInfo> so we know where an error comes from.
- Print error in Lookup.lookupClassQualified2 if we're trying
  to look a name up in a partial class.
- Propagate redeclares when instantiating an element of an empty
  array in InstVar.instArray, so we get the correct type.