### PR TITLE
Handle empty unit strings

### DIFF
--- a/Compiler/BackEnd/UnitCheck.mo
+++ b/Compiler/BackEnd/UnitCheck.mo
@@ -1154,6 +1154,7 @@ algorithm
     HashTableCrToUnit.HashTable HtCr2U;
 
   case (BackendDAE.VAR(varType=DAE.T_REAL(), values = SOME(DAE.VAR_ATTR_REAL(unit=SOME(DAE.SCONST(unitString))))), (HtCr2U, HtS2U, HtU2S))
+    guard(unitString <> "")
     equation
       cr = BackendVariable.varCref(var);
       (ut, HtS2U, HtU2S) = parse(unitString, cr, HtS2U, HtU2S);


### PR DESCRIPTION
This is a fix for [#3631](https://trac.openmodelica.org/OpenModelica/ticket/3631).