### PR TITLE
Allow inheritance when bootstrapping

### DIFF
--- a/Compiler/FFrontEnd/FLookup.mo
+++ b/Compiler/FFrontEnd/FLookup.mo
@@ -429,7 +429,7 @@ algorithm
     case (g, _, _, Absyn.NAMED_IMPORT(name = name, path = path) :: _, _, _)
       equation
         true = stringEqual(inName, name);
-        (g, r) = fq(g, inRef, path, inOptions, inMsg);
+        (g, r) = fq(g, path, inOptions, inMsg);
       then
         (g, r);
 
@@ -469,7 +469,7 @@ algorithm
     case (g, _, _, Absyn.UNQUAL_IMPORT(path = path) :: _, _, _)
       equation
         // Look up the import path.
-        (g, r) = fq(g, inRef, path, inOptions, inMsg);
+        (g, r) = fq(g, path, inOptions, inMsg);
         // Look up the name among the public member of the found package.
         (g, r) = id(g, r, inName, ignoreParents, inMsg);
       then
@@ -487,7 +487,6 @@ end imp_unqual;
 public function fq
 "Looks up a fully qualified path in ref"
   input Graph inGraph;
-  input Ref inRef;
   input Absyn.Path inName;
   input Options inOptions;
   input Msg inMsg "Message flag, SOME() outputs lookup error messages";

--- a/Compiler/FFrontEnd/FNode.mo
+++ b/Compiler/FFrontEnd/FNode.mo
@@ -3040,7 +3040,6 @@ algorithm
   outAvlValues := List.map(avlTreeValues, getAvlValue);
 end getAvlValues;
 
-
 // ************************ END AVL Tree implementation ***************************
 // ************************ END AVL Tree implementation ***************************
 // ************************ END AVL Tree implementation ***************************

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -169,6 +169,7 @@ protected function instantiateClass_dispatch
   input InnerOuter.InstHierarchy inIH;
   input SCode.Program inProgram;
   input SCode.Path inPath;
+  input Boolean doSCodeDep "Do SCode dependency (if the debug flag is also enabled)";
   output FCore.Cache outCache;
   output FCore.Graph outEnv;
   output InnerOuter.InstHierarchy outIH;
@@ -193,7 +194,9 @@ algorithm
     case (cache,ih,(cdecls as (_ :: _)),(path as Absyn.IDENT()))
       equation
         cache = FCore.setCacheClassName(cache,path);
-        cdecls = InstUtil.scodeFlatten(cdecls, inPath);
+        if doSCodeDep then
+          cdecls = InstUtil.scodeFlatten(cdecls, inPath);
+        end if;
         (cache,env) = Builtin.initialGraph(cache);
         env_1 = FGraphBuildEnv.mkProgramGraph(cdecls, FCore.USERDEFINED(), env);
 
@@ -218,7 +221,9 @@ algorithm
     case (cache,ih,(cdecls as (_ :: _)),(path as Absyn.QUALIFIED()))
       equation
         cache = FCore.setCacheClassName(cache,path);
-        cdecls = InstUtil.scodeFlatten(cdecls, inPath);
+        if doSCodeDep then
+          cdecls = InstUtil.scodeFlatten(cdecls, inPath);
+        end if;
         pathstr = Absyn.pathString(path);
 
         //System.startTimer();
@@ -292,6 +297,7 @@ public function instantiateClass
   input InnerOuter.InstHierarchy inIH;
   input SCode.Program inProgram;
   input SCode.Path inPath;
+  input Boolean doSCodeDep=true "Do SCode dependency (if the debug flag is also enabled)";
   output FCore.Cache outCache;
   output FCore.Graph outEnv;
   output InnerOuter.InstHierarchy outIH;
@@ -315,7 +321,7 @@ algorithm
     // instantiate a class
     case (cache,ih,cdecls as _::_,path)
       equation
-        (outCache,outEnv,outIH,outDAElist) = instantiateClass_dispatch(cache,ih,cdecls,path);
+        (outCache,outEnv,outIH,outDAElist) = instantiateClass_dispatch(cache,ih,cdecls,path,doSCodeDep);
       then
         (outCache,outEnv,outIH,outDAElist);
 
@@ -2123,7 +2129,6 @@ algorithm
 
         (cache, env1,ih) = InstUtil.addClassdefsToEnv(cache, env, ih, pre, cdefelts, impl, SOME(mods));
 
