### PR TITLE
Fix for #3608.

### DIFF
--- a/Compiler/Util/StringUtil.mo
+++ b/Compiler/Util/StringUtil.mo
@@ -280,5 +280,12 @@ algorithm
   res := System.stringAllocatorResult(ext, res);
 end repeat;
 
+function quote
+  "Adds quotation marks to the beginning and end of a string."
+  input String inString;
+  output String outString = stringAppendList({"\"", inString, "\""});
+  annotation(__OpenModelica_EarlyInline = true);
+end quote;
+
 annotation(__OpenModelica_Interface="util");
 end StringUtil;


### PR DESCRIPTION
- Return an empty string for the type in Interactive.getComponentInfo
  when the type can't be found, instead of returning the unqualified
  class path.