### PR TITLE
Fix for #2964.

### DIFF
--- a/Compiler/FrontEnd/ClassInf.mo
+++ b/Compiler/FrontEnd/ClassInf.mo
@@ -759,6 +759,16 @@ algorithm
   end match;
 end isTypeOrRecord;
 
+public function isRecord
+  input State inState;
+  output Boolean outIsRecord;
+algorithm
+  outIsRecord := match inState
+    case RECORD() then true;
+    else false;
+  end match;
+end isRecord;
+
 public function stateToSCodeRestriction
 "@author: adrpo
  ClassInf.State -> SCode.Restriction"

--- a/Compiler/FrontEnd/DAE.mo
+++ b/Compiler/FrontEnd/DAE.mo
@@ -1197,12 +1197,10 @@ uniontype EqMod "To generate the correct set of equations, the translator has to
     Option<Values.Value> modifierAsValue "modifier as Value option" ;
     Properties properties "properties" ;
     Absyn.Exp modifierAsAbsynExp "keep the untyped modifier as an absyn expression for modification comparison";
-    SourceInfo info;
   end TYPED;
 
   record UNTYPED
     Absyn.Exp exp;
-    SourceInfo info;
   end UNTYPED;
 
 end EqMod;
@@ -1221,19 +1219,18 @@ uniontype Mod "Modification"
     SCode.Final   finalPrefix "final prefix";
     SCode.Each    eachPrefix "each prefix";
     list<SubMod>  subModLst;
-    Option<EqMod> eqModOption;
+    Option<EqMod> binding;
+    SourceInfo    info;
   end MOD;
 
   record REDECL
     SCode.Final finalPrefix "final prefix";
     SCode.Each  eachPrefix "each prefix";
-    list<tuple<SCode.Element, Mod>> tplSCodeElementModLst;
+    list<tuple<SCode.Element, Mod>> elements;
   end REDECL;
 
   record NOMOD end NOMOD;
-
 end Mod;
-
 
 public
 uniontype ClockKind

--- a/Compiler/FrontEnd/InstExtends.mo
+++ b/Compiler/FrontEnd/InstExtends.mo
@@ -178,8 +178,8 @@ algorithm
           rest_els := SCodeUtil.addRedeclareAsElementsToExtends(rest_els,
             list(e for e guard(SCodeUtil.isRedeclareElement(e)) in rest_els));
 