-
         //// fprintln(Flags.INST_TRACE, "after InstUtil.addClassdefsToEnv ENV: " + if_(stringEq(className, "PortVolume"), FGraph.printGraphStr(env1), " no env print "));
 
         // adrpo: TODO! DO SOME CHECKS HERE!
@@ -2135,6 +2140,7 @@ algorithm
         (cache,env2,ih,emods,extcomps,eqs2,initeqs2,alg2,initalg2) =
         InstExtends.instExtendsAndClassExtendsList(cache, env1, ih, mods, pre, extendselts, extendsclasselts, els, ci_state, className, impl, false)
         "2. EXTENDS Nodes inst_extends_list only flatten inhteritance structure. It does not perform component instantiations.";
+
 
         // print("Extended Elements inst:\n" + InstUtil.printElementAndModList(extcomps));
 

--- a/Compiler/FrontEnd/Patternm.mo
+++ b/Compiler/FrontEnd/Patternm.mo
@@ -39,44 +39,46 @@ encapsulated package Patternm
   This module contains the patternmatch algorithm for the MetaModelica
   matchcontinue expression."
 
-public import Absyn;
-public import AvlTreeString;
-public import Ceval;
-public import ClassInf;
-public import ConnectionGraph;
-public import DAE;
-public import FCore;
-public import HashTableStringToPath;
-public import SCode;
-public import Dump;
-public import InnerOuter;
-public import GlobalScript;
-public import Prefix;
-public import Types;
-public import UnitAbsyn;
+import Absyn;
+import Ceval;
+import ClassInf;
+import ConnectionGraph;
+import DAE;
+import FCore;
+import HashTableStringToPath;
+import SCode;
+import Dump;
+import InnerOuter;
+import GlobalScript;
+import Prefix;
+import Types;
+import UnitAbsyn;
 
-protected import Algorithm;
-protected import BaseHashTable;
-protected import ComponentReference;
-protected import Connect;
-protected import DAEUtil;
-protected import Expression;
-protected import ExpressionDump;
-protected import Error;
-protected import Flags;
-protected import FGraph;
-protected import Inst;
-protected import InstSection;
-protected import InstTypes;
-protected import InstUtil;
-protected import List;
-protected import Lookup;
-protected import MetaUtil;
-protected import SCodeUtil;
-protected import Static;
-protected import System;
-protected import Util;
-protected import SCodeDump;
+protected
+
+import Algorithm;
+import AvlTreeString;
+import BaseHashTable;
+import ComponentReference;
+import Connect;
+import DAEUtil;
+import Expression;
+import ExpressionDump;
+import Error;
+import Flags;
+import FGraph;
+import Inst;
+import InstSection;
+import InstTypes;
+import InstUtil;
+import List;
+import Lookup;
+import MetaUtil;
+import SCodeUtil;
+import Static;
+import System;
+import Util;
+import SCodeDump;
 
 protected function generatePositionalArgs "author: KS
   This function is used in the following cases:

--- a/Compiler/FrontEnd/SCode.mo
+++ b/Compiler/FrontEnd/SCode.mo
@@ -739,6 +739,17 @@ algorithm
   end match;
 end isElementExtends;
 
+public function isElementExtendsOrClassExtends
+  "Check if an element extends another class."
+  input Element ele;
+  output Boolean isExtend;
+algorithm
+  isExtend := match(ele)
+    case EXTENDS() then true;
+    else false;
+  end match;
+end isElementExtendsOrClassExtends;
+
 public function isNotElementClassExtends "
 check if an element is not of type CLASS_EXTENDS."
   input Element ele;

--- a/Compiler/Util/AvlTreeString2.mo
+++ b/Compiler/Util/AvlTreeString2.mo
@@ -1,0 +1,19 @@
+encapsulated package AvlTreeString2 "AvlTree for String to Integer. New implementation only used by the backend (until we get a new bootstrapping tarball)"
+  import BaseAvlTree;
+  extends BaseAvlTree;
+  redeclare type AvlKey = String;
+  redeclare type AvlValue = Integer;
+  redeclare function extends keyStr
+  algorithm
+    str := key;
+  end keyStr;
+  redeclare function extends valueStr
+  algorithm
+    str := String(value);
+  end valueStr;
+  redeclare function extends avlKeyCompare
+  algorithm
+    c := stringCompare(key1,key2);
+  end avlKeyCompare;
+annotation(__OpenModelica_Interface="util");
+end AvlTreeString2;

