### PR TITLE
Rewrote Absyn.pathString

### DIFF
--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -437,7 +437,7 @@ algorithm
       print("\n  extends ExternalObject;");
       print("\n origin: ");
       paths = DAEUtil.getElementSourceTypes(source);
-      paths_lst = List.map(paths, Absyn.pathString);
+      paths_lst = list(Absyn.pathString(p) for p in paths);
       path_str = stringDelimitList(paths_lst, ", ");
       print(path_str + "\n");
       print("end ");print(Absyn.pathString(path));
@@ -2280,7 +2280,7 @@ protected
   String dimensions;
 algorithm
   paths := DAEUtil.getElementSourceTypes(inVar.source);
-  paths_lst := List.map(paths, Absyn.pathString);
+  paths_lst := list(Absyn.pathString(p) for p in paths);
   unreplaceableStr := if inVar.unreplaceable then " unreplaceable" else "";
   dimensions := ExpressionDump.dimensionsString(inVar.arryDim);
   dimensions := if dimensions <> "" then " [" + dimensions + "]" else "";

--- a/Compiler/FFrontEnd/FGraph.mo
+++ b/Compiler/FFrontEnd/FGraph.mo
@@ -1752,7 +1752,7 @@ algorithm
         crefPrefix = PrefixUtil.prefixAdd(inSourceName,{},{},inPrefix,SCode.CONST(),ClassInf.UNKNOWN(Absyn.IDENT("")), Absyn.dummyInfo); // variability doesn't matter
 
         // name = inTargetClassName + "$" + ComponentReference.printComponentRefStr(PrefixUtil.prefixToCref(crefPrefix));
-        name = inTargetClassName + "$" + Absyn.pathString2NoLeadingDot(Absyn.stringListPath(listReverse(Absyn.pathToStringList(PrefixUtil.prefixToPath(crefPrefix)))), "$")
+        name = inTargetClassName + "$" + Absyn.pathString(Absyn.stringListPath(listReverse(Absyn.pathToStringList(PrefixUtil.prefixToPath(crefPrefix)))), "$", usefq=false)
                ; // + "$" + Absyn.pathString2NoLeadingDot(getGraphName(inSourceEnv), "$");
         // name = "'$" + inTargetClassName + "@" + Absyn.pathString(Absyn.stringListPath(listReverse(Absyn.pathToStringList(PrefixUtil.prefixToPath(crefPrefix))))) + "'";
         // name = "'$" + getGraphNameStr(inSourceEnv) + "." + Absyn.pathString(Absyn.stringListPath(listReverse(Absyn.pathToStringList(PrefixUtil.prefixToPath(crefPrefix))))) + "'";

--- a/Compiler/FrontEnd/DAEUtil.mo
+++ b/Compiler/FrontEnd/DAEUtil.mo
@@ -2638,7 +2638,7 @@ algorithm
     else
       equation
         true = Flags.isSet(Flags.FAILTRACE);
-        msg = stringDelimitList(List.mapMap(getFunctionList(functions), functionName, Absyn.pathString), "\n  ");
+        msg = stringDelimitList(List.mapMap(getFunctionList(functions), functionName, Absyn.pathStringDefault), "\n  ");
         msg = "DAEUtil.getNamedFunction failed: " + Absyn.pathString(path) + "\nThe following functions were part of the cache:\n  " + msg;
         // Error.addMessage(Error.INTERNAL_ERROR,{msg});
         Debug.traceln(msg);
@@ -2660,7 +2660,7 @@ algorithm
     case (_,_,_) then Util.getOption(avlTreeGet(functions, path));
     else
       equation
-        msg = stringDelimitList(List.mapMap(getFunctionList(functions), functionName, Absyn.pathString), "\n  ");
+        msg = stringDelimitList(List.mapMap(getFunctionList(functions), functionName, Absyn.pathStringDefault), "\n  ");
         msg = "DAEUtil.getNamedFunction failed: " + Absyn.pathString(path) + "\nThe following functions were part of the cache:\n  " + msg;
         Error.addSourceMessage(Error.INTERNAL_ERROR,{msg},info);
       then fail();
