### PR TITLE
Cleanup DAE.Mod.REDECL.

### DIFF
--- a/Compiler/FrontEnd/DAE.mo
+++ b/Compiler/FrontEnd/DAE.mo
@@ -1226,7 +1226,8 @@ uniontype Mod "Modification"
   record REDECL
     SCode.Final finalPrefix "final prefix";
     SCode.Each  eachPrefix "each prefix";
-    list<tuple<SCode.Element, Mod>> elements;
+    SCode.Element element;
+    Mod mod;
   end REDECL;
 
   record NOMOD end NOMOD;

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -3799,7 +3799,7 @@ algorithm
         (cache,env,ih,elMod::res);
 
     // Special case for components being redeclared, we might instantiate partial classes when instantiating var(-> instVar2->instClass) to update component in env.
-    case (cache,env,ih,pre,((comp,(cmod as DAE.REDECL(_,_,{(redComp,_)}))) :: xs),ci_state,impl)
+    case (cache,env,ih,pre,((comp,(cmod as DAE.REDECL(element = redComp))) :: xs),ci_state,impl)
       equation
         info = SCode.elementInfo(redComp);
         umod = Mod.unelabMod(cmod);
@@ -3887,7 +3887,6 @@ public function redeclareType
   output SCode.Element outElement = inElement;
   output DAE.Mod outMod = DAE.NOMOD();
 protected
-  list<tuple<SCode.Element, DAE.Mod>> redecls;
   SCode.Element redecl_el;
   SCode.Mod mod;
   DAE.Mod redecl_mod, m, old_m;
@@ -3897,93 +3896,85 @@ protected
   list<SCode.Element> cc_comps;
   list<Absyn.ComponentRef> crefs;
 algorithm
-  if Mod.isRedeclareMod(inMod) then
-    DAE.REDECL(elements = redecls) := inMod;
-  else
+  if not Mod.isRedeclareMod(inMod) then
     outMod := Mod.merge(inMod, inCmod);
     return;
   end if;
 
-  for redecl in redecls loop
-    (redecl_el, redecl_mod) := redecl;
-    redecl_name := SCode.elementName(redecl_el);
+  DAE.REDECL(element = redecl_el, mod = redecl_mod) := inMod;
+  redecl_name := SCode.elementName(redecl_el);
 
-    (outElement, outMod, found) := matchcontinue (redecl_el, inElement)
-      // Redeclaration of component.
-      case (SCode.COMPONENT(),
-            SCode.COMPONENT(prefixes = SCode.PREFIXES(replaceablePrefix = SCode.REPLACEABLE(cc = cc))))
-        algorithm
-          true := redecl_name == inElement.name;
+  (outElement, outMod) := matchcontinue (redecl_el, inElement)
+    // Redeclaration of component.
+    case (SCode.COMPONENT(),
+          SCode.COMPONENT(prefixes = SCode.PREFIXES(replaceablePrefix = SCode.REPLACEABLE(cc = cc))))
+      algorithm
+        true := redecl_name == inElement.name;
 
-          mod := InstUtil.chainRedeclares(inMod, redecl_el.modifications);
-          crefs := InstUtil.getCrefFromMod(mod);
-          (outCache, outEnv, outIH) := updateComponentsInEnv(inCache, inEnv,
-            inIH, inPrefix, DAE.NOMOD(), crefs, inState, inImpl);
-          (outCache, m) := Mod.elabMod(outCache, outEnv, outIH, inPrefix, mod,
-            inImpl, Mod.COMPONENT(redecl_name), redecl_el.info);
-          (outCache, old_m) := Mod.elabMod(outCache, outEnv, outIH, inPrefix,
-            inElement.modifications, inImpl, Mod.COMPONENT(inElement.name), inElement.info);
+        mod := InstUtil.chainRedeclares(inMod, redecl_el.modifications);
+        crefs := InstUtil.getCrefFromMod(mod);
+        (outCache, outEnv, outIH) := updateComponentsInEnv(inCache, inEnv,
+          inIH, inPrefix, DAE.NOMOD(), crefs, inState, inImpl);
+        (outCache, m) := Mod.elabMod(outCache, outEnv, outIH, inPrefix, mod,
+          inImpl, Mod.COMPONENT(redecl_name), redecl_el.info);
+        (outCache, old_m) := Mod.elabMod(outCache, outEnv, outIH, inPrefix,
+          inElement.modifications, inImpl, Mod.COMPONENT(inElement.name), inElement.info);
 