--- a/Compiler/Util/BaseAvlTree.mo
+++ b/Compiler/Util/BaseAvlTree.mo
@@ -1,0 +1,533 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2014, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated partial package BaseAvlTree
+
+replaceable type AvlKey = Integer; // TODO: We should have an Any type
+replaceable type AvlValue = Integer; // TODO: We should have an Any type
+
+uniontype AvlTree "The binary tree data structure
+ "
+  record NODE
+    Option<AvlTreeValue> value "Value" ;
+    Integer height "heigth of tree, used for balancing";
+    Option<AvlTree> left "left subtree" ;
+    Option<AvlTree> right "right subtree" ;
+  end NODE;
+
+end AvlTree;
+
+uniontype AvlTreeValue "Each node in the binary tree can have a value associated with it."
+  record VALUE
+    AvlKey key "Key" ;
+    AvlValue value "Value" ;
+  end VALUE;
+
+end AvlTreeValue;
+
+replaceable partial function keyStr "prints a key to a string"
+  input AvlKey key;
+  output String str;
+end keyStr;
+
+replaceable partial function valueStr "prints a Value to a string"
+  input AvlValue value;
+  output String str;
+end valueStr;
+
+replaceable partial function avlKeyCompare
+  input AvlKey key1;
+  input AvlKey key2;
+  output Integer c;
+end avlKeyCompare;
+
+function avlTreeNew "Return an empty tree"
+  output AvlTree tree;
+algorithm
+  tree := NODE(NONE(),0,NONE(),NONE());
+  annotation(__OpenModelica_EarlyInline = true);
+end avlTreeNew;
+
+function avlTreeToList "return tree as a flat list of tuples"
+  input AvlTree tree;
+  output list<tuple<AvlKey,AvlValue>> lst;
+algorithm
+  lst := avlTreeToList2(SOME(tree));
+end avlTreeToList;
+
+function joinAvlTrees "joins two trees by adding the second one to the first"
+  input AvlTree t1;
+  input AvlTree t2;
+  output AvlTree outTree;
+algorithm
+  outTree := avlTreeAddLst(avlTreeToList(t2),t1);
+end joinAvlTrees;
+
+protected
+
+function avlTreeToList2 "help function to avlTreeToList"
+  input Option<AvlTree> tree;
+  output list<tuple<AvlKey,AvlValue>> lst;
+algorithm
+  lst := match(tree)
+  local Option<AvlTree> r,l; AvlKey k; AvlValue v;
+    case NONE() then {};
+    case(SOME(NODE(value = NONE(),left = l,right = r) )) equation
+      lst = listAppend(avlTreeToList2(l),avlTreeToList2(r));
+    then lst;
+    case(SOME(NODE(value=SOME(VALUE(k,v)),left = l, right = r))) equation
+      lst = listAppend(avlTreeToList2(l),avlTreeToList2(r));
+    then (k,v)::lst;
+  end match;
+end avlTreeToList2;
+
+public
+
+function avlTreeAddLst "Adds a list of (key,value) pairs"
+  input list<tuple<AvlKey,AvlValue>> inValues;
+  input AvlTree inTree;
+  output AvlTree outTree;
+algorithm
+  outTree := match(inValues,inTree)
+    local
+      AvlKey key;
+      list<tuple<AvlKey,AvlValue>> values;
+      AvlValue val;
+      AvlTree tree;
+    case({},tree) then tree;
+    case((key,val)::values,tree) equation
+      tree = avlTreeAdd(tree,key,val);
+      tree = avlTreeAddLst(values,tree);
+    then tree;
+  end match;
+end avlTreeAddLst;
+
+function avlTreeAddFold
+  input AvlKey key;
+  input AvlValue value;
+  input AvlTree tree;
+  output AvlTree outAvlTree;
+algorithm
+  outAvlTree := avlTreeAdd(tree,key,value);
+end avlTreeAddFold;
+
+function avlTreeAdd "
+ Add a tuple (key,value) to the AVL tree."
+  input AvlTree inAvlTree;
+  input AvlKey inKey;
+  input AvlValue inValue;
+  output AvlTree outAvlTree;
+algorithm
+  outAvlTree := matchcontinue (inAvlTree,inKey,inValue)
+    local
+      AvlKey key,rkey;
+      AvlValue value,rval;
+      Option<AvlTree> left,right;
+      Integer h;
+      AvlTree t_1,t,bt;
+
+      /* empty tree*/
+    case (NODE(value = NONE(),left = NONE(),right = NONE()),key,value)
+      then NODE(SOME(VALUE(key,value)),1,NONE(),NONE());
+
+      /* Replace this node.*/
+    case (NODE(value = SOME(VALUE(rkey,_)),height=h,left = left,right = right),key,value)
+      equation
+        0 = avlKeyCompare(rkey, key);
+        bt = balance(NODE(SOME(VALUE(rkey,value)),h,left,right));
+      then
+        bt;
+
+        /* Insert to right  */
+    case (NODE(value = SOME(VALUE(rkey,rval)),height=h,left = left,right = (right)),key,value)
+      equation
+        true = avlKeyCompare(key,rkey) > 0;
+        t = createEmptyAvlIfNone(right);
+        t_1 = avlTreeAdd(t, key, value);
+        bt = balance(NODE(SOME(VALUE(rkey,rval)),h,left,SOME(t_1)));
+      then
+        bt;
+
+        /* Insert to left subtree */
+    case (NODE(value = SOME(VALUE(rkey,rval)),height=h,left = left ,right = right),key,value)
+      equation
+        /*true = stringCompare(key,rkey) < 0;*/
+         t = createEmptyAvlIfNone(left);
+        t_1 = avlTreeAdd(t, key, value);
+        bt = balance(NODE(SOME(VALUE(rkey,rval)),h,SOME(t_1),right));
+      then
+        bt;
+    case (_,_,_)
+      equation
+        print("avlTreeAdd failed\n");
+      then
+        fail();
+  end matchcontinue;
+end avlTreeAdd;
+
+function printAvlTreeStr "
+  Prints the avl tree to a string"
+  input AvlTree inAvlTree;
+  output String outString;
+algorithm
+  outString := match (inAvlTree)
+    local
+      AvlKey rkey;
+      String s1,s2,s3,res;
+      AvlValue rval;
+      Option<AvlTree> l,r;
+      Integer h;
+
+    case (NODE(value = SOME(VALUE(rkey,rval)),height = h,left = l,right = r))
+      equation
+        s2 = getOptionStr(l, printAvlTreeStr);
+        s3 = getOptionStr(r, printAvlTreeStr);
+        res = "< value=" + valueStr(rval) + ",key=" + keyStr(rkey) + ",height="+ intString(h)+ s2 + s3 + ">\n";
+      then
+        res;
+    case (NODE(value = NONE(),left = l,right = r))
+      equation
+        s2 = getOptionStr(l, printAvlTreeStr);
+        s3 = getOptionStr(r, printAvlTreeStr);
+        res = "<NONE," + s2 + ", "+ s3 + ">";
+
+      then
+        res;
+  end match;
+end printAvlTreeStr;
+
+protected
+
+function createEmptyAvlIfNone "Help function to AvlTreeAdd2"
+input Option<AvlTree> t;
+output AvlTree outT;
+algorithm
+  outT := match(t)
+    case(NONE()) then NODE(NONE(),0,NONE(),NONE());
+    case(SOME(outT)) then outT;
+  end match;
+end createEmptyAvlIfNone;
+
+function balance "Balances a AvlTree"
+  input AvlTree inBt;
+  output AvlTree outBt;
+algorithm
+  outBt := matchcontinue(inBt)
+    local Integer d; AvlTree bt;
+    case(bt) equation
+      d = differenceInHeight(bt);
+      bt = doBalance(d,bt);
+    then bt;
+    else equation
+      print("balance failed\n");
+    then fail();
+  end matchcontinue;
+end balance;
+
+function doBalance "perform balance if difference is > 1 or < -1"
+  input Integer difference;
+  input AvlTree inBt;
+  output AvlTree outBt;
+algorithm
+  outBt := matchcontinue(difference,inBt)
+    local AvlTree bt;
+    case(-1,bt) then computeHeight(bt);
+    case(0,bt) then computeHeight(bt);
+    case(1,bt) then computeHeight(bt);
+      /* d < -1 or d > 1 */
+    case(_,bt) equation
+      bt = doBalance2(difference,bt);
+    then bt;
+    else inBt;
+  end  matchcontinue;
+end doBalance;
+
+function doBalance2 "help function to doBalance"
+  input Integer difference;
+  input AvlTree inBt;
+  output AvlTree outBt;
+algorithm
+  outBt := matchcontinue(difference,inBt)
+    local AvlTree bt;
+    case(_,bt) equation
+      true = difference < 0;
+      bt = doBalance3(bt);
+      bt = rotateLeft(bt);
+     then bt;
+    case(_,bt) equation
+      true = difference > 0;
+      bt = doBalance4(bt);
+      bt = rotateRight(bt);
+     then bt;
+  end matchcontinue;
+end doBalance2;
+
+function doBalance3 "help function to doBalance2"
+  input AvlTree inBt;
+  output AvlTree outBt;
+algorithm
+  outBt := matchcontinue(inBt)
+  local AvlTree rr,bt;
+    case(bt) equation
+      true = differenceInHeight(getOption(rightNode(bt))) > 0;
+      rr = rotateRight(getOption(rightNode(bt)));
+      bt = setRight(bt,SOME(rr));
+    then bt;
+    else inBt;
+  end matchcontinue;
+end doBalance3;
+
+function doBalance4 "help function to doBalance2"
+  input AvlTree inBt;
+  output AvlTree outBt;
+algorithm
+  outBt := match(inBt)
+  local AvlTree rl,bt;
+  case(bt) equation
+      true = differenceInHeight(getOption(leftNode(bt))) < 0;
+      rl = rotateLeft(getOption(leftNode(bt)));
+      bt = setLeft(bt,SOME(rl));
+    then bt;
+  end match;
+end doBalance4;
+
+function setRight "set right treenode"
+  input AvlTree node;
+  input Option<AvlTree> right;
+  output AvlTree outNode;
+algorithm
+  outNode := match(node,right)
+   local Option<AvlTreeValue> value;
+    Option<AvlTree> l,r;
+    Integer height;
+    case(NODE(value,height,l,_),_) then NODE(value,height,l,right);
+  end match;
+end setRight;
+
+function setLeft "set left treenode"
+  input AvlTree node;
+  input Option<AvlTree> left;
+  output AvlTree outNode;
+algorithm
+  outNode := match(node,left)
+  local Option<AvlTreeValue> value;
+    Option<AvlTree> l,r;
+    Integer height;
+    case(NODE(value,height,_,r),_) then NODE(value,height,left,r);
+  end match;
+end setLeft;
+
+function leftNode "Retrieve the left subnode"
+  input AvlTree node;
+  output Option<AvlTree> subNode;
+algorithm
+  subNode := match(node)
+    case(NODE(left = subNode)) then subNode;
+  end match;
+end leftNode;
+
+function rightNode "Retrieve the right subnode"
+  input AvlTree node;
+  output Option<AvlTree> subNode;
+algorithm
+  subNode := match(node)
+    case(NODE(right = subNode)) then subNode;
+  end match;
+end rightNode;
+
+function exchangeLeft "help function to balance"
+  input AvlTree inode;
+  input AvlTree iparent;
+  output AvlTree outParent "updated parent";
+algorithm
+  outParent := match(inode,iparent)
+    local
+      AvlTree bt,node,parent;
+
+    case(node,parent) equation
+      parent = setRight(parent,leftNode(node));
+      parent = balance(parent);
+      node = setLeft(node,SOME(parent));
+      bt = balance(node);
+    then bt;
+  end match;
+end exchangeLeft;
+
+function exchangeRight "help function to balance"
+  input AvlTree inode;
+  input AvlTree iparent;
+  output AvlTree outParent "updated parent";
+algorithm
+  outParent := match(inode,iparent)
+    local AvlTree bt,node,parent;
+    case(node,parent) equation
+      parent = setLeft(parent,rightNode(node));
+      parent = balance(parent);
+      node = setRight(node,SOME(parent));
+      bt = balance(node);
+    then bt;
+  end match;
+end exchangeRight;
+
+function rotateLeft "help function to balance"
+input AvlTree node;
+output AvlTree outNode "updated node";
+algorithm
+  outNode := exchangeLeft(getOption(rightNode(node)),node);
+end rotateLeft;
+
+function getOption "Retrieve the value of an option"
+  replaceable type T subtypeof Any;
+  input Option<T> opt;
+  output T val;
+algorithm
+  val := match(opt)
+    case(SOME(val)) then val;
+  end match;
+end getOption;
+
+function rotateRight "help function to balance"
+input AvlTree node;
+output AvlTree outNode "updated node";
+algorithm
+  outNode := exchangeRight(getOption(leftNode(node)),node);
+end rotateRight;
+
+function differenceInHeight "help function to balance, calculates the difference in height
+between left and right child"
+input AvlTree node;
+output Integer diff;
+algorithm
+  diff := match(node)
+  local Integer lh,rh;
+    Option<AvlTree> l,r;
+    case(NODE(left=l,right=r)) equation
+      lh = getHeight(l);
+      rh = getHeight(r);
+    then lh - rh;
+  end match;
+end differenceInHeight;
+
+public function avlTreeGet
+  "Get a value from the binary tree given a key."
+  input AvlTree inAvlTree;
+  input AvlKey inKey;
+  output AvlValue outValue;
+algorithm
+  outValue := match (inAvlTree,inKey)
+    local
+      AvlKey rkey,key;
+    case (NODE(value = SOME(VALUE(key=rkey))),key)
+      then avlTreeGet2(inAvlTree,avlKeyCompare(key,rkey),key);
+  end match;
+end avlTreeGet;
+
+protected function avlTreeGet2
+  "Get a value from the binary tree given a key."
+  input AvlTree inAvlTree;
+  input Integer keyComp "0=get value from current node, 1=search right subtree, -1=search left subtree";
+  input AvlKey inKey;
+  output AvlValue outValue;
+algorithm
+  outValue := match (inAvlTree,keyComp,inKey)
+    local
+      AvlKey key;
+      AvlValue rval;
+      AvlTree left,right;
+
+    // hash func Search to the right
+    case (NODE(value = SOME(VALUE(value=rval))),0,_)
+      then rval;
+
+    // search to the right
+    case (NODE(right = SOME(right)),1,key)
+      then avlTreeGet(right, key);
+
+    // search to the left
+    case (NODE(left = SOME(left)),-1,key)
+      then avlTreeGet(left, key);
+  end match;
+end avlTreeGet2;
+
+function getOptionStr "Retrieve the string from a string option.
+  If NONE() return empty string."
+  input Option<Type_a> inTypeAOption;
+  input FuncTypeType_aToString inFuncTypeTypeAToString;
+  output String outString;
+  replaceable type Type_a subtypeof Any;
+  partial function FuncTypeType_aToString
+    input Type_a inTypeA;
+    output String outString;
+  end FuncTypeType_aToString;
+algorithm
+  outString := match (inTypeAOption,inFuncTypeTypeAToString)
+    local
+      String str;
+      Type_a a;
+      FuncTypeType_aToString r;
+    case (SOME(a),r)
+      equation
+        str = r(a);
+      then
+        str;
+    case (NONE(),_) then "";
+  end match;
+end getOptionStr;
+
+function computeHeight "compute the heigth of the AvlTree and store in the node info"
+  input AvlTree bt;
+  output AvlTree outBt;
+algorithm
+ outBt := match(bt)
+ local Option<AvlTree> l,r;
+   Option<AvlTreeValue> v;
+   AvlValue val;
+   Integer hl,hr,height;
+ case(NODE(value=v as SOME(VALUE()),left=l,right=r)) equation
+    hl = getHeight(l);
+    hr = getHeight(r);
+    height = intMax(hl,hr) + 1;
+ then NODE(v,height,l,r);
+ end match;
+end computeHeight;
+
+function getHeight "Retrieve the height of a node"
+  input Option<AvlTree> bt;
+  output Integer height;
+algorithm
+  height := match(bt)
+    case(NONE()) then 0;
+    case(SOME(NODE(height = height))) then height;
+  end match;
+end getHeight;
+
+annotation(__OpenModelica_Interface="util", __OpenModelica_isBaseClass=true);
+end BaseAvlTree;

