### PR TITLE
attempt to make OMEdit work under Windows with Cpp

### DIFF
--- a/Compiler/Main/Main.mo
+++ b/Compiler/Main/Main.mo
@@ -762,7 +762,7 @@ algorithm
         // do we have the correct libexec stuff?
         true = System.directoryExists(omHome + "\\mingw\\libexec\\gcc\\mingw32\\4.4.0");
         newPath = stringAppendList({omHome,"\\bin;",
-                                    omHome,"\\lib;",
+                                    omHome,"\\lib\\omc\\cpp;",
                                     omHome,"\\mingw\\bin;",
                                     omHome,"\\mingw\\libexec\\gcc\\mingw32\\4.4.0\\;",
                                     oldPath});


### PR DESCRIPTION
In OMEdit under Windows:
  - select Tools->Options->Simulation->Target Language: Cpp
  - select Tools->Options->Simulation->Target Compiler: gcc
  - open a model, e.g. Modelica.Blocks.Examples.Filter
  - simulate ->

This results in:

    Process crashed
    Simulation process failed. Exited with code -1073741515.

This is most likely because the path of the Cpp dll's is not set. It is:

$(omHome)\\lib\\omc\\cpp

Should this path possibly be added to OMCompiler/Compiler/Main/Main.mo?
