### PR TITLE
Fix potential memory overrun for large models

### DIFF
--- a/SimulationRuntime/c/simulation/solver/linearSolverKlu.c
+++ b/SimulationRuntime/c/simulation/solver/linearSolverKlu.c
@@ -317,7 +317,12 @@ void printMatrixCSC(int* Ap, int* Ai, double* Ax, int n)
 {
   int i, j, k, l;
 
-  char buffer[400][4096] = {0};
+  char **buffer = (char**)malloc(sizeof(char*)*n);
+  for (l=0; l<n; l++)
+  {
+    buffer[l] = (char*)malloc(sizeof(char)*n*20);
+    buffer[l][0] = 0;
+  }
 
   k = 0;
   for (i = 0; i < n; i++)
@@ -338,18 +343,20 @@ void printMatrixCSC(int* Ap, int* Ai, double* Ax, int n)
   for (l = 0; l < n; l++)
   {
     infoStreamPrint(LOG_LS_V, 0, "%s", buffer[l]);
+    free(buffer[l]);
   }
-
+  free(buffer);
 }
 
 static
 void printMatrixCSR(int* Ap, int* Ai, double* Ax, int n)
 {
   int i, j, k;
-  char buffer[1024] = {0};
+  char *buffer = (char*)malloc(sizeof(char)*n*15);
   k = 0;
   for (i = 0; i < n; i++)
   {
+    buffer[0] = 0;
     for (j = 0; j < n; j++)
     {
       if ((k < Ap[i + 1]) && (Ai[k] == j))
@@ -363,8 +370,8 @@ void printMatrixCSR(int* Ap, int* Ai, double* Ax, int n)
       }
     }
     infoStreamPrint(LOG_LS_V, 0, "%s", buffer);
-    memset(buffer, 0, 1024);
   }
+  free(buffer);
 }
 
 #endif

--- a/SimulationRuntime/c/simulation/solver/linearSolverLis.c
+++ b/SimulationRuntime/c/simulation/solver/linearSolverLis.c
@@ -109,21 +109,22 @@ freeLisData(void **voiddata)
 
 void printLisMatrixCSR(LIS_MATRIX A, int n)
 {
-  char buffer[16384];
   int i, j;
   /* A matrix */
   infoStreamPrint(LOG_LS_V, 1, "A matrix [%dx%d] nnz = %d ", n, n, A->nnz);
   for(i=0; i<n; i++)
   {
+    char *buffer = (char*)malloc(sizeof(char)*A->ptr[i+1]*50);
     buffer[0] = 0;
-    for(j=A->ptr[i]; j<A->ptr[i+1]; j++){
+    for(j=A->ptr[i]; j<A->ptr[i+1]; j++)
+    {
        sprintf(buffer, "%s(%d,%d,%g) ", buffer, i, A->index[j], A->value[j]);
     }
     infoStreamPrint(LOG_LS_V, 0, "%s", buffer);
+    free(buffer);
   }
 
   messageClose(LOG_LS_V);
-
 }
 
 /*! \fn getAnalyticalJacobian
@@ -262,7 +263,7 @@ solveLis(DATA *data, threadData_t *threadData, int sysNumber)
   /* Log A*x=b */
   if(ACTIVE_STREAM(LOG_LS_V))
   {
-    char buffer[16384];
+    char *buffer = (char*)malloc(sizeof(char)*n*25);
 
     printLisMatrixCSR(solverData->A, n);
 
@@ -275,6 +276,7 @@ solveLis(DATA *data, threadData_t *threadData, int sysNumber)
       infoStreamPrint(LOG_LS_V, 0, "%s", buffer);
     }
     messageClose(LOG_LS_V);
+    free(buffer);
   }
 
   /* print solution */

--- a/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
+++ b/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
@@ -51,24 +51,30 @@ void debugMatrixDoubleLS(int logName, char* matrixName, double* matrix, int n, i
   {
     int i, j;
     int sparsity = 0;
-    char buffer[4096];
+    char *buffer = (char*)malloc(sizeof(char)*m*18);
 
     infoStreamPrint(logName, 1, "%s [%dx%d-dim]", matrixName, n, m);
     for(i=0; i<n;i++)
     {
       buffer[0] = 0;
       for(j=0; j<m; j++)
-        if (sparsity) {
+      {
+        if (sparsity)
+        {
           if (fabs(matrix[i + j*(m-1)])<1e-12)
             sprintf(buffer, "%s 0", buffer);
           else
             sprintf(buffer, "%s *", buffer);
-        } else {
+        }
+        else
+        {
           sprintf(buffer, "%s%12.4g ", buffer, matrix[i + j*(m-1)]);
         }
+      }
       infoStreamPrint(logName, 0, "%s", buffer);
     }
     messageClose(logName);
+    free(buffer);
   }
 }
 
@@ -77,7 +83,7 @@ void debugVectorDoubleLS(int logName, char* vectorName, double* vector, int n)
    if(ACTIVE_STREAM(logName))
   {
     int i;
-    char buffer[4096];
+    char *buffer = (char*)malloc(sizeof(char)*n*22);
 
     infoStreamPrint(logName, 1, "%s [%d-dim]", vectorName, n);
     buffer[0] = 0;
@@ -91,6 +97,7 @@ void debugVectorDoubleLS(int logName, char* vectorName, double* vector, int n)
         sprintf(buffer, "%s%16.8g ", buffer, vector[i]);
     }
     infoStreamPrint(logName, 0, "%s", buffer);
+    free(buffer);
     messageClose(logName);
   }
 }