-          if isSome(cc) then
-            // Constraining type on the component:
-            // Extract components belonging to constraining class.
-            cc_comps := InstUtil.extractConstrainingComps(cc, inEnv, inPrefix);
-            // Keep previous constraining class mods.
-            redecl_mod := InstUtil.keepConstrainingTypeModifersOnly(redecl_mod, cc_comps);
-            old_m := InstUtil.keepConstrainingTypeModifersOnly(old_m, cc_comps);
+        if isSome(cc) then
+          // Constraining type on the component:
+          // Extract components belonging to constraining class.
+          cc_comps := InstUtil.extractConstrainingComps(cc, inEnv, inPrefix);
+          // Keep previous constraining class mods.
+          redecl_mod := InstUtil.keepConstrainingTypeModifersOnly(redecl_mod, cc_comps);
+          old_m := InstUtil.keepConstrainingTypeModifersOnly(old_m, cc_comps);
 
-            m := Mod.merge(m, redecl_mod, redecl_name);
-            m := Mod.merge(m, old_m, redecl_name);
-            m := Mod.merge(m, inCmod, redecl_name);
-          else
-            // No constraining type on comp, throw away modifiers prior to redeclaration:
-            m := Mod.merge(redecl_mod, m, redecl_name);
-            m := Mod.merge(m, old_m, redecl_name);
-            m := Mod.merge(inCmod, m, redecl_name);
-          end if;
+          m := Mod.merge(m, redecl_mod, redecl_name);
+          m := Mod.merge(m, old_m, redecl_name);
+          m := Mod.merge(m, inCmod, redecl_name);
+        else
+          // No constraining type on comp, throw away modifiers prior to redeclaration:
+          m := Mod.merge(redecl_mod, m, redecl_name);
+          m := Mod.merge(m, old_m, redecl_name);
+          m := Mod.merge(inCmod, m, redecl_name);
+        end if;
 
-          (outCache, outElement) :=
-            propagateRedeclCompAttr(outCache, outEnv, inElement, redecl_el);
-          outElement := SCode.setComponentMod(outElement, mod);
-        then
-          (outElement, m, true);
+        (outCache, outElement) :=
+          propagateRedeclCompAttr(outCache, outEnv, inElement, redecl_el);
+        outElement := SCode.setComponentMod(outElement, mod);
+      then
+        (outElement, m);
 
-      // Redeclaration of class.
-      case (SCode.CLASS(), SCode.CLASS())
-        algorithm
-          true := redecl_name == inElement.name;
-          (outCache, outEnv, outIH) := updateComponentsInEnv(inCache, inEnv, inIH,
-            inPrefix, inMod, {Absyn.CREF_IDENT(inElement.name, {})}, inState, inImpl);
-        then
-          (inElement, redecl_mod, true);
+    // Redeclaration of class.
+    case (SCode.CLASS(), SCode.CLASS())
+      algorithm
+        true := redecl_name == inElement.name;
+        (outCache, outEnv, outIH) := updateComponentsInEnv(inCache, inEnv, inIH,
+          inPrefix, inMod, {Absyn.CREF_IDENT(inElement.name, {})}, inState, inImpl);
+      then
+        (inElement, redecl_mod);
 
-      // Local redeclaration of class type path is an id.
-      case (SCode.CLASS(), SCode.COMPONENT())
-        algorithm
-          name := Absyn.typeSpecPathString(inElement.typeSpec);
-          true := redecl_name == name;
-          (outCache, outEnv, outIH) := updateComponentsInEnv(inCache, inEnv, inIH,
-            inPrefix, inMod, {Absyn.CREF_IDENT(name, {})}, inState, inImpl);
-        then
-          (inElement, redecl_mod, true);
+    // Local redeclaration of class type path is an id.
+    case (SCode.CLASS(), SCode.COMPONENT())
+      algorithm
+        name := Absyn.typeSpecPathString(inElement.typeSpec);
+        true := redecl_name == name;
+        (outCache, outEnv, outIH) := updateComponentsInEnv(inCache, inEnv, inIH,
+          inPrefix, inMod, {Absyn.CREF_IDENT(name, {})}, inState, inImpl);
+      then
+        (inElement, redecl_mod);
 