@@ -3734,7 +3734,7 @@ algorithm
       equation
         lst = avlTreeToList(ft);
         lstInvalid = List.select(lst, isInvalidFunctionEntry);
-        str = stringDelimitList(List.map(List.map(lstInvalid, Util.tuple21), Absyn.pathString), "\n ");
+        str = stringDelimitList(list(Absyn.pathString(p) for p in List.map(lstInvalid, Util.tuple21)), "\n ");
         str = "\n " + str + "\n";
         Error.addMessage(Error.NON_INSTANTIATED_FUNCTION, {str});
         fns = List.mapMap(List.select(lst, isValidFunctionEntry), Util.tuple22, Util.getOption);
@@ -3747,7 +3747,7 @@ public function getFunctionNames
   input DAE.FunctionTree ft;
   output list<String> strs;
 algorithm
-  strs := List.mapMap(getFunctionList(ft), functionName, Absyn.pathString);
+  strs := List.mapMap(getFunctionList(ft), functionName, Absyn.pathStringDefault);
 end getFunctionNames;
 
 protected function isInvalidFunctionEntry

--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -12062,6 +12062,7 @@ protected function makeMatrix
 protected
   list<DAE.Exp> col;
   Integer r;
+  import listReverse = MetaModelica.Dangerous.listReverseInPlace;
 algorithm
   res := {};
   col := {};

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -113,51 +113,54 @@ protected partial function BasicTypeAttrTyper
 end BasicTypeAttrTyper;
 
 // protected imports
-protected import BaseHashTable;
-protected import Builtin;
-protected import Ceval;
-protected import ConnectUtil;
-protected import ComponentReference;
-protected import Config;
-protected import DAEUtil;
-protected import Debug;
-protected import Dump;
-protected import Error;
-protected import ErrorExt;
-protected import Expression;
-protected import ExpressionDump;
-protected import Flags;
-protected import FGraph;
-protected import FGraphBuildEnv;
-protected import FNode;
-protected import Global;
-protected import HashTable;
-protected import HashTable5;
-protected import InstSection;
-protected import InstBinding;
-protected import InstVar;
-protected import InstFunction;
-protected import InstUtil;
-protected import InstExtends;
-protected import List;
-protected import Lookup;
-protected import MetaUtil;
-protected import PrefixUtil;
-protected import SCodeUtil;
-protected import Static;
-protected import Types;
-protected import UnitParserExt;
-protected import Util;
-protected import Values;
-protected import ValuesUtil;
-protected import System;
-protected import SCodeDump;
-protected import UnitAbsynBuilder;
-protected import NFSCodeFlattenRedeclare;
-protected import InstStateMachineUtil;
-protected import HashTableSM1;
+protected
 
-protected import DAEDump; // BTH
+import BaseHashTable;
+import Builtin;
+import Ceval;
+import ConnectUtil;
+import ComponentReference;
+import Config;
+import DAEUtil;
+import Debug;
+import Dump;
+import Error;
+import ErrorExt;
+import Expression;
+import ExpressionDump;
+import Flags;
+import FGraph;
+import FGraphBuildEnv;
+import FNode;
+import GC;
+import Global;
+import HashTable;
+import HashTable5;
+import InstSection;
+import InstBinding;
+import InstVar;
+import InstFunction;
+import InstUtil;
+import InstExtends;
+import List;
+import Lookup;
+import MetaUtil;
+import PrefixUtil;
+import SCodeUtil;
+import Static;
+import Types;
+import UnitParserExt;
+import Util;
+import Values;
+import ValuesUtil;
+import System;
+import SCodeDump;
+import UnitAbsynBuilder;
+import NFSCodeFlattenRedeclare;
+import InstStateMachineUtil;
+import HashTableSM1;
+
+import DAEDump; // BTH
 
 protected function instantiateClass_dispatch
 " instantiate a class.
