### PR TITLE
Add configure option --with-msys=msys-root

### DIFF
--- a/Compiler/boot/Makefile.common
+++ b/Compiler/boot/Makefile.common
@@ -135,8 +135,21 @@ $(GEN_DIR)_main.o: $(GEN_DIR)_main.c
 $(GEN_DIR)_main_omc.c: $(GEN_DIR)_main.c
 	cp -a $^ $@
 
+$(GEN_DIR)_main_static_omc.c: $(GEN_DIR)_main.c
+	sed -e s/DLLImport// -e s/DLLExport// $^ > $@.tmp
+	mv $@.tmp $@
+
+$(GEN_DIR)_main_static.c: $(GEN_DIR)_main_static_omc.c
+	cp -a $^ $@
+
 $(GEN_DIR)_main_omc.o: $(GEN_DIR)_main_omc.c
 	$(CC) -c $(GEN_DIR)_main_omc.c -o  $(GEN_DIR)_main_omc.o $(CFLAGS) $(CPPFLAGS)
+
+$(GEN_DIR)_main_static_omc.o: $(GEN_DIR)_main_static_omc.c
+	$(CC) -c $(GEN_DIR)_main_static_omc.c -o  $(GEN_DIR)_main_static_omc.o $(CFLAGS) $(CPPFLAGS)
+
+$(GEN_DIR)_main_static.o: $(GEN_DIR)_main_static.c
+	$(CC) -DOMC_ENTRYPOINT_STATIC -c $(GEN_DIR)_main_static.c -o  $(GEN_DIR)_main_static.o $(CFLAGS) $(CPPFLAGS)
 
 $(OMHOME)/$(LIB_OMC)/libOpenModelicaCompiler$(SHREXT): $(ALL_OBJECTS) $(OMHOME)/$(LIB_OMC)/libomcruntime.a $(OMHOME)/$(LIB_OMC)/libomparse.a $(GEN_DIR)_main_omc.o
 	@test ! -z "`echo $(ALL_OBJECTS)`" || (echo Empty dependencies for $@ ; false)
@@ -145,20 +158,19 @@ $(OMHOME)/$(LIB_OMC)/libOpenModelicaCompiler$(SHREXT): $(ALL_OBJECTS) $(OMHOME)/
 
 ifeq (${STATIC},)
 #shared
-$(GEN_DIR)omc$(EXE_EXT): $(OMHOME)/$(LIB_OMC)/libOpenModelicaCompiler$(SHREXT) $(GEN_DIR)_main_omc.o $(GEN_DIR)_main.o
+$(GEN_DIR)omc$(EXE_SUFFIX)$(EXE_EXT): $(OMHOME)/$(LIB_OMC)/libOpenModelicaCompiler$(SHREXT) $(GEN_DIR)_main_omc.o $(GEN_DIR)_main.o
 	$(CC) $(GEN_DIR)_main.o $(RPATH) $(CFLAGS) $(CPPFLAGS) -o $@ $(LDFLAGS) -lOpenModelicaCompiler
-install: $(GEN_DIR)omc$(EXE_EXT) install-interface
+install: $(GEN_DIR)omc$(EXE_SUFFIX)$(EXE_EXT) install-interface
 	cp -a $< $(OMHOME)/bin/
 	test ! "$(SHREXT)" = ".dll" || cp -a $(OMHOME)/$(LIB_OMC)/libOpenModelicaCompiler$(SHREXT) $(OMHOME)/bin/
 
 else
 #static
-$(GEN_DIR)omc$(EXE_EXT): $(ALL_OBJECTS) $(GEN_DIR)_main.o $(GEN_DIR)_main_omc.o $(OMHOME)/$(LIB_OMC)/libomcruntime.a $(OMHOME)/$(LIB_OMC)/libomparse.a
+$(GEN_DIR)omc$(EXE_SUFFIX)$(EXE_EXT): $(ALL_OBJECTS) $(GEN_DIR)_main_static.o $(GEN_DIR)_main_static_omc.o $(OMHOME)/$(LIB_OMC)/libomcruntime.a $(OMHOME)/$(LIB_OMC)/libomparse.a
 	@test ! -z "`echo $(ALL_OBJECTS)`" || (echo Empty dependencies for $@ ; false)
