### PR TITLE
Fix redeclare issue with generic types.

### DIFF
--- a/Compiler/FrontEnd/InstBinding.mo
+++ b/Compiler/FrontEnd/InstBinding.mo
@@ -618,7 +618,9 @@ algorithm
 
     case (cache,_,DAE.NOMOD(),_) then (cache,DAE.UNBOUND());
 
-    case (cache,_,DAE.REDECL(),_) then (cache,DAE.UNBOUND());
+    case (_, _, DAE.REDECL(), _)
+      then makeBinding(inCache, inEnv, inAttributes, inMod.mod, inType,
+        inPrefix, componentName, inInfo);
 
     // adrpo: if the binding is missing for a parameter and
     //        the parameter has a start value modification,


### PR DESCRIPTION
- Use the modifier in redeclares in InstBinding.makeBinding,
  so that constants with redeclared type are constant evaluated.