@@ -196,6 +199,11 @@ algorithm
 
         // set the source of this element
         source = DAEUtil.addElementSourcePartOfOpt(DAE.emptyElementSource, FGraph.getScopePath(env));
+
+        if Flags.isSet(Flags.GC_PROF) then
+          print(GC.profStatsStr(GC.getProfStats(), head="GC stats after pre-frontend work (building graphs):") + "\n");
+        end if;
+
         (cache,env_2,ih,dae2) = instClassInProgram(cache, env_1, ih, cdecls, path, source);
         // check the models for balancing
         //Debug.fcall2(Flags.CHECK_MODEL_BALANCE, checkModelBalancing, SOME(path), dae1);
@@ -234,6 +242,10 @@ algorithm
 
         //System.startTimer();
         //print("\nInstClass");
+        if Flags.isSet(Flags.GC_PROF) then
+          print(GC.profStatsStr(GC.getProfStats(), head="GC stats after pre-frontend work (building graphs):") + "\n");
+        end if;
+
         (cache,env_2,ih,_,dae,_,_,_,_,_) = instClass(cache,env_2,ih,
           UnitAbsynBuilder.emptyInstStore(),DAE.NOMOD(), makeTopComponentPrefix(env_2, n), cdef,
           {}, false, InstTypes.TOP_CALL(), ConnectionGraph.EMPTY, Connect.emptySet) "impl";
@@ -5423,7 +5435,7 @@ protected function emptyInstHashTableSized
   input Integer size;
   output InstHashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(Absyn.pathHashMod,Absyn.pathEqual,Absyn.pathString,opaqVal));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(Absyn.pathHashMod,Absyn.pathEqual,Absyn.pathStringDefault,opaqVal));
 end emptyInstHashTableSized;
 
 /* end HashTable */
@@ -5542,7 +5554,7 @@ algorithm
 
     case (_)
       equation
-        str = Absyn.pathString2NoLeadingDot(Absyn.stringListPath(listReverse(Absyn.pathToStringList(PrefixUtil.prefixToPath(inPrefix)))), "$");
+        str = Absyn.pathString(PrefixUtil.prefixToPath(inPrefix), "$", usefq=false, reverse=true);
       then
         str;
 

--- a/Compiler/FrontEnd/NFSCodeFlattenRedeclare.mo
+++ b/Compiler/FrontEnd/NFSCodeFlattenRedeclare.mo
@@ -553,7 +553,7 @@ algorithm
     // shouldn't happen.
     case (_, _, _, {})
       equation
-        bc_strl = List.map(inBaseClasses, Absyn.pathString);
+        bc_strl = list(Absyn.pathString(p) for p in inBaseClasses);
         bcl_str = stringDelimitList(bc_strl, ", ");
         err_msg = "NFSCodeFlattenRedeclare.pushRedeclareIntoExtends2 couldn't find the base classes {"
           + bcl_str + "} for " + inName;
@@ -871,7 +871,7 @@ algorithm
     case (_, _, _, _, _, _)
       equation
         print("pushing: " + inName + " redeclare: " + NFSCodeEnv.itemStr(inRedeclare) + "\n\t");
-        print("into baseclases: " + stringDelimitList(List.map(inBaseClasses, Absyn.pathString), ", ") + "\n\t");
+        print("into baseclases: " + stringDelimitList(list(Absyn.pathString(p) for p in inBaseClasses), ", ") + "\n\t");
         print("called from env: " + NFSCodeEnv.getEnvName(inEnv) + "\n");
         print("-----------------\n");
       then ();

--- a/Compiler/FrontEnd/Types.mo
+++ b/Compiler/FrontEnd/Types.mo
@@ -2225,7 +2225,7 @@ algorithm
 
     case (DAE.T_FUNCTION(funcArg = params, funcResultType = restype, source = ts))
       equation
