### PR TITLE
Constant variable names as constant patterns

### DIFF
--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -625,13 +625,11 @@ algorithm
     (outCache, args, consts, _, tty, _, slots) := elabTypes(outCache, inEnv, pos_args,
       named_args, {tty}, true, true, inImplicit, NOT_EXTERNAL_OBJECT_MODEL_SCOPE(),
       NONE(), inPrefix, inInfo);
-
     if not Types.isFunctionPointer(tty) then
       (outCache, path) := Inst.makeFullyQualified(outCache, inEnv, path);
       (outCache, Util.SUCCESS()) := instantiateDaeFunction(outCache, inEnv,
         path, false, NONE(), true);
     end if;
-
     tty2 := stripExtraArgsFromType(slots, tty);
     tty2 := Types.makeFunctionPolymorphicReference(tty2);
     ty := Types.simplifyType(tty2);

--- a/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -54,6 +54,7 @@ import GC;
 import Graph;
 import List;
 import Mod;
+import Patternm;
 import SCode;
 
 public
@@ -1147,7 +1148,9 @@ function findLiteralsHelper
 algorithm
   exp := inExp;
   tpl := inTpl;
-  (exp, tpl) := Expression.traverseExpBottomUp(exp, replaceLiteralExp, tpl);
+  (exp, tpl) := Expression.traverseExpBottomUp(exp,
+    function Patternm.traverseConstantPatternsHelper(func=replaceLiteralExp),
+    tpl);
   (exp, tpl) := Expression.traverseExpTopDown(exp, replaceLiteralArrayExp, tpl);
 end findLiteralsHelper;
 

--- a/Compiler/Template/CodegenCFunctions.tpl
+++ b/Compiler/Template/CodegenCFunctions.tpl
@@ -3800,10 +3800,14 @@ template patternMatch(Pattern pat, Text rhs, Text onPatternFail, Text &varDecls,
         case c as SCONST(__) then
           let escstr = Util.escapeModelicaStringToCString(c.string)
           'if (<%unescapedStringLength(escstr)%> != MMC_STRLEN(<%urhs%>) || strcmp("<%escstr%>", MMC_STRINGDATA(<%urhs%>)) != 0) <%onPatternFail%>;<%\n%>'
+        case c as SHARED_LITERAL(exp=d as SCONST(__)) then
+          let escstr = Util.escapeModelicaStringToCString(d.string)
+          'if (<%unescapedStringLength(escstr)%> != MMC_STRLEN(<%urhs%>) || strcmp(MMC_STRINGDATA(_OMC_LIT<%c.index%>), MMC_STRINGDATA(<%urhs%>)) != 0) <%onPatternFail%>;<%\n%>'
         case c as BCONST(__) then 'if (<%boolStrC(c.bool)%> != <%urhs%>) <%onPatternFail%>;<%\n%>'
         case c as LIST(valList = {}) then 'if (!listEmpty(<%urhs%>)) <%onPatternFail%>;<%\n%>'
         case c as META_OPTION(exp = NONE()) then 'if (!optionNone(<%urhs%>)) <%onPatternFail%>;<%\n%>'
         case c as ENUM_LITERAL() then 'if (<%c.index%> != <%urhs%>) <%onPatternFail%>;<%\n%>'
+        case c as SHARED_LITERAL() then 'if (!valueEq(_OMC_LIT<%c.index%>, <%urhs%>)) <%onPatternFail%>;<%\n%>'
         else error(sourceInfo(), 'UNKNOWN_CONSTANT_PATTERN <%printExpStr(p.exp)%>')
       %>>>
   case p as PAT_SOME(__) then
@@ -6655,7 +6659,8 @@ template switchIndex(Pattern pattern, Integer extraArg)
 ::=
   match pattern
     case PAT_CALL(__) then 'case <%getValueCtor(index)%>'
-    case PAT_CONSTANT(exp=e as SCONST(__)) then 'case <%stringHashDjb2Mod(e.string,extraArg)%> /* <%e.string%> */'
+    case PAT_CONSTANT(exp=e as SCONST(__))
+    case PAT_CONSTANT(exp=SHARED_LITERAL(exp=e as SCONST(__))) then 'case <%stringHashDjb2Mod(e.string,extraArg)%> /* <%e.string%> */'
     case PAT_CONSTANT(exp=e as ICONST(__)) then 'case <%e.integer%>'
     else 'default'
 end switchIndex;

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -905,6 +905,8 @@ public constant Message META_ALL_EMPTY = MESSAGE(5036, TRANSLATION(), NOTIFICATI
   Util.gettext("All patterns in call were empty: %s."));
 public constant Message DUPLICATE_DEFINITION = MESSAGE(5037, TRANSLATION(), ERROR(),
   Util.gettext("The same variable is being defined twice: %s."));
+public constant Message PATTERN_VAR_NOT_VARIABLE = MESSAGE(5038, TRANSLATION(), ERROR(),
+  Util.gettext("Identifiers need to point to local or output variables. Variable %s is %s."));
 
 public constant Message COMPILER_ERROR = MESSAGE(5999, TRANSLATION(), ERROR(),
   Util.notrans("%s"));

--- a/Compiler/boot/Makefile.common
+++ b/Compiler/boot/Makefile.common
@@ -63,6 +63,7 @@ bootstrap-from-tarball: $(PATCHES)
 	OPENMODELICA_BACKEND_STUBS=1 $(MAKE) -f $(defaultMakefileTarget) generate-files-in-steps OMC=$(BOOTSTRAP_OMC)
 	# Patch _main.c to avoid a new tarball
 	$(PATCH_SOURCES)
+	echo '#include "Patternm.h"' >> build/SimCodeFunctionUtil_includes.h
 	# We have not compiled OpenModelicaScriptingAPI.mo yet
 	touch build/OpenModelicaScriptingAPI.h
 	$(MAKE) -f $(defaultMakefileTarget) install INCLUDESOURCES=1 OMC=$(BOOTSTRAP_OMC)

--- a/SimulationRuntime/c/meta/meta_modelica.c
+++ b/SimulationRuntime/c/meta/meta_modelica.c
@@ -134,7 +134,7 @@ modelica_boolean valueEq(modelica_metatype lhs, modelica_metatype rhs)
     return d1 == d2;
   }
   if (MMC_HDRISSTRING(h_lhs)) {
-    return 0 == strcmp(MMC_STRINGDATA(lhs),MMC_STRINGDATA(rhs));
+    return MMC_STRLEN(lhs)==MMC_STRLEN(rhs) && 0 == strcmp(MMC_STRINGDATA(lhs),MMC_STRINGDATA(rhs));
   }
 
   numslots = MMC_HDRSLOTS(h_lhs);


### PR DESCRIPTION
This fixes #3005 by allowing constant identifiers that evaluate to
constant literal expressions of suitable type (boxed, integer, real,
string, boolean, enumeration) to be used in a pattern. For boxed
variables, we replace the pattern expression with a shared literal
and perform valueEq on this. This should prove to be fast especially
if referenceEq holds (such as when passing a constant to a function).