### PR TITLE
Fixes to compile with Visual Studio 2010

### DIFF
--- a/Compiler/runtime/FMIImpl.c
+++ b/Compiler/runtime/FMIImpl.c
@@ -373,15 +373,6 @@ void FMIImpl__initializeFMI1Import(fmi1_import_t* fmi, void** fmiInfo, fmi_versi
   const char* guid = fmi1_import_get_GUID(fmi);
   /* Read the FMI description from FMU's modelDescription.xml file. */
   const char* description = fmi1_import_get_description(fmi);
-  if (description != NULL) {
-    int hasEscape = 0;
-    omc__escapedStringLength(description,0,&hasEscape);
-    if (hasEscape) {
-      description = (const char*)omc__escapedString(description,0);
-    }
-  } else {
-    description = "";
-  }
   /* Read the FMI generation tool from FMU's modelDescription.xml file. */
   const char* generationTool = fmi1_import_get_generation_tool(fmi);
   /* Read the FMI generation date and time from FMU's modelDescription.xml file. */
@@ -395,12 +386,41 @@ void FMIImpl__initializeFMI1Import(fmi1_import_t* fmi, void** fmiInfo, fmi_versi
   /* construct continuous states list record */
   int i = 1;
   void* continuousStatesList = mmc_mk_nil();
+  void* eventIndicatorsList = mmc_mk_nil();
+  void* enumItems = mmc_mk_nil();
+  fmi1_import_type_definitions_t* typeDefinitions = NULL;
+  size_t typeDefinitionsSize;
+  /* Read the FMI Default Experiment Start value from FMU's modelDescription.xml file. */
+  double experimentStartTime = fmi1_import_get_default_experiment_start(fmi);
+  /* Read the FMI Default Experiment Stop value from FMU's modelDescription.xml file. */
+  double experimentStopTime = fmi1_import_get_default_experiment_stop(fmi);
+  /* Read the FMI Default Experiment Tolerance value from FMU's modelDescription.xml file. */
+  double experimentTolerance = fmi1_import_get_default_experiment_tolerance(fmi);
+  /* Read the model variables from the FMU's modelDescription.xml file and create a list of it. */
+  fmi1_import_variable_list_t* model_variables_list = fmi1_import_get_variable_list(fmi);
+  size_t model_variables_list_size = fmi1_import_get_variable_list_size(model_variables_list);
+  /* get model variables value reference list */
+  const fmi1_value_reference_t* model_variables_value_reference_list = fmi1_import_get_value_referece_list(model_variables_list);
+  int xInputPlacement = -120;
+  int yInputPlacement = 60;
+  int xOutputPlacement = 100;
+  int yOutputPlacement = 60;
+
+  if (description != NULL) {
+    int hasEscape = 0;
+    omc__escapedStringLength(description,0,&hasEscape);
+    if (hasEscape) {
+      description = (const char*)omc__escapedString(description,0);
+    }
+  } else {
+    description = "";
+  }
+
   for (; i <= numberOfContinuousStates ; i++) {
     continuousStatesList = mmc_mk_cons(mmc_mk_icon(i), continuousStatesList);
   }
   /* construct event indicators list record */
   i = 1;
-  void* eventIndicatorsList = mmc_mk_nil();
   for (; i <= numberOfEventIndicators ; i++) {
     eventIndicatorsList = mmc_mk_cons(mmc_mk_icon(i), eventIndicatorsList);
   }
@@ -408,88 +428,60 @@ void FMIImpl__initializeFMI1Import(fmi1_import_t* fmi, void** fmiInfo, fmi_versi
   *fmiInfo = FMI__INFO(mmc_mk_scon_check_null(fmi_version_to_string(version)), mmc_mk_icon(fmiType), mmc_mk_scon_check_null(modelName), mmc_mk_scon_check_null(modelIdentifier), mmc_mk_scon_check_null(guid), mmc_mk_scon_check_null(description),
       mmc_mk_scon_check_null(generationTool), mmc_mk_scon_check_null(generationDateAndTime), mmc_mk_scon_check_null(namingConvention), continuousStatesList, eventIndicatorsList);
   /* get the type definitions */
-  fmi1_import_type_definitions_t* typeDefinitions = fmi1_import_get_type_definitions(fmi);
-  size_t typeDefinitionsSize = typeDefinitions ? fmi1_import_get_type_definition_number(typeDefinitions) : 0;
+  typeDefinitions = fmi1_import_get_type_definitions(fmi);
+  typeDefinitionsSize = typeDefinitions ? fmi1_import_get_type_definition_number(typeDefinitions) : 0;
   i = 0;
   *typeDefinitionsList = mmc_mk_nil();
-  void* enumItems = mmc_mk_nil();
   for (; i < typeDefinitionsSize ; i++) {
     fmi1_import_variable_typedef_t* variableTypeDef = fmi1_import_get_typedef(typeDefinitions, i);
     const char* name = fmi1_import_get_type_name(variableTypeDef);
     char* name_safe = makeStringFMISafe(name);
     void* typeName = mmc_mk_scon_check_null(name_safe);
-    free(name_safe);
+    fmi1_import_enumeration_typedef_t* enumTypeDef = NULL;
     const char* description = fmi1_import_get_type_description(variableTypeDef);
+    const char* quantity = "";
+    int min = 0;
+    int max = 0;
+    unsigned int itemsSize = 0;
+    free(name_safe);
     /* check if type is enum */
     if (fmi1_import_get_base_type(variableTypeDef) != fmi1_base_type_enum) {
       continue;
     }
     /* get the TypeDefinition as EnumerationType */
-    fmi1_import_enumeration_typedef_t* enumTypeDef = fmi1_import_get_type_as_enum(variableTypeDef);
-    const char* quantity = "";
-    int min = 0;
-    int max = 0;
-    unsigned int itemsSize = 0;
+    enumTypeDef = fmi1_import_get_type_as_enum(variableTypeDef);
     enumItems = mmc_mk_nil();
-    void* enumItem = NULL;
     if (enumTypeDef) {
+      void* enumItem = NULL;
+      unsigned int j;
       quantity = fmi1_import_get_type_quantity(variableTypeDef);
       min = fmi1_import_get_enum_type_min(enumTypeDef);
       max = fmi1_import_get_enum_type_max(enumTypeDef);
       itemsSize = fmi1_import_get_enum_type_size(enumTypeDef);
-      unsigned int j = itemsSize;
       /* get the enumeration items. Loop the items in reverse order so that they are stored in correct order. */
-      for (; j > 0 ; j--) {
+      for (j = itemsSize; j > 0 ; j--) {
         const char* itemName = fmi1_import_get_enum_type_item_name(enumTypeDef, j);
         const char* itemDescription = fmi1_import_get_enum_type_item_description(enumTypeDef, j);
         enumItem = FMI__ENUMERATIONITEM(mmc_mk_scon_check_null(itemName), mmc_mk_scon_check_null(itemDescription));
         enumItems = mmc_mk_cons(enumItem, enumItems);
       }
     }
-    void* typeDefinition = FMI__ENUMERATIONTYPE(typeName, mmc_mk_scon_check_null(description), mmc_mk_scon_check_null(quantity), mmc_mk_icon(min), mmc_mk_icon(max), enumItems);
-    *typeDefinitionsList = mmc_mk_cons(typeDefinition, *typeDefinitionsList);
+    *typeDefinitionsList = mmc_mk_cons(FMI__ENUMERATIONTYPE(typeName, mmc_mk_scon_check_null(description), mmc_mk_scon_check_null(quantity), mmc_mk_icon(min), mmc_mk_icon(max), enumItems), *typeDefinitionsList);
   }
-  /* Read the FMI Default Experiment Start value from FMU's modelDescription.xml file. */
-  double experimentStartTime = fmi1_import_get_default_experiment_start(fmi);
-  /* Read the FMI Default Experiment Stop value from FMU's modelDescription.xml file. */
-  double experimentStopTime = fmi1_import_get_default_experiment_stop(fmi);
-  /* Read the FMI Default Experiment Tolerance value from FMU's modelDescription.xml file. */
-  double experimentTolerance = fmi1_import_get_default_experiment_tolerance(fmi);
   /* construct FMIEXPERIMENTANNOTATION record */
   *experimentAnnotation = FMI__EXPERIMENTANNOTATION(mmc_mk_rcon(experimentStartTime), mmc_mk_rcon(experimentStopTime), mmc_mk_rcon(experimentTolerance));
-  /* Read the model variables from the FMU's modelDescription.xml file and create a list of it. */
-  fmi1_import_variable_list_t* model_variables_list = fmi1_import_get_variable_list(fmi);
   *modelVariablesInstance = mmc_mk_some(model_variables_list);
-  size_t model_variables_list_size = fmi1_import_get_variable_list_size(model_variables_list);
-  /* get model variables value reference list */
-  const fmi1_value_reference_t* model_variables_value_reference_list = fmi1_import_get_value_referece_list(model_variables_list);
   i = 0;
   *modelVariablesList = mmc_mk_nil();
-  int xInputPlacement = -120;
-  int yInputPlacement = 60;
-  int xOutputPlacement = 100;
-  int yOutputPlacement = 60;
   for (; i < model_variables_list_size ; i++) {
     fmi1_import_variable_t* model_variable = fmi1_import_get_variable(model_variables_list, i);
     void* variable_instance = mmc_mk_icon((intptr_t)model_variable);
     char *name = getFMI1ModelVariableName(model_variable);
     void* variable_name = mmc_mk_scon_check_null(name);
-    free(name);
     const char* description = fmi1_import_get_variable_description(model_variable);
-    if (description != NULL) {
-      int hasEscape = 0;
-      omc__escapedStringLength(description,0,&hasEscape);
-      if (hasEscape) {
-        description = (const char*)omc__escapedString(description,0);
-      }
-    } else {
-      description = "";
-    }
-    void* variable_description = mmc_mk_scon_check_null(description);
     const char* base_type = getFMI1ModelVariableBaseType(model_variable);
     char* base_type_safe = makeStringFMISafe(base_type);
     void* variable_base_type = mmc_mk_scon_check_null(base_type_safe);
-    free(base_type_safe);
     void* variable_variability = mmc_mk_scon_check_null(getFMI1ModelVariableVariability(model_variable));
     const char* causality = getFMI1ModelVariableCausality(model_variable);
     void* variable_causality = mmc_mk_scon_check_null(causality);
@@ -502,6 +494,21 @@ void FMIImpl__initializeFMI1Import(fmi1_import_t* fmi, void** fmiInfo, fmi_versi
     void* variable_x2_placement = mmc_mk_icon(0);
     void* variable_y1_placement = mmc_mk_icon(0);
     void* variable_y2_placement = mmc_mk_icon(0);
+    void* variable_description = NULL;
+    void* variable = NULL;
+    fmi1_base_type_enu_t type = fmi1_import_get_variable_base_type(model_variable);
+    free(base_type_safe);
+    free(name);
+    if (description != NULL) {
+      int hasEscape = 0;
+      omc__escapedStringLength(description,0,&hasEscape);
+      if (hasEscape) {
+        description = (const char*)omc__escapedString(description,0);
+      }
+    } else {
+      description = "";
+    }
+    variable_description = mmc_mk_scon_check_null(description);
     if ((strcmp(causality,"input") == 0) && input_connectors) {
       variable_x1_placement = mmc_mk_icon(xInputPlacement);
       variable_x2_placement = mmc_mk_icon(xInputPlacement+20);
@@ -516,8 +523,6 @@ void FMIImpl__initializeFMI1Import(fmi1_import_t* fmi, void** fmiInfo, fmi_versi
       yOutputPlacement -= 25;
     }
     //fprintf(stderr, "%s Variable name = %s, valueReference = %d\n", getFMI1ModelVariableBaseType(model_variable), getFMI1ModelVariableName(model_variable), model_variables_value_reference_list[i]);fflush(NULL);
-    void* variable = NULL;
-    fmi1_base_type_enu_t type = fmi1_import_get_variable_base_type(model_variable);
     switch (type) {
       case fmi1_base_type_real:
         variable = FMI__REALVARIABLE(variable_instance, variable_name, variable_description, variable_base_type, variable_variability, variable_causality,
@@ -551,32 +556,13 @@ void FMIImpl__initializeFMI2Import(fmi2_import_t* fmi, void** fmiInfo, fmi_versi
   const char* modelName = fmi2_import_get_model_name(fmi);
   /* Read the FMI type */
   fmi2_fmu_kind_enu_t fmiType = fmi2_import_get_fmu_kind(fmi);
-  /* Read the model identifier from FMU's modelDescription.xml file. */
-  const char* modelIdentifier = NULL;
-  switch (fmiType) {
-    case fmi2_fmu_kind_me:
-    case fmi2_fmu_kind_me_and_cs:
-      modelIdentifier = fmi2_import_get_model_identifier_ME(fmi);
-      break;
-    case fmi2_fmu_kind_cs:
-      modelIdentifier = fmi2_import_get_model_identifier_CS(fmi);
-      break;
-    default: break;
-  }
   /* Read the FMI GUID from FMU's modelDescription.xml file. */
   const char* guid = fmi2_import_get_GUID(fmi);
   /* Read the FMI description from FMU's modelDescription.xml file. */
   const char* description = fmi2_import_get_description(fmi);
-  if (description != NULL) {
-    int hasEscape = 0;
-    omc__escapedStringLength(description,0,&hasEscape);
-    if (hasEscape) {
-      description = (const char*)omc__escapedString(description,0);
-    }
-  } else {
-    description = "";
-  }
-/* Read the FMI generation tool from FMU's modelDescription.xml file. */
+  /* Read the model identifier from FMU's modelDescription.xml file. */
+  const char* modelIdentifier = NULL;
+  /* Read the FMI generation tool from FMU's modelDescription.xml file. */
   const char* generationTool = fmi2_import_get_generation_tool(fmi);
   /* Read the FMI generation date and time from FMU's modelDescription.xml file. */
   const char* generationDateAndTime = fmi2_import_get_generation_date_and_time(fmi);
@@ -589,12 +575,54 @@ void FMIImpl__initializeFMI2Import(fmi2_import_t* fmi, void** fmiInfo, fmi_versi
   /* construct continuous states list record */
   int i = 1;
   void* continuousStatesList = mmc_mk_nil();
+  void* eventIndicatorsList = mmc_mk_nil();
+  fmi2_import_type_definitions_t* typeDefinitions = fmi2_import_get_type_definitions(fmi);
+  size_t typeDefinitionsSize = typeDefinitions ? fmi2_import_get_type_definition_number(typeDefinitions) : 0;
+  void* enumItems = mmc_mk_nil();
+  /* Read the FMI Default Experiment Start value from FMU's modelDescription.xml file. */
+  double experimentStartTime = fmi2_import_get_default_experiment_start(fmi);
+  /* Read the FMI Default Experiment Stop value from FMU's modelDescription.xml file. */
+  double experimentStopTime = fmi2_import_get_default_experiment_stop(fmi);
+  /* Read the FMI Default Experiment Tolerance value from FMU's modelDescription.xml file. */
+  double experimentTolerance = fmi2_import_get_default_experiment_tolerance(fmi);
+  /* Read the model variables from the FMU's modelDescription.xml file and create a list of it. */
+  int sortOrder = 0;
+  /* sortOrder specifies the order of the variables in the list: 0 - original order as found
+  in the XML file; 1 - sorted alfabetically by variable name; 2 sorted by
+  types/value references. */
+  fmi2_import_variable_list_t* model_variables_list = fmi2_import_get_variable_list(fmi, sortOrder);
+  size_t model_variables_list_size = fmi2_import_get_variable_list_size(model_variables_list);
+  /* get model variables value reference list */
+  const fmi2_value_reference_t* model_variables_value_reference_list = fmi2_import_get_value_referece_list(model_variables_list);
+  int xInputPlacement = -120;
+  int yInputPlacement = 60;
+  int xOutputPlacement = 100;
+  int yOutputPlacement = 60;
+
+  switch (fmiType) {
+    case fmi2_fmu_kind_me:
+    case fmi2_fmu_kind_me_and_cs:
+      modelIdentifier = fmi2_import_get_model_identifier_ME(fmi);
+      break;
+    case fmi2_fmu_kind_cs:
+      modelIdentifier = fmi2_import_get_model_identifier_CS(fmi);
+      break;
+    default: break;
+  }
+  if (description != NULL) {
+    int hasEscape = 0;
+    omc__escapedStringLength(description,0,&hasEscape);
+    if (hasEscape) {
+      description = (const char*)omc__escapedString(description,0);
+    }
+  } else {
+    description = "";
+  }
   for (; i <= numberOfContinuousStates ; i++) {
     continuousStatesList = mmc_mk_cons(mmc_mk_icon(i), continuousStatesList);
   }
   /* construct event indicators list record */
   i = 1;
-  void* eventIndicatorsList = mmc_mk_nil();
   for (; i <= numberOfEventIndicators ; i++) {
     eventIndicatorsList = mmc_mk_cons(mmc_mk_icon(i), eventIndicatorsList);
   }
@@ -602,18 +630,24 @@ void FMIImpl__initializeFMI2Import(fmi2_import_t* fmi, void** fmiInfo, fmi_versi
   *fmiInfo = FMI__INFO(mmc_mk_scon_check_null(fmi_version_to_string(version)), mmc_mk_icon(fmiType), mmc_mk_scon_check_null(modelName), mmc_mk_scon_check_null(modelIdentifier), mmc_mk_scon_check_null(guid), mmc_mk_scon_check_null(description),
       mmc_mk_scon_check_null(generationTool), mmc_mk_scon_check_null(generationDateAndTime), mmc_mk_scon_check_null(namingConvention), continuousStatesList, eventIndicatorsList);
 
-  fmi2_import_type_definitions_t* typeDefinitions = fmi2_import_get_type_definitions(fmi);
-  size_t typeDefinitionsSize = typeDefinitions ? fmi2_import_get_type_definition_number(typeDefinitions) : 0;
   *typeDefinitionsList = mmc_mk_nil();
-  void* enumItems = mmc_mk_nil();
 
   for(i = 0; i < typeDefinitionsSize; ++i) {
     fmi2_import_variable_typedef_t* variableTypeDef = fmi2_import_get_typedef(typeDefinitions, i);
     const char* name = fmi2_import_get_type_name(variableTypeDef);
     char* name_safe = makeStringFMISafe(name);
     void* typeName = mmc_mk_scon_check_null(name_safe);
-    free(name_safe);
     const char* description = fmi2_import_get_type_description(variableTypeDef);
+    fmi2_import_enumeration_typedef_t* enumTypeDef = NULL;
+    const char* quantity = "";
+    int min = 0;
+    int max = 0;
+    unsigned itemsSize = 0;
+    void* enumItem = NULL;
+
+    enumItems = mmc_mk_nil();
+
+    free(name_safe);
 
     /* check if type is enum */
     if(fmi2_import_get_base_type(variableTypeDef) != fmi1_base_type_enum) {
@@ -621,21 +655,15 @@ void FMIImpl__initializeFMI2Import(fmi2_import_t* fmi, void** fmiInfo, fmi_versi
     }
 
     /* get the TypeDefinition as EnumerationType */
-    fmi2_import_enumeration_typedef_t* enumTypeDef = fmi2_import_get_type_as_enum(variableTypeDef);
-    const char* quantity = "";
-    int min = 0;
-    int max = 0;
-    unsigned itemsSize = 0;
-    enumItems = mmc_mk_nil();
-    void* enumItem = NULL;
+    enumTypeDef = fmi2_import_get_type_as_enum(variableTypeDef);
 
     if(enumTypeDef) {
+      unsigned j;
       quantity = fmi2_import_get_type_quantity(variableTypeDef);
       min = fmi2_import_get_enum_type_min(enumTypeDef);
       max = fmi2_import_get_enum_type_max(enumTypeDef);
       itemsSize = fmi2_import_get_enum_type_size(enumTypeDef);
 
-      unsigned j;
       for(j = itemsSize; j > 0; --j) {
         const char* itemName = fmi2_import_get_enum_type_item_name(enumTypeDef, j);
         const char* itemDescription = fmi2_import_get_enum_type_item_description(enumTypeDef, j);
@@ -644,54 +672,23 @@ void FMIImpl__initializeFMI2Import(fmi2_import_t* fmi, void** fmiInfo, fmi_versi
       }
     }
 
-    void* typeDefinition = FMI__ENUMERATIONTYPE(typeName, mmc_mk_scon_check_null(description), mmc_mk_scon_check_null(quantity), mmc_mk_icon(min), mmc_mk_icon(max), enumItems);
-    *typeDefinitionsList = mmc_mk_cons(typeDefinition, *typeDefinitionsList);
+    *typeDefinitionsList = mmc_mk_cons(FMI__ENUMERATIONTYPE(typeName, mmc_mk_scon_check_null(description), mmc_mk_scon_check_null(quantity), mmc_mk_icon(min), mmc_mk_icon(max), enumItems), *typeDefinitionsList);
   }
 
-  /* Read the FMI Default Experiment Start value from FMU's modelDescription.xml file. */
-  double experimentStartTime = fmi2_import_get_default_experiment_start(fmi);
-  /* Read the FMI Default Experiment Stop value from FMU's modelDescription.xml file. */
-  double experimentStopTime = fmi2_import_get_default_experiment_stop(fmi);
-  /* Read the FMI Default Experiment Tolerance value from FMU's modelDescription.xml file. */
-  double experimentTolerance = fmi2_import_get_default_experiment_tolerance(fmi);
   *experimentAnnotation = FMI__EXPERIMENTANNOTATION(mmc_mk_rcon(experimentStartTime), mmc_mk_rcon(experimentStopTime), mmc_mk_rcon(experimentTolerance));
-  /* Read the model variables from the FMU's modelDescription.xml file and create a list of it. */
-  int sortOrder = 0;
-  /* sortOrder specifies the order of the variables in the list: 0 - original order as found
-  in the XML file; 1 - sorted alfabetically by variable name; 2 sorted by
-  types/value references. */
-  fmi2_import_variable_list_t* model_variables_list = fmi2_import_get_variable_list(fmi, sortOrder);
   *modelVariablesInstance = mmc_mk_some(model_variables_list);
-  size_t model_variables_list_size = fmi2_import_get_variable_list_size(model_variables_list);
-  /* get model variables value reference list */
-  const fmi2_value_reference_t* model_variables_value_reference_list = fmi2_import_get_value_referece_list(model_variables_list);
   i = 0;
   *modelVariablesList = mmc_mk_nil();
-  int xInputPlacement = -120;
-  int yInputPlacement = 60;
-  int xOutputPlacement = 100;
-  int yOutputPlacement = 60;
   for (; i < model_variables_list_size ; i++) {
     fmi2_import_variable_t* model_variable = fmi2_import_get_variable(model_variables_list, i);
     void* variable_instance = mmc_mk_icon((intptr_t)model_variable);
     char *name = getFMI2ModelVariableName(model_variable);
     void* variable_name = mmc_mk_scon_check_null(name);
-    free(name);
     const char* description = fmi2_import_get_variable_description(model_variable);
-    if (description != NULL) {
-      int hasEscape = 0;
-      omc__escapedStringLength(description,0,&hasEscape);
-      if (hasEscape) {
-        description = (const char*)omc__escapedString(description,0);
-      }
-    } else {
-      description = "";
-    }
-    void* variable_description = mmc_mk_scon_check_null(description);
+    void* variable_description = NULL;
     const char* base_type = getFMI2ModelVariableBaseType(model_variable);
     char* base_type_safe = makeStringFMISafe(base_type);
     void* variable_base_type = mmc_mk_scon_check_null(base_type_safe);
-    free(base_type_safe);
     void* variable_variability = mmc_mk_scon_check_null(getFMI2ModelVariableVariability(model_variable));
     const char* causality = getFMI2ModelVariableCausality(model_variable);
     void* variable_causality = mmc_mk_scon_check_null(causality);
@@ -704,6 +701,20 @@ void FMIImpl__initializeFMI2Import(fmi2_import_t* fmi, void** fmiInfo, fmi_versi
     void* variable_x2_placement = mmc_mk_icon(0);
     void* variable_y1_placement = mmc_mk_icon(0);
     void* variable_y2_placement = mmc_mk_icon(0);
+    void* variable = NULL;
+    fmi2_base_type_enu_t type = fmi2_import_get_variable_base_type(model_variable);
+    free(base_type_safe);
+    free(name);
+    if (description != NULL) {
+      int hasEscape = 0;
+      omc__escapedStringLength(description,0,&hasEscape);
+      if (hasEscape) {
+        description = (const char*)omc__escapedString(description,0);
+      }
+    } else {
+      description = "";
+    }
+    variable_description = mmc_mk_scon_check_null(description);
     if ((strcmp(causality,"input") == 0) && input_connectors) {
       variable_x1_placement = mmc_mk_icon(xInputPlacement);
       variable_x2_placement = mmc_mk_icon(xInputPlacement+20);
@@ -718,8 +729,6 @@ void FMIImpl__initializeFMI2Import(fmi2_import_t* fmi, void** fmiInfo, fmi_versi
       yOutputPlacement -= 25;
     }
     //fprintf(stderr, "%s Variable name = %s, valueReference = %d\n", getFMI2ModelVariableBaseType(model_variable), getFMI2ModelVariableName(model_variable), model_variables_value_reference_list[i]);fflush(NULL);
-    void* variable = NULL;
-    fmi2_base_type_enu_t type = fmi2_import_get_variable_base_type(model_variable);
     switch (type) {
       case fmi2_base_type_real:
         variable = FMI__REALVARIABLE(variable_instance, variable_name, variable_description, variable_base_type, variable_variability, variable_causality,
@@ -755,6 +764,11 @@ void FMIImpl__initializeFMI2Import(fmi2_import_t* fmi, void** fmiInfo, fmi_versi
 int FMIImpl__initializeFMIImport(const char* file_name, const char* working_directory, int fmi_log_level, int input_connectors, int output_connectors,
     void** fmiContext, void** fmiInstance, void** fmiInfo, void** typeDefinitionsList, void** experimentAnnotation, void** modelVariablesInstance, void** modelVariablesList)
 {
+  // JM callbacks
+  static jm_callbacks callbacks;
+  static int init_jm_callbacks = 0;
+  fmi_import_context_t* context;
+  fmi_version_enu_t version;
   *fmiContext = mmc_mk_some(0);
   *fmiInstance = mmc_mk_some(0);
   *fmiInfo = NULL;
@@ -762,9 +776,6 @@ int FMIImpl__initializeFMIImport(const char* file_name, const char* working_dire
   *experimentAnnotation = NULL;
   *modelVariablesInstance = mmc_mk_some(0);
   *modelVariablesList = NULL;
-  // JM callbacks
-  static jm_callbacks callbacks;
-  static int init_jm_callbacks = 0;
   if (!init_jm_callbacks) {
     init_jm_callbacks = 1;
     callbacks.malloc = malloc;
@@ -775,14 +786,13 @@ int FMIImpl__initializeFMIImport(const char* file_name, const char* working_dire
     callbacks.log_level = fmi_log_level;
     callbacks.context = 0;
   }
-  fmi_import_context_t* context = fmi_import_allocate_context(&callbacks);
+  context = fmi_import_allocate_context(&callbacks);
   *fmiContext = mmc_mk_some(context);
   // extract the fmu file and read the version
-  fmi_version_enu_t version;
   version = fmi_import_get_fmi_version(context, file_name, working_directory);
   if ((version <= fmi_version_unknown_enu) || (version >= fmi_version_unsupported_enu)) {
-    fmi_import_free_context(context);
     const char* tokens[1] = {fmi_version_to_string(version)};
+    fmi_import_free_context(context);
     c_add_message(NULL,-1, ErrorType_scripting, ErrorLevel_error, gettext("The FMU version is %s. Unknown/Unsupported FMU version."), tokens, 1);
     return 0;
   }
@@ -790,6 +800,7 @@ int FMIImpl__initializeFMIImport(const char* file_name, const char* working_dire
     static int init_fmi1_callback_functions = 0;
     // FMI callback functions
     static fmi1_callback_functions_t fmi1_callback_functions;
+    fmi1_import_t* fmi;
     if (!init_fmi1_callback_functions) {
       init_fmi1_callback_functions = 1;
       fmi1_callback_functions.logger = fmi1logger;
@@ -797,7 +808,6 @@ int FMIImpl__initializeFMIImport(const char* file_name, const char* working_dire
       fmi1_callback_functions.freeMemory = free;
     }
     // parse the xml file
-    fmi1_import_t* fmi;
     fmi = fmi1_import_parse_xml(context, working_directory);
     if(!fmi) {
       fmi_import_free_context(context);
@@ -821,6 +831,8 @@ int FMIImpl__initializeFMIImport(const char* file_name, const char* working_dire
     static int init_fmi2_callback_functions = 0;
     // FMI callback functions
     static fmi2_callback_functions_t fmi2_callback_functions;
+    fmi2_import_t* fmi;
+    fmi2_fmu_kind_enu_t fmiType;
     if (!init_fmi2_callback_functions) {
       init_fmi2_callback_functions = 1;
       fmi2_callback_functions.logger = fmi2logger;
@@ -828,7 +840,6 @@ int FMIImpl__initializeFMIImport(const char* file_name, const char* working_dire
       fmi2_callback_functions.freeMemory = free;
     }
     // parse the xml file
-    fmi2_import_t* fmi;
     fmi = fmi2_import_parse_xml(context, working_directory, NULL);
     if(!fmi) {
       fmi_import_free_context(context);
@@ -836,11 +847,11 @@ int FMIImpl__initializeFMIImport(const char* file_name, const char* working_dire
       return 0;
     }
     /* remove the following block once we have support for FMI 2.0 CS. */
-    fmi2_fmu_kind_enu_t fmiType = fmi2_import_get_fmu_kind(fmi);
+    fmiType = fmi2_import_get_fmu_kind(fmi);
     if (fmiType == fmi2_fmu_kind_cs || fmiType == fmi2_fmu_kind_me_and_cs) {
+      const char* tokens[1] = {fmi2_fmu_kind_to_string(fmiType)};
       fmi2_import_free(fmi);
       fmi_import_free_context(context);
-      const char* tokens[1] = {fmi2_fmu_kind_to_string(fmiType)};
       c_add_message(NULL,-1, ErrorType_scripting, ErrorLevel_error, gettext("The FMU version is 2.0 and FMU type is %s. Unsupported FMU type. Only FMI 2.0 ModelExchange is supported."), tokens, 1);
       return 0;
     }
@@ -872,12 +883,12 @@ void FMIImpl__releaseFMIImport(void *ptr1, void *ptr2, void *ptr3, const char* f
   intptr_t fmiInstance = (intptr_t)MMC_FETCH(MMC_OFFSET(MMC_UNTAGPTR(ptr2),1));
   intptr_t fmiContext = (intptr_t)MMC_FETCH(MMC_OFFSET(MMC_UNTAGPTR(ptr3),1));
   if (strcmp(fmiVersion, "1.0") == 0) {
-    free((fmi1_import_variable_list_t*)fmiModeVariablesInstance);
     fmi1_import_t* fmi = (fmi1_import_t*)fmiInstance;
+    free((fmi1_import_variable_list_t*)fmiModeVariablesInstance);
     fmi1_import_free(fmi);
   } else if (strcmp(fmiVersion, "2.0") == 0) {
-    free((fmi2_import_variable_list_t*)fmiModeVariablesInstance);
     fmi2_import_t* fmi = (fmi2_import_t*)fmiInstance;
+    free((fmi2_import_variable_list_t*)fmiModeVariablesInstance);
     fmi2_import_free(fmi);
   }
   fmi_import_free_context((fmi_import_context_t*)fmiContext);

--- a/Compiler/runtime/GraphStreamExt_omc.cpp
+++ b/Compiler/runtime/GraphStreamExt_omc.cpp
@@ -42,30 +42,46 @@ extern "C" {
 }
 
 #define UNBOX_OFFSET 1
+#if !defined(_MSC_VER)
 #include "GraphStreamExt_impl.cpp"
+#else
+#include "errorext.h"
+#define GRAPHSTREAM_MSVS() c_add_message(NULL, -1, ErrorType_scripting, ErrorLevel_error, "Graphstream not supported on Visual Studio.", NULL, 0);MMC_THROW();
+#endif
 
 extern "C" {
 
 extern void GraphStreamExt_newStream(threadData_t *threadData, const char* streamName, const char* host, int port, int debug)
 {
+#if defined(_MSC_VER)
+  GRAPHSTREAM_MSVS();
+#else
   GraphStreamExtImpl_newStream(
       streamName,
       host,
       port,
       debug);
+#endif
 }
 
 extern void GraphStreamExt_addNode(threadData_t *threadData, const char* streamName, const char* sourceId, int timeId, const char* nodeId)
 {
+#if defined(_MSC_VER)
+  GRAPHSTREAM_MSVS();
+#else
   GraphStreamExtImpl_addNode(
       streamName,
       sourceId,
       timeId,
       nodeId);
+#endif
 }
 
 extern void GraphStreamExt_addEdge(threadData_t *threadData, const char* streamName, const char* sourceId, int timeId, const char* nodeIdSource, const char* nodeIdTarget, int directed)
 {
+#if defined(_MSC_VER)
+  GRAPHSTREAM_MSVS();
+#else
   GraphStreamExtImpl_addEdge(
       streamName,
       sourceId,
@@ -73,10 +89,14 @@ extern void GraphStreamExt_addEdge(threadData_t *threadData, const char* streamN
       nodeIdSource,
       nodeIdTarget,
       directed);
+#endif
 }
 
 extern void GraphStreamExt_addNodeAttribute(threadData_t *threadData, const char* streamName, const char* sourceId, int timeId, const char* nodeId, const char* attribute, void* value)
 {
+#if defined(_MSC_VER)
+  GRAPHSTREAM_MSVS();
+#else
   GraphStreamExtImpl_addNodeAttribute(
       streamName,
       sourceId,
@@ -84,10 +104,14 @@ extern void GraphStreamExt_addNodeAttribute(threadData_t *threadData, const char
       nodeId,
       attribute,
       value);
+#endif
 }
 
 extern void GraphStreamExt_addEdgeAttribute(threadData_t *threadData, const char* streamName, const char* sourceId, int timeId, const char* nodeIdSource, const char* nodeIdTarget, const char* attribute, void* value)
 {
+#if defined(_MSC_VER)
+  GRAPHSTREAM_MSVS();
+#else
   GraphStreamExtImpl_addEdgeAttribute(
       streamName,
       sourceId,
@@ -96,20 +120,28 @@ extern void GraphStreamExt_addEdgeAttribute(threadData_t *threadData, const char
       nodeIdTarget,
       attribute,
       value);
+#endif
 }
 
 extern void GraphStreamExt_addGraphAttribute(threadData_t *threadData, const char* streamName, const char* sourceId, int timeId, const char* attribute, void* value)
 {
+#if defined(_MSC_VER)
+  GRAPHSTREAM_MSVS();
+#else
   GraphStreamExtImpl_addGraphAttribute(
       streamName,
       sourceId,
       timeId,
       attribute,
       value);
+#endif
 }
 
 extern void GraphStreamExt_changeNodeAttribute(threadData_t *threadData, const char* streamName, const char* sourceId, int timeId, const char* nodeId, const char* attribute, void* oldvalue, void* newvalue)
 {
+#if defined(_MSC_VER)
+  GRAPHSTREAM_MSVS();
+#else
   GraphStreamExtImpl_changeNodeAttribute(
       streamName,
       sourceId,
@@ -118,10 +150,14 @@ extern void GraphStreamExt_changeNodeAttribute(threadData_t *threadData, const c
       attribute,
       oldvalue,
       newvalue);
+#endif
 }
 
 extern void GraphStreamExt_changeEdgeAttribute(threadData_t *threadData, const char* streamName, const char* sourceId, int timeId, const char* nodeIdSource, const char* nodeIdTarget, const char* attribute, void* oldvalue, void* newvalue)
 {
+#if defined(_MSC_VER)
+  GRAPHSTREAM_MSVS();
+#else
   GraphStreamExtImpl_changeEdgeAttribute(
     streamName,
     sourceId,
@@ -131,10 +167,14 @@ extern void GraphStreamExt_changeEdgeAttribute(threadData_t *threadData, const c
     attribute,
     oldvalue,
     newvalue);
+#endif
 }
 
 extern void GraphStreamExt_changeGraphAttribute(threadData_t *threadData, const char* streamName, const char* sourceId, int timeId, const char* attribute, void* oldvalue, void* newvalue)
 {
+#if defined(_MSC_VER)
+  GRAPHSTREAM_MSVS();
+#else
   GraphStreamExtImpl_changeGraphAttribute(
     streamName,
     sourceId,
@@ -142,11 +182,16 @@ extern void GraphStreamExt_changeGraphAttribute(threadData_t *threadData, const 
     attribute,
     oldvalue,
     newvalue);
+#endif
 }
 
 extern void GraphStreamExt_cleanup(threadData_t *threadData)
 {
+#if defined(_MSC_VER)
+  GRAPHSTREAM_MSVS();
+#else
   GraphStreamExtImpl_cleanup();
+#endif
 }
 
 }

--- a/Compiler/runtime/HpcOmBenchmarkExt_omc.cpp
+++ b/Compiler/runtime/HpcOmBenchmarkExt_omc.cpp
@@ -2,26 +2,48 @@
 #include "meta_modelica.h"
 #define ADD_METARECORD_DEFINITIONS static
 #include "OpenModelicaBootstrappingHeader.h"
+
+#if !defined(_MSC_VER)
 #include "HpcOmBenchmarkExt.cpp"
+#else
+#include "errorext.h"
+#define HPC_OM_VS() c_add_message(NULL, -1, ErrorType_scripting, ErrorLevel_error, "HpcOmBenchmark not supported on Visual Studio.", NULL, 0);MMC_THROW();
+#endif
 
 extern "C" {
 extern void* HpcOmBenchmarkExt_requiredTimeForOp()
 {
+#if defined(_MSC_VER)
+  HPC_OM_VS();
+#else
   return HpcOmBenchmarkExtImpl__requiredTimeForOp();
+#endif
 }
 
 extern void* HpcOmBenchmarkExt_requiredTimeForComm()
 {
+#if defined(_MSC_VER)
+  HPC_OM_VS();
+#else
   return HpcOmBenchmarkExtImpl__requiredTimeForComm();
+#endif
 }
 
 extern void* HpcOmBenchmarkExt_readCalcTimesFromXml(const char *filename)
 {
+#if defined(_MSC_VER)
+  HPC_OM_VS();
+#else
   return HpcOmBenchmarkExtImpl__readCalcTimesFromXml(filename);
+#endif
 }
 
 extern void* HpcOmBenchmarkExt_readCalcTimesFromJson(const char *filename)
 {
+#if defined(_MSC_VER)
+  HPC_OM_VS();
+#else
   return HpcOmBenchmarkExtImpl__readCalcTimesFromJson(filename);
+#endif
 }
 }

--- a/Compiler/runtime/HpcOmSchedulerExt_omc.cpp
+++ b/Compiler/runtime/HpcOmSchedulerExt_omc.cpp
@@ -2,17 +2,30 @@
 #include "meta_modelica.h"
 #define ADD_METARECORD_DEFINITIONS static
 #include "OpenModelicaBootstrappingHeader.h"
+
+#if !defined(_MSC_VER)
 #include "HpcOmSchedulerExt.cpp"
+#else
+#include "errorext.h"
+#define HPC_OM_VS() c_add_message(NULL, -1, ErrorType_scripting, ErrorLevel_error, "HpcOmScheduler not supported on Visual Studio.", NULL, 0);MMC_THROW();
+#endif
 
 extern "C" {
 
 extern void* HpcOmSchedulerExt_readScheduleFromGraphMl(const char *filename)
 {
+#if defined(_MSC_VER)
+  HPC_OM_VS();
+#else
   return HpcOmSchedulerExtImpl__readScheduleFromGraphMl(filename);
+#endif
 }
 
 extern void* HpcOmSchedulerExt_scheduleMetis(modelica_metatype xadjIn, modelica_metatype adjncyIn, modelica_metatype vwgtIn, modelica_metatype adjwgtIn, int npartsIn)
 {
+#if defined(_MSC_VER)
+  HPC_OM_VS();
+#else
   int xadjNelts = (int)MMC_HDRSLOTS(MMC_GETHDR(xadjIn)); //number of elements in xadj-array
   int adjncyNelts = (int)MMC_HDRSLOTS(MMC_GETHDR(adjncyIn)); //number of elements in adjncy-array
   int vwgtNelts = (int)MMC_HDRSLOTS(MMC_GETHDR(vwgtIn)); //number of elements in vwgt-array
@@ -91,7 +104,7 @@ extern void* HpcOmSchedulerExt_schedulehMetis(modelica_metatype xadjIn, modelica
     hewgts[i] = adjwgtElem;
   }
   return HpcOmSchedulerExtImpl__scheduleMetis(vwgts, eptr, eint, hewgts, vwgtsNelts, eptrNelts, nparts);
+#endif
 }
-
 
 }

--- a/Compiler/runtime/SimulationResultsCmp.c
+++ b/Compiler/runtime/SimulationResultsCmp.c
@@ -553,18 +553,20 @@ void* SimulationResultsCmp_compareResults(int isResultCmp, int runningTestsuite,
   /*  fprintf(stderr, "Open File %s\n", filename); */
   if (UNKNOWN_PLOT == SimulationResultsImpl__openFile(filename,&simresglob_c)) {
     char *str = (char*) GC_malloc(25+strlen(filename));
+    void *res = NULL;
     *str = 0;
     strcat(strcat(str,"Error opening file: "), filename);
-    void *res = mmc_mk_scon(str);
+    res = mmc_mk_scon(str);
     GC_free(str);
     return mmc_mk_cons(res,mmc_mk_nil());
   }
   /* fprintf(stderr, "Open File %s\n", reffilename); */
   if (UNKNOWN_PLOT == SimulationResultsImpl__openFile(reffilename,&simresglob_ref)) {
     char *str = (char*) GC_malloc(35+strlen(reffilename));
+    void *res = NULL;
     *str = 0;
     strcat(strcat(str,"Error opening reference file: "), reffilename);
-    void *res = mmc_mk_scon(str);
+    res = mmc_mk_scon(str);
     GC_free(str);
     return mmc_mk_cons(res,mmc_mk_nil());
   }

--- a/Compiler/runtime/TaskGraphResultsCmp.cpp
+++ b/Compiler/runtime/TaskGraphResultsCmp.cpp
@@ -27,6 +27,9 @@
  * See the full OSMC Public License conditions for more details.
  *
  */
+
+#if !defined(_MSC_VER)
+
 #include "TaskGraphResultsCmp.h"
 
 Node::Node() : id(""), name(""), calcTime(-1), threadId(""), taskNumber(-1), taskId(-1), simCodeEqs()
@@ -959,4 +962,6 @@ void* TaskGraphResultsCmp_checkCodeGraph(const char *filename, const char *codeF
 
   return res;
 }
+#endif
+
 #endif

--- a/Compiler/runtime/TaskGraphResultsCmp.h
+++ b/Compiler/runtime/TaskGraphResultsCmp.h
@@ -28,6 +28,8 @@
  *
  */
 
+#if !defined(_MSC_VER)
+
 #include <list>
 #include <string>
 #include <sstream>
@@ -252,3 +254,5 @@ protected:
   static bool CompareGraphsLevel(Graph *referenceGraph, Graph *g2, NodeComparator nodeComparator, bool checkCalcTime, std::string *errorMsg);
 };
 #endif //TGRC_GRAPHCOMPARATOR
+
+#endif

--- a/Compiler/runtime/TaskGraphResults_omc.cpp
+++ b/Compiler/runtime/TaskGraphResults_omc.cpp
@@ -1,21 +1,34 @@
+#if !defined(_MSC_VER)
 extern "C" {
 #include "openmodelica.h"
 #include "meta_modelica.h"
 #define ADD_METARECORD_DEFINITIONS static
 #include "OpenModelicaBootstrappingHeader.h"
 }
-
 #include "TaskGraphResultsCmp.cpp"
+#else
+#include "meta_modelica.h"
+#include "errorext.h"
+#define TASKGRAPH_VS() c_add_message(NULL, -1, ErrorType_scripting, ErrorLevel_error, "TaskGraphResults not supported on Visual Studio.", NULL, 0);MMC_THROW();
+#endif
 
 extern "C" {
 void* TaskGraphResults_checkTaskGraph(const char *filename,const char *reffilename)
 {
+#if defined(_MSC_VER)
+  TASKGRAPH_VS();
+#else
   return TaskGraphResultsCmp_checkTaskGraph(filename,reffilename);
+#endif
 }
 
 void* TaskGraphResults_checkCodeGraph(const char *filename,const char *reffilename)
 {
+#if defined(_MSC_VER)
+  TASKGRAPH_VS();
+#else
   return TaskGraphResultsCmp_checkCodeGraph(filename,reffilename);
+#endif
 }
 
 }

--- a/Compiler/runtime/printimpl.c
+++ b/Compiler/runtime/printimpl.c
@@ -90,11 +90,12 @@ static void make_key()
 
 static print_members* getMembers(threadData_t *threadData)
 {
+  print_members *res;
   if (threadData && threadData->localRoots[LOCAL_ROOT_PRINT_MO]) {
     return threadData->localRoots[LOCAL_ROOT_PRINT_MO];
   }
   pthread_once(&printimpl_once_create_key,make_key);
-  print_members *res = (print_members*) pthread_getspecific(printimplKey);
+  res = (print_members*) pthread_getspecific(printimplKey);
   if (res != NULL) return res;
   res = (print_members*) calloc(1,sizeof(print_members));
   pthread_setspecific(printimplKey,res);

--- a/SimulationRuntime/c/util/omc_msvc.h
+++ b/SimulationRuntime/c/util/omc_msvc.h
@@ -60,6 +60,14 @@ static union MSVC_FLOAT_HACK __NAN = {{0x00, 0x00, 0xC0, 0x7F}};
  */
 #if defined(_MSC_VER)
 
+#ifndef S_ISDIR
+#define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
+#endif
+
+#ifndef S_ISREG
+#define S_ISREG(mode)  (((mode) & S_IFMT) == S_IFREG)
+#endif
+
 /* get rid of inline for MSVC */
 #define OMC_INLINE
 


### PR DESCRIPTION
Mostly related to only declaring variables at the top of a block.