-        funcstr = stringDelimitList(List.map(ts, Absyn.pathString), ", ");
+        funcstr = stringDelimitList(list(Absyn.pathString(pt) for pt in ts), ", ");
         paramstrs = List.map(params, unparseParam);
         paramstr = stringDelimitList(paramstrs, ", ");
         restypestr = unparseType(restype);
@@ -6489,7 +6489,7 @@ algorithm
 
     else
       equation
-        pathStr = stringDelimitList(List.map(pathLst, Absyn.pathString), ", ");
+        pathStr = stringDelimitList(list(Absyn.pathString(p) for p in pathLst), ", ");
         bindingsStr = polymorphicBindingsStr(bindings);
         solvedBindingsStr = polymorphicBindingsStr(solvedBindings);
         unsolvedBindingsStr = polymorphicBindingsStr(unsolvedBindings);
@@ -7839,7 +7839,7 @@ algorithm
     // yeha, we have some
     case (ts)
       equation
-        s = " origin: " + stringDelimitList(List.map(ts, Absyn.pathString), ", ");
+        s = " origin: " + stringDelimitList(list(Absyn.pathString(t) for t in ts), ", ");
       then
         s;
   end matchcontinue;

--- a/Compiler/Main/Main.mo
+++ b/Compiler/Main/Main.mo
@@ -290,13 +290,13 @@ algorithm
       equation
         names = List.map(cls,Absyn.className);
         names = List.map1(names,Absyn.joinPaths,scope);
-        res = "{" + stringDelimitList(List.map(names,Absyn.pathString),",") + "}\n";
+        res = "{" + stringDelimitList(list(Absyn.pathString(n) for n in names),",") + "}\n";
       then res;
 
     case(Absyn.PROGRAM(classes=cls,within_=Absyn.TOP()))
       equation
         names = List.map(cls,Absyn.className);
-        res = "{" + stringDelimitList(List.map(names,Absyn.pathString),",") + "}\n";
+        res = "{" + stringDelimitList(list(Absyn.pathString(n) for n in names),",") + "}\n";
       then res;
 
   end match;

--- a/Compiler/Script/CevalScript.mo
+++ b/Compiler/Script/CevalScript.mo
@@ -2403,7 +2403,7 @@ algorithm
 
         if Flags.isSet(Flags.DYN_LOAD) then
           print("[dynload]: [SOME SYMTAB] not in in CF list: removed deps:" +
-          stringDelimitList(List.map(functionDependencies, Absyn.pathString) ,", ") + "\n");
+          stringDelimitList(list(Absyn.pathString(fdep) for fdep in functionDependencies) ,", ") + "\n");
         end if;
         //print("\nfunctions in SYMTAB: " + Interactive.dumpCompiledFunctions(syt)
 

--- a/Compiler/Script/Interactive.mo
+++ b/Compiler/Script/Interactive.mo
@@ -14664,7 +14664,7 @@ algorithm
         s1 = Dump.unparseWithin(w);
         /* adeas31 2012-01-25: false indicates that the classnamesrecursive doesn't look into protected sections */
         (_, paths) = getClassNamesRecursive(NONE(), p, false, {});
-        s2 = stringAppendList(List.map1r(List.map(paths,Absyn.pathString),stringAppend,"\n  "));
+        s2 = stringAppendList(List.map1r(list(Absyn.pathString(p) for p in paths),stringAppend,"\n  "));
         Error.addMessage(Error.INSERT_CLASS, {name,s1,s2});
       then
         fail();

