### PR TITLE
Improve performance of getComponents API.

### DIFF
--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -4472,9 +4472,7 @@ end updateComponentInEnv3;
 
 public function makeEnvFromProgram
 "This function takes a SCode.Program and builds an environment."
-  input FCore.Cache inCache;
   input SCode.Program prog;
-  input SCode.Path path;
   output FCore.Cache outCache;
   output FCore.Graph env_1;
 protected
@@ -4482,7 +4480,7 @@ protected
   FCore.Cache cache;
 algorithm
   // prog := scodeFlatten(prog, path);
-  (cache, env) := Builtin.initialGraph(inCache);
+  (cache, env) := Builtin.initialGraph(FCore.emptyCache());
   env_1 := FGraphBuildEnv.mkProgramGraph(prog, FCore.USERDEFINED(),env);
   outCache := cache;
 end makeEnvFromProgram;

--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -1636,7 +1636,7 @@ algorithm
       equation
         absynClass = Interactive.getPathedClassInProgram(classpath, p);
         (sp, st) = GlobalScriptUtil.symbolTableToSCode(st);
-        (cache, env) = Inst.makeEnvFromProgram(FCore.emptyCache(), sp, Absyn.IDENT(""));
+        (cache, env) = Inst.makeEnvFromProgram(sp);
         (cache,(cl as SCode.CLASS(name=name,encapsulatedPrefix=encflag,restriction=restr)),env) = Lookup.lookupClass(cache, env, classpath, NONE());
         env = FGraph.openScope(env, encflag, SOME(name), FGraph.restrictionToScopeType(restr));
         (_, env) = Inst.partialInstClassIn(cache, env, InnerOuter.emptyInstHierarchy, DAE.NOMOD(), Prefix.NOPRE(),

--- a/Compiler/Script/GlobalScriptUtil.mo
+++ b/Compiler/Script/GlobalScriptUtil.mo
@@ -290,7 +290,7 @@ algorithm
     case (st as GlobalScript.SYMBOLTABLE(lstVarVal = vars))
       equation
         (p_1,st) = symbolTableToSCode(st);
-        (_,env) = Inst.makeEnvFromProgram(FCore.emptyCache(), p_1, Absyn.IDENT(""));
+        (_,env) = Inst.makeEnvFromProgram(p_1);
         // Reverse the variable list to make sure iterators overwrite other
         // variables (iterators are appended to the front of the list).
         vars = listReverse(vars);


### PR DESCRIPTION
- Cache the work done by Interactive.buildEnvForGraphicProgram
  instead of redoing it for every single component when calling
  getComponentAnnotations.