-          outMod := Mod.elabUntypedMod(emod, inEnv, Prefix.NOPRE(), Mod.EXTENDS(el.baseClassPath));
-          outMod := Mod.merge(mod, outMod, inEnv, Prefix.NOPRE());
+          outMod := Mod.elabUntypedMod(emod, Mod.EXTENDS(el.baseClassPath));
+          outMod := Mod.merge(mod, outMod, "", false);
 
           (outCache, _, outIH, _, els2, eq2, ieq2, alg2, ialg2) :=
             instExtendsAndClassExtendsList2(outCache, cenv, outIH, outMod, inPrefix,
@@ -659,9 +659,9 @@ algorithm
         dmod = InstUtil.chainRedeclares(mod, dmod);
         // false = Absyn.pathEqual(FGraph.getGraphName(env),FGraph.getGraphName(cenv)) and SCode.elementEqual(c,inClass);
         // modifiers should be evaluated in the current scope for derived!
-        //daeDMOD = Mod.elabUntypedMod(dmod, env, Prefix.NOPRE(), Mod.DERIVED(tp));
+        //daeDMOD = Mod.elabUntypedMod(dmod, Mod.DERIVED(tp));
         (cache,daeDMOD) = Mod.elabMod(cache, env, ih, pre, dmod, impl, Mod.DERIVED(tp), info);
-        mod = Mod.merge(mod, daeDMOD, env, pre);
+        mod = Mod.merge(mod, daeDMOD);
         // print("DER: " + SCodeDump.unparseElementStr(inClass, SCodeDump.defaultOptions) + "\n");
         (cache,env,ih,elt,eq,ieq,alg,ialg,mod) = instDerivedClassesWork(cache, cenv, ih, mod, pre, c, impl, info, numIter >= Global.recursionDepthLimit, numIter+1)
         "Mod.lookup_modification_p(mod, c) => innermod & We have to merge and apply modifications as well!" ;
@@ -757,7 +757,7 @@ algorithm
         // cmod2 = Mod.getModifs(inMod, id, m);
         cmod2 = Mod.lookupCompModificationFromEqu(inMod, id);
         // Debug.traceln("\tSpecific mods on comp: " +  Mod.printModStr(cmod2));
-        cmod = Mod.merge(cmod2, cmod, inEnv, Prefix.NOPRE());
+        cmod = Mod.merge(cmod2, cmod, id, false);
         mod_rest = inMod; //mod_rest = Mod.removeMod(inMod, id);
       then
         ((comp, cmod, b), mod_rest);
@@ -772,7 +772,7 @@ algorithm
       equation
         DAE.REDECL(_, _, (comp2, cmod2)::_) = Mod.lookupCompModification(inMod, id);
         mod_rest = inMod; //mod_rest = Mod.removeMod(inMod, id);
-        cmod2 = Mod.merge(cmod2, cmod1, inEnv, Prefix.NOPRE());
+        cmod2 = Mod.merge(cmod2, cmod1, id, false);
         comp2 = SCode.mergeWithOriginal(comp2, comp1);
         // comp2 = SCode.renameElement(comp2, id);
       then

--- a/Compiler/FrontEnd/Lookup.mo
+++ b/Compiler/FrontEnd/Lookup.mo
@@ -2303,7 +2303,7 @@ algorithm
         SCode.ATTR(d,ct,prl,var,_),tp,mod,comment,cond,info)),cmod) :: rest), _)
       equation
         (cache,mod_1) = Mod.elabMod(cache, env, InnerOuter.emptyInstHierarchy, Prefix.NOPRE(), mod, true, Mod.COMPONENT(id), info);
-        mod_1 = Mod.merge(mods,mod_1,env,Prefix.NOPRE());
+        mod_1 = Mod.merge(mods,mod_1);
         // adrpo: this was wrong, you won't find any id modification there!!!
         // bjozac: This was right, you will find id modification unless modifers does not belong to component!
         // adrpo 2009-11-23 -> solved by selecting the full modifier if the component modifier is empty!
@@ -2311,7 +2311,7 @@ algorithm
         fullMod = mod_1;
         selectedMod = selectModifier(compMod, fullMod); // if the first one is empty use the other one.
         (cache,cmod) = Mod.updateMod(cache,env,InnerOuter.emptyInstHierarchy,Prefix.NOPRE(),cmod,true,info);
-        selectedMod = Mod.merge(cmod,selectedMod,env,Prefix.NOPRE());
+        selectedMod = Mod.merge(cmod,selectedMod);
         umod = Mod.unelabMod(selectedMod);
         (cache, env, res) = buildRecordConstructorElts(cache, env, rest, mods);
         // - Prefixes (constant, parameter, final, discrete, input, output, ...) of the remaining record components are removed.
@@ -2331,7 +2331,7 @@ algorithm
         SCode.ATTR(d,ct,prl,SCode.CONST(),_),tp,mod as SCode.NOMOD(),comment,cond,info)), cmod) :: rest),_)
       equation
         (cache,mod_1) = Mod.elabMod(cache, env, InnerOuter.emptyInstHierarchy, Prefix.NOPRE(), mod, true, Mod.COMPONENT(id), info);
-        mod_1 = Mod.merge(mods,mod_1,env,Prefix.NOPRE());
+        mod_1 = Mod.merge(mods,mod_1);
         // adrpo: this was wrong, you won't find any id modification there!!!
         // bjozac: This was right, you will find id modification unless modifers does not belong to component!
         // adrpo 2009-11-23 -> solved by selecting the full modifier if the component modifier is empty!