--- a/Compiler/Util/List.mo
+++ b/Compiler/Util/List.mo
@@ -3192,6 +3192,35 @@ algorithm
   end for;
 end fold2;
 
+public function fold22<T, FT1, FT2, ArgT1, ArgT2>
+  "Takes a list and a function operating on list elements having three extra
+   arguments that is 'updated', thus returned from the function, and three constant
+   arguments that are not updated. fold will call the function for each element in
+   a sequence, updating the start values."
+  input list<T> inList;
+  input FoldFunc inFoldFunc;
+  input ArgT1 inExtraArg1;
+  input ArgT2 inExtraArg2;
+  input FT1 inStartValue1;
+  input FT2 inStartValue2;
+  output FT1 outResult1 = inStartValue1;
+  output FT2 outResult2 = inStartValue2;
+
+  partial function FoldFunc
+    input T inElement;
+    input ArgT1 inConstantArg1;
+    input ArgT2 inConstantArg2;
+    input FT1 inFoldArg1;
+    input FT2 inFoldArg2;
+    output FT1 outFoldArg1;
+    output FT2 outFoldArg2;
+  end FoldFunc;
+algorithm
+  for e in inList loop
+    (outResult1, outResult2) := inFoldFunc(e, inExtraArg1, inExtraArg2, outResult1, outResult2);
+  end for;
+end fold22;
+
 public function foldList<T, FT>
   input list<list<T>> inList;
   input FoldFunc inFoldFunc;