--- a/Compiler/Template/CodegenFMUCommon.tpl
+++ b/Compiler/Template/CodegenFMUCommon.tpl
@@ -217,7 +217,7 @@ case SIMVAR(__) then
     case T_REAL(__) then '<Real<%StartString(simvar)/*%> <%ScalarVariableTypeRealAttribute(unit,displayUnit)*/%>/>'
     case T_BOOL(__) then '<Boolean<%StartString(simvar)%>/>'
     case T_STRING(__) then '<String<%StartString(simvar)%>/>'
-    case T_ENUMERATION(__) then '<Enumeration declaredType="<%Absyn.pathString2NoLeadingDot(path, ".")%>"<%StartString(simvar)%>/>'
+    case T_ENUMERATION(__) then '<Enumeration declaredType="<%Absyn.pathString(path, ".", false)%>"<%StartString(simvar)%>/>'
     else 'UNKOWN_TYPE'
 end ScalarVariableType;
 
@@ -556,7 +556,7 @@ case SIMVAR(__) then
     case T_INTEGER(__) then '<Integer<%ScalarVariableTypeCommonAttribute2(simvar, stateVars)%>/>'
     case T_BOOL(__) then '<Boolean<%ScalarVariableTypeCommonAttribute2(simvar, stateVars)%>/>'
     case T_STRING(__) then '<String<%ScalarVariableTypeCommonAttribute2(simvar, stateVars)%>/>'
-    case T_ENUMERATION(__) then '<Enumeration declaredType="<%Absyn.pathString2NoLeadingDot(path, ".")%>"<%ScalarVariableTypeCommonAttribute2(simvar, stateVars)%>/>'
+    case T_ENUMERATION(__) then '<Enumeration declaredType="<%Absyn.pathString(path, ".", false)%>"<%ScalarVariableTypeCommonAttribute2(simvar, stateVars)%>/>'
     else 'UNKOWN_TYPE'
 end ScalarVariableType2;
 
@@ -687,7 +687,7 @@ match type_
   case T_ENUMERATION(__) then
   if isFMIVersion20(FMUVersion) then
   <<
-  <SimpleType name="<%Absyn.pathString2NoLeadingDot(path, ".")%>">
+  <SimpleType name="<%Absyn.pathString(path, ".", false)%>">
     <Enumeration>
       <%names |> name hasindex i0 fromindex 1 => '<Item name="<%name%>" value="<%i0%>"/>' ;separator="\n"%>
     </Enumeration>
@@ -695,7 +695,7 @@ match type_
   >>
   else
   <<
-  <Type name="<%Absyn.pathString2NoLeadingDot(path, ".")%>">
+  <Type name="<%Absyn.pathString(path, ".", false)%>">
     <EnumerationType>
       <%names |> name => '<Item name="<%name%>"/>' ;separator="\n"%>
     </EnumerationType>

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -1293,11 +1293,12 @@ package Absyn
     end THREAD;
   end ReductionIterType;
 
-  function pathString2NoLeadingDot "Tail-recursive version, with string builder (stringDelimitList is optimised)"
+  function pathString
     input Path path;
     input String delimiter;
+    input Boolean usefq;
     output String outString;
-  end pathString2NoLeadingDot;
+  end pathString;
 
   function pathLastIdent
     input Path inPath;