-	$(CC) $(GEN_DIR)_main.o $(RPATH) $(CFLAGS) $(CPPFLAGS) -o $@ $(GEN_DIR)_main_omc.o $(ALL_OBJECTS) $(LDFLAGS)
-install: $(GEN_DIR)omc$(EXE_EXT) install-interface
-	cp -a $(GEN_DIR)omc$(EXE_EXT) $(OMHOME)/bin/
-
+	$(CC) $(GEN_DIR)_main_static.o $(RPATH) $(CFLAGS) $(CPPFLAGS) -o $@ $(GEN_DIR)_main_static_omc.o $(ALL_OBJECTS) $(LDFLAGS)
+install: $(GEN_DIR)omc$(EXE_SUFFIX)$(EXE_EXT) install-interface
+	cp -a $< $(OMHOME)/bin/
 endif
 
 install-interface:

--- a/Compiler/boot/Makefile.in
+++ b/Compiler/boot/Makefile.in
@@ -8,6 +8,7 @@ CFLAGS=@CFLAGS@
 TOP_DIR=@abs_top_builddir@
 OMHOME=@OMBUILDDIR@
 EXE_EXT=@EXE@
+EXE_SUFFIX=
 
 LIB_OMC=lib/@host_short@/omc
 LDFLAGS=-L.  -L$(GEN_DIR) -L"$(OMHOME)/$(LIB_OMC)" -lomparse -lomcruntime -lOpenModelicaRuntimeC -lModelicaExternalC -lomantlr3 $(CORBALIBS) $(FMILIB) $(GSLIB) @RT_LDFLAGS@ @LIBSOCKET@ @LIBLPSOLVE55@ @OMC_LIBS@ @GRAPHLIB@ -lexpat @LD_LAPACK@

--- a/Makefile.common
+++ b/Makefile.common
@@ -139,6 +139,7 @@ umfpack: $(OMBUILDDIR)/$(LIB_OMC)/libumfpack$(SHREXT)
 
 umfpack-clean:
 	if test -d 3rdParty/SuiteSparse/build ; then cd 3rdParty/SuiteSparse/build && make clean ; fi
+	rm -rf 3rdParty/SuiteSparse/build
 	rm -rf $(OMBUILDDIR)/include/omc/c/suitesparse
 	rm -f $(OMBUILDDIR)/$(LIB_OMC)/libumfpack.a
 	rm -f $(OMBUILDDIR)/$(LIB_OMC)/libamd.a

--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,19 @@ host_short=$host_cpu-$host_os
 echo "build_short: $build_short"
 echo "host_short: $host_short"
 
+AS_IF([test "x$with_UMFPACK" = xyes],
+[
+  FINAL_MESSAGES="$FINAL_MESSAGES\nSimulations may use UMFPACK: Yes"
+  UMFPACK_TARGET="umfpack";
+  WITH_UMFPACK="#define WITH_UMFPACK"
+  UMFPACK_LDFLAGS="-lumfpack -lklu -lbtf -lcolamd -lamd"
+],[
+  FINAL_MESSAGES="$FINAL_MESSAGES\nSimulations may use UMFPACK: No"
+  UMFPACK_TARGET="";
+  WITH_UMFPACK="/* Without UMFPACK */"
+  UMFPACK_LDFLAGS=""
+])
+
 if echo $host | grep -i darwin; then
   DARWIN=1
 else
@@ -130,6 +143,22 @@ AC_PROG_CXX
 AC_PROG_CPP
 AC_PROG_MAKE_SET
 AC_PROG_FC