--- a/Compiler/boot/GenerateInterface.mos
+++ b/Compiler/boot/GenerateInterface.mos
@@ -3,7 +3,11 @@ if not loadFile(inFile) then
   print("Failed to load file: " + inFile + "\n" + getErrorString());
   exit(1);
 end if;
-if OpenModelica.Scripting.writeFile(outFile, OpenModelica.Scripting.list(exportKind=OpenModelica.Scripting.ExportKind.MetaModelicaInterface)) and OpenModelica.Scripting.compareFilesAndMove(outFile,stringReplace(outFile,".stamp.mo.tmp",".interface.mo")) then
+if classAnnotationExists(className, __OpenModelica_isBaseClass) then
+  if OpenModelica.Scripting.writeFile(outFile, OpenModelica.Scripting.readFile(inFile)) and OpenModelica.Scripting.compareFilesAndMove(outFile,stringReplace(outFile,".stamp.mo.tmp",".interface.mo")) then
+    exit(0);
+  end if;
+elseif OpenModelica.Scripting.writeFile(outFile, OpenModelica.Scripting.list(exportKind=OpenModelica.Scripting.ExportKind.MetaModelicaInterface)) and OpenModelica.Scripting.compareFilesAndMove(outFile,stringReplace(outFile,".stamp.mo.tmp",".interface.mo")) then
   exit(0);
 end if;
 print(getErrorString());

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -152,7 +152,6 @@ if true then /* Suppress output */
 
   // "Util";
     "../Util/Array.mo",