--- a/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
+++ b/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
@@ -560,7 +560,12 @@ void printMatrixCSC(int* Ap, int* Ai, double* Ax, int n)
 {
   int i, j, k, l;
 
-  char buffer[400][4096] = {0};
+  char **buffer = (char**)malloc(sizeof(char*)*n);
+  for (l=0; l<n; l++)
+  {
+    buffer[l] = (char*)malloc(sizeof(char)*n*20);
+    buffer[l][0] = 0;
+  }
 
   k = 0;
   for (i = 0; i < n; i++)
@@ -578,20 +583,22 @@ void printMatrixCSC(int* Ap, int* Ai, double* Ax, int n)
       }
     }
   }
-  for (l = 0; l < n; l++)
+  for (l=0; l<n; l++)
   {
     infoStreamPrint(LOG_LS_V, 0, "%s", buffer[l]);
+    free(buffer[l]);
   }
-
+  free(buffer);
 }
 
 void printMatrixCSR(int* Ap, int* Ai, double* Ax, int n)
 {
   int i, j, k;
-  char buffer[1024] = {0};
+  char *buffer = (char*)malloc(sizeof(char)*n*20);
   k = 0;
   for (i = 0; i < n; i++)
   {
+    buffer[0] = 0;
     for (j = 0; j < n; j++)
     {
       if ((k < Ap[i + 1]) && (Ai[k] == j))
@@ -605,8 +612,8 @@ void printMatrixCSR(int* Ap, int* Ai, double* Ax, int n)
       }
     }
     infoStreamPrint(LOG_LS_V, 0, "%s", buffer);
-    memset(buffer, 0, 1024);
   }
+  free(buffer);
 }
 
 #endif

