### PR TITLE
Various fixes for diff API and updating annotations

### DIFF
--- a/Compiler/FrontEnd/DAE.mo
+++ b/Compiler/FrontEnd/DAE.mo
@@ -1011,6 +1011,12 @@ public uniontype CodeType
   record C_EXPRESSION
   end C_EXPRESSION;
 
+  record C_EXPRESSION_OR_MODIFICATION
+  end C_EXPRESSION_OR_MODIFICATION;
+
+  record C_MODIFICATION
+  end C_MODIFICATION;
+
   record C_TYPENAME
   end C_TYPENAME;
 

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -334,6 +334,7 @@ algorithm
         "OpenModelica" = Absyn.pathLastIdent(path2);
       then Util.assoc(name,{
         ("Expression",    DAE.T_CODE(DAE.C_EXPRESSION(),DAE.emptyTypeSource)),
+        ("ExpressionOrModification",    DAE.T_CODE(DAE.C_EXPRESSION_OR_MODIFICATION(),DAE.emptyTypeSource)),
         ("TypeName",      DAE.T_CODE(DAE.C_TYPENAME(),DAE.emptyTypeSource)),
         ("VariableName",  DAE.T_CODE(DAE.C_VARIABLENAME(),DAE.emptyTypeSource)),
         ("VariableNames", DAE.T_CODE(DAE.C_VARIABLENAMES(),DAE.emptyTypeSource))

--- a/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -828,6 +828,7 @@ type $Code "Code quoting is not a uniontype yet because that would require enabl
 Besides, it has special semantics."
 
 type Expression "An expression of some kind" end Expression;
+type ExpressionOrModification "An expression or modification of some kind" end ExpressionOrModification;
 type TypeName "A path, for example the name of a class, e.g. A.B.C or .A.B" end TypeName;
 type VariableName "A variable name, e.g. a.b or a[1].b[3].c" end VariableName;
 type VariableNames "An array of variable names, e.g. {a.b,a[1].b[3].c}, or a single VariableName" end VariableNames;
@@ -931,6 +932,7 @@ end Internal;
 package Scripting
 
 import OpenModelica.$Code.Expression;
+import OpenModelica.$Code.ExpressionOrModification;
 import OpenModelica.$Code.TypeName;
 import OpenModelica.$Code.VariableName;
 import OpenModelica.$Code.VariableNames;
@@ -2810,7 +2812,7 @@ end closeSimulationResultFile;
 
 function addClassAnnotation
   input TypeName class_;
-  input Expression annotate;
+  input ExpressionOrModification annotate;
   output Boolean bool;
 external "builtin";
 annotation(preferredView="text",Documentation(info="<html>
@@ -2819,6 +2821,7 @@ and the annotation to set.</p>
 <p>Usage: addClassAnnotation(Modelica, annotate = Documentation(info = \"&lt;html&gt;&lt;/html&gt;\"))</p>
 </html>"));
 end addClassAnnotation;
+
 
 function getParameterNames
   input TypeName class_;

--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -1805,6 +1805,12 @@ algorithm
       then
         (inExp, ty, ty, SOME(Values.ARRAY({},{0})), fn);
 
+    case (Absyn.IDENT(name = "$array"), _)
+      algorithm
+        ty := List.foldr(dims, Types.liftArray, inType);
+      then
+        (inExp, ty, ty, SOME(Values.ARRAY({},{0})), fn);
+
     case (Absyn.IDENT(name = "list"), _)
       algorithm
         (exp, ty) := Types.matchType(inExp, inType, DAE.T_METABOXED_DEFAULT, true);
@@ -12339,6 +12345,7 @@ algorithm
       DAE.Properties prop;
       DAE.Type ty;
       DAE.CodeType ct2;
+      Absyn.CodeNode cn;
 
     // first; try to elaborate the exp (maybe there is a binding in the environment that says v is a VariableName
     case (_,_)
@@ -12351,8 +12358,15 @@ algorithm
       then
         dexp;
 
+    case (Absyn.CODE(code=Absyn.C_MODIFICATION()),DAE.C_EXPRESSION_OR_MODIFICATION())
+      then DAE.CODE(exp.code,DAE.T_UNKNOWN_DEFAULT);
+    case (Absyn.CODE(code=Absyn.C_EXPRESSION()),DAE.C_EXPRESSION())
+      then DAE.CODE(exp.code,DAE.T_UNKNOWN_DEFAULT);
+
     // Expression
     case (_,DAE.C_EXPRESSION())
+      then DAE.CODE(Absyn.C_EXPRESSION(exp),DAE.T_UNKNOWN_DEFAULT);
+    case (_,DAE.C_EXPRESSION_OR_MODIFICATION())
       then DAE.CODE(Absyn.C_EXPRESSION(exp),DAE.T_UNKNOWN_DEFAULT);
 
     // Type Name

--- a/Compiler/FrontEnd/Types.mo
+++ b/Compiler/FrontEnd/Types.mo
@@ -1190,6 +1190,9 @@ algorithm
     case Values.CODE(A=Absyn.C_EXPRESSION())
       then DAE.T_CODE(DAE.C_EXPRESSION(), {});
 
+    case Values.CODE(A=Absyn.C_MODIFICATION())
+      then DAE.T_CODE(DAE.C_MODIFICATION(), {});
+
     case (v)
       equation
         str = "- Types.typeOfValue failed: " + ValuesUtil.valString(v);
@@ -2567,6 +2570,7 @@ algorithm
 
     // Code
     case (DAE.T_CODE(DAE.C_EXPRESSION(),_)) then "$Code(Expression)";
+    case (DAE.T_CODE(DAE.C_EXPRESSION_OR_MODIFICATION(),_)) then "$Code(ExpressionOrModification)";
     case (DAE.T_CODE(DAE.C_TYPENAME(),_)) then "$Code(TypeName)";
     case (DAE.T_CODE(DAE.C_VARIABLENAME(),_)) then "$Code(VariableName)";
     case (DAE.T_CODE(DAE.C_VARIABLENAMES(),_)) then "$Code(VariableName[:])";
@@ -7323,6 +7327,8 @@ public function printCodeTypeStr
 algorithm
   str := match ct
     case DAE.C_EXPRESSION() then "OpenModelica.Code.Expression";
+    case DAE.C_EXPRESSION_OR_MODIFICATION() then "OpenModelica.Code.ExpressionOrModification";
+    case DAE.C_MODIFICATION() then "OpenModelica.Code.Modification";
     case DAE.C_TYPENAME() then "OpenModelica.Code.TypeName";
     case DAE.C_VARIABLENAME() then "OpenModelica.Code.VariableName";
     case DAE.C_VARIABLENAMES() then "OpenModelica.Code.VariableNames";

--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -726,6 +726,7 @@ algorithm
       list<Absyn.Path> paths;
       list<Absyn.NamedArg> nargs;
       list<Absyn.Class> classes;
+      list<Absyn.ElementArg> eltargs;
       Absyn.Within within_;
       BackendDAE.EqSystem syst;
       BackendDAE.Shared shared;
@@ -1490,7 +1491,15 @@ algorithm
       then
         (cache,Values.BOOL(true),GlobalScript.SYMBOLTABLE(p,NONE(),ic,iv,cf,lf));
 
-    case (cache,_,"addClassAnnotation",_,st as GlobalScript.SYMBOLTABLE(),_)
+    case (cache,_,"addClassAnnotation",{Values.CODE(Absyn.C_TYPENAME(classpath)),Values.CODE(Absyn.C_MODIFICATION(Absyn.CLASSMOD(elementArgLst=eltargs,eqMod=Absyn.NOMOD())))},GlobalScript.SYMBOLTABLE(p,_,ic,iv,cf,lf),_)
+      algorithm
+        absynClass := Interactive.getPathedClassInProgram(classpath, p);
+        absynClass := Interactive.addClassAnnotationToClass(absynClass, Absyn.ANNOTATION(eltargs));
+        p := Interactive.updateProgram(Absyn.PROGRAM({absynClass}, if Absyn.pathIsIdent(classpath) then Absyn.TOP() else Absyn.WITHIN(Absyn.stripLast(classpath))), p);
+      then
+        (cache,Values.BOOL(true),GlobalScript.SYMBOLTABLE(p,NONE(),ic,iv,cf,lf));
+
+    case (cache,_,"addClassAnnotation",{_,v},st as GlobalScript.SYMBOLTABLE(),_)
       then
         (cache,Values.BOOL(false),st);
 

--- a/Parser/BaseModelica_Lexer.g
+++ b/Parser/BaseModelica_Lexer.g
@@ -325,6 +325,7 @@ NL: '\r\n' | '\n' | '\r';
 CODE : '$Code';
 CODE_NAME : '$TypeName';
 CODE_EXP : '$Exp';
+CODE_ANNOTATION : '$annotation';
 CODE_VAR : '$Var';
 
 STRING : '"' STRING_GUTS '"'

--- a/Parser/Modelica.g
+++ b/Parser/Modelica.g
@@ -1613,6 +1613,7 @@ code_expression returns [void* ast]
         }
       }
   | CODE_NAME LPAR name=name_path RPAR {ast = Absyn__CODE(Absyn__C_5fTYPENAME(name));}
+  | CODE_ANNOTATION cmod=class_modification { ast = Absyn__CODE(Absyn__C_5fMODIFICATION(Absyn__CLASSMOD(cmod, Absyn__NOMOD))); }
   | CODE_VAR LPAR cr=component_reference RPAR {ast = Absyn__CODE(Absyn__C_5fVARIABLENAME(cr.ast));}
   )
   ;


### PR DESCRIPTION
- Made {a for a in as} unparse correctly
- Made diff handle badly unparsed strings (extra spaces added)
- Some unparsing fixes
- Allow modifications for addClassAnnotation API