-    //"../Util/AvlTree.mo",
     "../Util/AvlTreeString.mo",
     "../Util/BaseHashTable.mo",
     "../Util/BaseHashSet.mo",
@@ -316,6 +315,9 @@ if true then /* Suppress output */
     "../Template/SimCodeDump.mo",
     "../Template/TaskSystemDump.mo",
     "../Template/VisualXMLTpl.mo",
+
+    "../Util/BaseAvlTree.mo",
+    "../Util/AvlTreeString2.mo",
 
     "../Util/DiffAlgorithm.mo",
     "../Util/FMI.mo",

--- a/Compiler/boot/Makefile.common
+++ b/Compiler/boot/Makefile.common
@@ -101,7 +101,7 @@ interfaces: $(ALL_INTERFACES) $(ALL_SOURCES)
 
 %.stamp.mo:
 	@mkdir -p build
-	@echo 'echo(false);inFile := "$<";outFile := "$@.tmp"; runScript("GenerateInterface.mos"); print(getErrorString()); print("Something went horribly wrong for $@\\n"); exit(1);' > "$@.mos"
+	@echo 'echo(false);inFile := "$<";outFile := "$@.tmp"; className := $$TypeName($(@:$(GEN_DIR)%.stamp.mo=%)); runScript("GenerateInterface.mos"); print(getErrorString()); print("Something went horribly wrong for $@\\n"); exit(1);' > "$@.mos"
 	$(OMC) -n=1 $@.mos
 	@touch $@
 %.interface.mo: %.stamp.mo


### PR DESCRIPTION
This fixes some issues in #3573, by making it possible to extend and
redeclare elements in different files also in the bootstrapped
compiler. The base package needs to be marked as such since the
definitions are part of the interface.