### PR TITLE
Fix fmi buildproject Windows makefile

### DIFF
--- a/SimulationRuntime/fmi/export/buildproject/Makefile.omdev.mingw
+++ b/SimulationRuntime/fmi/export/buildproject/Makefile.omdev.mingw
@@ -1,7 +1,7 @@
 # Manually created Makefile
 
-top_builddir = ../../../../../
-PROJECTDIR = ../../../../../build/share/omc/runtime/c/fmi/buildproject/
+top_builddir = ../../../..
+PROJECTDIR = $(OMBUILDDIR)/share/omc/runtime/c/fmi/buildproject/
 
 default: install
 


### PR DESCRIPTION
This changes are needed if one only checkouts OMCompiler and not OpenModelica super project.