+
+
+AC_ARG_WITH(msys, [  --with-msys[=no]              Point to an msys installation, to setup CPPFLAGS, etc automatically.],
+  [
+    if echo $host_cpu | grep -q x86_64; then
+      MINGWNUM=mingw64
+    else
+      MINGWNUM=mingw32
+    fi
+    CPPFLAGS="$CPPFLAGS -I$withval/$MINGWNUM/include -I$withval/$MINGWNUM/include/tre"
+    LDFLAGS="$LDFLAGS -L$withval/$MINGWNUM/lib"
+    echo "Got: $CPPFLAGS"
+  ],
+  [
+  ]
+)
 
 CFLAGS_BEFORE="$CFLAGS"
 CFLAGS="$CFLAGS -Werror"
@@ -488,7 +517,14 @@ fi
 fi
 
 # Cannot use AX_LAPACK since it assumes a Fortran compiler is used
-AC_ARG_WITH(lapack,  [  --with-lapack=[-llapack -lblas]    (use -llapack -lblas to use system-provided version instead of OpenBLAS. Use openblas for automatically detected OpenBLAS. Use --with-lapack=openblas-NEHALEM or other OpenBLAS target to compile against a certain architecture. Note that you need to include BLAS in this.)],[LD_LAPACK="$withval"],[LD_LAPACK="-llapack -lblas"])
+AC_ARG_WITH(lapack,  [  --with-lapack=[-llapack -lblas]    (use -llapack -lblas to use system-provided version instead of OpenBLAS. Use openblas for automatically detected OpenBLAS. Use --with-lapack=openblas-NEHALEM or other OpenBLAS target to compile against a certain architecture. Note that you need to include BLAS in this.)],[LD_LAPACK="$withval"],
+  [
+    if test ! -z "$MINGWNUM"; then
+      LD_LAPACK="-Wl,-Bstatic -lopenblas -lgfortran -lquadmath -Wl,-Bdynamic"
+    else
+      LD_LAPACK="-llapack -lblas"
+    fi
+  ])
 
 if test "$LD_LAPACK" = "no"; then
   FINAL_MESSAGES="$FINAL_MESSAGES\nLAPACK IS NOT AVAILABLE! ONLY USED FOR CROSS-COMPILING/BOOTSTRAPPING"
@@ -574,6 +610,12 @@ AC_CHECK_LIB(pthread,pthread_self,[RT_LDFLAGS="$RT_LDFLAGS $LIBS"],[AC_MSG_ERROR
 
 LIBS=""
 
+AC_ARG_WITH(ipopt, [  --without-ipopt              Disable compilation ipopt], [
+  if test "$withval" = "no"; then
+    NO_IPOPT=yes
+  fi
+]
+],[])
 if ! test "$NO_IPOPT" = "yes"; then
   FINAL_MESSAGES="$FINAL_MESSAGES\nSimulations may use IPOPT: Yes"
   WITH_IPOPT="#define WITH_IPOPT"
@@ -678,7 +720,7 @@ elif echo "$host" | grep -iq "mingw"; then
   AC_CHECK_TOOL(WINDRES, windres, [AC_MSG_ERROR([no])])
   CMAKE_EXTRA_DEFINES="-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_RC_COMPILER=$WINDRES"
   CPPFLAGS="$CPPFLAGS -DMSYS2_AUTOCONF=1"
-  OMC_LIBS="$OMC_LIBS -lwsock32 -Wl,-Bstatic -lstdc++ -ltre  -lintl -Wl,-Bdynamic -liconv -lshlwapi"
+  OMC_LIBS="$OMC_LIBS -lwsock32 -Wl,-Bstatic -lstdc++ -ltre  -lintl -liconv -Wl,-Bdynamic -lshlwapi"
   UMFPACK_SHARED=OFF
 else
   APP=""


### PR DESCRIPTION
The msys configure option makes it easier to find the msys
installation, making cross-compilation simpler.

The 64-bit omc.exe now compiles, and targets were added to also
compile a static version of that executable.