### PR TITLE
Add input index to M_init.xml file

### DIFF
--- a/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -242,7 +242,7 @@ algorithm
         "Template did not find the simulation variable for "+ ComponentReference.printComponentRefStr(cref) + ". ";
         Error.addInternalError(errstr, sourceInfo());*/
       then
-         SimCodeVar.SIMVAR(badcref, BackendDAE.VARIABLE(), "", "", "", -2, NONE(), NONE(), NONE(), NONE(), false, DAE.T_REAL_DEFAULT, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.INTERNAL(), NONE(), {}, false, true, false);
+         SimCodeVar.SIMVAR(badcref, BackendDAE.VARIABLE(), "", "", "", -2, NONE(), NONE(), NONE(), NONE(), false, DAE.T_REAL_DEFAULT, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.INTERNAL(), NONE(), {}, false, true, false, NONE());
   end matchcontinue;
 end cref2simvar;
 

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -2317,7 +2317,7 @@ algorithm
 
     case(DAE.CREF(cr, ty)::rest) equation
       slst = List.map(dims, intString);
-      var = SimCodeVar.SIMVAR(cr, BackendDAE.VARIABLE(), "", "", "", 0, NONE(), NONE(), NONE(), NONE(), false, ty, false, SOME(name), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), slst, false, true, false);
+      var = SimCodeVar.SIMVAR(cr, BackendDAE.VARIABLE(), "", "", "", 0, NONE(), NONE(), NONE(), NONE(), false, ty, false, SOME(name), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), slst, false, true, false, NONE());
       tempvars = createTempVarsforCrefs(rest, {var});
     then listAppend(listReverse(tempvars), itempvars);
   end match;
@@ -2353,7 +2353,7 @@ algorithm
       arrayCref = ComponentReference.getArrayCref(cr);
       inst_dims = ComponentReference.crefDims(cr);
       numArrayElement = List.map(inst_dims, ExpressionDump.dimensionString);
-      var = SimCodeVar.SIMVAR(cr, BackendDAE.VARIABLE(), "", "", "", 0, NONE(), NONE(), NONE(), NONE(), false, ty, false, arrayCref, SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), numArrayElement, false, true, false);
+      var = SimCodeVar.SIMVAR(cr, BackendDAE.VARIABLE(), "", "", "", 0, NONE(), NONE(), NONE(), NONE(), false, ty, false, arrayCref, SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), numArrayElement, false, true, false, NONE());
     then createTempVarsforCrefs(rest, var::itempvars);
   end match;
 end createTempVarsforCrefs;
@@ -2396,13 +2396,13 @@ algorithm
         arraycref := ComponentReference.crefStripSubs(cr);
         ty := ComponentReference.crefTypeFull(cr);
         var := SimCodeVar.SIMVAR(cr, BackendDAE.VARIABLE(), "", "", "", 0, NONE(), NONE(), NONE(), NONE(), false,
-              ty, false, SOME(arraycref), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, true, false);
+              ty, false, SOME(arraycref), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, true, false, NONE());
 
         /* The rest don't need to be marked i.e. we have 'NONE()'. Just create simvars. */
         ttmpvars := {var};
         for cr in crlst loop
           ty := ComponentReference.crefTypeFull(cr);
-          var := SimCodeVar.SIMVAR(cr, BackendDAE.VARIABLE(), "", "", "", 0, NONE(), NONE(), NONE(), NONE(), false, ty, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, true, false);
+          var := SimCodeVar.SIMVAR(cr, BackendDAE.VARIABLE(), "", "", "", 0, NONE(), NONE(), NONE(), NONE(), false, ty, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, true, false, NONE());
           ttmpvars := var::ttmpvars;
         end for;
         ttmpvars := listReverse(ttmpvars);
@@ -3920,7 +3920,7 @@ algorithm
       currVar = ComponentReference.crefPrefixDer(currVar);
       derivedCref = Differentiate.createDifferentiatedCrefName(currVar, cref, inMatrixName);
       isProtected = getProtected(dae_var_attr);
-      r1 = SimCodeVar.SIMVAR(derivedCref, BackendDAE.STATE_DER(), "", "", "", inIndex, NONE(), NONE(), NONE(), NONE(), false, DAE.T_REAL_DEFAULT, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, isProtected, hideResult);
+      r1 = SimCodeVar.SIMVAR(derivedCref, BackendDAE.STATE_DER(), "", "", "", inIndex, NONE(), NONE(), NONE(), NONE(), false, DAE.T_REAL_DEFAULT, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, isProtected, hideResult, NONE());
     then
       createAllDiffedSimVars(restVar, cref, inAllVars, inIndex+1, inMatrixName, r1::iVars);
 
