### PR TITLE
Generating modelica output in the flat DAE dump

### DIFF
--- a/Compiler/FrontEnd/ComponentReference.mo
+++ b/Compiler/FrontEnd/ComponentReference.mo
@@ -507,7 +507,9 @@ public function crefStr
   input DAE.ComponentRef inComponentRef;
   output String outString;
 algorithm
-  outString:= crefToStr("",inComponentRef,".");
+  outString := if Flags.getConfigBool(Flags.MODELICA_OUTPUT)
+                    then crefToStr("",inComponentRef,"__")
+                    else crefToStr("",inComponentRef,".");
 end crefStr;
 
 public function crefModelicaStr

--- a/Compiler/Template/AbsynDumpTV.mo
+++ b/Compiler/Template/AbsynDumpTV.mo
@@ -901,4 +901,14 @@ package Tpl
   end addTemplateError;
 end Tpl;
 
+package Flags
+  uniontype ConfigFlag end ConfigFlag;
+  constant ConfigFlag MODELICA_OUTPUT;
+  function getConfigBool
+    input ConfigFlag inFlag;
+    output Boolean outValue;
+  end getConfigBool;
+end Flags;
+
+
 end AbsynDumpTV;

--- a/Compiler/Template/AbsynDumpTpl.tpl
+++ b/Compiler/Template/AbsynDumpTpl.tpl
@@ -687,6 +687,9 @@ match path
   case FULLYQUALIFIED(__) then
     '.<%dumpPath(path)%>'
   case QUALIFIED(__) then
+    if (Flags.getConfigBool(Flags.MODELICA_OUTPUT)) then
+    '<%name%>__<%dumpPath(path)%>'
+    else
     '<%name%>.<%dumpPath(path)%>'
   case IDENT(__) then
     '<%name%>'

--- a/Compiler/Template/DAEDumpTV.mo
+++ b/Compiler/Template/DAEDumpTV.mo
@@ -1398,6 +1398,24 @@ package System
     input Boolean unescapeNewline;
     output String escapedString;
   end escapedString;
+
+  function stringReplace
+    input String str;
+    input String source;
+    input String target;
+    output String res;
+  end stringReplace;
+
 end System;
+
+package Flags
+  uniontype ConfigFlag end ConfigFlag;
+  constant ConfigFlag MODELICA_OUTPUT;
+  function getConfigBool
+    input ConfigFlag inFlag;
+    output Boolean outValue;
+  end getConfigBool;
+end Flags;
+
 
 end DAEDumpTV;

--- a/Compiler/Template/DAEDumpTpl.tpl
+++ b/Compiler/Template/DAEDumpTpl.tpl
@@ -27,11 +27,12 @@ template dumpComp(DAEDump.compWithSplitElements fixedDae)
   match fixedDae case COMP_WITH_SPLIT(__) then
     let cmt_str = dumpCommentOpt(comment)
     let ann_str = dumpClassAnnotation(comment)
+    let name_rep = if (Flags.getConfigBool(Flags.MODELICA_OUTPUT)) then System.stringReplace(name, ".","__") else name
     <<
-    class <%name%><%cmt_str%>
+    class <%name_rep%><%cmt_str%>
     <%dumpCompStream(spltElems)%>
     <%if ann_str then "  "%><%ann_str%>
-    end <%name%>;<%\n%>
+    end <%name_rep%>;<%\n%>
     >>
 end dumpComp;
 
@@ -526,6 +527,11 @@ template dumpCref(ComponentRef c)
 ::=
 match c
   case CREF_QUAL(__) then
+    if (Flags.getConfigBool(Flags.MODELICA_OUTPUT)) then
+    <<
+    <%ident%><%dumpSubscripts(subscriptLst)%>__<%dumpCref(componentRef)%>
+    >>
+    else
     <<
     <%ident%><%dumpSubscripts(subscriptLst)%>.<%dumpCref(componentRef)%>
     >>
@@ -550,6 +556,10 @@ end dumpTypeDimensions;
 template dumpSubscripts(list<Subscript> subscriptLst)
 ::=
   if subscriptLst then