--- a/SimulationRuntime/c/simulation/solver/newtonIteration.c
+++ b/SimulationRuntime/c/simulation/solver/newtonIteration.c
@@ -240,7 +240,7 @@ int _omc_newton(int(*f)(int*, double*, double*, void*, int), DATA_NEWTON* solver
     /* debug output */
     if(ACTIVE_STREAM(LOG_NLS_JAC))
     {
-      char buffer[4096];
+      char *buffer = (char*)malloc(sizeof(char)*solverData->n*15);
 
       infoStreamPrint(LOG_NLS_JAC, 1, "jacobian matrix [%dx%d]", (int)*n, (int)*n);
       for(i=0; i<solverData->n;i++)
@@ -251,6 +251,7 @@ int _omc_newton(int(*f)(int*, double*, double*, void*, int), DATA_NEWTON* solver
         infoStreamPrint(LOG_NLS_JAC, 0, "%s", buffer);
       }
       messageClose(LOG_NLS_JAC);
+      free(buffer);
     }
 
     if (solveLinearSystem(n, iwork, fvec, fjac, solverData) != 0)

--- a/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -372,7 +372,7 @@ static int wrapper_fvec_hybrj(const integer* n, const double* x, double* f, doub
 
       if(ACTIVE_STREAM(LOG_NLS_JAC))
       {
-        char buffer[16384];
+        char *buffer = (char*)malloc(sizeof(char)*(*n)*25);
         infoStreamPrint(LOG_NLS_JAC, 1, "jacobian matrix [%dx%d]", (int)*n, (int)*n);
         for(i=0; i<*n; i++)
         {
@@ -382,6 +382,7 @@ static int wrapper_fvec_hybrj(const integer* n, const double* x, double* f, doub
           infoStreamPrint(LOG_NLS_JAC, 0, "%s", buffer);
         }
         messageClose(LOG_NLS_JAC);
+        free(buffer);
       }
     }
     /* reset residual function again */
@@ -646,7 +647,7 @@ int solveHybrd(DATA *data, threadData_t *threadData, int sysNumber)
         /* debug output */
         if(ACTIVE_STREAM(LOG_NLS_JAC))
         {
-          char buffer[4096];
+          char *buffer = (char*)malloc(sizeof(char)*solverData->n*15);
 
           infoStreamPrint(LOG_NLS_JAC, 1, "jacobian matrix [%dx%d]", (int)solverData->n, (int)solverData->n);
           for(i=0; i<solverData->n; i++)
@@ -657,6 +658,7 @@ int solveHybrd(DATA *data, threadData_t *threadData, int sysNumber)
             infoStreamPrint(LOG_NLS_JAC, 0, "%s", buffer);
           }
           messageClose(LOG_NLS_JAC);
+          free(buffer);
         }
 
         /* check for error  */

--- a/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -99,7 +99,8 @@ int initializeNLScsvData(DATA* data, NONLINEAR_SYSTEM_DATA* systemData)
  */
 int print_csvLineCallStatsHeader(OMC_WRITE_CSV* csvData)
 {
-  char buffer[1024] = "";
+  char buffer[1024];
+  buffer[0] = 0;
 
   /* number of call */
   sprintf(buffer,"numberOfCall");

--- a/SimulationRuntime/c/simulation/solver/omc_math.c
+++ b/SimulationRuntime/c/simulation/solver/omc_math.c
@@ -737,21 +737,26 @@ void _omc_printVector(_omc_vector* vec, const char* name, const int logLevel)
  *  \param [in]  [logLevel] !TODO: DESCRIBE ME!
  */
 void _omc_printMatrix(_omc_matrix* mat, const char* name, const int logLevel) {
-  _omc_size i, j;
-  char buffer[4096];
-  if (!ACTIVE_STREAM(logLevel)) return;
+  if (ACTIVE_STREAM(logLevel))
+  {
+    _omc_size i, j;
+    char *buffer = (char*)malloc(sizeof(char)*mat->cols*20);
 
-  assertStreamPrint(NULL, NULL != mat->data, "matrix data is NULL pointer");
+    assertStreamPrint(NULL, NULL != mat->data, "matrix data is NULL pointer");
 
-  infoStreamPrint(logLevel, 1, "%s", name);
-  for (i = 0; i < mat->rows; ++i) {
-    buffer[0] = 0;
-    for (j = 0; j < mat->cols; ++j){
-      sprintf(buffer, "%s%10g ", buffer, _omc_getMatrixElement(mat, i, j));
+    infoStreamPrint(logLevel, 1, "%s", name);
+    for (i = 0; i < mat->rows; ++i)
+    {
+      buffer[0] = 0;
+      for (j = 0; j < mat->cols; ++j)
+      {
+        sprintf(buffer, "%s%10g ", buffer, _omc_getMatrixElement(mat, i, j));
+      }
+      infoStreamPrint(logLevel, 0, "%s", buffer);
     }
-    infoStreamPrint(logLevel, 0, "%s", buffer);
+    messageClose(logLevel);
+    free(buffer);
   }
-  messageClose(logLevel);
 }
 
 /*! \fn _omc_scalar _omc_euclideanVectorNorm(_omc_vector* vec)

--- a/SimulationRuntime/c/simulation/solver/stateset.c
+++ b/SimulationRuntime/c/simulation/solver/stateset.c
@@ -191,7 +191,7 @@ static void getAnalyticalJacobianSet(DATA* data, threadData_t *threadData, unsig
   /*
   if(ACTIVE_STREAM(LOG_DSS))
   {
-    char buffer[4096];
+    char *buffer = (char*)malloc(sizeof(char)*data->simulationInfo->analyticJacobians[jacIndex].sizeCols*10);
 
     infoStreamPrint(LOG_DSS, "jacobian %dx%d [id: %d]", data->simulationInfo->analyticJacobians[jacIndex].sizeRows, data->simulationInfo->analyticJacobians[jacIndex].sizeCols, jacIndex);
     INDENT(LOG_DSS);
@@ -202,6 +202,7 @@ static void getAnalyticalJacobianSet(DATA* data, threadData_t *threadData, unsig
         sprintf(buffer, "%s%.5e ", buffer, jac[i*data->simulationInfo->analyticJacobians[jacIndex].sizeCols+j]);
       infoStreamPrint(LOG_DSS, "%s", buffer);
     }
+    free(buffer);
     RELEASE(LOG_DSS);
   }
   */
@@ -335,7 +336,7 @@ int stateSelection(DATA *data, threadData_t *threadData, char reportError, int s
     if((pivot(set->J, set->nDummyStates, set->nCandidates, set->rowPivot, set->colPivot) != 0) && reportError)
     {
       /* error, report the matrix and the time */
-      char buffer[4096];
+      char *buffer = (char*)malloc(sizeof(char)*data->simulationInfo->analyticJacobians[set->jacobianIndex].sizeCols*10);
 
       warningStreamPrint(LOG_DSS, 1, "jacobian %dx%d [id: %ld]", data->simulationInfo->analyticJacobians[set->jacobianIndex].sizeRows, data->simulationInfo->analyticJacobians[set->jacobianIndex].sizeCols, set->jacobianIndex);
       for(i=0; i < data->simulationInfo->analyticJacobians[set->jacobianIndex].sizeRows; i++)
@@ -345,6 +346,7 @@ int stateSelection(DATA *data, threadData_t *threadData, char reportError, int s
           sprintf(buffer, "%s%.5e ", buffer, set->J[i*data->simulationInfo->analyticJacobians[set->jacobianIndex].sizeCols+j]);
         warningStreamPrint(LOG_DSS, 0, "%s", buffer);
       }
+      free(buffer);
 
       for(i=0; i<set->nCandidates; i++)
         warningStreamPrint(LOG_DSS, 0, "%s", set->statescandidates[i]->name);


### PR DESCRIPTION
This is a fix for the remaining issue of [#3590](https://trac.openmodelica.org/OpenModelica/ticket/3590) (LOG_NLS_JAC, LOG_DSS, LOG_LS_V, ...).