@@ -3928,7 +3928,7 @@ algorithm
       ({_}, _) = BackendVariable.getVar(currVar, inAllVars);
       derivedCref = Differentiate.createDifferentiatedCrefName(currVar, cref, inMatrixName);
       isProtected = getProtected(dae_var_attr);
-      r1 = SimCodeVar.SIMVAR(derivedCref, BackendDAE.STATE_DER(), "", "", "", inIndex, NONE(), NONE(), NONE(), NONE(), false, DAE.T_REAL_DEFAULT, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, isProtected, hideResult);
+      r1 = SimCodeVar.SIMVAR(derivedCref, BackendDAE.STATE_DER(), "", "", "", inIndex, NONE(), NONE(), NONE(), NONE(), false, DAE.T_REAL_DEFAULT, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, isProtected, hideResult, NONE());
     then
       createAllDiffedSimVars(restVar, cref, inAllVars, inIndex+1, inMatrixName, r1::iVars);
 
@@ -3936,14 +3936,14 @@ algorithm
       currVar = ComponentReference.crefPrefixDer(currVar);
       derivedCref = Differentiate.createDifferentiatedCrefName(currVar, cref, inMatrixName);
       isProtected = getProtected(dae_var_attr);
-      r1 = SimCodeVar.SIMVAR(derivedCref, BackendDAE.VARIABLE(), "", "", "", -1, NONE(), NONE(), NONE(), NONE(), false, DAE.T_REAL_DEFAULT, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, isProtected, hideResult);
+      r1 = SimCodeVar.SIMVAR(derivedCref, BackendDAE.VARIABLE(), "", "", "", -1, NONE(), NONE(), NONE(), NONE(), false, DAE.T_REAL_DEFAULT, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, isProtected, hideResult, NONE());
     then
       createAllDiffedSimVars(restVar, cref, inAllVars, inIndex, inMatrixName, r1::iVars);
 
     case(BackendDAE.VAR(varName=currVar, values = dae_var_attr)::restVar, cref, _, _, _, _) equation
       derivedCref = Differentiate.createDifferentiatedCrefName(currVar, cref, inMatrixName);
       isProtected = getProtected(dae_var_attr);
-      r1 = SimCodeVar.SIMVAR(derivedCref, BackendDAE.VARIABLE(), "", "", "", -1, NONE(), NONE(), NONE(), NONE(), false, DAE.T_REAL_DEFAULT, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, isProtected, hideResult);
+      r1 = SimCodeVar.SIMVAR(derivedCref, BackendDAE.VARIABLE(), "", "", "", -1, NONE(), NONE(), NONE(), NONE(), false, DAE.T_REAL_DEFAULT, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, isProtected, hideResult, NONE());
     then
       createAllDiffedSimVars(restVar, cref, inAllVars, inIndex, inMatrixName, r1::iVars);
 
@@ -6335,6 +6335,8 @@ protected
   SimCodeVar.SimVar simvar;
   SimCodeVar.SimVar derivSimvar;
   Boolean isalias;
