### PR TITLE
Add a simple Modelica diff based on tree parsing

### DIFF
--- a/Compiler/Lexers/LexerModelicaDiff.mo
+++ b/Compiler/Lexers/LexerModelicaDiff.mo
@@ -33,22 +33,27 @@ end LexTable;
 function scan "Scan starts the lexical analysis, load the tables and consume the program to output the tokens"
   input String fileName "input source code file";
   output list<Token> tokens "return list of tokens";
+  output list<Token> errorTokens;
 protected
   String contents;
 algorithm
   contents := System.readFile(fileName);
-  tokens := lex(fileName,contents);
+  (tokens, errorTokens) := lex(fileName,contents);
 end scan;
 
 function scanString "Scan starts the lexical analysis, load the tables and consume the program to output the tokens"
   input String fileSource "input source code file";
   output list<Token> tokens "return list of tokens";
+  output list<Token> errorTokens;
 algorithm
-  tokens := lex("<StringSource>",fileSource);
+  (tokens, errorTokens) := lex("<StringSource>",fileSource);
 end scanString;
 
 
 import DiffAlgorithm;
+protected
+import Error;
+public
 function action
   input Integer act;
   input Integer startSt;
@@ -57,9 +62,11 @@ function action
   input Boolean debug;
   input String fileNm;
   input String fileContents;
+  input list<Token> inErrorTokens;
   output Token token;
   output Integer mm_startSt;
   output Integer bufferRet;
+  output list<Token> errorTokens=inErrorTokens;
 protected
   SourceInfo info;
   String sToken;
@@ -70,472 +77,478 @@ algorithm
   (token) := match (act)
     local
       Token tok;
