### PR TITLE
New optimization module to wrap function calls

### DIFF
--- a/Compiler/BackEnd/BackendDAECreate.mo
+++ b/Compiler/BackEnd/BackendDAECreate.mo
@@ -637,7 +637,7 @@ algorithm
         dae_var_attr = DAEUtil.setProtectedAttr(dae_var_attr, b);
         dae_var_attr = setMinMaxFromEnumeration(t, dae_var_attr);
         (dae_var_attr, source, _) = Inline.inlineStartAttribute(dae_var_attr, source, (SOME(functionTree), {DAE.NORM_INLINE()}));
-    ts = BackendDAEUtil.setTearingSelectAttribute(comment);
+        ts = BackendDAEUtil.setTearingSelectAttribute(comment);
       then
         (BackendDAE.VAR(name, kind_1, dir, prl, tp, NONE(), NONE(), dims, source, dae_var_attr, ts, comment, ct, DAEUtil.toDAEInnerOuter(io), false));
   end match;

--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -7067,7 +7067,7 @@ protected function allPreOptimizationModules
     (BackendDAEOptimize.expandDerOperator, "expandDerOperator"),
     (BackendDAEOptimize.removeEqualFunctionCalls, "removeEqualFunctionCalls"),
     (SynchronousFeatures.clockPartitioning, "clockPartitioning"),
-    (CommonSubExpression.CSE_EachCall, "CSE_EachCall"),
+    (CommonSubExpression.wrapFunctionCalls, "wrapFunctionCalls"),
     (IndexReduction.findStateOrder, "findStateOrder"),
     (BackendDAEOptimize.introduceDerAlias, "introduceDerAlias"),
     (DynamicOptimization.inputDerivativesForDynOpt, "inputDerivativesForDynOpt"), // only for dyn. opt.
@@ -7101,6 +7101,7 @@ protected function allPostOptimizationModules
   output list<tuple<BackendDAEFunc.optimizationModule, String>> allPostOptimizationModules = {
     (BackendInline.lateInlineFunction, "lateInlineFunction"),
     (DynamicOptimization.simplifyConstraints, "simplifyConstraints"),
+    (CommonSubExpression.wrapFunctionCalls, "wrapFunctionCalls"),
     (CommonSubExpression.CSE, "CSE"),
     (OnRelaxation.relaxSystem, "relaxSystem"),
     (InlineArrayEquations.inlineArrayEqn, "inlineArrayEqn"),
@@ -7256,10 +7257,13 @@ algorithm
       enabledModules := "extendDynamicOptimization"::enabledModules;
     end if;
 
-    if Flags.getConfigBool(Flags.CSE_CALL) or
-       Flags.getConfigBool(Flags.CSE_EACHCALL) or
-       Flags.getConfigBool(Flags.CSE_BINARY) then
+    if Flags.getConfigBool(Flags.CSE_BINARY) then
       enabledModules := "CSE"::enabledModules;
+    end if;
+
+    if Flags.getConfigBool(Flags.CSE_CALL) or
+       Flags.getConfigBool(Flags.CSE_EACHCALL) then
+      enabledModules := "wrapFunctionCalls"::enabledModules;
     end if;
 
     if Flags.isSet(Flags.ON_RELAXATION) then

--- a/Compiler/BackEnd/BackendEquation.mo
+++ b/Compiler/BackEnd/BackendEquation.mo
@@ -1286,6 +1286,25 @@ algorithm
   end match;
 end traverseOptEquation_WithStop;
 
+public function calculateOptArrEqnSizeProperly "author: lochel"
+  input array<Option<BackendDAE.Equation>> inEquOptArr;
+  output Integer outSize = 0;
+algorithm
+  for optEq in inEquOptArr loop
+    outSize := match optEq
+      local
+        Integer size;
+        BackendDAE.Equation eq;
+
+      case SOME(eq) equation
+        size = BackendEquation.equationSize(eq);
+      then outSize+size;
+
+      else outSize;
+    end match;
+  end for;
+end calculateOptArrEqnSizeProperly;
+
 public function traverseEquationArray_WithUpdate<T> "author: Frenkel TUD
   Traverses all equations of a BackendDAE.EquationArray."
   input BackendDAE.EquationArray inEquationArray;
@@ -1304,6 +1323,7 @@ protected
   array<Option<BackendDAE.Equation>> equOptArr;
 algorithm
   (equOptArr, outTypeA) := BackendDAEUtil.traverseArrayNoCopyWithUpdate(inEquationArray.equOptArr, inFuncWithUpdate, traverseOptEquation_WithUpdate, inTypeA);
+  outEquationArray.size := calculateOptArrEqnSizeProperly(equOptArr);
   outEquationArray.equOptArr := equOptArr;
 end traverseEquationArray_WithUpdate;
 

--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -1514,7 +1514,7 @@ algorithm
 end createVar;
 
 public function createCSEVar "Creates a cse variable with the name of inCref.
-  TODO: discrete real varaibales are not treated correctly"
+  TODO: discrete real variables are not treated correctly"
   input DAE.ComponentRef inCref;
   input DAE.Type inType;
   output BackendDAE.Var outVar;
@@ -1530,15 +1530,43 @@ algorithm
       DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(path), source=typeLst) = inType;
       source = DAE.SOURCE(Absyn.dummyInfo, {}, NONE(), {}, path::typeLst, {}, {});
       varKind = if Types.isDiscreteType(inType) then BackendDAE.DISCRETE() else BackendDAE.VARIABLE();