+  DAE.ComponentRef name;
+  Integer len;
 algorithm
   SimCodeVar.SIMVARS(stateVars, derivativeVars, algVars, discreteAlgVars, intAlgVars, boolAlgVars, inputVars, outputVars,
     aliasVars, intAliasVars, boolAliasVars, paramVars, intParamVars, boolParamVars,
@@ -6349,6 +6351,20 @@ algorithm
   outHS := BaseHashSet.add(simvar.name, outHS);
   if (not isalias) and (BackendVariable.isStateVar(dlowVar) or BackendVariable.isAlgState(dlowVar)) then
     outHS := BaseHashSet.add(derivSimvar.name, outHS);
+  end if;
+
+  // If it is an input variable, we give it an index
+  if (not isalias) and BackendVariable.isVarOnTopLevelAndInputNoDerInput(dlowVar) then
+    simvar := match simvar
+      case SimCodeVar.SIMVAR()
+        algorithm
+          simvar.inputIndex := SOME(arrayCreate(1,-2));
+        then simvar;
+      else
+        algorithm
+          Error.addInternalError("Failed to SimCodeUtil.extractVarFromVar of input variable", sourceInfo());
+        then fail();
+    end match;
   end if;
 
   // figure out in which lists to put it
@@ -6928,6 +6944,9 @@ end isAliasVar;
 protected function sortSimvars
   input SimCodeVar.SimVars unsortedSimvars;
   output SimCodeVar.SimVars sortedSimvars = unsortedSimvars;
+protected
+  Integer i = 0;
+  array<Integer> arr;
 algorithm
   sortedSimvars.stateVars := List.sort(sortedSimvars.stateVars, simVarCompareByCrefSubsAtEndlLexical);
   sortedSimvars.derivativeVars := List.sort(sortedSimvars.derivativeVars, simVarCompareByCrefSubsAtEndlLexical);
@@ -6936,6 +6955,19 @@ algorithm
   sortedSimvars.intAlgVars := List.sort(sortedSimvars.intAlgVars, simVarCompareByCrefSubsAtEndlLexical);
   sortedSimvars.boolAlgVars := List.sort(sortedSimvars.boolAlgVars, simVarCompareByCrefSubsAtEndlLexical);
   sortedSimvars.inputVars := List.sort(sortedSimvars.inputVars, simVarCompareByCrefSubsAtEndlLexical);
+  for v in sortedSimvars.inputVars loop
+    // Set input indexes as they appear in the sorted order; is mutable since we need the same index in the other lists of vars...
+    i := match v
+      case SimCodeVar.SIMVAR(inputIndex=SOME(arr))
+        algorithm
+          arrayUpdate(arr, 1, i);
+        then i + 1;
+      else
+        algorithm
+          Error.addInternalError("Failed to update indexes of simvars", sourceInfo());
+        then fail();
+    end match;
+  end for;
   sortedSimvars.outputVars := List.sort(sortedSimvars.outputVars, simVarCompareByCrefSubsAtEndlLexical);
   sortedSimvars.aliasVars := List.sort(sortedSimvars.aliasVars, simVarCompareByCrefSubsAtEndlLexical);
   sortedSimvars.intAliasVars := List.sort(sortedSimvars.intAliasVars, simVarCompareByCrefSubsAtEndlLexical);
@@ -7601,7 +7633,7 @@ algorithm
                             and isFixed;
       then
         SimCodeVar.SIMVAR(cr, kind, commentStr, unit, displayUnit, -1 /* use -1 to get an error in simulation if something failed */,
-        minValue, maxValue, initVal, nomVal, isFixed, type_, isDiscrete, arrayCref, aliasvar, source, caus, NONE(), numArrayElement, isValueChangeable, isProtected, hideResult);
+        minValue, maxValue, initVal, nomVal, isFixed, type_, isDiscrete, arrayCref, aliasvar, source, caus, NONE(), numArrayElement, isValueChangeable, isProtected, hideResult, NONE());
 
     // Start value of states may be changeable
     case ((BackendDAE.VAR(varName = cr,
@@ -7630,7 +7662,7 @@ algorithm
         // print("name: " + ComponentReference.printComponentRefStr(cr) + "indx: " + intString(indx) + "\n");
       then
         SimCodeVar.SIMVAR(cr, kind, commentStr, unit, displayUnit, -1 /* use -1 to get an error in simulation if something failed */,
-        minValue, maxValue, initVal, nomVal, isFixed, type_, isDiscrete, arrayCref, aliasvar, source, caus, NONE(), numArrayElement, true, isProtected, hideResult);
+        minValue, maxValue, initVal, nomVal, isFixed, type_, isDiscrete, arrayCref, aliasvar, source, caus, NONE(), numArrayElement, true, isProtected, hideResult, NONE());
 
     case ((BackendDAE.VAR(varName = cr,
       varKind = kind,
@@ -7658,7 +7690,7 @@ algorithm
         // print("name: " + ComponentReference.printComponentRefStr(cr) + "indx: " + intString(indx) + "\n");
       then
         SimCodeVar.SIMVAR(cr, kind, commentStr, unit, displayUnit, -1 /* use -1 to get an error in simulation if something failed */,
-        minValue, maxValue, initVal, nomVal, isFixed, type_, isDiscrete, arrayCref, aliasvar, source, caus, NONE(), numArrayElement, false, isProtected, hideResult);
+        minValue, maxValue, initVal, nomVal, isFixed, type_, isDiscrete, arrayCref, aliasvar, source, caus, NONE(), numArrayElement, false, isProtected, hideResult, NONE());
   end match;
 end dlowvarToSimvar;
 
@@ -12002,6 +12034,22 @@ public function getSimEqSystemsByIndexLst
 algorithm
   sesOut := List.map1(idcs,getSimEqSysForIndex,allSes);
 end getSimEqSystemsByIndexLst;
+
+public function getInputIndex
+  input SimCodeVar.SimVar var;
+  output Integer inputIndex;
+protected
+  array<Integer> v;
+algorithm
+  inputIndex := match var
+    case SimCodeVar.SIMVAR(inputIndex=SOME(v)) guard arrayLength(v)==1 then arrayGet(v, 1);
+    case SimCodeVar.SIMVAR(inputIndex=SOME(_))
+      algorithm
+        Error.addInternalError("Failed to SimCodeUtil.getInputIndex of variable", sourceInfo());
+      then fail();
+    else -1;
+  end match;
+end getInputIndex;
 
 annotation(__OpenModelica_Interface="backend");
 end SimCodeUtil;

--- a/Compiler/SimCode/SimCodeVar.mo
+++ b/Compiler/SimCode/SimCodeVar.mo
@@ -101,6 +101,7 @@ public uniontype SimVar "Information about a variable in a Modelica model."
     Boolean isValueChangeable;
     Boolean isProtected;
     Boolean hideResult;
+    Option<array<Integer>> inputIndex;
   end SIMVAR;
 end SimVar;
 

--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -5506,18 +5506,26 @@ template ScalarVariableAttribute(SimVar simVar, Integer classIndex, String class
       let description = if comment then 'description = "<%Util.escapeModelicaStringToXmlString(comment)%>"'
       let alias = getAliasVar(aliasvar)
       let caus = getCausality(causality)
+      let inputIndex = getInputIndexXml(simVar)
       <<
       name = "<%Util.escapeModelicaStringToXmlString(crefStrNoUnderscore(name))%>"
       valueReference = "<%valueReference%>"
       <%description%>
       variability = "<%variability%>" isDiscrete = "<%isDiscrete%>"
-      causality = "<%caus%>" isValueChangeable = "<%isValueChangeable%>"
+      causality = "<%caus%>"<%inputIndex%> isValueChangeable = "<%isValueChangeable%>"
       alias = <%alias%>
       classIndex = "<%classIndex%>" classType = "<%classType%>"
       isProtected = "<%isProtected%>" hideResult = "<%hideResult%>"
       <%getInfoArgs(info)%>
       >>
 end ScalarVariableAttribute;
+
+template getInputIndexXml(SimVar simVar)
+::=
+  match SimCodeUtil.getInputIndex(simVar)
+    case -1 then ""
+    case ix then ' inputIndex="<%ix%>"'
+end getInputIndexXml;
 
 template getInfoArgs(builtin.SourceInfo info)
 ::=

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -308,14 +308,14 @@ package SimCode
     end SIMCODE;
   end SimCode;
 
-	uniontype PartitionData
-	  record PARTITIONDATA
-	    Integer numPartitions;
-	    list<list<Integer>> partitions; // which equations are assigned to the partitions
-	    list<list<Integer>> activatorsForPartitions; // which activators can activate each partition
-	    list<Integer> stateToActivators; // which states belong to which activator
-	  end PARTITIONDATA;
-	end PartitionData;
+  uniontype PartitionData
+    record PARTITIONDATA
+      Integer numPartitions;
+      list<list<Integer>> partitions; // which equations are assigned to the partitions
+      list<list<Integer>> activatorsForPartitions; // which activators can activate each partition
+      list<Integer> stateToActivators; // which states belong to which activator
+    end PARTITIONDATA;
+  end PartitionData;
 
   uniontype ClockedPartition
     record CLOCKED_PARTITION
@@ -872,12 +872,16 @@ package SimCodeUtil
     output list<SimCode.SimEqSystem> deps;
   end computeDependencies;
 
-	function getSimEqSystemsByIndexLst
-	  input list<Integer> idcs;
-	  input list<SimCode.SimEqSystem> allSes;
-	  output list<SimCode.SimEqSystem> sesOut;
-	end getSimEqSystemsByIndexLst;
+  function getSimEqSystemsByIndexLst
+    input list<Integer> idcs;
+    input list<SimCode.SimEqSystem> allSes;
+    output list<SimCode.SimEqSystem> sesOut;
+  end getSimEqSystemsByIndexLst;
 
+  function getInputIndex
+    input SimCodeVar.SimVar var;
+    output Integer inputIndex;
+  end getInputIndex;
 end SimCodeUtil;
 
 package SimCodeFunctionUtil

--- a/SimulationRuntime/c/simulation/results/simulation_result_mat.cpp
+++ b/SimulationRuntime/c/simulation/results/simulation_result_mat.cpp
@@ -75,8 +75,8 @@ static void generateData_1(DATA *data, threadData_t *threadData, double* &data_1
 static int calcDataSize(simulation_result *self,DATA *data);
 static const VAR_INFO** calcDataNames(simulation_result *self,DATA *data,int dataSize);
 
-static const struct VAR_INFO timeValName = {0,"time","Simulation time [s]",{"",-1,-1,-1,-1}};
-static const struct VAR_INFO cpuTimeValName = {0,"$cpuTime","cpu time [s]",{"",-1,-1,-1,-1}};
+static const struct VAR_INFO timeValName = {0,-1,"time","Simulation time [s]",{"",-1,-1,-1,-1}};
+static const struct VAR_INFO cpuTimeValName = {0,-1,"$cpuTime","cpu time [s]",{"",-1,-1,-1,-1}};
 
 static int calcDataSize(simulation_result *self,DATA *data)
 {

--- a/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -342,8 +342,13 @@ static void XMLCALL endElement(void *userData, const char *name)
 
 static void read_var_info(omc_ScalarVariable *v, VAR_INFO *info)
 {
+  modelica_integer inputIndex;
   read_value_string(findHashStringString(v,"name"), &info->name);
   debugStreamPrint(LOG_DEBUG, 1, "read var %s from setup file", info->name);
+
+  read_value_long(findHashStringStringNull(v,"inputIndex"), &inputIndex, -1);
+  info->inputIndex = inputIndex;
+  debugStreamPrint(LOG_DEBUG, 0, "read input index %d from setup file", info->inputIndex);
 
   read_value_int(findHashStringString(v,"valueReference"), &info->id);
   debugStreamPrint(LOG_DEBUG, 0, "read for %s id %d from setup file", info->name, info->id);
@@ -423,6 +428,7 @@ void read_input_xml(MODEL_DATA* modelData,
   hash_string_long *mapAlias = NULL, *mapAliasParam = NULL;
   long *it, *itParam;
   mmc_sint_t i;
+  int inputIndex = 0;
 
   modelica_integer nxchk, nychk, npchk;
   modelica_integer nyintchk, npintchk;
@@ -837,9 +843,9 @@ static inline void read_value_bool(const char *s, modelica_boolean* res)
 /* reads integer value from a string */
 static inline void read_value_long(const char *s, modelica_integer* res, modelica_integer default_value)
 {
-  if (*s == '\0') {
+  if (s == NULL || *s == '\0') {
     *res = default_value;
-  } if (0 == strcmp(s, "true")) {
+  } else if (0 == strcmp(s, "true")) {
     *res = 1;
   } else if (0 == strcmp(s, "false")) {
     *res = 0;

--- a/SimulationRuntime/c/simulation_data.h
+++ b/SimulationRuntime/c/simulation_data.h
@@ -44,7 +44,7 @@
 #include "util/rational.h"
 #include "util/list.h"
 
-#define omc_dummyVarInfo {-1,"","",omc_dummyFileInfo}
+#define omc_dummyVarInfo {-1,-1,"","",omc_dummyFileInfo}
 #define omc_dummyEquationInfo {-1,0,"",-1,NULL}
 #define omc_dummyFunctionInfo {-1,"",omc_dummyFileInfo}
 #define omc_dummyRealAttribute {NULL,NULL,DBL_MAX,-DBL_MAX,0,0,1.0,0,0.0}
@@ -62,6 +62,7 @@ struct DATA;
 typedef struct VAR_INFO
 {
   int id;
+  int inputIndex; /* -1 means not an input */
   const char *name;
   const char *comment;
   FILE_INFO info;


### PR DESCRIPTION
This is so that we can map external input files (or OPC input) to a
variable name from an index. Previously, you only knew how many input
variables there were, not in which order they should be given.