@@ -2339,7 +2339,7 @@ algorithm
         fullMod = mod_1;
         selectedMod = selectModifier(compMod, fullMod); // if the first one is empty use the other one.
         (cache,cmod) = Mod.updateMod(cache,env,InnerOuter.emptyInstHierarchy,Prefix.NOPRE(),cmod,true,info);
-        selectedMod = Mod.merge(cmod,selectedMod,env,Prefix.NOPRE());
+        selectedMod = Mod.merge(cmod,selectedMod);
         umod = Mod.unelabMod(selectedMod);
         (cache, env, res) = buildRecordConstructorElts(cache, env, rest, mods);
         // - Prefixes (constant, parameter, final, discrete, input, output, ...) of the remaining record components are removed.
@@ -2358,7 +2358,7 @@ algorithm
         SCode.ATTR(d,ct,prl,var as SCode.CONST(),_),tp,mod,comment,cond,info)),cmod) :: rest), _)
       equation
         (cache,mod_1) = Mod.elabMod(cache, env, InnerOuter.emptyInstHierarchy, Prefix.NOPRE(), mod, true, Mod.COMPONENT(id), info);
-        mod_1 = Mod.merge(mods,mod_1,env,Prefix.NOPRE());
+        mod_1 = Mod.merge(mods,mod_1);
         // adrpo: this was wrong, you won't find any id modification there!!!
         // bjozac: This was right, you will find id modification unless modifers does not belong to component!
         // adrpo 2009-11-23 -> solved by selecting the full modifier if the component modifier is empty!
@@ -2366,7 +2366,7 @@ algorithm
         fullMod = mod_1;
         selectedMod = selectModifier(compMod, fullMod); // if the first one is empty use the other one.
         (cache,cmod) = Mod.updateMod(cache,env,InnerOuter.emptyInstHierarchy,Prefix.NOPRE(),cmod,true,info);
-        selectedMod = Mod.merge(cmod,selectedMod,env,Prefix.NOPRE());
+        selectedMod = Mod.merge(cmod,selectedMod);
         umod = Mod.unelabMod(selectedMod);
         (cache, env, res) = buildRecordConstructorElts(cache, env, rest, mods);
         // - Prefixes (constant, parameter, final, discrete, input, output, ...) of the remaining record components are removed.
@@ -2385,7 +2385,7 @@ algorithm
         SCode.ATTR(d,ct,prl,_,_),tp,mod,comment,cond,info)),cmod) :: rest), _)
       equation
         (cache,mod_1) = Mod.elabMod(cache, env, InnerOuter.emptyInstHierarchy, Prefix.NOPRE(), mod, true, Mod.COMPONENT(id), info);
-        mod_1 = Mod.merge(mods,mod_1,env,Prefix.NOPRE());
+        mod_1 = Mod.merge(mods,mod_1);
         // adrpo: this was wrong, you won't find any id modification there!!!
         // bjozac: This was right, you will find id modification unless modifers does not belong to component!
         // adrpo 2009-11-23 -> solved by selecting the full modifier if the component modifier is empty!
@@ -2393,7 +2393,7 @@ algorithm
         fullMod = mod_1;
         selectedMod = selectModifier(compMod, fullMod); // if the first one is empty use the other one.
         (cache,cmod) = Mod.updateMod(cache,env,InnerOuter.emptyInstHierarchy,Prefix.NOPRE(),cmod,true,info);
