### PR TITLE
Fix code generation for String(enum)

### DIFF
--- a/SimulationRuntime/c/util/modelica_string.c
+++ b/SimulationRuntime/c/util/modelica_string.c
@@ -231,9 +231,12 @@ modelica_string modelica_boolean_to_modelica_string(modelica_boolean b, modelica
 
 /* Convert a modelica_enumeration to a modelica_string, used in String(b) */
 
-modelica_string modelica_enumeration_to_modelica_string(modelica_integer nr,const modelica_string e[],modelica_integer minLen, modelica_boolean leftJustified)
+modelica_string enum_to_modelica_string(modelica_integer nr, const char *e[],modelica_integer minLen, modelica_boolean leftJustified)
 {
-  return mmc_mk_scon(e[nr-1]);
+  size_t sz = snprintf(NULL, 0, leftJustified ? "%-*s" : "%*s", (int) minLen, e[nr-1]);
+  void *res = alloc_modelica_string(sz);
+  sprintf(MMC_STRINGDATA(res), leftJustified ? "%-*s" : "%*s", (int) minLen, e[nr-1]);
+  return res;
 }
 
 modelica_string alloc_modelica_string(int length)

--- a/SimulationRuntime/c/util/modelica_string.h
+++ b/SimulationRuntime/c/util/modelica_string.h
@@ -59,7 +59,7 @@ extern modelica_string modelica_integer_to_modelica_string(modelica_integer i,
 extern modelica_string modelica_boolean_to_modelica_string(modelica_boolean b,
                                    modelica_integer minLen, modelica_boolean leftJustified);
 
-extern modelica_string modelica_enumeration_to_modelica_string(modelica_integer nr, const modelica_string e[],
+extern modelica_string enum_to_modelica_string(modelica_integer nr, const char *e[],
                                    modelica_integer minLen, modelica_boolean leftJustified);
 
 /* Escape string */


### PR DESCRIPTION
Previously, the integer_to_string routines were called instead of
the enumeration case.