-    case (1) // #line 29 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("WHITESPACE",TokenId.WHITESPACE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (2) // #line 30 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("NEWLINE",TokenId.NEWLINE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (3) // #line 31 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("UNSIGNED_REAL",TokenId.UNSIGNED_REAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (4) // #line 32 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("UNSIGNED_REAL",TokenId.UNSIGNED_REAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (5) // #line 33 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("UNSIGNED_REAL",TokenId.UNSIGNED_REAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (6) // #line 34 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_ALGORITHM",TokenId.T_ALGORITHM,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (7) // #line 35 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_AND",TokenId.T_AND,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (8) // #line 36 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_ANNOTATION",TokenId.T_ANNOTATION,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (9) // #line 37 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("BLOCK",TokenId.BLOCK,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (10) // #line 38 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("CLASS",TokenId.CLASS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (11) // #line 39 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("CONNECT",TokenId.CONNECT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (12) // #line 40 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("CONNECTOR",TokenId.CONNECTOR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (13) // #line 41 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("CONSTANT",TokenId.CONSTANT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (14) // #line 42 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("DISCRETE",TokenId.DISCRETE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (15) // #line 43 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("DER",TokenId.DER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (16) // #line 44 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("DEFINEUNIT",TokenId.DEFINEUNIT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (17) // #line 45 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("EACH",TokenId.EACH,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (18) // #line 46 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("ELSE",TokenId.ELSE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (19) // #line 47 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("ELSEIF",TokenId.ELSEIF,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (20) // #line 48 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("ELSEWHEN",TokenId.ELSEWHEN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (21) // #line 49 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_END",TokenId.T_END,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (22) // #line 50 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("ENUMERATION",TokenId.ENUMERATION,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (23) // #line 51 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("EQUATION",TokenId.EQUATION,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (24) // #line 52 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("ENCAPSULATED",TokenId.ENCAPSULATED,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (25) // #line 53 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("EXPANDABLE",TokenId.EXPANDABLE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (26) // #line 54 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("EXTENDS",TokenId.EXTENDS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (27) // #line 55 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("CONSTRAINEDBY",TokenId.CONSTRAINEDBY,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (28) // #line 56 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("EXTERNAL",TokenId.EXTERNAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (29) // #line 57 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_FALSE",TokenId.T_FALSE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (30) // #line 58 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("FINAL",TokenId.FINAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (31) // #line 59 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("FLOW",TokenId.FLOW,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (32) // #line 60 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("FOR",TokenId.FOR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (33) // #line 61 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("FUNCTION",TokenId.FUNCTION,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (34) // #line 62 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("IF",TokenId.IF,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (35) // #line 63 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("IMPORT",TokenId.IMPORT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (36) // #line 64 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_IN",TokenId.T_IN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (37) // #line 65 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_INITIAL",TokenId.T_INITIAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (38) // #line 66 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("INNER",TokenId.INNER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (39) // #line 67 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_INPUT",TokenId.T_INPUT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (40) // #line 68 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("LOOP",TokenId.LOOP,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (41) // #line 69 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("MODEL",TokenId.MODEL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (42) // #line 70 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_NOT",TokenId.T_NOT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (43) // #line 71 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_OUTER",TokenId.T_OUTER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (44) // #line 72 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("OPERATOR",TokenId.OPERATOR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (45) // #line 73 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("OVERLOAD",TokenId.OVERLOAD,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (46) // #line 74 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_OR",TokenId.T_OR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (47) // #line 75 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_OUTPUT",TokenId.T_OUTPUT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (48) // #line 76 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_PACKAGE",TokenId.T_PACKAGE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (49) // #line 77 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("PARAMETER",TokenId.PARAMETER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (50) // #line 78 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("PARTIAL",TokenId.PARTIAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (51) // #line 79 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("PROTECTED",TokenId.PROTECTED,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (52) // #line 80 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("PUBLIC",TokenId.PUBLIC,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (53) // #line 81 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("RECORD",TokenId.RECORD,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (54) // #line 82 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("REDECLARE",TokenId.REDECLARE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (55) // #line 83 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("REPLACEABLE",TokenId.REPLACEABLE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (56) // #line 84 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("RESULTS",TokenId.RESULTS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (57) // #line 85 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("THEN",TokenId.THEN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (58) // #line 86 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_TRUE",TokenId.T_TRUE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (59) // #line 87 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("TYPE",TokenId.TYPE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (60) // #line 88 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("WHEN",TokenId.WHEN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (61) // #line 89 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("WHILE",TokenId.WHILE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (62) // #line 90 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("WITHIN",TokenId.WITHIN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (63) // #line 91 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("RETURN",TokenId.RETURN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (64) // #line 92 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("BREAK",TokenId.BREAK,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (65) // #line 94 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("LPAR",TokenId.LPAR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (66) // #line 95 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("RPAR",TokenId.RPAR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (67) // #line 96 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("LBRACK",TokenId.LBRACK,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (68) // #line 97 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("RBRACK",TokenId.RBRACK,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (69) // #line 98 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("LBRACE",TokenId.LBRACE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (70) // #line 99 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("RBRACE",TokenId.RBRACE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (71) // #line 100 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("EQEQ",TokenId.EQEQ,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (72) // #line 101 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("EQUALS",TokenId.EQUALS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (73) // #line 102 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("COMMA",TokenId.COMMA,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (74) // #line 103 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("ASSIGN",TokenId.ASSIGN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (75) // #line 104 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("COLONCOLON",TokenId.COLONCOLON,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (76) // #line 105 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("COLON",TokenId.COLON,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (77) // #line 106 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("SEMICOLON",TokenId.SEMICOLON,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (78) // #line 108 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("PURE",TokenId.PURE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (79) // #line 109 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("IMPURE",TokenId.IMPURE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (80) // #line 110 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("T_OPTIMIZATION",TokenId.T_OPTIMIZATION,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (81) // #line 112 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("PLUS_EW",TokenId.PLUS_EW,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (82) // #line 113 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("MINUS_EW",TokenId.MINUS_EW,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (83) // #line 114 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("STAR_EW",TokenId.STAR_EW,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (84) // #line 115 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("SLASH_EW",TokenId.SLASH_EW,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (85) // #line 116 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("POWER_EW",TokenId.POWER_EW,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (86) // #line 118 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("STAR",TokenId.STAR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (87) // #line 119 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("MINUS",TokenId.MINUS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (88) // #line 120 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("PLUS",TokenId.PLUS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (89) // #line 121 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("LESSEQ",TokenId.LESSEQ,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (90) // #line 122 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("LESSGT",TokenId.LESSGT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (91) // #line 123 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("LESS",TokenId.LESS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (92) // #line 124 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("GREATER",TokenId.GREATER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (93) // #line 125 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("GREATEREQ",TokenId.GREATEREQ,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (94) // #line 127 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("POWER",TokenId.POWER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (95) // #line 128 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("SLASH",TokenId.SLASH,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (96) // #line 130 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("SUBTYPEOF",TokenId.SUBTYPEOF,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (97) // #line 132 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("STREAM",TokenId.STREAM,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (98) // #line 134 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("DOT",TokenId.DOT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (99) // #line 136 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("IDENT",TokenId.IDENT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (100) // #line 137 "lexerModelicaDiff.l"
-      equation
-        tok = TOKEN("UNSIGNED_INTEGER",TokenId.UNSIGNED_INTEGER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
-      then tok;
-    case (101) // #line 139 "lexerModelicaDiff.l"
-      equation
-        mm_startSt = 7;
-        bufferRet = buffer;
+    case (1) // #line 35 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.WHITESPACE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (2) // #line 36 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.NEWLINE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (3) // #line 37 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.UNSIGNED_REAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (4) // #line 38 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.UNSIGNED_REAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (5) // #line 39 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.UNSIGNED_REAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (6) // #line 40 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.ALGORITHM,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (7) // #line 41 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.AND,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (8) // #line 42 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.ANNOTATION,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (9) // #line 43 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.BLOCK,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (10) // #line 44 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.CLASS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (11) // #line 45 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.CONNECT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (12) // #line 46 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.CONNECTOR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (13) // #line 47 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.CONSTANT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (14) // #line 48 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.DISCRETE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (15) // #line 49 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.DER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (16) // #line 50 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.DEFINEUNIT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (17) // #line 51 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.EACH,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (18) // #line 52 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.ELSE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (19) // #line 53 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.ELSEIF,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (20) // #line 54 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.ELSEWHEN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (21) // #line 55 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.END,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (22) // #line 56 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.ENUMERATION,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (23) // #line 57 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.EQUATION,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (24) // #line 58 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.ENCAPSULATED,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (25) // #line 59 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.EXPANDABLE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (26) // #line 60 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.EXTENDS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (27) // #line 61 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.CONSTRAINEDBY,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (28) // #line 62 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.EXTERNAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (29) // #line 63 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.FALSE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (30) // #line 64 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.FINAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (31) // #line 65 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.FLOW,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (32) // #line 66 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.FOR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (33) // #line 67 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.FUNCTION,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (34) // #line 68 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.IF,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (35) // #line 69 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.IMPORT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (36) // #line 70 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.IN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (37) // #line 71 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.INITIAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (38) // #line 72 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.INNER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (39) // #line 73 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.INPUT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (40) // #line 74 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.LOOP,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (41) // #line 75 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.MODEL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (42) // #line 76 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.NOT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (43) // #line 77 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.OUTER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (44) // #line 78 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.OPERATOR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (45) // #line 79 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.OVERLOAD,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (46) // #line 80 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.OR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (47) // #line 81 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.OUTPUT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (48) // #line 82 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.PACKAGE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (49) // #line 83 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.PARAMETER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (50) // #line 84 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.PARTIAL,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (51) // #line 85 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.PROTECTED,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (52) // #line 86 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.PUBLIC,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (53) // #line 87 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.RECORD,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (54) // #line 88 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.REDECLARE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (55) // #line 89 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.REPLACEABLE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (56) // #line 90 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.RESULTS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (57) // #line 91 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.THEN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (58) // #line 92 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.TRUE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (59) // #line 93 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.TYPE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (60) // #line 94 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.WHEN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (61) // #line 95 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.WHILE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (62) // #line 96 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.WITHIN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (63) // #line 97 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.RETURN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (64) // #line 98 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.BREAK,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (65) // #line 100 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.LPAR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (66) // #line 101 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.RPAR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (67) // #line 102 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.LBRACK,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (68) // #line 103 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.RBRACK,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (69) // #line 104 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.LBRACE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (70) // #line 105 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.RBRACE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (71) // #line 106 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.EQEQ,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (72) // #line 107 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.EQUALS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (73) // #line 108 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.COMMA,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (74) // #line 109 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.ASSIGN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (75) // #line 110 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.COLONCOLON,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (76) // #line 111 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.COLON,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (77) // #line 112 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.SEMICOLON,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (78) // #line 114 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.PURE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (79) // #line 115 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.IMPURE,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (80) // #line 116 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.OPTIMIZATION,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (81) // #line 118 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.PLUS_EW,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (82) // #line 119 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.MINUS_EW,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (83) // #line 120 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.STAR_EW,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (84) // #line 121 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.SLASH_EW,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (85) // #line 122 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.POWER_EW,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (86) // #line 124 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.STAR,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (87) // #line 125 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.MINUS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (88) // #line 126 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.PLUS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (89) // #line 127 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.LESSEQ,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (90) // #line 128 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.LESSGT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (91) // #line 129 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.LESS,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (92) // #line 130 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.GREATER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (93) // #line 131 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.GREATEREQ,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (94) // #line 133 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.POWER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (95) // #line 134 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.SLASH,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (96) // #line 136 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.SUBTYPEOF,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (97) // #line 138 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.STREAM,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (98) // #line 140 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.DOT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (99) // #line 142 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.IDENT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (100) // #line 144 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.IDENT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (101) // #line 146 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId.UNSIGNED_INTEGER,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+      then tok;
+    case (102) // #line 148 "lexerModelicaDiff.l"
+      algorithm
+        mm_startSt := 7;
+        bufferRet := buffer;
       then noToken;
-    case (102) // #line 144 "lexerModelicaDiff.l"
-      equation
-        bufferRet = buffer;
+    case (103) // #line 153 "lexerModelicaDiff.l"
+      algorithm
+        bufferRet := buffer;
       then noToken;
-    case (103) // #line 145 "lexerModelicaDiff.l"
-      equation
-        bufferRet = buffer;
+    case (104) // #line 154 "lexerModelicaDiff.l"
+      algorithm
+        bufferRet := buffer;
       then noToken;
-    case (104) // #line 146 "lexerModelicaDiff.l"
-      equation
-        mm_startSt = 1;
-        tok = TOKEN("STRING",TokenId.STRING,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+    case (105) // #line 155 "lexerModelicaDiff.l"
+      algorithm
+        mm_startSt := 1;
+        tok := TOKEN(fileNm,TokenId.STRING,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
       then tok;
-    case (105) // #line 147 "lexerModelicaDiff.l"
-      equation
-        bufferRet = buffer;
+    case (106) // #line 156 "lexerModelicaDiff.l"
+      algorithm
+        bufferRet := buffer;
       then noToken;
-    case (106) // #line 148 "lexerModelicaDiff.l"
-      equation
-        bufferRet = buffer;
+    case (107) // #line 157 "lexerModelicaDiff.l"
+      algorithm
+        bufferRet := buffer;
       then noToken;
-    case (107) // #line 151 "lexerModelicaDiff.l"
-      equation
-        mm_startSt = 3;
-        bufferRet = buffer;
+    case (108) // #line 160 "lexerModelicaDiff.l"
+      algorithm
+        mm_startSt := 3;
+        bufferRet := buffer;
       then noToken;
-    case (108) // #line 156 "lexerModelicaDiff.l"
-      equation
-        mm_startSt = 1;
-        tok = TOKEN("BLOCK_COMMENT",TokenId.BLOCK_COMMENT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+    case (109) // #line 165 "lexerModelicaDiff.l"
+      algorithm
+        mm_startSt := 1;
+        tok := TOKEN(fileNm,TokenId.BLOCK_COMMENT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
       then tok;
-    case (109) // #line 157 "lexerModelicaDiff.l"
-      equation
-        bufferRet = buffer;
+    case (110) // #line 166 "lexerModelicaDiff.l"
+      algorithm
+        bufferRet := buffer;
       then noToken;
-    case (110) // #line 158 "lexerModelicaDiff.l"
-      equation
-        bufferRet = buffer;
+    case (111) // #line 167 "lexerModelicaDiff.l"
+      algorithm
+        bufferRet := buffer;
       then noToken;
-    case (111) // #line 165 "lexerModelicaDiff.l"
-      equation
-        mm_startSt = 5;
-        bufferRet = buffer;
+    case (112) // #line 174 "lexerModelicaDiff.l"
+      algorithm
+        mm_startSt := 5;
+        bufferRet := buffer;
       then noToken;
-    case (112) // #line 171 "lexerModelicaDiff.l"
-      equation
-        mm_startSt = 1;
-        tok = TOKEN("LINE_COMMENT",TokenId.LINE_COMMENT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+    case (113) // #line 180 "lexerModelicaDiff.l"
+      algorithm
+        mm_startSt := 1;
+        tok := TOKEN(fileNm,TokenId.LINE_COMMENT,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
       then tok;
-    case (113) // #line 172 "lexerModelicaDiff.l"
-      equation
-        bufferRet = buffer;
+    case (114) // #line 181 "lexerModelicaDiff.l"
+      algorithm
+        bufferRet := buffer;
       then noToken;
-    case (114) // #line 175 "lexerModelicaDiff.l"
-      equation
+    case (115) // #line 184 "lexerModelicaDiff.l"
+      algorithm
+        tok := TOKEN(fileNm,TokenId._NO_TOKEN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+        errorTokens := tok :: errorTokens;
       then noToken;
 
     else
-      equation
+      algorithm
         print("\nLexer unknown rule, action="+String(act)+"\n");
-        tok = TOKEN("",TokenId._NO_TOKEN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
+        tok := TOKEN(fileNm,TokenId._NO_TOKEN,fileContents,mm_pos-buffer,buffer,lineNrStart,mm_ePos+1,mm_linenr,mm_sPos+1);
         print(printToken(tok));
       then fail();
   end match;
@@ -543,6 +556,9 @@ end action;
 
 type TokenId = enumeration(
   _NO_TOKEN,
+  ALGORITHM,
+  AND,
+  ANNOTATION,
   ASSIGN,
   BLOCK,
   BLOCK_COMMENT,
@@ -564,6 +580,7 @@ type TokenId = enumeration(
   ELSEIF,
   ELSEWHEN,
   ENCAPSULATED,
+  END,
   ENUMERATION,
   EQEQ,
   EQUALS,
@@ -571,6 +588,7 @@ type TokenId = enumeration(
   EXPANDABLE,
   EXTENDS,
   EXTERNAL,
+  FALSE,
   FINAL,
   FLOW,
   FOR,
@@ -581,7 +599,10 @@ type TokenId = enumeration(
   IF,
   IMPORT,
   IMPURE,
+  IN,
+  INITIAL,
   INNER,
+  INPUT,
   LBRACE,
   LBRACK,
   LESS,
@@ -595,8 +616,14 @@ type TokenId = enumeration(
   MODEL,
   MODELICA,
   NEWLINE,
+  NOT,
   OPERATOR,
+  OPTIMIZATION,
+  OR,
+  OUTER,
+  OUTPUT,
   OVERLOAD,
+  PACKAGE,
   PARAMETER,
   PARTIAL,
   PLUS,
@@ -623,22 +650,8 @@ type TokenId = enumeration(
   STRING,
   SUBTYPEOF,
   THEN,
+  TRUE,
   TYPE,
-  T_ALGORITHM,
-  T_AND,
-  T_ANNOTATION,
-  T_END,
-  T_FALSE,
-  T_IN,
-  T_INITIAL,
-  T_INPUT,
-  T_NOT,
-  T_OPTIMIZATION,
-  T_OR,
-  T_OUTER,
-  T_OUTPUT,
-  T_PACKAGE,
-  T_TRUE,
   UNSIGNED_INTEGER,
   UNSIGNED_REAL,
   WHEN,
@@ -649,7 +662,7 @@ type TokenId = enumeration(
 
 uniontype Token
   record TOKEN
-    String name;
+    String fileName;
     TokenId id;
     String fileContents;
     Integer byteOffset,length;
@@ -660,18 +673,19 @@ uniontype Token
   end TOKEN;
 end Token;
 
-constant Token noToken = TOKEN("",TokenId._NO_TOKEN,"",0,0,0,0,0,0);
+constant Token noToken = TOKEN("<NoFile>",TokenId._NO_TOKEN,"",0,0,0,0,0,0);
 
 function printToken
   input Token token;
   output String strTk;
 protected
-  String tokName,contents;
-  Integer lns,cns,lne,cne,byteOffset,length;
+  TokenId id;
+  String contents;
+  Integer byteOffset,length;
 algorithm
-  TOKEN(name=tokName,lineNumberStart=lns,columnNumberStart=cns,lineNumberEnd=lne,columnNumberEnd=cne,fileContents=contents,byteOffset=byteOffset,length=length) := token;
+  TOKEN(id=id, fileContents=contents, byteOffset=byteOffset, length=length) := token;
   contents := if length>0 then substring(contents,byteOffset,byteOffset+length-1) else "";
-  strTk := "[TOKEN:" + tokName + " '" +  contents + "' (" + intString(lns) + ":" + intString(cns) + "-"+ intString(lne) + ":" + intString(cne) +")]";
+  strTk := "[TOKEN:" + String(id) + " '" +  contents +"' (" + intString(token.lineNumberStart) + ":" + intString(token.columnNumberStart) + "-"+ intString(token.lineNumberEnd) + ":" + intString(token.columnNumberEnd) +")]";
 end printToken;
 
 function tokenContent
@@ -684,12 +698,35 @@ algorithm
   contents := if length>0 then substring(contents,byteOffset,byteOffset+length-1) else "";
 end tokenContent;
 
+function tokenContentEq
+  input Token token1, token2;
+  output Boolean b;
+protected
+  String contents1,contents2;
+  Integer offset1,length1,offset2,length2;
+algorithm
+  TOKEN(fileContents=contents1,byteOffset=offset1,length=length1) := token1;
+  TOKEN(fileContents=contents2,byteOffset=offset2,length=length2) := token2;
+  // We do not need to know in which order to sort. If lengths differ, the tokens differ
+  b := if length1 <> length2 then false else (0 == System.strcmp_offset(contents1, offset1, length1, contents2, offset2, length2));
+end tokenContentEq;
+
+function tokenSourceInfo
+  input Token token;
+  output SourceInfo info;
+algorithm
+  info := match t as token
+    case TOKEN() then SOURCEINFO(t.fileName, false, t.lineNumberStart, t.columnNumberStart, t.lineNumberEnd, t.columnNumberEnd, 0.0);
+  end match;
+end tokenSourceInfo;
+
 protected
 
 function lex "Scan starts the lexical analysis, load the tables and consume the program to output the tokens"
   input String fileName "input source code file";
   input String contents;
   output list<Token> tokens "return list of tokens";
+  output list<Token> errorTokens={};
 protected
   Integer startSt,numStates,i,r,cTok,cTok2,currSt,pos,sPos,ePos,linenr,contentLen,numBacktrack,buffer,lineNrStart;
   list<Integer> cProg,cProg2;
@@ -728,10 +765,11 @@ algorithm
   i := 1;
   while i <= contentLen loop
      cTok := stringGet(contents,i);
-     (tokens,numBacktrack,startSt,currSt,pos,sPos,ePos,linenr,lineNrStart,buffer,states,numStates) := consume(cTok,tokens,contents,startSt,currSt,pos,sPos,ePos,linenr,lineNrStart,buffer,states,numStates,fileName);
+     (tokens,numBacktrack,startSt,currSt,pos,sPos,ePos,linenr,lineNrStart,buffer,states,numStates,errorTokens) := consume(cTok,tokens,contents,startSt,currSt,pos,sPos,ePos,linenr,lineNrStart,buffer,states,numStates,fileName,errorTokens);
      i := i - numBacktrack + 1;
   end while;
   tokens := listReverseInPlace(tokens);
+  errorTokens := listReverseInPlace(errorTokens);
 end lex;
 
 function consume
@@ -744,6 +782,7 @@ function consume
   input array<Integer> inStates;
   input Integer inNumStates;
   input String fileName;
+  input list<Token> inErrorTokens;
   output list<Token> resToken;
   output Integer bkBuffer = 0;
   output Integer mm_startSt;
@@ -751,6 +790,7 @@ function consume
   output Integer buffer;
   output array<Integer> states;
   output Integer numStates;
+  output list<Token> errorTokens=inErrorTokens;
 protected
   Token tok;
   Integer act,buffer2;
@@ -818,7 +858,7 @@ algorithm
       print("\nFound rule: " + String(act));
     end if;
 
-    (tok,mm_startSt,buffer2) := action(act,mm_startSt,mm_currSt,mm_pos,mm_sPos,mm_ePos,mm_linenr,lineNrStart,buffer,debug,fileName,fileContents);
+    (tok,mm_startSt,buffer2,errorTokens) := action(act,mm_startSt,mm_currSt,mm_pos,mm_sPos,mm_ePos,mm_linenr,lineNrStart,buffer,debug,fileName,fileContents,errorTokens);
 
     if (debug==true) then
       print("\nDid action");
@@ -984,27 +1024,27 @@ algorithm
 end checkArrayModelica;
 
 package LexTable
-  constant Integer yy_limit = 397;
-  constant Integer yy_finish = 441;
+  constant Integer yy_limit = 398;
+  constant Integer yy_finish = 456;
   constant Integer yy_acclist[:] = array(
-      115,  114,    1,  114,    2,  114,  101,  114,  114,   65,
-      114,   66,  114,   86,  114,   88,  114,   73,  114,   87,
-      114,   98,  114,   95,  114,  100,  114,   76,  114,   77,
-      114,   91,  114,   72,  114,   92,  114,   99,  114,   67,
-      114,   68,  114,   94,  114,   99,  114,   99,  114,   99,
-      114,   99,  114,   99,  114,   99,  114,   99,  114,   99,
-      114,   99,  114,   99,  114,   99,  114,   99,  114,   99,
-      114,   99,  114,   99,  114,   99,  114,   69,  114,   70,
-      114,  109,  114,  110,  114,  109,  114,  113,  114,  112,
-      114,  105,  114,  106,  114,  104,  105,  114,  105,  114,
+      116,  115,    1,  115,    2,  115,  102,  115,  115,   65,
+      115,   66,  115,   86,  115,   88,  115,   73,  115,   87,
+      115,   98,  115,   95,  115,  101,  115,   76,  115,   77,
+      115,   91,  115,   72,  115,   92,  115,   99,  115,   67,
+      115,   68,  115,   94,  115,   99,  115,   99,  115,   99,
+      115,   99,  115,   99,  115,   99,  115,   99,  115,   99,
+      115,   99,  115,   99,  115,   99,  115,   99,  115,   99,
+      115,   99,  115,   99,  115,   99,  115,   69,  115,   70,
+      115,  110,  115,  111,  115,  110,  115,  114,  115,  113,
+      115,  106,  115,  107,  115,  105,  106,  115,  106,  115,
 
-        1,   99,   83,   81,   82,   84,    5,   85,  107,  111,
-        3,  100,   75,   74,   89,   90,   71,   93,   99,   99,
+        1,   83,   81,   82,   84,    5,   85,  108,  112,    3,
+      101,   75,   74,   89,   90,   71,   93,   99,   99,   99,
        99,   99,   99,   99,   99,   99,   99,   99,   99,   99,
-       99,   99,   99,   99,   99,   99,   99,   34,   99,   99,
-       36,   99,   99,   99,   99,   99,   46,   99,   99,   99,
+       99,   99,   99,   99,   99,   99,   34,   99,   99,   36,
+       99,   99,   99,   99,   99,   46,   99,   99,   99,   99,
        99,   99,   99,   99,   99,   99,   99,   99,   99,   99,
-       99,  108,  102,  103,    3,    4,   99,    7,   99,   99,
+      109,  103,  104,  100,    3,    4,   99,    7,   99,   99,
        99,   99,   99,   99,   99,   15,   99,   99,   99,   99,
        99,   21,   99,   99,   99,   99,   99,   99,   99,   99,
        32,   99,   99,   99,   99,   99,   99,   99,   99,   42,
@@ -1050,60 +1090,60 @@ package LexTable
        42,   44,   46,   48,   50,   52,   54,   56,   58,   60,
        62,   64,   66,   68,   70,   72,   74,   76,   78,   80,
        82,   84,   86,   88,   90,   92,   94,   96,   99,  101,
-      102,  103,  103,  104,  105,  106,  107,  108,  109,  110,
-      111,  112,  113,  113,  114,  115,  116,  117,  118,  119,
-      120,  121,  122,  123,  124,  125,  126,  127,  128,  129,
-      130,  131,  132,  133,  134,  135,  136,  137,  138,  140,
+      102,  102,  102,  103,  104,  105,  106,  107,  108,  109,
+      110,  111,  112,  112,  113,  114,  115,  116,  117,  118,
+      119,  120,  121,  122,  123,  124,  125,  126,  127,  128,
+      129,  130,  131,  132,  133,  134,  135,  136,  137,  139,
 
-      141,  143,  144,  145,  146,  147,  149,  150,  151,  152,
-      153,  154,  155,  156,  157,  158,  159,  160,  161,  162,
-      163,  164,  165,  165,  166,  166,  166,  167,  168,  170,
-      171,  172,  173,  174,  175,  176,  178,  179,  180,  181,
-      182,  184,  185,  186,  187,  188,  189,  190,  191,  193,
-      194,  195,  196,  197,  198,  199,  200,  202,  203,  204,
-      205,  206,  207,  208,  209,  210,  211,  212,  213,  214,
-      215,  216,  217,  218,  219,  220,  221,  222,  223,  224,
-      224,  225,  225,  226,  227,  228,  229,  230,  231,  232,
-      233,  234,  235,  237,  239,  240,  241,  242,  243,  244,
+      140,  142,  143,  144,  145,  146,  148,  149,  150,  151,
+      152,  153,  154,  155,  156,  157,  158,  159,  160,  161,
+      162,  163,  164,  165,  165,  166,  166,  166,  167,  168,
+      170,  171,  172,  173,  174,  175,  176,  178,  179,  180,
+      181,  182,  184,  185,  186,  187,  188,  189,  190,  191,
+      193,  194,  195,  196,  197,  198,  199,  200,  202,  203,
+      204,  205,  206,  207,  208,  209,  210,  211,  212,  213,
+      214,  215,  216,  217,  218,  219,  220,  221,  222,  223,
+      224,  224,  225,  225,  226,  227,  228,  229,  230,  231,
+      232,  233,  234,  235,  237,  239,  240,  241,  242,  243,
 
-      245,  246,  248,  249,  250,  251,  252,  253,  254,  256,
-      257,  258,  259,  260,  261,  262,  263,  264,  265,  266,
-      267,  269,  270,  271,  272,  273,  274,  275,  276,  278,
-      280,  282,  284,  285,  286,  287,  288,  290,  292,  294,
-      295,  296,  297,  298,  299,  300,  301,  302,  303,  304,
-      305,  306,  308,  310,  311,  312,  313,  314,  316,  318,
-      320,  321,  322,  324,  325,  326,  327,  328,  329,  330,
-      331,  332,  333,  334,  335,  336,  337,  338,  340,  341,
-      342,  343,  344,  345,  346,  347,  348,  350,  351,  352,
-      353,  354,  355,  356,  357,  358,  360,  362,  363,  364,
+      244,  245,  246,  248,  249,  250,  251,  252,  253,  254,
+      256,  257,  258,  259,  260,  261,  262,  263,  264,  265,
+      266,  267,  269,  270,  271,  272,  273,  274,  275,  276,
+      278,  280,  282,  284,  285,  286,  287,  288,  290,  292,
+      294,  295,  296,  297,  298,  299,  300,  301,  302,  303,
+      304,  305,  306,  308,  310,  311,  312,  313,  314,  316,
+      318,  320,  321,  322,  324,  325,  326,  327,  328,  329,
+      330,  331,  332,  333,  334,  335,  336,  337,  338,  340,
+      341,  342,  343,  344,  345,  346,  347,  348,  350,  351,
+      352,  353,  354,  355,  356,  357,  358,  360,  362,  363,
 
-      365,  367,  368,  369,  370,  371,  372,  374,  376,  377,
-      378,  379,  381,  383,  384,  386,  387,  388,  390,  391,
-      392,  393,  394,  395,  396,  397,  398,  399,  401,  402,
-      403,  405,  406,  407,  408,  410,  411,  413,  414,  415,
-      416,  418,  419,  420,  421,  422,  424,  425,  426,  428,
-      430,  431,  432,  434,  435,  437,  439,  441,  442,  444,
-      445,  446,  447,  448,  449,  451,  452,  454,  455,  456,
-      457,  458,  459,  460,  462,  464,  466,  467,  469,  471,
-      472,  474,  475,  476,  478,  479,  480,  481,  482,  484,
-      485,  487,  488,  490,  492,  494,  494
+      364,  365,  367,  368,  369,  370,  371,  372,  374,  376,
+      377,  378,  379,  381,  383,  384,  386,  387,  388,  390,
+      391,  392,  393,  394,  395,  396,  397,  398,  399,  401,
+      402,  403,  405,  406,  407,  408,  410,  411,  413,  414,
+      415,  416,  418,  419,  420,  421,  422,  424,  425,  426,
+      428,  430,  431,  432,  434,  435,  437,  439,  441,  442,
+      444,  445,  446,  447,  448,  449,  451,  452,  454,  455,
+      456,  457,  458,  459,  460,  462,  464,  466,  467,  469,
+      471,  472,  474,  475,  476,  478,  479,  480,  481,  482,
+      484,  485,  487,  488,  490,  492,  494,  494
 
    );
   constant Integer yy_ec[:] = array(
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    2,    1,    4,    1,    1,    1,    1,    5,    6,
-        7,    8,    9,   10,   11,   12,   13,   14,   14,   14,
-       14,   14,   14,   14,   14,   14,   14,   15,   16,   17,
-       18,   19,    1,    1,   20,   20,   20,   20,   21,   20,
-       20,   20,   20,   20,   20,   20,   20,   20,   20,   20,
-       20,   20,   20,   20,   20,   20,   20,   20,   20,   20,
-       22,   23,   24,   25,   26,    1,   27,   28,   29,   30,
+        1,    4,    5,    6,    5,    5,    5,    5,    7,    8,
+        9,   10,   11,   12,   13,   14,   15,   16,   16,   16,
+       16,   16,   16,   16,   16,   16,   16,   17,   18,   19,
+       20,   21,    5,    5,   22,   22,   22,   22,   23,   22,
+       22,   22,   22,   22,   22,   22,   22,   22,   22,   22,
+       22,   22,   22,   22,   22,   22,   22,   22,   22,   22,
+       24,   25,   26,   27,   22,    1,   28,   29,   30,   31,
 
-       31,   32,   33,   34,   35,   20,   36,   37,   38,   39,
-       40,   41,   42,   43,   44,   45,   46,   47,   48,   49,
-       50,   51,   52,    1,   53,    1,    1,    1,    1,    1,
+       32,   33,   34,   35,   36,   22,   37,   38,   39,   40,
+       41,   42,   43,   44,   45,   46,   47,   48,   49,   50,
+       51,   52,   53,    5,   54,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -1120,163 +1160,164 @@ package LexTable
         1,    1,    1,    1,    1
    );
   constant Integer yy_meta[:] = array(
-        1,    1,    1,    1,    2,    1,    1,    2,    2,    1,
-        2,    1,    2,    3,    1,    1,    1,    2,    1,    3,
-        3,    1,    1,    1,    2,    4,    3,    3,    3,    3,
-        3,    3,    3,    3,    3,    3,    3,    3,    3,    3,
-        3,    3,    3,    3,    3,    3,    3,    3,    3,    3,
-        3,    1,    1
+        1,    1,    1,    2,    2,    3,    3,    2,    2,    2,
+        2,    2,    2,    2,    2,    4,    2,    2,    2,    5,
+        2,    4,    4,    2,    5,    2,    2,    6,    6,    4,
+        4,    4,    6,    4,    4,    4,    4,    4,    4,    6,
+        4,    4,    4,    6,    4,    4,    4,    6,    4,    4,
+        6,    4,    2,    2
    );
   constant Integer yy_base[:] = array(
-        0,    0,   51,   52,  437,  436,   53,   58,  438,  441,
-      435,  441,  441,  431,  441,  441,  441,  441,  441,  441,
-       55,   57,   61,   56,  441,   59,  417,  416,    0,  441,
-      441,  441,   46,   47,   49,   56,   61,   67,   67,  393,
-      392,  391,   68,   74,  399,   50,   78,   84,  441,  441,
-      441,  441,  416,  441,  441,  441,  441,  441,   93,  426,
-        0,  422,  441,  441,  441,  441,  108,  441,  441,  441,
-      109,  112,  123,  441,  441,  441,  441,  441,  441,    0,
-      393,   28,  385,  393,  396,  383,   93,  377,  391,  375,
-      112,  372,   86,  380,  377,  375,  371,  374,    0,  371,
+        0,    0,   52,   53,  452,  451,   54,   55,  453,  456,
+       62,  456,  456,  427,  456,  456,  456,  456,  456,  456,
+       57,   59,   62,   66,  456,   61,  431,  430,    0,  456,
+      456,  456,   37,   21,   49,   56,   61,   67,   58,  408,
+      407,  406,   65,   72,  414,   71,   71,   85,  456,  456,
+      456,  456,  430,  456,  456,  456,  456,  456,  104,  121,
+      117,    0,  456,  456,  456,  456,  111,  456,  456,  456,
+      112,  116,  120,  456,  456,  456,  456,  456,  456,    0,
+      410,   62,  402,  410,  413,  400,   93,  394,  408,  392,
+      110,  389,  103,  397,  394,  392,  388,  391,    0,  388,
 
-      109,  371,  380,  364,   48,    0,  363,  376,  106,  366,
-      110,  116,  362,  376,  372,  356,  360,  116,  355,  441,
-      441,  148,  145,  141,  154,  385,  384,  357,    0,  356,
-      366,  367,  349,  125,  357,    0,  362,  356,  358,  361,
-        0,  349,  359,  358,  353,  339,  355,  333,    0,  351,
-      127,  334,  347,  331,  335,  344,    0,  331,  338,  135,
-      329,  335,  143,  325,  332,  337,  327,  335,  328,  318,
-      317,  331,  316,  321,  328,  327,  318,  319,  321,  340,
-      339,  338,  337,  307,  304,  312,  311,  302,  314,  299,
-      304,  299,    0,  139,  300,  309,  294,  299,  136,  306,
+      110,  388,  397,  381,  115,    0,  380,  393,  121,  383,
+      109,  124,  379,  393,  389,  373,  377,  124,  372,  456,
+      456,  152,  456,  151,  152,  160,  401,  400,  374,    0,
+      373,  383,  384,  366,  134,  374,    0,  379,  373,  375,
+      378,    0,  366,  376,  375,  370,  356,  372,  350,    0,
+      368,  131,  351,  364,  348,  352,  361,    0,  348,  355,
+      148,  346,  352,  135,  342,  349,  354,  344,  352,  345,
+      335,  334,  348,  333,  338,  345,  344,  335,  336,  338,
+      356,  355,  354,  353,  324,  321,  329,  328,  319,  331,
+      316,  321,  316,    0,  146,  317,  326,  311,  316,  143,
 
-      299,    0,  290,  291,  290,  297,  288,  285,    0,  292,
-      301,  289,  283,  279,  287,  296,  284,  286,  289,  284,
-        0,  275,  288,  289,  278,  271,  286,  262,    0,    0,
-        0,    0,  280,  275,  274,  281,    0,    0,    0,  278,
-      150,  275,  274,  272,  269,  258,  258,  265,  269,  268,
-      258,    0,    0,  261,  250,  263,  266,    0,    0,    0,
-      247,  256,    0,  245,  249,  255,  256,  259,  256,  255,
-      253,  245,  252,  235,  240,  240,  236,    0,  237,  230,
-      229,  228,  233,  244,  224,  224,    0,  237,  221,  239,
-      225,  237,  219,  235,  221,    0,    0,  223,  219,  207,
+      323,  316,    0,  307,  308,  307,  314,  305,  302,    0,
+      309,  318,  306,  300,  296,  304,  313,  301,  303,  306,
+      301,    0,  292,  305,  306,  295,  288,  303,  279,    0,
+        0,    0,    0,  297,  292,  291,  298,    0,    0,    0,
+      295,  157,  292,  291,  289,  286,  275,  275,  282,  286,
+      285,  275,    0,    0,  278,  267,  280,  283,    0,    0,
+        0,  264,  273,    0,  262,  266,  272,  273,  276,  273,
+      272,  270,  262,  269,  252,  257,  257,  253,    0,  254,
+      247,  246,  245,  250,  261,  241,  241,    0,  254,  238,
+      256,  242,  254,  236,  252,  238,    0,    0,  240,  236,
 
-        0,  230,  225,  210,  217,  208,    0,    0,  225,  220,
-      206,    0,    0,  218,    0,  214,  212,  206,  200,  209,
-      204,  211,  202,  203,  194,  199,  209,    0,  199,  196,
-        0,  191,  206,  202,    0,  200,    0,  199,  186,  201,
-        0,  187,  188,  185,  181,    0,  184,  187,    0,    0,
-      194,  185,    0,  182,    0,    0,    0,  173,    0,  174,
-      186,  184,  186,  181,    0,  173,    0,  180,  165,  147,
-      151,  159,  154,    0,    0,    0,  149,    0,    0,  155,
-        0,  153,  144,    0,  142,  150,  152,  148,    0,   69,
-        0,   22,    0,    0,    0,  441,  193,  197,  201,  204,
+      224,    0,  247,  242,  227,  234,  225,    0,    0,  242,
+      237,  223,    0,    0,  235,    0,  231,  229,  223,  217,
+      226,  221,  228,  219,  220,  211,  216,  226,    0,  216,
+      213,    0,  208,  223,  219,    0,  217,    0,  216,  203,
+      218,    0,  204,  205,  202,  198,    0,  201,  204,    0,
+        0,  211,  202,    0,  199,    0,    0,    0,  190,    0,
+      191,  203,  201,  203,  196,    0,  186,    0,  189,  154,
+      153,  157,  165,  160,    0,    0,    0,  156,    0,    0,
+      162,    0,  160,  151,    0,  148,  156,  157,  128,    0,
+       56,    0,   20,    0,    0,    0,  456,  201,  207,  213,
 
-      205
+      218,  221,  225
    );
   constant Integer yy_def[:] = array(
-      396,    1,  397,  397,  398,  398,  399,  399,  396,  396,
-      396,  396,  396,  400,  396,  396,  396,  396,  396,  396,
-      396,  396,  396,  396,  396,  396,  396,  396,  401,  396,
-      396,  396,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  396,  396,
-      396,  396,  396,  396,  396,  396,  396,  396,  396,  396,
-      401,  400,  396,  396,  396,  396,  396,  396,  396,  396,
-      396,  396,  396,  396,  396,  396,  396,  396,  396,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
+      397,    1,  398,  398,  399,  399,  400,  400,  397,  397,
+      397,  397,  397,  401,  397,  397,  397,  397,  397,  397,
+      397,  397,  397,  397,  397,  397,  397,  397,  402,  397,
+      397,  397,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  397,  397,
+      397,  397,  397,  397,  397,  397,  397,  397,  397,  397,
+      401,  403,  397,  397,  397,  397,  397,  397,  397,  397,
+      397,  397,  397,  397,  397,  397,  397,  397,  397,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
 
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  396,
-      396,  396,  396,  396,  396,  396,  396,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  396,
-      396,  396,  396,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  397,
+      397,  397,  397,  397,  397,  397,  397,  397,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      397,  397,  397,  397,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
 
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
 
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,  401,  401,  401,  401,  401,
-      401,  401,  401,  401,  401,    0,  396,  396,  396,  396,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,  402,  402,  402,  402,
+      402,  402,  402,  402,  402,  402,    0,  397,  397,  397,
 
-      396
+      397,  397,  397
    );
   constant Integer yy_nxt[:] = array(
-       10,   11,   12,   13,   14,   15,   16,   17,   18,   19,
-       20,   21,   22,   23,   24,   25,   26,   27,   28,   29,
-       29,   30,   10,   31,   32,   29,   33,   34,   35,   36,
-       37,   38,   29,   29,   39,   29,   40,   41,   42,   43,
-       44,   29,   45,   46,   47,   29,   29,   48,   29,   29,
-       29,   49,   50,   52,   52,   57,   58,  129,   53,   53,
-       57,   58,   63,   64,   69,   65,  130,   66,   67,   70,
-       74,  395,   71,   75,   72,   59,   76,   77,  158,   68,
-       59,   73,   81,   83,   82,   85,   87,   89,   86,   84,
-       88,   73,  159,   94,  113,  114,  121,   90,   99,   91,
+       10,   11,   12,   11,   10,   13,   14,   15,   16,   17,
+       18,   19,   20,   21,   22,   23,   24,   25,   26,   27,
+       28,   29,   29,   30,   10,   31,   32,   33,   34,   35,
+       36,   37,   38,   29,   29,   39,   29,   40,   41,   42,
+       43,   44,   29,   45,   46,   47,   29,   29,   48,   29,
+       29,   29,   49,   50,   52,   52,   57,   57,   83,   58,
+       58,   53,   53,   60,   84,   60,   63,   64,   69,   65,
+      396,   66,   67,   70,   81,   71,   82,   72,   59,   59,
+       76,   77,   74,   68,   73,   75,   85,   87,   89,   86,
+       99,   88,  130,   73,   94,  395,  100,  101,   90,  109,
 
-      109,   95,   92,   96,  100,  101,   97,  394,  105,   93,
-      106,  115,   98,  107,  108,  122,  110,  118,  119,  111,
-      116,   67,  124,   71,  135,   72,  144,  117,  123,  125,
-      145,  126,   73,  126,  162,  136,  127,  165,  123,  125,
-      140,  141,   73,  152,  167,  168,  177,  153,  163,  154,
-      178,  121,  166,  180,  124,  180,  169,  142,  181,  170,
-      171,  125,  182,  189,  182,  213,  204,  183,  190,  217,
-      122,  125,  205,  244,  250,  214,  283,  393,  251,  392,
-      391,  390,  389,  388,  387,  386,  245,  218,  385,  384,
-      383,  382,  284,   51,   51,   51,   51,   54,   54,   54,
+       91,  131,   95,   92,   96,  115,  105,   97,  106,  121,
+       93,  107,  108,   98,  116,  110,  113,  114,  111,  118,
+      119,  117,   60,  123,   60,  136,   67,  125,  122,   71,
+      127,   72,  127,  124,  126,  128,  137,  166,   73,  141,
+      142,   62,  124,  126,  145,  153,  159,   73,  146,  154,
+      163,  155,  167,  168,  169,  178,  143,  121,  394,  179,
+      160,  181,  218,  181,  164,  170,  182,  125,  171,  172,
+      183,  205,  183,  190,  126,  184,  122,  206,  191,  214,
+      219,  245,  251,  126,  284,  393,  252,  392,  391,  215,
+      390,  389,  388,  387,  246,  386,  385,  384,  383,  382,
 
-       54,   56,   56,   56,   56,   62,   62,   80,   80,  381,
-      380,  379,  378,  377,  376,  375,  374,  373,  372,  371,
-      370,  369,  368,  367,  366,  365,  364,  363,  362,  361,
-      360,  359,  358,  357,  356,  355,  354,  353,  352,  351,
-      350,  349,  348,  347,  346,  345,  344,  343,  342,  341,
-      340,  339,  338,  337,  336,  335,  334,  333,  332,  331,
-      330,  329,  328,  327,  326,  325,  324,  323,  322,  321,
-      320,  319,  318,  317,  316,  315,  314,  313,  312,  311,
-      310,  309,  308,  307,  306,  305,  304,  303,  302,  301,
-      300,  299,  298,  297,  296,  295,  294,  293,  292,  291,
+      285,   51,   51,   51,   51,   51,   51,   54,   54,   54,
+       54,   54,   54,   56,   56,   56,   56,   56,   56,   61,
+      381,   61,   61,   61,   80,  380,   80,   61,  379,   61,
+       61,  378,  377,  376,  375,  374,  373,  372,  371,  370,
+      369,  368,  367,  366,  365,  364,  363,  362,  361,  360,
+      359,  358,  357,  356,  355,  354,  353,  352,  351,  350,
+      349,  348,  347,  346,  345,  344,  343,  342,  341,  340,
+      339,  338,  337,  336,  335,  334,  333,  332,  331,  330,
+      329,  328,  327,  326,  325,  324,  323,  322,  321,  320,
+      319,  318,  317,  316,  315,  314,  313,  312,  311,  310,
 
-      290,  289,  288,  287,  286,  285,  282,  281,  280,  279,
-      278,  277,  276,  275,  274,  273,  272,  271,  270,  269,
-      268,  267,  266,  265,  264,  263,  262,  261,  260,  259,
-      258,  257,  256,  255,  254,  253,  252,  249,  248,  247,
-      246,  243,  242,  241,  240,  239,  238,  237,  236,  235,
-      183,  183,  181,  181,  234,  233,  232,  231,  230,  229,
-      228,  227,  226,  225,  224,  223,  222,  221,  220,  219,
-      216,  215,  212,  211,  210,  209,  208,  207,  206,  203,
-      202,  201,  200,  199,  198,  197,  196,  195,  194,  193,
-      192,  191,  188,  187,  186,  185,  184,  127,  127,  179,
+      309,  308,  307,  306,  305,  304,  303,  302,  301,  300,
+      299,  298,  297,  296,  295,  294,  293,  292,  291,  290,
+      289,  288,  287,  286,  283,  282,  281,  280,  279,  278,
+      277,  276,  275,  274,  273,  272,  271,  270,  269,  268,
+      267,  266,  265,  264,  263,  262,  261,  260,  259,  258,
+      257,  256,  255,  254,  253,  250,  249,  248,  247,  244,
+      243,  242,  241,  240,  239,  238,  237,  236,  184,  184,
+      182,  182,  235,  234,  233,  232,  231,  230,  229,  228,
+      227,  226,  225,  224,  223,  222,  221,  220,  217,  216,
+      213,  212,  211,  210,  209,  208,  207,  204,  203,  202,
 
-      176,  175,  174,  173,  172,  164,  161,  160,  157,  156,
-      155,  151,  150,  149,  148,  147,  146,  143,  139,  138,
-      137,  134,  133,  132,  131,  128,   61,   60,  120,  112,
-      104,  103,  102,   79,   78,   61,   60,  396,   55,   55,
-        9,  396,  396,  396,  396,  396,  396,  396,  396,  396,
-      396,  396,  396,  396,  396,  396,  396,  396,  396,  396,
-      396,  396,  396,  396,  396,  396,  396,  396,  396,  396,
-      396,  396,  396,  396,  396,  396,  396,  396,  396,  396,
-      396,  396,  396,  396,  396,  396,  396,  396,  396,  396,
-      396,  396,  396,  396
+      201,  200,  199,  198,  197,  196,  195,  194,  193,  192,
+      189,  188,  187,  186,  185,  128,  128,  180,  177,  176,
+      175,  174,  173,  165,  162,  161,  158,  157,  156,  152,
+      151,  150,  149,  148,  147,  144,  140,  139,  138,  135,
+      134,  133,  132,  129,  120,  112,  104,  103,  102,   79,
+       78,   62,  397,   55,   55,    9,  397,  397,  397,  397,
+      397,  397,  397,  397,  397,  397,  397,  397,  397,  397,
+      397,  397,  397,  397,  397,  397,  397,  397,  397,  397,
+      397,  397,  397,  397,  397,  397,  397,  397,  397,  397,
+      397,  397,  397,  397,  397,  397,  397,  397,  397,  397,
 
+      397,  397,  397,  397,  397,  397,  397,  397,  397,  397
    );
   constant Integer yy_chk[:] = array(
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -1284,56 +1325,57 @@ package LexTable
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    3,    4,    7,    7,   82,    3,    4,
-        8,    8,   21,   21,   22,   21,   82,   21,   21,   22,
-       24,  392,   23,   24,   23,    7,   26,   26,  105,   21,
-        8,   23,   33,   34,   33,   35,   36,   37,   35,   34,
-       36,   23,  105,   38,   46,   46,   59,   37,   39,   37,
+        1,    1,    1,    1,    3,    4,    7,    8,   34,    7,
+        8,    3,    4,   11,   34,   11,   21,   21,   22,   21,
+      393,   21,   21,   22,   33,   23,   33,   23,    7,    8,
+       26,   26,   24,   21,   23,   24,   35,   36,   37,   35,
+       39,   36,   82,   23,   38,  391,   39,   39,   37,   44,
 
-       44,   38,   37,   38,   39,   39,   38,  390,   43,   37,
-       43,   47,   38,   43,   43,   59,   44,   48,   48,   44,
-       47,   67,   71,   72,   87,   72,   93,   47,   67,   71,
-       93,   73,   72,   73,  109,   87,   73,  111,   67,   71,
-       91,   91,   72,  101,  112,  112,  118,  101,  109,  101,
-      118,  122,  111,  123,  124,  123,  112,   91,  123,  112,
-      112,  124,  125,  134,  125,  160,  151,  125,  134,  163,
-      122,  124,  151,  194,  199,  160,  241,  388,  199,  387,
-      386,  385,  383,  382,  380,  377,  194,  163,  373,  372,
-      371,  370,  241,  397,  397,  397,  397,  398,  398,  398,
+       37,   82,   38,   37,   38,   47,   43,   38,   43,   59,
+       37,   43,   43,   38,   47,   44,   46,   46,   44,   48,
+       48,   47,   60,   61,   60,   87,   67,   71,   59,   72,
+       73,   72,   73,   67,   71,   73,   87,  111,   72,   91,
+       91,   61,   67,   71,   93,  101,  105,   72,   93,  101,
+      109,  101,  111,  112,  112,  118,   91,  122,  389,  118,
+      105,  124,  164,  124,  109,  112,  124,  125,  112,  112,
+      126,  152,  126,  135,  125,  126,  122,  152,  135,  161,
+      164,  195,  200,  125,  242,  388,  200,  387,  386,  161,
+      384,  383,  381,  378,  195,  374,  373,  372,  371,  370,
 
-      398,  399,  399,  399,  399,  400,  400,  401,  401,  369,
-      368,  366,  364,  363,  362,  361,  360,  358,  354,  352,
-      351,  348,  347,  345,  344,  343,  342,  340,  339,  338,
-      336,  334,  333,  332,  330,  329,  327,  326,  325,  324,
-      323,  322,  321,  320,  319,  318,  317,  316,  314,  311,
-      310,  309,  306,  305,  304,  303,  302,  300,  299,  298,
-      295,  294,  293,  292,  291,  290,  289,  288,  286,  285,
-      284,  283,  282,  281,  280,  279,  277,  276,  275,  274,
-      273,  272,  271,  270,  269,  268,  267,  266,  265,  264,
-      262,  261,  257,  256,  255,  254,  251,  250,  249,  248,
+      242,  398,  398,  398,  398,  398,  398,  399,  399,  399,
+      399,  399,  399,  400,  400,  400,  400,  400,  400,  401,
+      369,  401,  401,  401,  402,  367,  402,  403,  365,  403,
+      403,  364,  363,  362,  361,  359,  355,  353,  352,  349,
+      348,  346,  345,  344,  343,  341,  340,  339,  337,  335,
+      334,  333,  331,  330,  328,  327,  326,  325,  324,  323,
+      322,  321,  320,  319,  318,  317,  315,  312,  311,  310,
+      307,  306,  305,  304,  303,  301,  300,  299,  296,  295,
+      294,  293,  292,  291,  290,  289,  287,  286,  285,  284,
+      283,  282,  281,  280,  278,  277,  276,  275,  274,  273,
 
-      247,  246,  245,  244,  243,  242,  240,  236,  235,  234,
-      233,  228,  227,  226,  225,  224,  223,  222,  220,  219,
-      218,  217,  216,  215,  214,  213,  212,  211,  210,  208,
-      207,  206,  205,  204,  203,  201,  200,  198,  197,  196,
-      195,  192,  191,  190,  189,  188,  187,  186,  185,  184,
-      183,  182,  181,  180,  179,  178,  177,  176,  175,  174,
-      173,  172,  171,  170,  169,  168,  167,  166,  165,  164,
-      162,  161,  159,  158,  156,  155,  154,  153,  152,  150,
-      148,  147,  146,  145,  144,  143,  142,  140,  139,  138,
-      137,  135,  133,  132,  131,  130,  128,  127,  126,  119,
+      272,  271,  270,  269,  268,  267,  266,  265,  263,  262,
+      258,  257,  256,  255,  252,  251,  250,  249,  248,  247,
+      246,  245,  244,  243,  241,  237,  236,  235,  234,  229,
+      228,  227,  226,  225,  224,  223,  221,  220,  219,  218,
+      217,  216,  215,  214,  213,  212,  211,  209,  208,  207,
+      206,  205,  204,  202,  201,  199,  198,  197,  196,  193,
+      192,  191,  190,  189,  188,  187,  186,  185,  184,  183,
+      182,  181,  180,  179,  178,  177,  176,  175,  174,  173,
+      172,  171,  170,  169,  168,  167,  166,  165,  163,  162,
+      160,  159,  157,  156,  155,  154,  153,  151,  149,  148,
 
-      117,  116,  115,  114,  113,  110,  108,  107,  104,  103,
-      102,  100,   98,   97,   96,   95,   94,   92,   90,   89,
-       88,   86,   85,   84,   83,   81,   62,   60,   53,   45,
-       42,   41,   40,   28,   27,   14,   11,    9,    6,    5,
-      396,  396,  396,  396,  396,  396,  396,  396,  396,  396,
-      396,  396,  396,  396,  396,  396,  396,  396,  396,  396,
-      396,  396,  396,  396,  396,  396,  396,  396,  396,  396,
-      396,  396,  396,  396,  396,  396,  396,  396,  396,  396,
-      396,  396,  396,  396,  396,  396,  396,  396,  396,  396,
-      396,  396,  396,  396
+      147,  146,  145,  144,  143,  141,  140,  139,  138,  136,
+      134,  133,  132,  131,  129,  128,  127,  119,  117,  116,
+      115,  114,  113,  110,  108,  107,  104,  103,  102,  100,
+       98,   97,   96,   95,   94,   92,   90,   89,   88,   86,
+       85,   84,   83,   81,   53,   45,   42,   41,   40,   28,
+       27,   14,    9,    6,    5,  397,  397,  397,  397,  397,
+      397,  397,  397,  397,  397,  397,  397,  397,  397,  397,
+      397,  397,  397,  397,  397,  397,  397,  397,  397,  397,
+      397,  397,  397,  397,  397,  397,  397,  397,  397,  397,
+      397,  397,  397,  397,  397,  397,  397,  397,  397,  397,
 
+      397,  397,  397,  397,  397,  397,  397,  397,  397,  397
    );
 
 end LexTable;
@@ -1355,21 +1397,21 @@ algorithm
     return;
   end if;
   b := match ida
-    case TokenId.IDENT then tokenContent(ta)==tokenContent(tb);
-    case TokenId.UNSIGNED_INTEGER then tokenContent(ta)==tokenContent(tb);
+    case TokenId.IDENT then tokenContentEq(ta,tb);
+    case TokenId.UNSIGNED_INTEGER then tokenContentEq(ta,tb);
     case TokenId.UNSIGNED_REAL
       then stringReal(tokenContent(ta))==stringReal(tokenContent(tb));
     case TokenId.BLOCK_COMMENT
       then valueEq(blockCommentCanonical(ta),blockCommentCanonical(tb));
-    case TokenId.LINE_COMMENT then tokenContent(ta)==tokenContent(tb);
-    case TokenId.STRING then tokenContent(ta)==tokenContent(tb);
+    case TokenId.LINE_COMMENT then tokenContentEq(ta,tb);
+    case TokenId.STRING then tokenContentEq(ta,tb);
     case TokenId.WHITESPACE then true; // tokenContent(ta)==tokenContent(tb);
     else true;
   end match;
 end modelicaDiffTokenEq;
 
 function modelicaDiffTokenWhitespace
-  import LexerModelicaDiff.{Token,TokenId,tokenContent};
+  import LexerModelicaDiff.{Token,TokenId};
   input Token t;
   output Boolean b;
 protected
@@ -1579,7 +1621,7 @@ algorithm
 end blockCommentCanonical;
 
 function deleteWhitespaceFollowedByEqualNonWhitespace
-  import LexerModelicaDiff.{Token,TokenId,TOKEN,tokenContent};
+  import LexerModelicaDiff.{Token,TokenId,TOKEN};
   import DiffAlgorithm.Diff;
   input list<tuple<Diff, Token>> inRest;
   output Boolean b;
@@ -1631,6 +1673,24 @@ algorithm
   end for;
   result := rest;
 end deleteWhitespaceFollowedByEqualNonWhitespace;
+
+function reportErrors
+  import LexerModelicaDiff.{Token,TokenId,tokenContent,tokenSourceInfo};
+  input list<Token> tokens;
+protected
+  Integer i=0;
+algorithm
+  for t in tokens loop
+    i := i+1;
+    if i>10 then
+      Error.addMessage(Error.SCANNER_ERROR_LIMIT, {});
+    end if;
+    Error.addSourceMessage(Error.SCANNER_ERROR, {tokenContent(t)}, tokenSourceInfo(t));
+  end for;
+  if not listEmpty(tokens) then
+    fail();
+  end if;
+end reportErrors;
 
 annotation(__OpenModelica_Interface="backend");
 

--- a/Compiler/Lexers/lexerModelicaDiff.l
+++ b/Compiler/Lexers/lexerModelicaDiff.l
@@ -1,5 +1,8 @@
 %{
 import DiffAlgorithm;
+protected
+import Error;
+public
 %}
 
 %x c_comment
@@ -10,9 +13,12 @@ whitespace1  [ \t]+
 whitespace2  \n
 letter       [a-zA-Z]
 wild         [_]
+nondigit     [_a-zA-Z]
+qchar        []_a-zA-Z0-9!#$%&()*+,./:;<>=?@[^{}| \-]
+sescape      "\\"['"=abfnryv\\]
 digit        [0-9]
+digitnondigit [_a-zA-Z0-9]
 digits       {digit}+
-ident        (({letter}|{wild})|['\'']({letter}|{digit}|[-*+/^=])*['\''])({letter}|{digit}|{wild})*
 exponent     ([e]|[E])([+]|[-])?{digits}
 real         {digits}[\.]({digits})?({exponent})?
 real2        {digits}{exponent}
@@ -31,9 +37,9 @@ initialalgorithm  "initial"{whitespace}"algorithm"
 {real}      return UNSIGNED_REAL;
 {real2}     return UNSIGNED_REAL;
 {real3}     return UNSIGNED_REAL;
-"algorithm" return T_ALGORITHM;
-"and" return T_AND;
-"annotation" return T_ANNOTATION;
+"algorithm" return ALGORITHM;
+"and" return AND;
+"annotation" return ANNOTATION;
 "block" return BLOCK;
 "class" return CLASS;
 "connect" return CONNECT;
@@ -46,7 +52,7 @@ initialalgorithm  "initial"{whitespace}"algorithm"
 "else" return ELSE;
 "elseif" return ELSEIF;
 "elsewhen" return ELSEWHEN;
-"end" return T_END;
+"end" return END;
 "enumeration" return ENUMERATION;
 "equation" return EQUATION;
 "encapsulated" return ENCAPSULATED;
@@ -54,26 +60,26 @@ initialalgorithm  "initial"{whitespace}"algorithm"
 "extends" return EXTENDS;
 "constrainedby" return CONSTRAINEDBY;
 "external" return EXTERNAL;
-"false" return T_FALSE;
+"false" return FALSE;
 "final" return FINAL;
 "flow" return FLOW;
 "for" return FOR;
 "function" return FUNCTION;
 "if" return IF;
 "import" return IMPORT;
-"in" return T_IN;
-"initial" return T_INITIAL;
+"in" return IN;
+"initial" return INITIAL;
 "inner" return INNER;
-"input" return T_INPUT;
+"input" return INPUT;
 "loop" return LOOP;
 "model" return MODEL;
-"not" return T_NOT;
-"outer" return T_OUTER;
+"not" return NOT;
+"outer" return OUTER;
 "operator" return OPERATOR;
 "overload" return OVERLOAD;
-"or" return T_OR;
-"output" return T_OUTPUT;
-"package" return T_PACKAGE;
+"or" return OR;
+"output" return OUTPUT;
+"package" return PACKAGE;
 "parameter" return PARAMETER;
 "partial" return PARTIAL;
 "protected" return PROTECTED;
@@ -83,7 +89,7 @@ initialalgorithm  "initial"{whitespace}"algorithm"
 "replaceable" return REPLACEABLE;
 "results" return RESULTS;
 "then" return THEN;
-"true" return T_TRUE;
+"true" return TRUE;
 "type" return TYPE;
 "when" return WHEN;
 "while" return WHILE;
@@ -107,7 +113,7 @@ initialalgorithm  "initial"{whitespace}"algorithm"
 
 "pure" return PURE;
 "impure" return IMPURE;
-"optimization" return T_OPTIMIZATION;
+"optimization" return OPTIMIZATION;
 
 ".+" return PLUS_EW;
 ".-" return MINUS_EW;
@@ -133,7 +139,10 @@ initialalgorithm  "initial"{whitespace}"algorithm"
 
 "\." return DOT;
 
-{ident}      return IDENT;
+{nondigit}{digitnondigit}* return IDENT;
+
+"'"({qchar}|{sescape})+"'"  return IDENT;
+
 {digits}     return UNSIGNED_INTEGER;
 
 "\""       {
@@ -189,21 +198,21 @@ algorithm
     return;
   end if;
   b := match ida
-    case TokenId.IDENT then tokenContent(ta)==tokenContent(tb);
-    case TokenId.UNSIGNED_INTEGER then tokenContent(ta)==tokenContent(tb);
+    case TokenId.IDENT then tokenContentEq(ta,tb);
+    case TokenId.UNSIGNED_INTEGER then tokenContentEq(ta,tb);
     case TokenId.UNSIGNED_REAL
       then stringReal(tokenContent(ta))==stringReal(tokenContent(tb));
     case TokenId.BLOCK_COMMENT
       then valueEq(blockCommentCanonical(ta),blockCommentCanonical(tb));
-    case TokenId.LINE_COMMENT then tokenContent(ta)==tokenContent(tb);
-    case TokenId.STRING then tokenContent(ta)==tokenContent(tb);
+    case TokenId.LINE_COMMENT then tokenContentEq(ta,tb);
+    case TokenId.STRING then tokenContentEq(ta,tb);
     case TokenId.WHITESPACE then true; // tokenContent(ta)==tokenContent(tb);
     else true;
   end match;
 end modelicaDiffTokenEq;
 
 function modelicaDiffTokenWhitespace
-  import LexerModelicaDiff.{Token,TokenId,tokenContent};
+  import LexerModelicaDiff.{Token,TokenId};
   input Token t;
   output Boolean b;
 protected
@@ -413,7 +422,7 @@ algorithm
 end blockCommentCanonical;
 
 function deleteWhitespaceFollowedByEqualNonWhitespace
-  import LexerModelicaDiff.{Token,TokenId,TOKEN,tokenContent};
+  import LexerModelicaDiff.{Token,TokenId,TOKEN};
   import DiffAlgorithm.Diff;
   input list<tuple<Diff, Token>> inRest;
   output Boolean b;
@@ -465,5 +474,23 @@ algorithm
   end for;
   result := rest;
 end deleteWhitespaceFollowedByEqualNonWhitespace;
+
+function reportErrors
+  import LexerModelicaDiff.{Token,TokenId,tokenContent,tokenSourceInfo};
+  input list<Token> tokens;
+protected
+  Integer i=0;
+algorithm
+  for t in tokens loop
+    i := i+1;
+    if i>10 then
+      Error.addMessage(Error.SCANNER_ERROR_LIMIT, {});
+    end if;
+    Error.addSourceMessage(Error.SCANNER_ERROR, {tokenContent(t)}, tokenSourceInfo(t));
+  end for;
+  if not listEmpty(tokens) then
+    fail();
+  end if;
+end reportErrors;
 
 annotation(__OpenModelica_Interface="backend");

--- a/Compiler/Main/Main.mo
+++ b/Compiler/Main/Main.mo
@@ -466,8 +466,7 @@ algorithm
       equation
         //print("Class to instantiate: " + Config.classToInstantiate() + "\n");
         isEmptyOrFirstIsModelicaFile(libs);
-        System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT);
-        System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT_CUMULATIVE);
+        SimCodeFunctionUtil.execStatReset();
         // Parse libraries and extra mo-files that might have been given at the command line.
         GlobalScript.SYMBOLTABLE(ast = p) = List.fold(libs, loadLib, GlobalScript.emptySymboltable);
         // Show any errors that occured during parsing.

--- a/Compiler/Parsers/SimpleModelicaParser.mo
+++ b/Compiler/Parsers/SimpleModelicaParser.mo
@@ -1,0 +1,2631 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2014, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package SimpleModelicaParser
+
+import LexerModelicaDiff.{Token,TokenId,tokenContent,printToken,modelicaDiffTokenEq};
+
+protected
+
+import DiffAlgorithm;
+import DiffAlgorithm.{diff,Diff};
+import Error;
+import Print;
+import StackOverflow;
+import System;
+import List;
+import StringUtil;
+import MetaModelica.Dangerous.listReverseInPlace;
+
+public
+
+uniontype ParseTree
+  record EMPTY
+  end EMPTY;
+  record NODE
+    ParseTree label;
+    list<ParseTree> nodes;
+  end NODE;
+  record LEAF
+    Token token;
+  end LEAF;
+end ParseTree;
+
+partial function partialParser
+  input list<Token> inTokens;
+  input list<ParseTree> inTree;
+  output list<Token> tokens = inTokens;
+  output list<ParseTree> outTree;
+protected
+  list<ParseTree> tree = {};
+end partialParser;
+
+function stored_definition
+  extends partialParser;
+protected
+  Boolean b;
+algorithm
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.WITHIN);
+  if b then
+    (tokens, tree, b) := LA1(tokens, tree, First.name);
+    if b then
+      (tokens, tree) := name(tokens, tree);
+    end if;
+    (tokens, tree) := scan(tokens, tree, TokenId.SEMICOLON);
+    outTree := makeNode(listReverse(tree))::{};
+    tree := {};
+  else
+    outTree := {};
+  end if;
+
+  (tokens, tree, b) := LA1(tokens, tree, First.class_definition);
+  while b loop
+    (tokens, tree, ) := scanOpt(tokens, tree, TokenId.FINAL);
+    (tokens, tree) := class_definition(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.SEMICOLON);
+    (tokens, tree, b) := LA1(tokens, tree, First.class_definition);
+    outTree := makeNode(listReverse(tree))::outTree;
+    tree := {};
+  end while;
+  // Eat trailing whitespace so nothing is stripped
+  (tokens, tree) := eatWhitespace(tokens, tree);
+  // Do an EOF check
+  if not listEmpty(tokens) then
+    error(tokens, tree, {});
+  end if;
+  outTree := makeNode(listReverse(listAppend(listAppend(tree, outTree), inTree)))::{};
+end stored_definition;
+
+function class_definition
+  extends partialParser;
+algorithm
+  tree := inTree;
+  (tokens, tree) := scanOpt(tokens, tree, TokenId.ENCAPSULATED);
+  (tokens, tree) := class_prefixes(tokens, tree);
+  (tokens, tree) := class_specifier(tokens, tree);
+  outTree := tree;
+end class_definition;
+
+function class_prefixes
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scanOpt(tokens, tree, TokenId.PARTIAL);
+  (tokens, tree, id) := peek(tokens, tree);
+  _ := match id
+    case TokenId.OPERATOR
+      algorithm
+        (tokens, tree) := consume(tokens, tree);
+        (tokens, tree) := LA1(tokens, tree, {TokenId.RECORD, TokenId.FUNCTION}, consume=true);
+      then ();
+    case TokenId.EXPANDABLE
+      algorithm
+        (tokens, tree) := consume(tokens, tree);
+        (tokens, tree) := scan(tokens, tree, TokenId.CONNECTOR);
+      then ();
+    case id guard listMember(id, {TokenId.PURE, TokenId.IMPURE})
+      algorithm
+        (tokens, tree) := consume(tokens, tree);
+        (tokens, tree, b) := scanOpt(tokens, tree, TokenId.OPERATOR);
+        (tokens, tree) := scanOneOf(tokens, tree, if b then {TokenId.FUNCTION} else {TokenId.FUNCTION, TokenId.RECORD});
+      then ();
+    else
+      algorithm
+        (tokens, tree) := scanOneOf(tokens, tree, {TokenId.CLASS, TokenId.MODEL, TokenId.RECORD, TokenId.BLOCK, TokenId.CONNECTOR, TokenId.TYPE, TokenId.PACKAGE, TokenId.FUNCTION, TokenId.OPERATOR});
+      then ();
+  end match;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end class_prefixes;
+
+function class_specifier
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  tree := inTree;
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.IDENT);
+  if b then
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.EQUALS);
+    if b then
+      (tokens, tree, b) := scanOpt(tokens, tree, TokenId.DER);
+      if b then
+        (tokens, tree) := scan(tokens, tree, TokenId.LPAR);
+        (tokens, tree) := name(tokens, tree);
+        (tokens, tree) := scan(tokens, tree, TokenId.COMMA);
+        (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+        while true loop
+          (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COMMA);
+          if not b then
+            break;
+          end if;
+          (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+        end while;
+        (tokens, tree) := scan(tokens, tree, TokenId.RPAR);
+        (tokens, tree) := comment(tokens, tree);
+      else
+        (tokens, tree) := short_class_specifier1(tokens, tree);
+      end if;
+    else
+      (tokens, tree) := string_comment(tokens, tree);
+      (tokens, tree) := composition(tokens, tree);
+      (tokens, tree) := scan(tokens, tree, TokenId.END);
+      (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+    end if;
+  else
+    (tokens, tree) := scan(tokens, tree, TokenId.EXTENDS);
+    (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+    (tokens, tree, b) := LA1(tokens, tree, First.class_modification);
+    if b then
+      (tokens, tree) := class_modification(tokens, tree);
+    end if;
+    (tokens, tree) := string_comment(tokens, tree);
+    (tokens, tree) := composition(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.END);
+    (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+  end if;
+  outTree := tree;
+end class_specifier;
+
+function short_class_specifier1
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.ENUMERATION);
+  if b then
+    (tokens, tree) := scan(tokens, tree, TokenId.LPAR);
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COLON);
+    if not b then
+      while true loop
+        (tokens, tree) := enumeration_literal(tokens, tree);
+        (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COMMA);
+        if not b then
+          break;
+        end if;
+      end while;
+    end if;
+    (tokens, tree) := scan(tokens, tree, TokenId.RPAR);
+  else
+    (tokens, tree) := base_prefix(tokens, tree);
+    (tokens, tree) := name(tokens, tree);
+    (tokens, tree, b) := LA1(tokens, tree, {TokenId.LBRACK});
+    if b then
+      (tokens, tree) := array_subscripts(tokens, tree);
+    end if;
+    (tokens, tree, b) := LA1(tokens, tree, First.class_modification);
+    if b then
+      (tokens, tree) := class_modification(tokens, tree);
+    end if;
+  end if;
+  (tokens, tree) := comment(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end short_class_specifier1;
+
+function enumeration_literal
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+  (tokens, tree) := comment(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end enumeration_literal;
+
+function composition
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := element_list(tokens, tree);
+  while true loop
+    (tokens, tree, b) := LA1(tokens, tree, {TokenId.PROTECTED, TokenId.PUBLIC, TokenId.INITIAL, TokenId.EQUATION, TokenId.ALGORITHM});
+    if not b then
+      break;
+    end if;
+    (tokens, tree, b) := LA1(tokens, tree, {TokenId.PROTECTED, TokenId.PUBLIC}, consume=true);
+    if b then
+      (tokens, tree) := element_list(tokens, tree);
+    else
+      (tokens, tree) := scanOpt(tokens, tree, TokenId.INITIAL);
+      (tokens, tree, b) := LA1(tokens, tree, {TokenId.ALGORITHM});
+      if b then
+        (tokens, tree) := algorithm_section(tokens, tree);
+      else
+        (tokens, tree) := equation_section(tokens, tree);
+      end if;
+    end if;
+  end while;
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.EXTERNAL);
+  if b then
+    (tokens, tree) := scanOpt(tokens, tree, TokenId.STRING); // language
+    (tokens, tree) := external_function_call(tokens, tree);
+    (tokens, tree, b) := LA1(tokens, tree, First._annotation);
+    if b then
+      (tokens, tree) := _annotation(tokens, tree);
+    end if;
+    (tokens, tree) := scan(tokens, tree, TokenId.SEMICOLON);
+  end if;
+
+  (tokens, tree, b) := LA1(tokens, tree, First._annotation);
+  if b then
+    (tokens, tree) := _annotation(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.SEMICOLON);
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end composition;
+
+function external_function_call
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree, b) := LAk(tokens, tree, {{TokenId.IDENT},{TokenId.LPAR}});
+  if not b then
+    (tokens, tree) := component_reference(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.EQUALS);
+  end if;
+  (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+  (tokens, tree) := scan(tokens, tree, TokenId.LPAR);
+  (tokens, tree) := expression_list(tokens, tree);
+  (tokens, tree) := scan(tokens, tree, TokenId.RPAR);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end external_function_call;
+
+function algorithm_section
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scanOpt(tokens, tree, TokenId.INITIAL);
+  (tokens, tree) := scan(tokens, tree, TokenId.ALGORITHM);
+  (tokens, tree) := statement_list(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end algorithm_section;
+
+function statement
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree, id) := peek(tokens, tree);
+  if id==TokenId.BREAK or id==TokenId.RETURN then
+    (tokens, tree) := consume(tokens, tree);
+  elseif listMember(id, First.component_reference) then
+    (tokens, tree) := component_reference(tokens, tree);
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.ASSIGN);
+    if b then
+      (tokens, tree) := expression(tokens, tree);
+    else
+      (tokens, tree) := function_call_args(tokens, tree);
+    end if;
+  elseif id==TokenId.IF then
+    (tokens, tree) := consume(tokens, tree);
+    (tokens, tree) := expression(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.THEN);
+    (tokens, tree) := statement_list(tokens, tree);
+    while true loop
+      (tokens, tree, b) := scanOpt(tokens, tree, TokenId.ELSEIF);
+      if not b then
+        break;
+      end if;
+      (tokens, tree) := expression(tokens, tree);
+      (tokens, tree) := scan(tokens, tree, TokenId.THEN);
+      (tokens, tree) := statement_list(tokens, tree);
+    end while;
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.ELSE);
+    if b then
+      (tokens, tree) := statement_list(tokens, tree);
+    end if;
+    (tokens, tree) := scan(tokens, tree, TokenId.END);
+    (tokens, tree) := scan(tokens, tree, TokenId.IF);
+  elseif id==TokenId.WHEN then
+    (tokens, tree) := consume(tokens, tree);
+    (tokens, tree) := expression(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.THEN);
+    (tokens, tree) := statement_list(tokens, tree);
+    while true loop
+      (tokens, tree, b) := scanOpt(tokens, tree, TokenId.ELSEWHEN);
+      if not b then
+        break;
+      end if;
+      (tokens, tree) := expression(tokens, tree);
+      (tokens, tree) := scan(tokens, tree, TokenId.THEN);
+      (tokens, tree) := statement_list(tokens, tree);
+    end while;
+    (tokens, tree) := scan(tokens, tree, TokenId.END);
+    (tokens, tree) := scan(tokens, tree, TokenId.WHEN);
+  elseif id==TokenId.FOR then
+    (tokens, tree) := consume(tokens, tree);
+    (tokens, tree) := for_indices(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.LOOP);
+    (tokens, tree) := statement_list(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.END);
+    (tokens, tree) := scan(tokens, tree, TokenId.FOR);
+  elseif id==TokenId.WHILE then
+    (tokens, tree) := consume(tokens, tree);
+    (tokens, tree) := expression(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.LOOP);
+    (tokens, tree) := statement_list(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.END);
+    (tokens, tree) := scan(tokens, tree, TokenId.WHILE);
+  else
+    (tokens, tree) := expression(tokens, tree);
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.ASSIGN);
+    if b then
+      (tokens, tree) := expression(tokens, tree);
+    end if;
+  end if;
+  (tokens, tree) := comment(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end statement;
+
+function statement_list
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  outTree := {};
+  while true loop
+    (tokens, tree, b) := LA1(tokens, tree, Follow.statement_equation);
+    if b then
+      break;
+    end if;
+    (tokens, tree) := statement(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.SEMICOLON);
+
+    outTree := makeNode(listReverse(tree))::outTree;
+    tree := {};
+  end while;
+  outTree := listAppend(tree, listAppend(outTree, inTree));
+end statement_list;
+
+function equation_section
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scanOpt(tokens, tree, TokenId.INITIAL);
+  (tokens, tree) := scan(tokens, tree, TokenId.EQUATION);
+  (tokens, tree) := equation_list(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end equation_section;
+
+function _equation
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree, id) := peek(tokens, tree);
+  if id==TokenId.IF then
+    (tokens, tree) := consume(tokens, tree);
+    (tokens, tree) := expression(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.THEN);
+    (tokens, tree) := equation_list(tokens, tree);
+    while true loop
+      (tokens, tree, b) := scanOpt(tokens, tree, TokenId.ELSEIF);
+      if not b then
+        break;
+      end if;
+      (tokens, tree) := expression(tokens, tree);
+      (tokens, tree) := scan(tokens, tree, TokenId.THEN);
+      (tokens, tree) := equation_list(tokens, tree);
+    end while;
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.ELSE);
+    if b then
+      (tokens, tree) := equation_list(tokens, tree);
+    end if;
+    (tokens, tree) := scan(tokens, tree, TokenId.END);
+    (tokens, tree) := scan(tokens, tree, TokenId.IF);
+  elseif id==TokenId.WHEN then
+    (tokens, tree) := consume(tokens, tree);
+    (tokens, tree) := expression(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.THEN);
+    (tokens, tree) := equation_list(tokens, tree);
+    while true loop
+      (tokens, tree, b) := scanOpt(tokens, tree, TokenId.ELSEWHEN);
+      if not b then
+        break;
+      end if;
+      (tokens, tree) := expression(tokens, tree);
+      (tokens, tree) := scan(tokens, tree, TokenId.THEN);
+      (tokens, tree) := equation_list(tokens, tree);
+    end while;
+    (tokens, tree) := scan(tokens, tree, TokenId.END);
+    (tokens, tree) := scan(tokens, tree, TokenId.WHEN);
+  elseif id==TokenId.FOR then
+    (tokens, tree) := consume(tokens, tree);
+    (tokens, tree) := for_indices(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.LOOP);
+    (tokens, tree) := equation_list(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.END);
+    (tokens, tree) := scan(tokens, tree, TokenId.FOR);
+  elseif id==TokenId.CONNECT then
+    (tokens, tree) := consume(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.LPAR);
+    (tokens, tree) := component_reference(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.COMMA);
+    (tokens, tree) := component_reference(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.RPAR);
+  else
+    (tokens, tree) := expression(tokens, tree);
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.EQUALS);
+    if b then
+      (tokens, tree) := expression(tokens, tree);
+    end if;
+  end if;
+  (tokens, tree) := comment(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end _equation;
+
+function equation_list
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  outTree := {};
+  while true loop
+    (tokens, tree, b) := LA1(tokens, tree, Follow.statement_equation);
+    if b then
+      break;
+    end if;
+    (tokens, tree) := _equation(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.SEMICOLON);
+
+    outTree := makeNode(listReverse(tree))::outTree;
+    tree := {};
+  end while;
+  outTree := listAppend(tree, listAppend(outTree, inTree));
+end equation_list;
+
+function element_list
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  outTree := {};
+  while true loop
+    (tokens, tree, b) := LA1(tokens, tree, First.element);
+    if not b then
+      break;
+    end if;
+    (tokens, tree) := element(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.SEMICOLON);
+
+    outTree := makeNode(listReverse(tree))::outTree;
+    tree := {};
+  end while;
+  outTree := listAppend(tree, listAppend(outTree, inTree));
+end element_list;
+
+function element
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b,b1;
+algorithm
+  (tokens, tree, id) := peek(tokens, tree);
+  _ := match id
+    case TokenId.IMPORT
+      algorithm
+        (tokens, tree) := import_clause(tokens, tree);
+      then ();
+    case TokenId.EXTENDS
+      algorithm
+        (tokens, tree) := extends_clause(tokens, tree);
+      then ();
+    else
+      algorithm
+        (tokens, tree) := scanOpt(tokens, tree, TokenId.REDECLARE);
+        (tokens, tree) := scanOpt(tokens, tree, TokenId.FINAL);
+        (tokens, tree) := scanOpt(tokens, tree, TokenId.INNER);
+        (tokens, tree) := scanOpt(tokens, tree, TokenId.OUTER);
+        (tokens, tree, b1) := scanOpt(tokens, tree, TokenId.REPLACEABLE);
+        (tokens, tree, b) := LA1(tokens, tree, First.class_definition);
+        if b then
+          (tokens, tree) := class_definition(tokens, tree);
+        else
+          (tokens, tree) := component_clause(tokens, tree);
+        end if;
+        if b1 then
+          (tokens, tree, b) := LA1(tokens, tree, {TokenId.CONSTRAINEDBY});
+          if b then
+            (tokens, tree) := constraining_clause(tokens, tree);
+            (tokens, tree) := comment(tokens, tree);
+          end if;
+        end if;
+      then ();
+  end match;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end element;
+
+function constraining_clause
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.CONSTRAINEDBY);
+  (tokens, tree) := name(tokens, tree);
+  (tokens, tree, b) := LA1(tokens, tree, First.class_modification);
+  if b then
+    (tokens, tree) := class_modification(tokens, tree);
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end constraining_clause;
+
+function component_clause
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := type_prefix(tokens, tree);
+  (tokens, tree) := type_specifier(tokens, tree);
+  (tokens, tree, b) := LA1(tokens, tree, {TokenId.LBRACK});
+  if b then
+    (tokens, tree) := array_subscripts(tokens, tree);
+  end if;
+  (tokens, tree) := component_list(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end component_clause;
+
+function import_clause
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.IMPORT);
+  (tokens, tree, b) := LAk(tokens, tree, {{TokenId.IDENT}, {TokenId.EQUALS}});
+  if b then
+    (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+    (tokens, tree) := scan(tokens, tree, TokenId.EQUALS);
+    (tokens, tree) := name(tokens, tree);
+  else
+    (tokens, tree) := name(tokens, tree);
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.STAR_EW);
+    if not b then
+      (tokens, tree, b) := scanOpt(tokens, tree, TokenId.DOT);
+      if b then
+        (tokens, tree) := scan(tokens, tree, TokenId.LBRACE);
+        (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+        while true loop
+          (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COMMA);
+          if not b then
+            break;
+          end if;
+          (tokens, tree, b) := scanOpt(tokens, tree, TokenId.IDENT);
+        end while;
+        (tokens, tree) := scan(tokens, tree, TokenId.RBRACE);
+      end if;
+    end if;
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end import_clause;
+
+function type_specifier = name;
+function base_prefix = type_prefix;
+
+function type_prefix
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := LA1(tokens, tree, {TokenId.FLOW, TokenId.STREAM}, consume=true);
+  (tokens, tree) := LA1(tokens, tree, {TokenId.DISCRETE, TokenId.PARAMETER, TokenId.CONSTANT}, consume=true);
+  (tokens, tree) := LA1(tokens, tree, {TokenId.INPUT, TokenId.OUTPUT}, consume=true);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end type_prefix;
+
+function array_subscripts
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.LBRACK);
+  (tokens, tree) := subscript(tokens, tree);
+  while true loop
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COMMA);
+    if not b then
+      break;
+    end if;
+    (tokens, tree) := subscript(tokens, tree);
+  end while;
+  (tokens, tree) := scan(tokens, tree, TokenId.RBRACK);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end array_subscripts;
+
+function subscript
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COLON);
+  if not b then
+    (tokens, tree) := expression(tokens, tree);
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end subscript;
+
+function component_list
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := component_declaration(tokens, tree);
+  while true loop
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COMMA);
+    if not b then
+      break;
+    end if;
+    (tokens, tree) := component_declaration(tokens, tree);
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end component_list;
+
+function component_declaration
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := declaration(tokens, tree);
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.IF);
+  if b then
+    (tokens, tree) := expression(tokens, tree);
+  end if;
+  // print("component_declaration: comment1 "+topTokenStr(tokens)+"\n");
+  (tokens, tree) := comment(tokens, tree);
+  // print("component_declaration: comment2 "+topTokenStr(tokens)+"\n");
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end component_declaration;
+
+function declaration
+  extends partialParser;
+  output ParseTree nodeName;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+  nodeName::_ := tree;
+  (tokens, tree, b) := LA1(tokens, tree, {TokenId.LBRACK});
+  if b then
+    (tokens, tree) := array_subscripts(tokens, tree);
+  end if;
+  (tokens, tree, b) := LA1(tokens, tree, First.modification);
+  // print("declaration has modification?: "+String(b)+"\n");
+  if b then
+    // print("before mod: "+topTokenStr(tokens)+"\n");
+    (tokens, tree) := modification(tokens, tree);
+    // print("after mod: "+topTokenStr(tokens)+"\n");
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end declaration;
+
+function component_clause1
+  extends partialParser;
+  output ParseTree nodeName;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := type_prefix(tokens, tree);
+  (tokens, tree) := type_specifier(tokens, tree);
+  (tokens, tree, nodeName) := component_declaration1(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end component_clause1;
+
+function component_declaration1
+  extends partialParser;
+  output ParseTree nodeName;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree, nodeName) := declaration(tokens, tree);
+  (tokens, tree) := comment(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end component_declaration1;
+
+function extends_clause
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.EXTENDS);
+  (tokens, tree) := name(tokens, tree);
+  (tokens, tree, b) := LA1(tokens, tree, First.class_modification);
+  if b then
+    (tokens, tree) := class_modification(tokens, tree);
+  end if;
+  (tokens, tree, b) := LA1(tokens, tree, First._annotation);
+  if b then
+    // (tokens, tree) := _annotation(tokens, tree);
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end extends_clause;
+
+function class_modification
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.LPAR);
+  (tokens, tree, b) := LA1(tokens, tree, First.argument);
+  if b then
+    (tokens, tree) := argument_list(tokens, tree);
+  end if;
+  (tokens, tree) := scan(tokens, tree, TokenId.RPAR);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end class_modification;
+
+function argument_list
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := argument(tokens, tree);
+  b := true;
+  while b loop
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COMMA);
+    if b then
+      (tokens, tree) := argument(tokens, tree);
+    end if;
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end argument_list;
+
+function argument
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+  ParseTree nodeName;
+algorithm
+  (tokens, tree, b) := LA1(tokens, tree, {TokenId.REDECLARE});
+  if b then
+    (tokens, tree, nodeName) := element_redeclaration(tokens, tree);
+  else
+    (tokens, tree, nodeName) := element_modification_or_replaceable(tokens, tree);
+  end if;
+  nodeName := makeNode(listReverse(tree), label=nodeName);
+  outTree := nodeName::inTree;
+end argument;
+
+function element_redeclaration
+  extends partialParser;
+  output ParseTree nodeName;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.REDECLARE);
+  (tokens, tree) := scanOpt(tokens, tree, TokenId.EACH);
+  (tokens, tree) := scanOpt(tokens, tree, TokenId.FINAL);
+  (tokens, tree, b) := LA1(tokens, tree, {TokenId.REPLACEABLE});
+  if b then
+    (tokens, tree) := element_replaceable(tokens, tree);
+  else
+    (tokens, tree, b) := LA1(tokens, tree, First.class_prefixes);
+    if b then
+      (tokens, tree, nodeName) := short_class_definition(tokens, tree);
+    else
+      (tokens, tree, nodeName) := component_clause1(tokens, tree);
+    end if;
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end element_redeclaration;
+
+function short_class_definition
+  extends partialParser;
+  output ParseTree nodeName;
+protected
+  TokenId id;
+  Boolean b;
+  Token nodeNameT;
+algorithm
+  (tokens, tree) := class_prefixes(tokens, tree);
+  (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+  nodeName::_ := tree;
+  (tokens, tree) := scan(tokens, tree, TokenId.EQUALS);
+  (tokens, tree) := short_class_specifier1(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end short_class_definition;
+
+function element_modification_or_replaceable
+  extends partialParser;
+  output ParseTree nodeName;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scanOpt(tokens, tree, TokenId.EACH);
+  (tokens, tree) := scanOpt(tokens, tree, TokenId.FINAL);
+  (tokens, tree, b) := LA1(tokens, tree, {TokenId.REPLACEABLE});
+  if b then
+    (tokens, tree, nodeName) := element_replaceable(tokens, tree);
+  else
+    (tokens, tree, nodeName) := element_modification(tokens, tree);
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end element_modification_or_replaceable;
+
+function element_replaceable
+  extends partialParser;
+  output ParseTree nodeName;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.REPLACEABLE);
+  (tokens, tree, b) := LA1(tokens, tree, First.component_clause);
+  if b then
+    (tokens, tree, nodeName) := component_clause1(tokens, tree);
+  else
+    (tokens, tree, nodeName) := short_class_definition(tokens, tree);
+  end if;
+  (tokens, tree, b) := LA1(tokens, tree, {TokenId.CONSTRAINEDBY});
+  if b then
+    (tokens, tree) := constraining_clause(tokens, tree);
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end element_replaceable;
+
+function element_modification
+  extends partialParser;
+  output ParseTree nodeName;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := name(tokens, tree);
+  nodeName::_ := tree;
+  (tokens, tree, b) := LA1(tokens, tree, First.modification);
+  if b then
+    (tokens, tree) := modification(tokens, tree);
+  end if;
+  (tokens, tree) := string_comment(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end element_modification;
+
+function modification
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree, b) := LA1(tokens, tree, First.class_modification);
+  if b then
+    (tokens, tree) := class_modification(tokens, tree);
+    (tokens, tree) := eatWhitespace(tokens, tree);
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.EQUALS);
+    (tokens, tree) := eatWhitespace(tokens, tree);
+    if b then
+      (tokens, tree) := expression(tokens, tree);
+    end if;
+  else
+    (tokens, tree) := eatWhitespace(tokens, tree);
+    (tokens, tree) := scanOneOf(tokens, tree, {TokenId.EQUALS, TokenId.ASSIGN});
+    (tokens, tree) := eatWhitespace(tokens, tree);
+    (tokens, tree) := expression(tokens, tree);
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end modification;
+
+function expression_list
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  while true loop
+    (tokens, tree) := expression(tokens, tree);
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COMMA);
+    if not b then
+      break;
+    end if;
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end expression_list;
+
+function expression
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.IF);
+  if b then
+    (tokens, tree) := expression(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.THEN);
+    (tokens, tree) := expression(tokens, tree);
+    while true loop
+      (tokens, tree, b) := scanOpt(tokens, tree, TokenId.ELSEIF);
+      if not b then
+        break;
+      end if;
+      (tokens, tree) := expression(tokens, tree);
+      (tokens, tree) := scan(tokens, tree, TokenId.THEN);
+      (tokens, tree) := expression(tokens, tree);
+    end while;
+    (tokens, tree) := scan(tokens, tree, TokenId.ELSE);
+    (tokens, tree) := expression(tokens, tree);
+  else
+    (tokens, tree) := simple_expression(tokens, tree);
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end expression;
+
+function simple_expression
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := logical_expression(tokens, tree);
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COLON);
+  if b then
+    (tokens, tree) := logical_expression(tokens, tree);
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COLON);
+    if b then
+      (tokens, tree) := logical_expression(tokens, tree);
+    end if;
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end simple_expression;
+
+function logical_expression
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := logical_term(tokens, tree);
+  while true loop
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.OR);
+    if not b then
+      break;
+    end if;
+    (tokens, tree) := logical_term(tokens, tree);
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end logical_expression;
+
+function logical_term
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := logical_factor(tokens, tree);
+  while true loop
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.AND);
+    if not b then
+      break;
+    end if;
+    (tokens, tree) := logical_factor(tokens, tree);
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end logical_term;
+
+function logical_factor
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.NOT);
+  (tokens, tree) := relation(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end logical_factor;
+
+function relation
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+  constant list<TokenId> rel_op = {TokenId.LESS, TokenId.LESSEQ, TokenId.GREATER, TokenId.GREATEREQ, TokenId.EQEQ, TokenId.LESSGT};
+algorithm
+  (tokens, tree) := arithmetic_expression(tokens, tree);
+  while true loop
+    (tokens, tree, b) := LA1(tokens, tree, rel_op, consume=true);
+    if not b then
+      break;
+    end if;
+    (tokens, tree) := arithmetic_expression(tokens, tree);
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end relation;
+
+function arithmetic_expression
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+  constant list<TokenId> add_op = {TokenId.PLUS, TokenId.MINUS, TokenId.PLUS_EW, TokenId.MINUS_EW};
+algorithm
+  (tokens, tree) := LA1(tokens, tree, add_op, consume=true);
+  (tokens, tree) := term(tokens, tree);
+  while true loop
+    (tokens, tree, b) := LA1(tokens, tree, add_op, consume=true);
+    if not b then
+      break;
+    end if;
+    (tokens, tree) := term(tokens, tree);
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end arithmetic_expression;
+
+function term
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+  constant list<TokenId> mul_op = {TokenId.STAR, TokenId.STAR_EW, TokenId.SLASH, TokenId.SLASH_EW};
+algorithm
+  (tokens, tree) := factor(tokens, tree);
+  while true loop
+    (tokens, tree, b) := LA1(tokens, tree, mul_op, consume=true);
+    if not b then
+      break;
+    end if;
+    (tokens, tree) := factor(tokens, tree);
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end term;
+
+function factor
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+  constant list<TokenId> pow_op = {TokenId.POWER, TokenId.POWER_EW};
+algorithm
+  (tokens, tree) := primary(tokens, tree);
+  while true loop
+    (tokens, tree, b) := LA1(tokens, tree, pow_op, consume=true);
+    if not b then
+      break;
+    end if;
+    (tokens, tree) := primary(tokens, tree);
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end factor;
+
+function primary
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree, b) := LA1(tokens, tree, {TokenId.UNSIGNED_INTEGER, TokenId.UNSIGNED_REAL, TokenId.FALSE, TokenId.TRUE, TokenId.END, TokenId.STRING});
+  if b then
+    (tokens, tree) := consume(tokens, tree);
+    outTree := makeNodePrependTree(listReverse(tree), inTree);
+    return;
+  end if;
+  (tokens, tree, id) := peek(tokens, tree);
+  if id==TokenId.LPAR then
+    (tokens, tree) := output_expression_list(tokens, tree);
+  elseif id==TokenId.LBRACE then
+    (tokens, tree) := scan(tokens, tree, TokenId.LBRACE);
+    (tokens, tree, b) := LA1(tokens, tree, {TokenId.RBRACE}); // Easier than checking First(expression), etc
+    if not b then
+      (tokens, tree) := function_arguments(tokens, tree);
+    end if;
+    (tokens, tree) := scan(tokens, tree, TokenId.RBRACE);
+  elseif id==TokenId.LBRACK then
+    (tokens, tree) := consume(tokens, tree);
+    (tokens, tree) := expression_list(tokens, tree);
+    while true loop
+      (tokens, tree, b) := scanOpt(tokens, tree, TokenId.SEMICOLON);
+      if not b then
+        break;
+      end if;
+      (tokens, tree) := expression_list(tokens, tree);
+    end while;
+    (tokens, tree) := scan(tokens, tree, TokenId.RBRACK);
+  elseif listMember(id, {TokenId.DER, TokenId.INITIAL}) then
+    (tokens, tree) := consume(tokens, tree);
+    (tokens, tree, b) := LA1(tokens, tree, {TokenId.LPAR});
+    if b then
+      (tokens, tree) := function_call_args(tokens, tree);
+    end if;
+  elseif listMember(id, {TokenId.DOT, TokenId.IDENT}) then
+    (tokens, tree) := component_reference(tokens, tree);
+    (tokens, tree, b) := LA1(tokens, tree, {TokenId.LPAR});
+    if b then
+      (tokens, tree) := function_call_args(tokens, tree);
+    end if;
+  else
+    error(tokens, tree, {});
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end primary;
+
+function function_call_args
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.LPAR);
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.RPAR); // Easier than checking First.expression, etc
+  if not b then
+    (tokens, tree) := function_arguments(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.RPAR);
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end function_call_args;
+
+function function_arguments
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+  list<ParseTree> tree2;
+algorithm
+  (tokens, tree, b) := LAk(tokens, tree, {{TokenId.IDENT}, {TokenId.EQUALS}});
+  if b then
+    (tokens, tree) := named_arguments(tokens, tree);
+  else
+    (tokens, tree) := function_argument(tokens, tree);
+    (tokens, tree2, b) := scanOpt(tokens, {}, TokenId.COMMA);
+    if b then
+      tree := makeNode(listReverse(tree2))::tree;
+      (tokens, tree) := function_arguments(tokens, tree);
+    else
+      (tokens, tree, b) := scanOpt(tokens, tree, TokenId.FOR);
+      if b then
+        (tokens, tree) := for_indices(tokens, tree);
+      end if;
+    end if;
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end function_arguments;
+
+function function_argument
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.FUNCTION);
+  if b then
+    (tokens, tree) := name(tokens, tree);
+    (tokens, tree) := scan(tokens, tree, TokenId.LPAR);
+    (tokens, tree, b) := LA1(tokens, tree, {TokenId.IDENT});
+    if b then
+      (tokens, tree) := named_arguments(tokens, tree);
+    end if;
+    (tokens, tree) := scan(tokens, tree, TokenId.RPAR);
+  else
+    (tokens, tree) := expression(tokens, tree);
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end function_argument;
+
+function named_arguments
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := named_argument(tokens, tree);
+  while true loop
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COMMA);
+    if not b then
+      break;
+    end if;
+    (tokens, tree) := named_argument(tokens, tree);
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end named_arguments;
+
+function named_argument
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+  (tokens, tree) := scan(tokens, tree, TokenId.EQUALS);
+  (tokens, tree) := expression(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end named_argument;
+
+function for_indices
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := for_index(tokens, tree);
+  while true loop
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.COMMA);
+    if not b then
+      break;
+    end if;
+    (tokens, tree) := for_index(tokens, tree);
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end for_indices;
+
+function for_index
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.IN);
+  if b then
+    (tokens, tree) := expression(tokens, tree);
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end for_index;
+
+function string_comment
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree, b) := scanOpt(tokens, tree, TokenId.STRING);
+  while b loop
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.PLUS);
+    if b then
+      (tokens, tree) := scan(tokens, tree, TokenId.STRING);
+    end if;
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end string_comment;
+
+function output_expression_list
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b1, b2;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.LPAR);
+  while true loop
+    (tokens, tree, b1) := scanOpt(tokens, tree, TokenId.COMMA);
+    (tokens, tree, b2) := scanOpt(tokens, tree, TokenId.RPAR);
+    if b2 then
+      break;
+    end if;
+    if not b1 then
+      (tokens, tree) := expression(tokens, tree);
+    end if;
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end output_expression_list;
+
+function name
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scanOpt(tokens, tree, TokenId.DOT);
+  (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+  while true loop
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.DOT);
+    if not b then
+      break;
+    end if;
+    (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end name;
+
+function component_reference
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scanOpt(tokens, tree, TokenId.DOT);
+  while true loop
+    (tokens, tree) := scan(tokens, tree, TokenId.IDENT);
+    (tokens, tree, b) := LA1(tokens, tree, {TokenId.LBRACK});
+    if b then
+      (tokens, tree) := array_subscripts(tokens, tree);
+    end if;
+    (tokens, tree, b) := scanOpt(tokens, tree, TokenId.DOT);
+    if not b then
+      break;
+    end if;
+  end while;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end component_reference;
+
+function comment
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := string_comment(tokens, tree);
+  (tokens, tree, b) := LA1(tokens, tree, First._annotation);
+  if b then
+    (tokens, tree) := _annotation(tokens, tree);
+  end if;
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end comment;
+
+function _annotation
+  extends partialParser;
+protected
+  TokenId id;
+  Boolean b;
+algorithm
+  (tokens, tree) := scan(tokens, tree, TokenId.ANNOTATION);
+  (tokens, tree) := class_modification(tokens, tree);
+  outTree := makeNodePrependTree(listReverse(tree), inTree);
+end _annotation;
+
+function parseTreeStr
+  input list<ParseTree> trees;
+  output String str;
+protected
+  Integer i;
+algorithm
+  i := Print.saveAndClearBuf();
+  try
+    for tree in trees loop
+      parseTreeStrWork(tree);
+    end for;
+    str := Print.getString();
+    Print.restoreBuf(i);
+  else
+    Print.restoreBuf(i);
+    fail();
+  end try;
+end parseTreeStr;
+
+function treeDiff
+  input list<ParseTree> t1, t2;
+  input Integer nTokens "The number of tokens in the larger tree; used to allocate arrays. Should be enough with the smaller tree, but there are no additional bounds checks this way.";
+  output list<tuple<Diff,list<ParseTree>>> res;
+protected
+  array<Token> diffSubtreeWorkArray1, diffSubtreeWorkArray2 "Used to handle diff of trees without using stack space or new allocations for every step";
+  list<ParseTree> tree;
+algorithm
+  diffSubtreeWorkArray1 := MetaModelica.Dangerous.arrayCreateNoInit(nTokens, LexerModelicaDiff.noToken);
+  diffSubtreeWorkArray2 := MetaModelica.Dangerous.arrayCreateNoInit(nTokens, LexerModelicaDiff.noToken);
+  if parseTreeEq(makeNode(t1), makeNode(t2), diffSubtreeWorkArray1=diffSubtreeWorkArray1, diffSubtreeWorkArray2=diffSubtreeWorkArray2) then
+    // We need to do one check here since we assume the trees are different in the diff algorithm...
+    res := {(Diff.Equal, t1)};
+    return;
+  end if;
+  res := treeDiffWork(t1, t2, 1, function parseTreeEq(diffSubtreeWorkArray1=diffSubtreeWorkArray1, diffSubtreeWorkArray2=diffSubtreeWorkArray2));
+end treeDiff;
+
+partial function CmpParseTreeFunc
+  input ParseTree t1, t2;
+  output Boolean b;
+end CmpParseTreeFunc;
+
+function treeDiffWork
+  input list<ParseTree> t1, t2;
+  input Integer depth;
+  input CmpParseTreeFunc compare;
+  output list<tuple<Diff,list<ParseTree>>> res, resLocal;
+protected
+  list<ParseTree> before, middle, after, addedTrees, deletedTrees;
+  Integer nadd, ndel;
+  ParseTree addedTree, deletedTree, addedLabel, deletedLabel;
+  Boolean addedBeforeDeleted, joinTrees;
+  tuple<Diff,list<ParseTree>> diff1;
+algorithm
+  // Speed-up. No deep compare for single nodes...
+  _ := match (t1, t2)
+    case ({NODE(nodes=before)}, {NODE(nodes=after)})
+      algorithm
+        res := treeDiffWork(before, after, depth, compare);
+        return;
+      then ();
+    case ({NODE(nodes=before)}, _)
+      algorithm
+        res := treeDiffWork(before, t2, depth, compare);
+        return;
+      then ();
+    case (_, {NODE(nodes=after)})
+      algorithm
+        res := treeDiffWork(t1, after, depth, compare);
+        return;
+      then ();
+    else ();
+  end match;
+  if debug then
+    print("Do diff at depth="+String(depth)+", len(t1)="+String(listLength(t1))+", len(t2)="+String(listLength(t2))+"\n");
+    print("top t1="+firstTokenDebugStr(t1)+"\n");
+    print("top t2="+firstTokenDebugStr(t2)+"\n");
+    print("all t1="+parseTreeStr(t1)+"\n");
+    print("all t2="+parseTreeStr(t2)+"\n");
+  end if;
+  res := diff(t1, t2, compare, parseTreeIsWhitespace, parseTreeNodeStr);
+  (nadd, ndel) := countDiffAddDelete(res);
+  if nadd > 1 then
+    res := fixMoveOperations(res, compare);
+    (nadd, ndel) := countDiffAddDelete(res);
+  end if;
+  if debug then
+    print("nadd: " + String(nadd) + " ndel: " + String(ndel) + "\n");
+    print(DiffAlgorithm.printDiffXml(res, parseTreeNodeStr) + "\n");
+  end if;
+  if depth>300 then
+    // Do nothing; it's a diff... Just not perfect and might be really slow to process...
+  elseif nadd==1 and ndel==1 then
+    (addedTree, deletedTree, before, middle, after, addedBeforeDeleted) := extractSingleAddDiffBeforeAndAfter(res);
+    // print("Doing tree diff on selected 1 addition + 1 deletion\n");
+    // print("Added tree:"+parseTreeNodeStr(addedTree)+"\n");
+    // print("Deleted tree:"+parseTreeNodeStr(deletedTree)+"\n");
+    joinTrees := true;
+    if compare(addedTree, deletedTree) then
+      // This is just a move operation; preserve whitespace
+      res := {(Diff.Equal,{deletedTree})};
+    elseif isLeaf(deletedTree) and isLeaf(addedTree) then
+      res := res;
+      joinTrees := false;
+    elseif listEmpty(before) and listEmpty(after) then
+      if debug then
+        print("before and after empty\n");
+      end if;
+      res := res;
+    else
+      res := treeDiffWork(getNodes(deletedTree), getNodes(addedTree), depth+1, compare);
+    end if;
+    if not joinTrees then
+      res := res;
+      if debug then
+        print("not joining trees"+DiffAlgorithm.printDiffTerminalColor(res, parseTreeNodeStr)+"\n");
+      end if;
+    elseif listEmpty(middle) then
+      // We have the add and delete next to each other.
+      // This means we can keep the diff as it since nothing moved.
+      if debug then
+        print("middle empty\n");
+      end if;
+      res := (Diff.Equal, before) :: listAppend(res, {(Diff.Equal, after)});
+    else
+      // We have a move with changes. Make the deleted simply be deleted.
+      // The added parts become the Equal and Added parts in the diff
+      res := list(i for i guard match i case (Diff.Delete,_) then false; else true; end match in res);
+      if addedBeforeDeleted then
+        res := (Diff.Equal, before) ::
+                listAppend(res,
+                  (Diff.Equal, middle) ::
+                  (Diff.Delete, {deletedTree}) ::
+                  {(Diff.Equal, after)});
+      else
+        res := (Diff.Equal, before) ::
+               (Diff.Delete, {deletedTree}) ::
+               (Diff.Equal, middle) ::
+               listAppend(res,{(Diff.Equal, after)});
+      end if;
+    end if;
+    if debug then
+      print(String(depth) + " merged tree size: " + String(stringLength(DiffAlgorithm.printActual(res, SimpleModelicaParser.parseTreeNodeStr))) + "\n");
+      print(String(depth) + " before top="+firstTokenDebugStr(before)+"\n");
+      print(" before all="+parseTreeStr(before)+"\n");
+      print("middle top="+firstTokenDebugStr(middle)+"\n");
+      print("after top="+firstTokenDebugStr(after)+"\n");
+      print("added top="+firstTokenDebugStr(addedTree::{})+"\n");
+      print("deleted top="+firstTokenDebugStr(deletedTree::{})+"\n");
+    end if;
+  elseif nadd>1 and ndel>1 then
+    (addedTrees, deletedTrees) := extractAdditionsDeletions(res);
+    // TODO: Move this into extractAdditionsDeletions?
+    addedTrees := list(t for t guard isLabeledNode(t) in addedTrees);
+    deletedTrees := list(t for t guard isLabeledNode(t) in deletedTrees);
+    // O(D*D)
+    for added in addedTrees loop
+      for deleted in deletedTrees loop
+        if compare(nodeLabel(added),nodeLabel(deleted)) then
+          resLocal := treeDiffWork(getNodes(deleted), getNodes(added), depth+1, compare);
+          res := replaceLabeledDiff(res, resLocal, nodeLabel(added), compare);
+        end if;
+      end for;
+    end for;
+  else
+    // print(DiffAlgorithm.printDiffXml(res, parseTreeNodeStr) + "\n");
+  end if;
+  res := filterDiffWhitespace(res);
+  if depth==1 then
+    // print(DiffAlgorithm.printDiffTerminalColor(res, parseTreeNodeStr) + "\n");
+  end if;
+end treeDiffWork;
+
+function parseTreeNodeStr
+  input ParseTree tree;
+  output String str;
+protected
+  Integer i;
+algorithm
+  i := Print.saveAndClearBuf();
+  try
+    parseTreeStrWork(tree);
+    str := Print.getString();
+    Print.restoreBuf(i);
+  else
+    Print.restoreBuf(i);
+    fail();
+  end try;
+end parseTreeNodeStr;
+
+protected
+
+function filterDiffWhitespace
+  input list<tuple<Diff,list<ParseTree>>> inDiff;
+  output list<tuple<Diff,list<ParseTree>>> diff;
+protected
+  list<tuple<Diff,list<ParseTree>>> diffLocal=inDiff;
+  tuple<Diff,list<ParseTree>> diff1;
+  Boolean firstIter, lastTokenNewline, hasAddedWS;
+  list<ParseTree> tree, treeLocal, tree1, tree2;
+  Integer length, level;
+  list<Integer> indentation;
+  list<Token> tokens;
+  Diff diffEnum;
+  String indentationStr;
+  Token tok;
+algorithm
+  diff := {};
+  firstIter := true;
+  while not listEmpty(diffLocal) loop
+    diffLocal := match diffLocal
+      // Do not delete whitespace in-between two tokens
+      case ((Diff.Delete, tree)::(diffLocal as ((Diff.Equal,_)::_)))
+        guard if firstIter then min(parseTreeIsWhitespaceOrPar(t) for t in tree) else false
+        algorithm
+          diff := (Diff.Equal, tree)::diff;
+        then diffLocal;
+      case ((diff1 as (Diff.Equal,_))::(Diff.Delete, tree)::(diffLocal as ((Diff.Equal,_)::_)))
+        guard min(parseTreeIsWhitespaceOrPar(t) for t in tree)
+        algorithm
+          diff := (Diff.Equal, tree)::diff1::diff;
+        then diffLocal;
+      case ((diff1 as (Diff.Equal,_))::(Diff.Delete, tree)::{})
+        guard min(parseTreeIsWhitespaceOrPar(t) for t in tree)
+        algorithm
+          diff := (Diff.Equal, tree)::diff1::diff;
+        then diffLocal;
+      case ((diff1 as (Diff.Equal,tree1 as (_::_)))::(Diff.Delete, tree)::(diffLocal as ((Diff.Equal,tree2 as (_::_))::_)))
+        guard needsWhitespaceBetweenTokens(lastToken(List.last(tree1)), firstTokenInTree(listGet(tree2, 1)))
+        algorithm
+          diff := (Diff.Equal, {LEAF(makeToken(TokenId.WHITESPACE, " "))})::diff1::diff;
+        then diffLocal;
+      case ((diff1 as (Diff.Equal,tree1 as (_::_)))::(Diff.Delete, tree)::(diffLocal as ((Diff.Equal,tree2 as (_::_))::_)))
+        algorithm
+          diff := diff1::diff;
+        then (Diff.Delete, tree)::diffLocal;
+      // Do not add whitespace for no good reason
+      case ((Diff.Add, tree)::(diffLocal as ((Diff.Equal,_)::_)))
+        guard if firstIter then min(parseTreeIsWhitespaceOrPar(t) for t in tree) else false
+        then diffLocal;
+      case ((diff1 as (Diff.Equal,_))::(Diff.Add, tree)::(diffLocal as ((Diff.Equal,_)::_)))
+        guard min(parseTreeIsWhitespaceOrPar(t) for t in tree)
+        algorithm
+          diff := diff1::diff;
+        then diffLocal;
+      // A normal tree :)
+      case diff1::diffLocal
+        algorithm
+          diff := diff1::diff;
+        then diffLocal;
+    end match;
+    firstIter := false;
+  end while;
+
+  diff := listReverseInPlace(diff);
+  // Look for indentation levels, try to fix added \n+WS to indent at the same level
+  lastTokenNewline := false;
+  indentation := {};
+  hasAddedWS := false;
+  for d in diff loop
+    _ := match d
+      case (Diff.Add,_)
+        algorithm
+          for t in tree loop
+            _ := match firstNTokensInTree_reverse(t, 2)
+              case {LexerModelicaDiff.TOKEN(id=TokenId.WHITESPACE, length=length),LexerModelicaDiff.TOKEN(id=TokenId.NEWLINE)}
+                algorithm
+                  hasAddedWS := true;
+                then ();
+              case {LexerModelicaDiff.TOKEN(id=TokenId.WHITESPACE, length=length)} guard lastTokenNewline
+                algorithm
+                  hasAddedWS := true;
+                then ();
+              else ();
+            end match;
+          end for;
+        then ();
+      case (_,tree)
+        algorithm
+          for t in tree loop
+            _ := match firstNTokensInTree_reverse(t, 2)
+              case {LexerModelicaDiff.TOKEN(id=TokenId.WHITESPACE, length=length),LexerModelicaDiff.TOKEN(id=TokenId.NEWLINE)}
+                algorithm
+                  indentation := length::indentation;
+                  lastTokenNewline := false;
+                then ();
+              case {LexerModelicaDiff.TOKEN(id=TokenId.WHITESPACE, length=length)} guard lastTokenNewline
+                algorithm
+                  indentation := length::indentation;
+                  lastTokenNewline := false;
+                then ();
+              case {LexerModelicaDiff.TOKEN(id=TokenId.NEWLINE)}
+                algorithm
+                  lastTokenNewline := true;
+                then ();
+              case tokens
+                algorithm
+                  lastTokenNewline := false;
+                then ();
+            end match;
+          end for;
+        then ();
+    end match;
+  end for;
+  if listEmpty(indentation) or (not hasAddedWS) then
+    if debug then
+      print("Skipping indentation as we could not auto-detect suitable indentation levels\n");
+    end if;
+    return;
+  end if;
+  // We have a known indentation level and added \n+WS; try to fix it
+  level := min(l for l in indentation);
+  indentationStr := StringUtil.repeat(" ", level);
+  diffLocal := {};
+  for d in diff loop
+    _ := match d
+      case (Diff.Delete,tree)
+        algorithm
+          diffLocal := d::diffLocal;
+        then ();
+      case (diffEnum, tree)
+        algorithm
+          treeLocal := {};
+          hasAddedWS := false;
+          for t in tree loop
+            _ := match (diffEnum, firstNTokensInTree_reverse(t, 2))
+              case (Diff.Equal, _) then ();
+              case (_, {LexerModelicaDiff.TOKEN(id=TokenId.WHITESPACE, length=length),tok as LexerModelicaDiff.TOKEN(id=TokenId.NEWLINE)})
+                algorithm
+                  treeLocal := replaceFirstTokensInTree(t, {tok,makeToken(TokenId.WHITESPACE, indentationStr)})::treeLocal;
+                  hasAddedWS := true;
+                then ();
+              case (_, {LexerModelicaDiff.TOKEN(id=TokenId.WHITESPACE, length=length)}) guard lastTokenNewline
+                algorithm
+                  replaceFirstTokensInTree(t, {makeToken(TokenId.WHITESPACE, indentationStr)});
+                  hasAddedWS := true;
+                then ();
+              else ();
+            end match;
+            lastTokenNewline := match lastToken(t) case LexerModelicaDiff.TOKEN(id=TokenId.NEWLINE) then true; else false; end match;
+          end for;
+          diffLocal := if hasAddedWS then (diffEnum, listReverse(treeLocal))::diffLocal else d::diffLocal;
+        then ();
+    end match;
+  end for;
+  diff := listReverseInPlace(diffLocal);
+end filterDiffWhitespace;
+
+function makeToken
+  input TokenId id;
+  input String str;
+  output Token token = LexerModelicaDiff.TOKEN("<dummy>", id, str, 1, stringLength(str), 0, 0, 0, 0);
+end makeToken;
+
+function replaceLabeledDiff
+  input list<tuple<Diff,list<ParseTree>>> inDiff, diffedNodes;
+  input ParseTree labelOfDiffedNodes;
+  input CmpParseTreeFunc compare;
+  output list<tuple<Diff,list<ParseTree>>> res={};
+protected
+  list<tuple<Diff,list<ParseTree>>> filtered;
+  list<ParseTree> lst, acc;
+algorithm
+  for diff in inDiff loop
+    res := match diff
+      case (Diff.Equal, _) then diff::res;
+      case (Diff.Add, lst) guard not max(compare(nodeLabel(t), labelOfDiffedNodes) for t in lst) then diff::res;
+      case (Diff.Delete, lst) guard not max(compare(nodeLabel(t), labelOfDiffedNodes) for t in lst) then diff::res;
+      case (Diff.Delete, lst) then (Diff.Delete, list(t for t guard not compare(nodeLabel(t), labelOfDiffedNodes) in lst))::res; // TODO: Handle the deletion better...
+      case (Diff.Add, lst)
+        algorithm
+          acc := {};
+          for t in lst loop
+            // Assuming adjacent to the delete node
+            if compare(nodeLabel(t), labelOfDiffedNodes) then
+              if not listEmpty(acc) then
+                res := (Diff.Add, listReverse(acc))::res;
+                acc := {};
+              end if;
+              // filtered := listReverse(diffedNodes);
+              filtered := listReverse(i for i guard match i case (Diff.Delete,_) then false; else true; end match in diffedNodes);
+              res := listAppend(filtered, res);
+            end if;
+          end for;
+          if not listEmpty(acc) then
+            res := (Diff.Add, listReverse(acc))::res;
+          end if;
+        then res;
+    end match;
+  end for;
+  res := listReverse(res);
+end replaceLabeledDiff;
+
+function isLabeledNode
+  input ParseTree tree;
+  output Boolean b;
+algorithm
+  b := match tree
+    case NODE(label=EMPTY()) then false;
+    case NODE() then true;
+    else false;
+  end match;
+end isLabeledNode;
+
+function nodeLabel
+  input ParseTree tree;
+  output ParseTree label;
+algorithm
+  label := match tree
+    case NODE() then tree.label;
+    else EMPTY();
+  end match;
+end nodeLabel;
+
+function parseTreeEq
+  input ParseTree t1, t2;
+  input array<Token> diffSubtreeWorkArray1, diffSubtreeWorkArray2;
+  output Boolean b;
+protected
+  Integer len1, len2;
+algorithm
+  // try
+    len1 := findTokens(t1, diffSubtreeWorkArray1);
+    len2 := findTokens(t2, diffSubtreeWorkArray2);
+  /*else
+    print("parseTreeEq failed: t1=" + parseTreeStr({t1}) + "\n");
+    print("parseTreeEq failed: t2=" + parseTreeStr({t2}) + "\n");
+  end try;*/
+  b := false;
+  if len1 <> len2 then
+    return;
+  end if;
+  for i in 1:len1 loop
+    if not modelicaDiffTokenEq(diffSubtreeWorkArray1[i], diffSubtreeWorkArray2[i]) then
+      return;
+    end if;
+  end for;
+  b := true;
+end parseTreeEq;
+
+function findTokens
+  input ParseTree t;
+  input array<Token> work;
+  input Integer inCount=0;
+  output Integer count=inCount;
+algorithm
+  if parseTreeIsWhitespaceOrPar(t) then
+    return;
+  end if;
+  _ := match t
+    case EMPTY() then ();
+    case LEAF()
+      algorithm
+        count := count+1;
+        arrayUpdate(work, count, t.token);
+      then ();
+    case NODE()
+      algorithm
+        for n in t.nodes loop
+          count := findTokens(n, work, count);
+        end for;
+      then ();
+  end match;
+end findTokens;
+
+function replaceFirstTokensInTree
+  input ParseTree t;
+  input list<Token> tokens;
+  output ParseTree tree;
+algorithm
+  (tree, {}) := replaceFirstTokensInTreeWork(t, tokens);
+end replaceFirstTokensInTree;
+
+function replaceFirstTokensInTreeWork
+  input ParseTree t;
+  input list<Token> inTokens;
+  output ParseTree tree=t;
+  output list<Token> tokens=inTokens;
+protected
+  list<ParseTree> work, acc;
+  ParseTree n;
+  Token tok;
+algorithm
+  (tree, tokens) := match (tree, tokens)
+    case (tree, {}) then (tree, tokens);
+    case (EMPTY(), _) then (tree, tokens);
+    case (LEAF(), tok::tokens) then (LEAF(tok), tokens);
+    case (NODE(), tokens)
+      algorithm
+        work := tree.nodes;
+        acc := {};
+        while not listEmpty(work) loop
+          n::work := work;
+          (n, tokens) := replaceFirstTokensInTreeWork(n, tokens);
+          if listEmpty(tokens) then
+            tree.nodes := listAppend(listReverse(acc), n::work);
+            return;
+          else
+            acc := n::acc;
+          end if;
+        end while;
+        tree.nodes := listReverse(acc);
+      then (tree, tokens);
+  end match;
+end replaceFirstTokensInTreeWork;
+
+function firstNTokensInTree_reverse
+  input ParseTree t;
+  input Integer n;
+  input list<Token> acc={};
+  output list<Token> tokens=acc;
+algorithm
+  if listLength(tokens)>1 then
+    return;
+  end if;
+  tokens := match t
+    case EMPTY() then tokens;
+    case LEAF() then t.token::tokens;
+    case NODE()
+      algorithm
+        for node in t.nodes loop
+          tokens := firstNTokensInTree_reverse(node, n, tokens);
+          if listLength(tokens)>1 then
+            return;
+          end if;
+        end for;
+      then acc;
+  end match;
+end firstNTokensInTree_reverse;
+
+function firstTokenInTree
+  input ParseTree t;
+  output Token token;
+algorithm
+  token := match t
+    case EMPTY() then fail();
+    case LEAF() then t.token;
+    case NODE() then firstTokenInTree(listGet(t.nodes, 1));
+  end match;
+end firstTokenInTree;
+
+function lastToken
+  input ParseTree t;
+  output Token token;
+algorithm
+  token := match t
+    case EMPTY() then fail();
+    case LEAF() then t.token;
+    case NODE() then lastToken(List.last(t.nodes));
+  end match;
+end lastToken;
+
+function fixMoveOperations "Move operations are very common, but result
+  in delete+add operations in the diff algorithm. Here we fix things so
+  the addition is using the exact same tokens as the original.
+
+  Time cost O(N*D). The number of diffs is typically low since we compare
+  parse trees"
+  input list<tuple<Diff,list<ParseTree>>> inDiff;
+  input CmpParseTreeFunc compare;
+  output list<tuple<Diff,list<ParseTree>>> diff = {};
+protected
+  list<ParseTree> lst, deleted={}, lst2;
+  Boolean changeFound=false;
+  tuple<Diff, list<ParseTree>> d1;
+algorithm
+  for d in inDiff loop
+    _ := match d
+      case (Diff.Delete, lst)
+        algorithm
+          deleted := listAppend(lst, deleted);
+        then ();
+      else ();
+    end match;
+  end for;
+  if listEmpty(deleted) then
+    diff := inDiff;
+    return;
+  end if;
+  for d in inDiff loop
+    d1 := match d
+      case (Diff.Add, lst)
+        algorithm
+          d1 := d;
+          for l1 in lst loop
+            if List.isMemberOnTrue(l1, deleted, compare) then
+              changeFound := true;
+              lst2 := {};
+              for l2 in lst loop
+                try
+                  lst2 := List.getMemberOnTrue(l1, deleted, compare)::lst2;
+                else
+                  lst2 := l2::lst2;
+                end try;
+              end for;
+              d1 := (Diff.Add, listReverseInPlace(lst2));
+              break;
+            end if;
+          end for;
+        then d1;
+      else d;
+    end match;
+    diff := d1::diff;
+  end for;
+  diff := if changeFound then listReverseInPlace(diff) else inDiff;
+end fixMoveOperations;
+
+function makeNode
+  input list<ParseTree> nodes;
+  input ParseTree label = EMPTY();
+  output ParseTree node;
+algorithm
+  node := match nodes
+    case {}
+      algorithm
+        error({}, nodes, {});
+      then fail();
+    case {node} guard match label case EMPTY() then true; else false; end match then node;
+    else NODE(label, nodes);
+  end match;
+end makeNode;
+
+function makeNodePrependTree
+  input list<ParseTree> nodes;
+  input list<ParseTree> tree;
+  input ParseTree label = EMPTY();
+  output list<ParseTree> outTree;
+algorithm
+  outTree := if not listEmpty(nodes) then makeNode(nodes, label)::tree else tree;
+end makeNodePrependTree;
+
+function isLeaf
+  input ParseTree t;
+  output Boolean b;
+algorithm
+  b := match t
+    case LEAF() then true;
+    else false;
+  end match;
+end isLeaf;
+
+function firstToken
+  input list<ParseTree> t;
+  output Token token;
+algorithm
+  token := match t
+    local
+      list<ParseTree> nodes;
+    case NODE(nodes=nodes)::_ then firstToken(nodes);
+    case LEAF(token)::_ then token;
+    else LexerModelicaDiff.noToken;
+  end match;
+end firstToken;
+
+function firstTokenDebugStr
+  input list<ParseTree> t;
+  output String str;
+protected
+  list<Token> l;
+algorithm
+  l := firstToken(t)::{};
+  str := Error.infoStr(topTokenSourceInfo(l))+" "+topTokenStr(l);
+end firstTokenDebugStr;
+
+function getNodes
+  input ParseTree t;
+  output list<ParseTree> nodes;
+algorithm
+  nodes := match t
+    case NODE() then t.nodes;
+    else {t};
+  end match;
+end getNodes;
+
+function extractSingleAddDiffBeforeAndAfter "Ignores whitespace"
+  input list<tuple<Diff,list<ParseTree>>> diffs;
+  output ParseTree addedTree, deletedTree;
+  output list<ParseTree> before, middle, after;
+  output Boolean addedBeforeDeleted;
+protected
+  Boolean foundAdded=false;
+  Boolean foundDeleted=false;
+  list<list<ParseTree>> acc={};
+  list<ParseTree> trees, lst;
+  Diff d;
+algorithm
+  for diff in diffs loop
+    _ := match diff
+      case (Diff.Add, lst)
+        algorithm
+          for tree in lst loop
+            if parseTreeIsWhitespace(tree) then
+              acc := acc;
+            elseif parseTreeIsWhitespaceOrPar(tree) then
+              acc := {tree}::acc;
+            else
+              if foundAdded then
+                Error.addInternalError("Found multiple Add subtrees", sourceInfo());
+                fail();
+              end if;
+              addedTree := tree;
+              foundAdded := true;
+              if foundDeleted then
+                middle := List.flatten(listReverse(acc));
+              else
+                addedBeforeDeleted := true;
+                before := List.flatten(listReverse(acc));
+              end if;
+            end if;
+          end for;
+          acc := {};
+        then ();
+      case (Diff.Delete, lst)
+        algorithm
+          for tree in lst loop
+            if parseTreeIsWhitespaceOrPar(tree) then
+              acc := {tree}::acc;
+            else
+              if foundDeleted then
+                Error.addInternalError("Found multiple Delete subtrees", sourceInfo());
+                fail();
+              end if;
+              deletedTree := tree;
+              foundDeleted := true;
+              if foundAdded then
+                middle := List.flatten(listReverse(acc));
+              else
+                addedBeforeDeleted := false;
+                before := List.flatten(listReverse(acc));
+              end if;
+              acc := {};
+            end if;
+          end for;
+        then ();
+      case (Diff.Equal, trees)
+        algorithm
+          acc := trees::acc;
+        then ();
+      case (d, _)
+        algorithm
+          Error.addInternalError("Found "+String(d)+" subtrees with multiple or zero entries", sourceInfo());
+        then fail();
+    end match;
+  end for;
+  true := foundAdded;
+  true := foundDeleted;
+  after := List.flatten(listReverse(acc));
+end extractSingleAddDiffBeforeAndAfter;
+
+function extractAdditionsDeletions
+  input list<tuple<Diff,list<ParseTree>>> diffs;
+  output list<ParseTree> addedTrees, deletedTrees;
+protected
+  list<list<ParseTree>> addedTreesAcc={}, deletedTreesAcc={};
+  list<ParseTree> lst;
+algorithm
+  for diff in diffs loop
+    _ := match diff
+      case (Diff.Add, lst)
+        algorithm
+          addedTreesAcc := lst::addedTreesAcc;
+        then ();
+      case (Diff.Delete, lst)
+        algorithm
+          deletedTreesAcc := lst::deletedTreesAcc;
+        then ();
+      else ();
+    end match;
+  end for;
+  addedTrees := List.flatten(listReverse(addedTreesAcc));
+  deletedTrees := List.flatten(listReverse(deletedTreesAcc));
+end extractAdditionsDeletions;
+
+function countDiffAddDelete
+  input list<tuple<Diff,list<ParseTree>>> diffs;
+  output Integer nadd=0;
+  output Integer ndel=0;
+protected
+  Diff d;
+  list<ParseTree> l;
+algorithm
+  for diff in diffs loop
+    (d,l) := diff;
+    if d == Diff.Add then
+      nadd := nadd+sum(if parseTreeIsWhitespaceOrPar(t) then 0 else 1 for t in l);
+    elseif d == Diff.Delete then
+      ndel := ndel+sum(if parseTreeIsWhitespaceOrPar(t) then 0 else 1 for t in l);
+    end if;
+  end for;
+end countDiffAddDelete;
+
+constant list<TokenId> whiteSpaceTokenIds = {
+    TokenId.LINE_COMMENT,
+    TokenId.BLOCK_COMMENT,
+    TokenId.NEWLINE,
+    TokenId.WHITESPACE
+};
+
+function dummyParseTreeIsWhitespaceFalse
+  // The diff-algorithm will strip leading whitespace, but these are
+  // sort of significant...
+  input ParseTree t1;
+  output Boolean b=false;
+end dummyParseTreeIsWhitespaceFalse;
+
+function parseTreeIsWhitespace
+  input ParseTree t1;
+  output Boolean b;
+protected
+  TokenId id;
+algorithm
+  b := match t1
+    case LEAF() then listMember(t1.token.id, whiteSpaceTokenIds);
+    else false;
+  end match;
+end parseTreeIsWhitespace;
+
+function parseTreeIsWhitespaceOrPar
+  input ParseTree t1;
+  output Boolean b;
+protected
+  TokenId id;
+algorithm
+  b := match t1
+    case LEAF() then listMember(t1.token.id, TokenId.LPAR::TokenId.RPAR::whiteSpaceTokenIds);
+    else false;
+  end match;
+end parseTreeIsWhitespaceOrPar;
+
+function eatWhitespace
+  extends partialParser;
+protected
+  TokenId id;
+  Token t;
+algorithm
+  tree := inTree;
+  while match tokens case LexerModelicaDiff.TOKEN(id=id)::_ then listMember(id, {TokenId.LINE_COMMENT, TokenId.BLOCK_COMMENT, TokenId.NEWLINE, TokenId.WHITESPACE}); else false; end match loop
+    t::tokens := tokens;
+    tree := LEAF(t)::tree;
+  end while;
+  outTree := tree;
+end eatWhitespace;
+
+function scanOpt
+  extends partialParser;
+  input TokenId id;
+  output Boolean found;
+protected
+  TokenId id2;
+  Token t;
+  list<Token> tokens2;
+algorithm
+  (tokens, tree) := eatWhitespace(tokens, inTree);
+  (tokens, tree, found) := match tokens
+    case (t as LexerModelicaDiff.TOKEN(id=id2))::tokens2 guard id==id2 then (tokens2, LEAF(t)::tree, true);
+    else (tokens, tree, false);
+  end match;
+  if not found then
+    // We want whitespace to be part of the next node; not added as a
+    // separate node that gets eaten in the previous one.
+    // This is bad for performance resons (we eat the same whitespace multiple
+    // times. But we do not want to backpatch and guess indentation level.
+    outTree := inTree;
+    tokens := inTokens;
+  else
+    outTree := tree;
+  end if;
+end scanOpt;
+
+function scan
+  extends partialParser;
+  input TokenId id;
+protected
+  Boolean found;
+  TokenId id2;
+algorithm
+  tree := inTree;
+  (tokens, tree, found) := scanOpt(tokens, tree, id);
+  if not found then
+    error(tokens, tree, {id});
+  end if;
+  outTree := tree;
+end scan;
+
+function scanOneOf
+  extends partialParser;
+  input list<TokenId> ids;
+protected
+  Boolean found;
+  TokenId id2;
+algorithm
+  tree := inTree;
+  (tokens, tree, found) := LA1(tokens, tree, ids, consume=true);
+  if not found then
+    error(tokens, tree, ids);
+  end if;
+  outTree := tree;
+end scanOneOf;
+
+function error
+  input list<Token> tokens;
+  input list<ParseTree> tree;
+  input list<TokenId> expected;
+protected
+  Integer i;
+  String s;
+  list<String> strs, res;
+  SourceInfo info;
+algorithm
+  info := topTokenSourceInfo(tokens);
+  res := ("Failed to scan top of input: " + topTokenStr(tokens) + "\n  Expected one of: " + (if listEmpty(expected) then "<EOF>" else stringDelimitList(list(tokenIdStr(id) for id in expected), ", ")) + "\n")::{};
+  res := ("  Current parse tree is:\n" + parseTreeStr(listReverse(tree)) + "\n  The parser stack is:\n")::res;
+  StackOverflow.setStacktraceMessages(0, 100);
+  for s in StackOverflow.readableStacktraceMessages() loop
+    (i, strs) := System.regex(s, "SimpleModelicaParser[^A-Za-z]([A-Za-z_0-9_]*)", 2, true, false);
+    _ := match (i, strs)
+      case (2, {_,s}) guard s<>"error"
+        algorithm
+          res := "\n"::s::res;
+        then ();
+      else ();
+    end match;
+  end for;
+  Error.addInternalError(stringAppendList(listReverse(res)), info);
+  fail();
+end error;
+
+function tokenIdStr
+  input TokenId id;
+  output String str = String(id);
+end tokenIdStr;
+
+function peek
+  extends partialParser;
+  output TokenId id;
+algorithm
+  tree := inTree;
+  (tokens, tree) := eatWhitespace(tokens, tree);
+  id := match tokens
+    case LexerModelicaDiff.TOKEN(id=id)::_ then id;
+    else TokenId._NO_TOKEN;
+  end match;
+  outTree := tree;
+end peek;
+
+function consume
+  extends partialParser;
+protected
+  Token t;
+algorithm
+  t::tokens := tokens;
+  outTree := LEAF(t)::inTree;
+end consume;
+
+function LA1 "Do look-ahead 1 token and see if the token is one of the given ones."
+  extends partialParser;
+  input list<TokenId> ids;
+  input Boolean consume=false;
+  output Boolean found;
+protected
+  TokenId id;
+algorithm
+  tree := inTree;
+  (tokens, tree) := eatWhitespace(tokens, tree);
+  found := match tokens
+    case LexerModelicaDiff.TOKEN(id=id)::_ then listMember(id, ids);
+    else false;
+  end match;
+  if found and consume then
+    (tokens,tree) := SimpleModelicaParser.consume(tokens, tree);
+  end if;
+  if not found then
+    outTree := inTree;
+    tokens := inTokens;
+  else
+    outTree := tree;
+  end if;
+end LA1;
+
+function LAk "Do look-ahead k tokens and see if the tokens match one of the given ones."
+  extends partialParser;
+  input list<list<TokenId>> idsLst "k sets of tokens to check";
+  output Boolean found;
+protected
+  TokenId id;
+  list<Token> tmp;
+algorithm
+  tree := inTree;
+  (tokens, tree) := eatWhitespace(tokens, tree);
+  outTree := tree;
+  tmp := tokens;
+  for ids in idsLst loop
+    found := match tmp
+      case LexerModelicaDiff.TOKEN(id=id)::tmp then listMember(id, ids);
+      else false;
+    end match;
+    if not found then
+      return;
+    end if;
+    (tmp) := eatWhitespace(tmp, {});
+  end for;
+end LAk;
+
+function parseTreeStrWork
+  input ParseTree tree;
+protected
+  Integer i;
+algorithm
+  _ := match tree
+    case LEAF() algorithm Print.printBuf(tokenContent(tree.token)); then ();
+    case EMPTY() algorithm Print.printBuf("<EMPTY>"); then ();
+    case NODE()
+      algorithm
+        for n in tree.nodes loop
+          parseTreeStrWork(n);
+        end for;
+      then ();
+  end match;
+end parseTreeStrWork;
+
+function topTokenStr
+  input list<Token> tokens;
+  output String str;
+protected
+  TokenId id;
+  Token t;
+algorithm
+  str := (match tokens case (t as LexerModelicaDiff.TOKEN(id=id))::_ then String(id)+" ("+tokenContent(t)+")"; else "EOF"; end match);
+end topTokenStr;
+
+function topTokenSourceInfo
+  input list<Token> tokens;
+  output SourceInfo info;
+protected
+  Token t;
+algorithm
+  info := (match tokens case t::_
+    then LexerModelicaDiff.tokenSourceInfo(t);
+    else SOURCEINFO("<SimpleModelicaParser>", false, 0, 0, 0, 0, 0.0); end match);
+end topTokenSourceInfo;
+
+function needsWhitespaceBetweenTokens
+  input Token first, last;
+  output Boolean b;
+protected
+  constant list<TokenId> notident = {
+    TokenId.ASSIGN,
+    TokenId.BLOCK_COMMENT,
+    TokenId.COLON,
+    TokenId.COLONCOLON,
+    TokenId.COMMA,
+    TokenId.DOT,
+    TokenId.EQEQ,
+    TokenId.EQUALS,
+    TokenId.GREATER,
+    TokenId.GREATEREQ,
+    TokenId.LBRACE,
+    TokenId.LBRACK,
+    TokenId.LESS,
+    TokenId.LESSEQ,
+    TokenId.LESSGT,
+    TokenId.LINE_COMMENT,
+    TokenId.LPAR,
+    TokenId.MINUS,
+    TokenId.MINUS_EW,
+    TokenId.NEWLINE,
+    TokenId.OPERATOR,
+    TokenId.PLUS,
+    TokenId.PLUS_EW,
+    TokenId.POWER,
+    TokenId.POWER_EW,
+    TokenId.RBRACE,
+    TokenId.RBRACK,
+    TokenId.RPAR,
+    TokenId.SEMICOLON,
+    TokenId.SLASH,
+    TokenId.SLASH_EW,
+    TokenId.STAR,
+    TokenId.STAR_EW,
+    TokenId.STRING,
+    TokenId.UNSIGNED_INTEGER,
+    TokenId.UNSIGNED_REAL,
+    TokenId.WHITESPACE
+  };
+  Boolean b1, b2;
+algorithm
+  if listMember(tokenId(first), notident) or listMember(tokenId(last), notident) then
+    b := false;
+    return;
+  end if;
+  // Assuming the grammar is nice to us...
+  b := true;
+end needsWhitespaceBetweenTokens;
+
+function tokenId
+  input Token t;
+  output TokenId id;
+algorithm
+  LexerModelicaDiff.TOKEN(id=id) := t;
+end tokenId;
+
+package First "First token possible for a given non-terminal in the Modelica 3 grammar"
+  constant list<TokenId> class_prefixes = {
+    TokenId.PARTIAL,
+    TokenId.CLASS,
+    TokenId.MODEL,
+    TokenId.OPERATOR,
+    TokenId.RECORD,
+    TokenId.BLOCK,
+    TokenId.EXPANDABLE,
+    TokenId.CONNECTOR,
+    TokenId.TYPE,
+    TokenId.PACKAGE,
+    TokenId.PURE,
+    TokenId.IMPURE,
+    TokenId.FUNCTION
+  };
+  constant list<TokenId> class_definition =
+    TokenId.FINAL ::
+    TokenId.ENCAPSULATED ::
+    class_prefixes
+  ;
+  constant list<TokenId> class_modification = {
+    TokenId.LPAR
+  };
+  constant list<TokenId> type_prefix = {
+    TokenId.FLOW,
+    TokenId.STREAM,
+    TokenId.DISCRETE,
+    TokenId.PARAMETER,
+    TokenId.CONSTANT,
+    TokenId.INPUT,
+    TokenId.OUTPUT
+  };
+  constant list<TokenId> class_modification = {
+    TokenId.LPAR
+  };
+  constant list<TokenId> _annotation = {
+    TokenId.ANNOTATION
+  };
+  constant list<TokenId> element_redeclaration = {
+    TokenId.REDECLARE
+  };
+  constant list<TokenId> name = {
+    TokenId.DOT,
+    TokenId.IDENT
+  };
+  constant list<TokenId> element_modification_or_replaceable =
+    TokenId.EACH::
+    TokenId.FINAL::
+    TokenId.REPLACEABLE::
+    name
+  ;
+  constant list<TokenId> argument = listAppend(
+    element_modification_or_replaceable,
+    element_redeclaration
+  );
+  constant list<TokenId> modification = {
+    TokenId.LPAR,
+    TokenId.EQUALS,
+    TokenId.ASSIGN
+  };
+  constant list<TokenId> component_clause = listAppend(type_prefix,name);
+  constant list<TokenId> element = listAppend(listAppend(component_clause, class_definition), {
+    TokenId.IMPORT,
+    TokenId.EXTENDS,
+    TokenId.REDECLARE,
+    TokenId.FINAL,
+    TokenId.INNER,
+    TokenId.OUTER,
+    TokenId.REPLACEABLE
+  });
+  constant list<TokenId> statement = {
+    TokenId.DOT,
+    TokenId.IDENT,
+    TokenId.LPAR,
+    TokenId.BREAK,
+    TokenId.RETURN,
+    TokenId.IF,
+    TokenId.FOR,
+    TokenId.WHILE,
+    TokenId.WHEN
+  };
+  constant list<TokenId> component_reference = {
+    TokenId.DOT,
+    TokenId.IDENT
+  };
+/*  constant list<TokenId> function_arguments =
+    TokenId.FUNCTION ::
+    TokenId.IDENT ::
+    expression
+  ; */
+end First;
+
+package Follow
+  constant list<TokenId> statement_equation = {
+    TokenId.INITIAL, // Only potential conflict
+    TokenId.EQUATION,
+    TokenId.ALGORITHM,
+    TokenId.PUBLIC,
+    TokenId.PROTECTED,
+    TokenId.EXTERNAL,
+    TokenId.ANNOTATION,
+    TokenId.ELSE,
+    TokenId.ELSEIF,
+    TokenId.END,
+    TokenId.ELSEWHEN
+  };
+end Follow;
+
+constant Boolean debug = false;
+
+annotation(__OpenModelica_Interface="backend");
+end SimpleModelicaParser;

--- a/Compiler/Script/CevalScript.mo
+++ b/Compiler/Script/CevalScript.mo
@@ -1328,6 +1328,7 @@ algorithm
             GlobalScript.SYMBOLTABLE(p,sp,ic,iv,(path,t)::cf),
             but where to get t? */
       equation
+        SimCodeFunctionUtil.execStatReset();
         mp = Settings.getModelicaPath(Config.getRunningTestsuite());
         strings = List.map(cvars, ValuesUtil.extractValueString);
         /* If the user requests a custom version to parse as, set it up */
@@ -1342,6 +1343,7 @@ algorithm
         end if;
         Print.clearBuf();
         newst = GlobalScript.SYMBOLTABLE(p,NONE(),{},iv,cf,lf);
+        SimCodeFunctionUtil.execStat("loadModel("+Absyn.pathString(path)+")");
       then
         (FCore.emptyCache(),Values.BOOL(b),newst);
 
@@ -1358,8 +1360,10 @@ algorithm
             lstVarVal = iv,compiledFunctions = cf,
             loadedFiles = lf)),_)
       equation
