### PR TITLE
Performance fixes.

### DIFF
--- a/Compiler/FFrontEnd/FGraph.mo
+++ b/Compiler/FFrontEnd/FGraph.mo
@@ -797,7 +797,7 @@ algorithm
 end getScopePath;
 
 public function getGraphNameStr
-"Returns the FQ name of the environment, see also getGraphPath"
+"Returns the FQ name of the environment."
   input Graph inGraph;
   output String outString;
 algorithm
@@ -810,7 +810,7 @@ algorithm
 end getGraphNameStr;
 
 public function getGraphName
-"Returns the FQ name of the environment, see also getEnvPath"
+"Returns the FQ name of the environment."
   input Graph inGraph;
   output Absyn.Path outPath;
 protected
@@ -827,7 +827,7 @@ algorithm
 end getGraphName;
 
 public function getGraphNameNoImplicitScopes
-"Returns the FQ name of the environment, see also getEnvPath"
+"Returns the FQ name of the environment."
   input Graph inGraph;
   output Absyn.Path outPath;
 protected

--- a/Compiler/FrontEnd/SCode.mo
+++ b/Compiler/FrontEnd/SCode.mo
@@ -3109,6 +3109,16 @@ algorithm
   end match;
 end elementIsClass;
 
+public function elementIsImport
+  input Element inElement;
+  output Boolean outIsImport;
+algorithm
+  outIsImport := match inElement
+    case IMPORT() then true;
+    else false;
+  end match;
+end elementIsImport;
+
 public function elementIsPublicImport
   input Element el;
   output Boolean b;


### PR DESCRIPTION
- Changed paths hashtable in InstExtends to a list of hashtables,
  to avoid the need to copy it when entering a new scope.
- Cleaned up and optimized various functions in InstExtends.
- Disabled state machine processing when using a Modelica version
  older than 3.3, to avoid creating expensive but unused hashtables.