-      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), NONE(), {}, source, NONE(), SOME(BackendDAE.AVOID()), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), NONE(), {}, source, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
     then outVar;
 
-    case (_) equation
+    else equation
       varKind = if Types.isDiscreteType(inType) then BackendDAE.DISCRETE() else BackendDAE.VARIABLE();
-      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), SOME(BackendDAE.AVOID()), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
     then outVar;
   end match;
 end createCSEVar;
+
+public function createCSEArrayVar "Creates a cse array variable with the name of inCref.
+  TODO: discrete real variables are not treated correctly"
+  input DAE.ComponentRef inCref;
+  input DAE.Type inType;
+  input DAE.InstDims inArryDim;
+  output BackendDAE.Var outVar;
+algorithm
+  outVar := match (inCref)
+    local
+      DAE.ElementSource source;
+      list<Absyn.Path> typeLst;
+      Absyn.Path path;
+      BackendDAE.VarKind varKind;
+
+    case (_) guard(ComponentReference.traverseCref(inCref, ComponentReference.crefIsRec, false)) equation
+      DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(path), source=typeLst) = inType;
+      source = DAE.SOURCE(Absyn.dummyInfo, {}, NONE(), {}, path::typeLst, {}, {});
+      varKind = if Types.isDiscreteType(inType) then BackendDAE.DISCRETE() else BackendDAE.VARIABLE();
+      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), NONE(), inArryDim, source, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
+    then outVar;
+
+    else equation
+      varKind = if Types.isDiscreteType(inType) then BackendDAE.DISCRETE() else BackendDAE.VARIABLE();
+      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), NONE(), inArryDim, DAE.emptyElementSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
+    then outVar;
+  end match;
+end createCSEArrayVar;
 
 public function copyVarNewName "author: Frenkel TUD 2012-5
   Create variable with new name as cref from other var."

--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -8415,6 +8415,24 @@ algorithm
   end match;
 end isCall;
 