-      // Local redeclaration of class, type is qualified.
-      case (SCode.CLASS(), SCode.COMPONENT())
-        algorithm
-          name := Absyn.pathFirstIdent(Absyn.typeSpecPath(inElement.typeSpec));
-          true := redecl_name == name;
-          (outCache, outEnv, outIH) := updateComponentsInEnv(inCache, inEnv, inIH,
-            inPrefix, inMod, {Absyn.CREF_IDENT(name, {})}, inState, inImpl);
-        then
-          (inElement, redecl_mod, true);
+    // Local redeclaration of class, type is qualified.
+    case (SCode.CLASS(), SCode.COMPONENT())
+      algorithm
+        name := Absyn.pathFirstIdent(Absyn.typeSpecPath(inElement.typeSpec));
+        true := redecl_name == name;
+        (outCache, outEnv, outIH) := updateComponentsInEnv(inCache, inEnv, inIH,
+          inPrefix, inMod, {Absyn.CREF_IDENT(name, {})}, inState, inImpl);
+      then
+        (inElement, redecl_mod);
 
-      else (inElement, DAE.NOMOD(), false);
-    end matchcontinue;
-
-    if found then
-      return;
-    end if;
-  end for;
+    else (inElement, DAE.NOMOD());
+  end matchcontinue;
 end redeclareType;
 
 protected function propagateRedeclCompAttr
@@ -4131,13 +4122,13 @@ algorithm
 
     // if we have a redeclare for a component
     case (cache,env,ih,_,
-        DAE.REDECL(_, _, {
-         (SCode.COMPONENT(
+        DAE.REDECL(element =
+         SCode.COMPONENT(
              name = name,
              prefixes = prefixes as SCode.PREFIXES(visibility = visibility),
              attributes = attributes,
              modifications = smod,
-             info = info),_)}),_,_,_,_,_)
+             info = info)),_,_,_,_,_)
       equation
         id = Absyn.crefFirstIdent(cref);
         true = stringEq(id, name);
@@ -4189,13 +4180,13 @@ algorithm
         (cache,env_1,ih,SOME(updatedComps));
 
     // redeclare class!
-    case (cache,env,ih,_,DAE.REDECL(_, _, {(compNew as SCode.CLASS(name = name),_)}),_,_,_,_,_)
+    case (cache,env,ih,_,DAE.REDECL(element = SCode.CLASS(name = name)),_,_,_,_,_)
       equation
         id = Absyn.crefFirstIdent(cref);
         true = stringEq(name, id);
         // fetch the original class!
         (cl, _) = Lookup.lookupClassLocal(env, name);
-        env = FGraph.updateClass(env, SCode.mergeWithOriginal(compNew, cl), pre, mod, FCore.CLS_UNTYPED(), env);
+        env = FGraph.updateClass(env, SCode.mergeWithOriginal(mod.element, cl), pre, mod, FCore.CLS_UNTYPED(), env);
         updatedComps = getUpdatedCompsHashTable(inUpdatedComps);
         updatedComps = BaseHashTable.add((cref,0),updatedComps);
       then
@@ -4914,56 +4905,18 @@ protected function modifyInstantiateClass
   output DAE.Mod omod1;
   output DAE.Mod omod2;
 algorithm
-  (omod1,omod2) := matchcontinue(inMod,path)
+  (omod1, omod2) := match inMod
     local
-      SCode.Final f;
-      SCode.Each e;
-      list<tuple<SCode.Element, DAE.Mod>> redecls,p1,p2;
-      Integer i1;
+      String id;
 
-    case(DAE.REDECL(f,e,redecls), _)
-      equation
-        (p1,p2) = modifyInstantiateClass2(redecls,path);
-        i1 = listLength(p1);
-        omod1 = if i1==0 then DAE.NOMOD() else DAE.REDECL(f,e,p1);
-        i1 = listLength(p2);
-        omod2 = if i1==0 then DAE.NOMOD() else DAE.REDECL(f,e,p2);
-      then
-        (omod1,omod2);
+    case DAE.REDECL(element = SCode.CLASS(name = id))
+      then if id == Absyn.pathString(path) then
+        (inMod, DAE.NOMOD()) else (DAE.NOMOD(), inMod);
 
     else (DAE.NOMOD(), inMod);
 
-  end matchcontinue;
+  end match;
 end modifyInstantiateClass;
