### PR TITLE
Fix for #3460.

### DIFF
--- a/Compiler/FrontEnd/InstExtends.mo
+++ b/Compiler/FrontEnd/InstExtends.mo
@@ -145,11 +145,15 @@ algorithm
             SOME(cls) := ocls;
             SCode.CLASS(name = cn, encapsulatedPrefix = encf, restriction = r) := cls;
           else
-            // Base class could not be found, print an error.
-            bc_str := Absyn.pathString(el.baseClassPath);
-            scope_str := FGraph.printGraphPathStr(inEnv);
-            Error.addSourceMessageAndFail(Error.LOOKUP_BASECLASS_ERROR,
-              {bc_str, scope_str}, el.info);
+            // Base class could not be found, print an error unless --permissive
+            // is used.
+            if Flags.getConfigBool(Flags.PERMISSIVE) then
+              bc_str := Absyn.pathString(el.baseClassPath);
+              scope_str := FGraph.printGraphPathStr(inEnv);
+              Error.addSourceMessage(Error.LOOKUP_BASECLASS_ERROR,
+                {bc_str, scope_str}, el.info);
+            end if;
+            fail();
           end if;
 
           (outCache, cenv, outIH, els1, eq1, ieq1, alg1, ialg1, mod) :=
@@ -213,6 +217,10 @@ algorithm
 
         then
           ();
+
+      // Skip any extends we couldn't handle if --permissive is given.
+      case SCode.EXTENDS() guard(Flags.getConfigBool(Flags.PERMISSIVE))
+        then ();
 
       case SCode.COMPONENT()
         algorithm

--- a/Compiler/Script/Interactive.mo
+++ b/Compiler/Script/Interactive.mo
@@ -9891,7 +9891,7 @@ algorithm
       Absyn.ComponentRef model_;
       Absyn.Program p;
       FCore.Cache cache;
-      Boolean b;
+      Boolean b, permissive;
       GlobalScript.SymbolTable st;
 
     case (model_,b,st as GlobalScript.SYMBOLTABLE(ast=p))
@@ -9903,9 +9903,12 @@ algorithm
         (cache,(c as SCode.CLASS(name=id,encapsulatedPrefix=encflag,restriction=restr)),env_1) = Lookup.lookupClass(cache,env, modelpath);
         env2 = FGraph.openScope(env_1, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
         ci_state = ClassInf.start(restr, FGraph.getGraphName(env2));
+        permissive = Flags.getConfigBool(Flags.PERMISSIVE);
+        Flags.setConfigBool(Flags.PERMISSIVE, true);
         (_,env_2,_,_,_) =
           Inst.partialInstClassIn(cache, env2, InnerOuter.emptyInstHierarchy, DAE.NOMOD(),
             Prefix.NOPRE(), ci_state, c, SCode.PUBLIC(), {}, 0);
+        Flags.setConfigBool(Flags.PERMISSIVE, permissive);
         comps1 = getPublicComponentsInClass(cdef);
         s1 = getComponentsInfo(comps1, b, "\"public\"", env_2);
         comps2 = getProtectedComponentsInClass(cdef);

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -1179,6 +1179,10 @@ constant ConfigFlag INIT_OPT_MODULES_ADD = CONFIG_FLAG(85, "initOptModules+",
 constant ConfigFlag INIT_OPT_MODULES_SUB = CONFIG_FLAG(86, "initOptModules-",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
   Util.gettext("Disables a list of init-optimization modules. See --help=optmodules for more info."));
+constant ConfigFlag PERMISSIVE = CONFIG_FLAG(87, "permissive",
+  NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
+  Util.gettext("Disables some error checks to allow erroneous models to compile."));
+
 
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
@@ -1270,7 +1274,8 @@ constant list<ConfigFlag> allConfigFlags = {
   POST_OPT_MODULES_ADD,
   POST_OPT_MODULES_SUB,
   INIT_OPT_MODULES_ADD,
-  INIT_OPT_MODULES_SUB
+  INIT_OPT_MODULES_SUB,
+  PERMISSIVE
 };
 
 public function new


### PR DESCRIPTION
- Added new flag --permissive, used to make the compiler less strict.
- Use --permissive in Interactive.getComponents2 to allow extends of
  non-existing classes.