+public function isPureCall
+  "Returns true if the given expression is a pure function call,
+   otherwise false."
+  input DAE.Exp inExp;
+  output Boolean outIsPureCall;
+algorithm
+  outIsPureCall := isCall(inExp) and not isImpure(inExp);
+end isPureCall;
+
+public function isImpureCall
+  "Returns true if the given expression is a pure function call,
+   otherwise false."
+  input DAE.Exp inExp;
+  output Boolean outIsPureCall;
+algorithm
+  outIsPureCall := isCall(inExp) and isImpure(inExp);
+end isImpureCall;
+
 public function isRecordCall
   "Returns true if the given expression is a record call,i.e. a function call without elements
    otherwise false."

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -694,7 +694,6 @@ constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG(12, "preOptModules",
   SOME(STRING_DESC_OPTION({
     ("clockPartitioning", Util.gettext("Does the clock partitioning.")),
     ("comSubExp", Util.gettext("replaces common sub expressions")),
-    ("CSE_EachCall", Util.gettext("Common Function Call Elimination")),
     ("dumpDAE", Util.gettext("dumps the DAE representation of the current transformation state")),
     ("dumpDAEXML", Util.gettext("dumps the DAE as xml representation of the current transformation state")),
     ("encapsulateWhenConditions", Util.gettext("This module replaces each when condition with a boolean variable.")),
@@ -724,7 +723,8 @@ constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG(12, "preOptModules",
     ("simplifyIfEquations", Util.gettext("Tries to simplify if equations by use of information from evaluated parameters.")),
     ("sortEqnsVars", Util.notrans("Heuristic sorting for equations and variables. This module requires +d=sortEqnsAndVars.")),
     ("stateMachineElab", Util.gettext("Does the elaboration of state machines.")),
-    ("unitChecking", Util.gettext("advanced unit checking: 1. calculation of unspecified unit information for variables; 2. unit consistency check for equations"))
+    ("unitChecking", Util.gettext("advanced unit checking: 1. calculation of unspecified unit information for variables; 2. unit consistency check for equations")),
+    ("wrapFunctionCalls", Util.gettext("This module wraps function calls to gain speed up."))
     })),
   Util.gettext("Sets the pre optimization modules to use in the back end. See --help=optmodules for more info."));
 
@@ -830,7 +830,8 @@ constant ConfigFlag POST_OPT_MODULES = CONFIG_FLAG(16, "postOptModules",
     ("solveLinearSystem", Util.notrans("solve linear system with newton step")),
     ("solveSimpleEquations", Util.notrans("Solves simple equations")),
     ("symEuler", Util.notrans("Rewrites the ode system for implicit Euler method. This module requires +symEuler.")),
-    ("tearingSystem", Util.notrans("For method selection use flag tearingMethod."))
+    ("tearingSystem", Util.notrans("For method selection use flag tearingMethod.")),
+    ("wrapFunctionCalls", Util.gettext("This module wraps function calls to gain speed up."))
     })),
   Util.gettext("Sets the post optimization modules to use in the back end. See --help=optmodules for more info."));
 
@@ -1043,7 +1044,7 @@ constant ConfigFlag GENERATE_DYN_OPTIMIZATION_PROBLEM = CONFIG_FLAG(60, "gDynOpt
 
 constant ConfigFlag CSE_CALL = CONFIG_FLAG(61,
   "cseCall", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
-  Util.gettext("Experimental feature: cse of duplicate call expressions (this deactivates module removeEqualFunctionCalls)"));
+  Util.gettext("Deprecated flag: Use --postOptModules+=wrapFunctionCalls instead."));
 
 constant ConfigFlag CSE_BINARY = CONFIG_FLAG(62,
   "cseBinary", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
@@ -1051,7 +1052,7 @@ constant ConfigFlag CSE_BINARY = CONFIG_FLAG(62,
 
 constant ConfigFlag CSE_EACHCALL = CONFIG_FLAG(63,
   "cseEachCall", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
-  Util.gettext("Experimental feature: cse of each call expression (this deactivates module removeEqualFunctionCalls)"));
+  Util.gettext("Deprecated flag: Use --postOptModules+=wrapFunctionCalls instead."));
 
 constant ConfigFlag MAX_SIZE_FOR_SOLVE_LINIEAR_SYSTEM = CONFIG_FLAG(64, "maxSizeSolveLinearSystem",
   NONE(), EXTERNAL(), INT_FLAG(0), NONE(),
@@ -1182,7 +1183,6 @@ constant ConfigFlag INIT_OPT_MODULES_SUB = CONFIG_FLAG(86, "initOptModules-",
 constant ConfigFlag PERMISSIVE = CONFIG_FLAG(87, "permissive",
   NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Disables some error checks to allow erroneous models to compile."));
-
 
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's


### PR DESCRIPTION
The new post-opt module `wrapFunctionCalls` (@jhag) replaces the implementation of `--cseCall` and `--cseEachCall`. Both flags can still be used but it is recommended to use `--postOptModules+=wrapFunctionCalls` instead.