+    if (Flags.getConfigBool(Flags.MODELICA_OUTPUT)) then
+    let sub_str = (subscriptLst |> s => dumpSubscript(s) ;separator="_")
+    '_<%sub_str%>'
+    else
     let sub_str = (subscriptLst |> s => dumpSubscript(s) ;separator=",")
     '[<%sub_str%>]'
 end dumpSubscripts;

--- a/Compiler/Template/ExpressionDumpTV.mo
+++ b/Compiler/Template/ExpressionDumpTV.mo
@@ -846,4 +846,13 @@ package Types
   end unparseType;
 end Types;
 
+package Flags
+  uniontype ConfigFlag end ConfigFlag;
+  constant ConfigFlag MODELICA_OUTPUT;
+  function getConfigBool
+    input ConfigFlag inFlag;
+    output Boolean outValue;
+  end getConfigBool;
+end Flags;
+
 end ExpressionDumpTV;

--- a/Compiler/Template/ExpressionDumpTpl.tpl
+++ b/Compiler/Template/ExpressionDumpTpl.tpl
@@ -213,6 +213,9 @@ match cref
   case CREF_QUAL(__) then
     let sub_str = dumpSubscripts(subscriptLst)
     let cref_str = dumpCref(componentRef)
+    if (Flags.getConfigBool(Flags.MODELICA_OUTPUT)) then
+    '<%ident%><%sub_str%>__<%cref_str%>'
+    else
     '<%ident%><%sub_str%>.<%cref_str%>'
   case WILD() then '_'
   case OPTIMICA_ATTR_INST_CREF(__) then
@@ -223,6 +226,10 @@ end dumpCref;
 template dumpSubscripts(list<DAE.Subscript> subscripts)
 ::=
 if subscripts then
+  if (Flags.getConfigBool(Flags.MODELICA_OUTPUT)) then
+  let sub_str = (subscripts |> sub => dumpSubscript(sub) ;separator="_")
+  '_<%sub_str%>'
+  else
   let sub_str = (subscripts |> sub => dumpSubscript(sub) ;separator=",")
   '[<%sub_str%>]'
 end dumpSubscripts;

--- a/Compiler/Template/ExpressionDumpTpl.tpl
+++ b/Compiler/Template/ExpressionDumpTpl.tpl
@@ -61,9 +61,16 @@ match exp
     let func_str = AbsynDumpTpl.dumpPathNoQual(path)
     let argl = dumpExpList(expList, stringDelimiter, ", ")
     'function <%func_str%>(<%argl%>)'
+  case ARRAY(array={}) then
+    if (Flags.getConfigBool(Flags.MODELICA_OUTPUT)) then
+    'fill(0,0)'
+    else
+    let expl = dumpExpList(array, stringDelimiter, ", ")
+    '<%if typeinfo() then (if scalar then '/* scalar <%unparseType(ty)%>*/' else '/* non-scalar <%unparseType(ty)%> */ ')%>{<%expl%>}'
   case ARRAY(__) then
     let expl = dumpExpList(array, stringDelimiter, ", ")
     '<%if typeinfo() then (if scalar then '/* scalar <%unparseType(ty)%>*/' else '/* non-scalar <%unparseType(ty)%> */ ')%>{<%expl%>}'
+
   case MATRIX(__) then
     let mat_str = (matrix |> row => dumpExpList(row, stringDelimiter, ", ") ;separator="}, {")
     '<%if typeinfo() then '/* matrix <%unparseType(ty) %> */ '%>{{<%mat_str%>}}'


### PR DESCRIPTION
This is a fix for bug 2588.

Now when the -m flag is set, valid modelica code is generated when dumping the DAE.
With this fix I tried to cover the language structures that I know of that generate invalid modelica code:
* The dot operator on variable names is replaced by underscores
* The expansion of array into many variables with the same name are now dumped as different variables a_1, a_2 a_3. The same for multidimensional arrays.
* Adrian Pop pointed me that empty arrays constructors {} are also invalid so they are replaced by fill(0,0). Perhaps some more more work is needed here to correctly type the fill call.

Does any body knows some more language structs that would generate invalid modelica code in the DAE dump??