+        SimCodeFunctionUtil.execStatReset();
         name = Util.testsuiteFriendlyPath(name);
         newp = loadFile(name, encoding, p, b);
+        SimCodeFunctionUtil.execStat("loadFile("+name+")");
       then
         (FCore.emptyCache(),Values.BOOL(true),GlobalScript.SYMBOLTABLE(newp,NONE(),ic,iv,cf,lf));
 

--- a/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -2830,6 +2830,12 @@ algorithm
   end match;
 end codegenPeekTryThrowIndex;
 
+public function execStatReset
+algorithm
+  System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT);
+  System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT_CUMULATIVE);
+end execStatReset;
+
 public function execStat
   "Prints an execution stat on the format:
   *** %name% -> time: %time%, memory %memory%

--- a/Compiler/SimCode/SimCodeMain.mo
+++ b/Compiler/SimCode/SimCodeMain.mo
@@ -673,8 +673,7 @@ algorithm
     case (cache, graph, _, (st as GlobalScript.SYMBOLTABLE(ast=p)), filenameprefix, _, _, _) equation
       // calculate stuff that we need to create SimCode data structure
       System.realtimeTick(ClockIndexes.RT_CLOCK_FRONTEND);
-      System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT);
-      System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT_CUMULATIVE);
+      SimCodeFunctionUtil.execStatReset();
       (cache, graph, dae, st) = CevalScriptBackend.runFrontEnd(cache, graph, className, st, false);
       SimCodeFunctionUtil.execStat("FrontEnd");
       timeFrontend = System.realtimeTock(ClockIndexes.RT_CLOCK_FRONTEND);