-
-protected function modifyInstantiateClass2
-"Helper function for modifyInstantiateClass"
-  input list<tuple<SCode.Element, DAE.Mod>> redecls;
-  input Absyn.Path path;
-  output list<tuple<SCode.Element, DAE.Mod>> omod1;
-  output list<tuple<SCode.Element, DAE.Mod>> omod2;
-algorithm
-  (omod1,omod2) := matchcontinue(redecls,path)
-    local
-      list<tuple<SCode.Element, DAE.Mod>> rest,rec2,rec1;
-      tuple<SCode.Element, DAE.Mod> head;
-      DAE.Mod m;
-      String id1,id2;
-    case({},_) then ({},{});
-    case( (head as  (SCode.CLASS(name = id1),_))::rest, _)
-      equation
-        id2 = Absyn.pathString(path);
-        true = stringEq(id1,id2);
-        (rec1,rec2) = modifyInstantiateClass2(rest,path);
-      then
-        (head::rec1,rec2);
-    case(head::rest,_)
-      equation
-        (rec1,rec2) = modifyInstantiateClass2(rest,path);
-      then
-        (rec1,head::rec2);
-  end matchcontinue;
-end modifyInstantiateClass2;
 
 protected function removeSelfReferenceAndUpdate
 " BZ 2007-07-03

--- a/Compiler/FrontEnd/InstExtends.mo
+++ b/Compiler/FrontEnd/InstExtends.mo
@@ -770,7 +770,7 @@ algorithm
 
     case ((comp1 as SCode.CLASS(name = id, prefixes = SCode.PREFIXES(replaceablePrefix = SCode.REPLACEABLE(_))), cmod1, b), _, _)
       equation
-        DAE.REDECL(_, _, (comp2, cmod2)::_) = Mod.lookupCompModification(inMod, id);
+        DAE.REDECL(element = comp2, mod = cmod2) = Mod.lookupCompModification(inMod, id);
         mod_rest = inMod; //mod_rest = Mod.removeMod(inMod, id);
         cmod2 = Mod.merge(cmod2, cmod1, id, false);
         comp2 = SCode.mergeWithOriginal(comp2, comp1);

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -2810,7 +2810,7 @@ algorithm
     case (_,SCode.REDECL(f, e, SCode.CLASS(name = nInner, classDef = SCode.DERIVED(typeSpec = Absyn.TPATH(path = Absyn.IDENT(nDerivedInner))))))
       equation
         // lookup the class mod in the outer
-        (DAE.REDECL(elements = (cls,_)::_)) = Mod.lookupModificationP(inModOuter, Absyn.IDENT(nDerivedInner));
+        DAE.REDECL(element = cls) = Mod.lookupModificationP(inModOuter, Absyn.IDENT(nDerivedInner));
         cls = SCode.setClassName(nInner, cls);
       then
         SCode.REDECL(f, e, cls);
@@ -2819,7 +2819,7 @@ algorithm
     case (_,SCode.REDECL(f, e, SCode.CLASS(name = nInner, classDef = SCode.DERIVED(typeSpec = Absyn.TPATH(path = Absyn.IDENT(_))))))
       equation
         // lookup the class mod in the outer
-        (DAE.REDECL(elements = (cls,_)::_)) = Mod.lookupModificationP(inModOuter, Absyn.IDENT(nInner));
+        DAE.REDECL(element = cls) = Mod.lookupModificationP(inModOuter, Absyn.IDENT(nInner));
       then
         SCode.REDECL(f, e, cls);
 
@@ -7906,7 +7906,7 @@ algorithm
       Absyn.Path path;
     // you cannot redeclare a basic type, only the properties and the binding, i.e.
     // redeclare constant Boolean standardOrderComponents = true
-    case (DAE.REDECL(_, _, {(SCode.COMPONENT(typeSpec=Absyn.TPATH(path=path)), _)})) equation
+    case DAE.REDECL(element = SCode.COMPONENT(typeSpec=Absyn.TPATH(path=path))) equation
       true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
 
         name = Absyn.pathFirstIdent(path);
@@ -7914,7 +7914,7 @@ algorithm
       true = listMember(name, {"Real", "Integer", "Boolean", "String", "Clock"});
     then true;
 
-    case (DAE.REDECL(_, _, {(SCode.COMPONENT(typeSpec=Absyn.TPATH(path=path)), _)})) equation
+    case DAE.REDECL(element = SCode.COMPONENT(typeSpec=Absyn.TPATH(path=path))) equation
       false = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
 
       name = Absyn.pathFirstIdent(path);


### PR DESCRIPTION
- Change the list of elements to one element, since redeclare
  modifiers always have exactly one element anyway. This simplifies the
  redeclare handling code a lot.