--- a/Compiler/Util/HashTableStringToPath.mo
+++ b/Compiler/Util/HashTableStringToPath.mo
@@ -98,7 +98,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(System.stringHashDjb2Mod,stringEq,Util.id,Absyn.pathString));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(System.stringHashDjb2Mod,stringEq,Util.id,Absyn.pathStringDefault));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/Compiler/Util/System.mo
+++ b/Compiler/Util/System.mo
@@ -1186,5 +1186,49 @@ annotation(Documentation(info="<html>
 </html>"));
 end dladdr;
 
+class StringAllocator
+  extends ExternalObject;
+  function constructor
+    input Integer sz;
+    output StringAllocator str;
+  external "C" str=StringAllocator_constructor(sz) annotation(Include="
+void* StringAllocator_constructor(int sz)
+{
+  return mmc_alloc_scon(sz);
+}
+");
+  end constructor;
+  function destructor
+    input StringAllocator str;
+  algorithm
+    /* Nothing */
+  end destructor;
+end StringAllocator;
+
+function stringAllocatorStringCopy
+  input StringAllocator dest;
+  input String source;
+  input Integer destOffset=0;
+external "C" om_stringAllocatorStringCopy(dest,source,destOffset) annotation(Include="
+void om_stringAllocatorStringCopy(void *dest, char *source, int destOffset) {
+  strcpy(MMC_STRINGDATA(dest)+destOffset, source);
+}
+", Documentation(info="<html>
+<p>Does a strcpy into the (input) destination. This is dangerous and not valid Modelica.</p>
+<p>Make sure the String has been allocated properly and is not shared. The input lengths are not validated, so this function can write out of bounds if called incorrectly.</p>
+</html>"));
+end stringAllocatorStringCopy;
+
+function stringAllocatorResult<T>
+  input StringAllocator sa;
+  input T dummy annotation(__OpenModelica_UnusedVariable=true);
+  output T res;
+external "C" res=om_stringAllocatorResult(sa) annotation(Include="
+const char* om_stringAllocatorResult(void *sa) {
+  return sa;
+}
+");
+end stringAllocatorResult;
+
 annotation(__OpenModelica_Interface="util");
 end System;

--- a/Compiler/Util/VisualXML.mo
+++ b/Compiler/Util/VisualXML.mo
@@ -445,7 +445,7 @@ algorithm
     case(BackendDAE.VAR(varName=varName, varType = varType, source=source), (varLst,crefs))
       algorithm
        paths := DAEUtil.getElementSourceTypes(source);
-       paths_lst := List.map(paths, Absyn.pathString);
+       paths_lst := list(Absyn.pathString(p) for p in paths);
          //print("paths_lst "+stringDelimitList(paths_lst, "; ")+"\n");
        (obj,idx) := hasVisPath(paths,1);
        true := Util.stringNotEqual(obj,"");

--- a/Compiler/runtime/Dynload_omc.cpp
+++ b/Compiler/runtime/Dynload_omc.cpp
@@ -57,13 +57,13 @@ extern void* DynLoad_executeFunction(threadData_t*  threadData, int _inFuncHandl
   return retarg;
 }
 
-extern void* omc_Absyn_pathString2(threadData_t*,void*,void*);
+extern void* omc_Absyn_pathString(threadData_t*,void*,void*,int,int);
 
 static const char* path_to_name(void* path, char del)
 {
   threadData_t *threadData = (threadData_t *) pthread_getspecific(mmc_thread_data_key);
   char delStr[2] = {del,'\0'};
-  return MMC_STRINGDATA(omc_Absyn_pathString2(threadData, path, mmc_mk_scon(delStr)));
+  return MMC_STRINGDATA(omc_Absyn_pathString(threadData, path, mmc_mk_scon(delStr), 0, 0));
 }
 
 }

--- a/SimulationRuntime/c/util/ModelicaUtilities.c
+++ b/SimulationRuntime/c/util/ModelicaUtilities.c
@@ -83,8 +83,9 @@ void ModelicaFormatError(const char* string, ...) {
 
 char* ModelicaAllocateString(size_t len) {
   char *res = ModelicaAllocateStringWithErrorReturn(len);
-  if(!res)
+  if (!res) {
     ModelicaFormatError("%s:%d: ModelicaAllocateString failed", __FILE__, __LINE__);
+  }
   return res;
 }
 


### PR DESCRIPTION
The new implementation of pathString uses external object
System.StringAllocator to allocate a string as well as
System.stringAllocatorStringCopy to write into this external object
in a way that regular MetaModelica functions cannot. This avoids
a bunch of list creation and delimiting of string lists.

The size of the String is first detected by traversing the path,
which is needed in order to allocate a string of the correct length.
After this, the data is copied into the correct places.