--- a/Compiler/Util/DiffAlgorithm.mo
+++ b/Compiler/Util/DiffAlgorithm.mo
@@ -83,7 +83,7 @@ algorithm
   start2 := 1;
   end1 := arrayLength(arr1);
   end2 := arrayLength(arr2);
-  out := diffSeq(arr1,arr2,equals,isWhitespace,toString,1,arrayLength(arr1),1,arrayLength(arr2));
+  out := diffSeq(arr1, arr2, equals, isWhitespace, toString, 1, arrayLength(arr1), 1, arrayLength(arr2));
 end diff;
 
 partial function partialPrintDiff<T>
@@ -123,7 +123,7 @@ algorithm
       case (Diff.Delete,ts)
         then (DiffStrings.delOpen,DiffStrings.delClose,ts,DiffStrings.printDelete);
     end match;
-    if b or (DiffStrings.printEqual and DiffStrings.printAdd and DiffStrings.printDelete /* optimization */) then
+    if not listEmpty(ts) and (b or (DiffStrings.printEqual and DiffStrings.printAdd and DiffStrings.printDelete /* optimization */)) then
       Print.printBuf(open);
       for t in ts loop
         Print.printBuf(toString(t));

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -696,6 +696,10 @@ public constant Message GENERATE_SEPARATE_CODE_DEPENDENCIES_FAILED_UNKNOWN_PACKA
   Util.gettext("Failed to get dependencies for package %s. %s contains an import to non-existing package %s."));
 public constant Message USE_OF_PARTIAL_CLASS = MESSAGE(285, TRANSLATION(), ERROR(),
   Util.gettext("component %s contains the definition of a partial class %s.\nPlease redeclare it to any package compatible with %s."));