-        selectedMod = Mod.merge(cmod,selectedMod,env,Prefix.NOPRE());
+        selectedMod = Mod.merge(cmod,selectedMod);
         umod = Mod.unelabMod(selectedMod);
         (cache, env, res) = buildRecordConstructorElts(cache, env, rest, mods);
         // - Prefixes (constant, parameter, final, discrete, input, output, ...) of the remaining record components are removed.

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -569,7 +569,7 @@ public constant Message INVALID_CLASS_RESTRICTION = MESSAGE(220, TRANSLATION(), 
 public constant Message CONNECT_IN_INITIAL_EQUATION = MESSAGE(221, TRANSLATION(), ERROR(),
   Util.gettext("Connect equations are not allowed in initial equation sections."));
 public constant Message FINAL_COMPONENT_OVERRIDE = MESSAGE(222, TRANSLATION(), ERROR(),
-  Util.gettext("Trying to override final component %s with modifier %s."));
+  Util.gettext("Trying to override final element %s with modifier '%s'."));
 public constant Message NOTIFY_NOT_LOADED = MESSAGE(223, SCRIPTING(), NOTIFICATION(),
   Util.gettext("Automatically loaded package %s %s due to uses annotation."));
 public constant Message REINIT_MUST_BE_REAL = MESSAGE(224, TRANSLATION(), ERROR(),
@@ -707,8 +707,6 @@ public constant Message SETTING_FIXED_ATTRIBUTE = MESSAGE(503, TRANSLATION(), WA
   Util.gettext("Using over-determined solver for initialization. Setting fixed=false to the following variables: %s."));
 public constant Message FAILED_TO_EVALUATE_FUNCTION = MESSAGE(506, TRANSLATION(), ERROR(),
   Util.gettext("Failed to evaluate function: %s."));
-public constant Message FINAL_OVERRIDE = MESSAGE(508, TRANSLATION(), ERROR(),
-  Util.gettext("Trying to override final variable in component %s and scope %s by using modifiers: %s and %s that do not agree."));
 public constant Message WARNING_RELATION_ON_REAL = MESSAGE(509, TRANSLATION(), WARNING(),
   Util.gettext("In component %s, in relation %s, %s on Real numbers is only allowed inside functions."));
 public constant Message OUTER_MODIFICATION = MESSAGE(512, TRANSLATION(), WARNING(),

--- a/Compiler/Util/Util.mo
+++ b/Compiler/Util/Util.mo
@@ -1723,5 +1723,35 @@ algorithm
   s := stringDelimitList(List.map(lst,intString),", ");
 end intLstString;
 
+public function sourceInfoIsEmpty
+  "Returns whether the given SourceInfo is empty or not."
+  input SourceInfo inInfo;
+  output Boolean outIsEmpty;
+algorithm
+  outIsEmpty := match inInfo
+    case SOURCEINFO(fileName = "") then true;
+    else false;
+  end match;
+end sourceInfoIsEmpty;
+
+public function sourceInfoIsEqual
+  "Returns whether two SourceInfo are equal or not."
+  input SourceInfo inInfo1;
+  input SourceInfo inInfo2;
+  output Boolean outIsEqual;
+algorithm
+  outIsEqual := match (inInfo1, inInfo2)
+    case (SOURCEINFO(), SOURCEINFO())
+      then inInfo1.fileName == inInfo2.fileName and
+           inInfo1.isReadOnly == inInfo2.isReadOnly and
+           inInfo1.lineNumberStart == inInfo2.lineNumberStart and
+           inInfo1.columnNumberStart == inInfo2.columnNumberStart and
+           inInfo1.lineNumberEnd == inInfo2.lineNumberEnd and
+           inInfo1.columnNumberEnd == inInfo2.columnNumberEnd;
+
+    else false;
+  end match;
+end sourceInfoIsEqual;
+
 annotation(__OpenModelica_Interface="util");
 end Util;


### PR DESCRIPTION
- Move SourceInfo from DAE.EqMod to DAE.Mod, so we don't loose them
  for modifiers without bindings.
- Rename DAE.MOD.eqModOption to binding,
         DAE.REDECL.tplSCodeElementModLst to elements.
- Add check for final modification in Mod.merge.