+public constant Message SCANNER_ERROR = MESSAGE(286, SYNTAX(), ERROR(),
+  Util.gettext("Syntax error, unrecognized input: %s."));
+public constant Message SCANNER_ERROR_LIMIT = MESSAGE(287, SYNTAX(), ERROR(),
+  Util.gettext("Additional syntax errors were suppressed."));
 
 public constant Message UNBOUND_PARAMETER_WITH_START_VALUE_WARNING = MESSAGE(499, TRANSLATION(), WARNING(),
   Util.gettext("Parameter %s has no value, and is fixed during initialization (fixed=true), using available start value (start=%s) as default value."));

--- a/Compiler/Util/StackOverflow.mo
+++ b/Compiler/Util/StackOverflow.mo
@@ -111,6 +111,14 @@ function getStacktraceMessages
 </html>"));
 end getStacktraceMessages;
 
+function setStacktraceMessages
+  input Integer numSkip;
+  input Integer numFrames;
+  external "C" mmc_setStacktraceMessages_threadData(OpenModelica.threadData(), numSkip, numFrames)annotation(Documentation(info="<html>
+<p>Generate a stacktrace at the current position of code.</p>
+</html>"));
+end setStacktraceMessages;
+
 function hasStacktraceMessages
   output Boolean b;
   external "C" b=mmc_hasStacktraceMessages(OpenModelica.threadData())annotation(Documentation(info="<html>

--- a/Compiler/Util/StringUtil.mo
+++ b/Compiler/Util/StringUtil.mo
@@ -265,5 +265,20 @@ algorithm
   outStrings := listReverseInPlace(outStrings);
 end wordWrap;
 
+function repeat
+  "Repeat str n times"
+  input String str;
+  input Integer n;
+  output String res="";
+protected
+  Integer len = stringLength(str);
+  System.StringAllocator ext = System.StringAllocator(len*n);
+algorithm
+  for i in 0:n-1 loop
+    System.stringAllocatorStringCopy(ext, str, len*i);
+  end for;
+  res := System.stringAllocatorResult(ext, res);
+end repeat;
+
 annotation(__OpenModelica_Interface="util");
 end StringUtil;

--- a/Compiler/Util/System.mo
+++ b/Compiler/Util/System.mo
@@ -80,6 +80,19 @@ public function strcmp
   external "C" outInteger=System_strcmp(inString1,inString2) annotation(Library = "omcruntime");
 end strcmp;
 
+public function strcmp_offset
+"Like strcmp, but also takes offset and lengths of the strings in order to avoid building them through substring"
+  input String string1;
+  input Integer offset1;
+  input Integer length1;
+  input String string2;
+  input Integer offset2;
+  input Integer length2;
+  output Integer outInteger;
+
+  external "C" outInteger=System_strcmp_offset(string1,offset1,length1,string2,offset2,length2) annotation(Library = "omcruntime");
+end strcmp_offset;
+
 public function stringFind "locates substring searchStr in str. If succeeds return position, otherwise return -1"
   input String str;
   input String searchStr;
@@ -1194,6 +1207,9 @@ class StringAllocator
   external "C" str=StringAllocator_constructor(sz) annotation(Include="
 void* StringAllocator_constructor(int sz)
 {
+  if (sz < 0) {
+    MMC_THROW();
+  }
   return mmc_alloc_scon(sz);
 }
 ");
@@ -1221,7 +1237,7 @@ end stringAllocatorStringCopy;
 
 function stringAllocatorResult<T>
   input StringAllocator sa;
-  input T dummy annotation(__OpenModelica_UnusedVariable=true);
+  input T dummy "This is just added so we do not make an extra allocation for the string" annotation(__OpenModelica_UnusedVariable=true);
   output T res;
 external "C" res=om_stringAllocatorResult(sa) annotation(Include="
 const char* om_stringAllocatorResult(void *sa) {

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -278,6 +278,7 @@ if true then /* Suppress output */
     "../FrontEnd/UnitChecker.mo",
 
     "../Lexers/LexerModelicaDiff.mo",
+    "../Parsers/SimpleModelicaParser.mo",
 
     "../Script/Refactor.mo",
     "../Script/RewriteRules.mo",

--- a/Compiler/runtime/System_omc.c
+++ b/Compiler/runtime/System_omc.c
@@ -255,6 +255,15 @@ extern int System_strcmp(const char *str1, const char *str2)
   return res;
 }
 
+extern int System_strcmp_offset(const char *str1, int offset1, int length1, const char *str2, int offset2, int length2)
+{
+  int n = length1 > length2 ? length1 : length2;
+  int res = strncmp(str1+offset1-1, str2+offset2-1, n);
+  if (res>0) res = 1;
+  else if (res<0) res = -1;
+  return res;
+}
+
 extern int System_getHasExpandableConnectors()
 {
   return hasExpandableConnectors;


### PR DESCRIPTION
There is a hand-written parse tree generator for a relaxed version of
the Modelica grammar.

There exists an algorithm for tree merging, which is based on trying
to diff all the subtrees in a node, to figure out which subtrees
changed (syntactically, not lexically). Only these subtrees are then
traversed.

Diff algorithms scale O(N*D), which made the old scanner-based diff
slow since N and D are both very large (many whitespace changes).
The new diff has a low N (because entires subtrees are pruned away
early on), and a low D (because whitespace changes are often pruned
away in semantically identical subtreees).

However, the algorithm still scales poorly if there is a large number
of nested classes in the file. It works much better when models are
stored in separate files (takes around 1-2 seconds for 300 kB files).
The lexer-based diff did spend hours to perform this diff however...

The diff is patched to perform move operations in order to preserve
whitespace better (otherwise whitespace would be reset to the updated
file).

Token content is performed using a tokenContentEq operation, which
can do string comparison on substrings directly (to avoid creating
strings only to compare them). The (Boolean) tree comparison is
linear in both memory and time.

There is a labelling of some nodes (like named modifications), in order
to know which subtrees belong together in a comparison.

Whitespace and indentation is considered in a similar way as the old
comparison algorithm.