### PR TITLE
Add support for input output variables

### DIFF
--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -1645,12 +1645,10 @@ algorithm
 end setBindValue;
 
 public function setVarDirectionTpl
-  input BackendDAE.Var inVar;
-  input DAE.VarDirection inDir;
-  output BackendDAE.Var outVar;
-  output DAE.VarDirection outDir = inDir;
+  input output BackendDAE.Var var;
+  input output DAE.VarDirection dir;
 algorithm
-  outVar := setVarDirection(inVar, inDir);
+  var.varDirection := dir;
 end setVarDirectionTpl;
 
 public function setVarDirection "author: lochel

--- a/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/Compiler/BackEnd/SymbolicJacobian.mo
@@ -3173,14 +3173,14 @@ protected function calculateJacobianRow2 "author: PA
   output list<tuple<Integer, Integer, BackendDAE.Equation>> outLst = {};
   output BackendDAE.Shared oShared = iShared;
 protected
-	DAE.Exp e, e_1, e_2, dcrexp;
-	BackendDAE.Var v;
-	DAE.ComponentRef cr, dcr;
-	list<tuple<Integer, Integer, BackendDAE.Equation>> es, result;
-	Integer vindx;
-	list<Integer> vindxs;
-	String str;
-	BackendDAE.Shared shared;
+  DAE.Exp e, e_1, e_2, dcrexp;
+  BackendDAE.Var v;
+  DAE.ComponentRef cr, dcr;
+  list<tuple<Integer, Integer, BackendDAE.Equation>> es, result;
+  Integer vindx;
+  list<Integer> vindxs;
+  String str;
+  BackendDAE.Shared shared;
 algorithm
   try
     for vindx in inIntegerLst loop
@@ -3424,15 +3424,13 @@ algorithm
 end jacobianConstant;
 
 protected function varsNotInRelations
-  input DAE.Exp inExp;
-  input tuple<BackendDAE.Variables,Boolean> inTpl;
-  output DAE.Exp outExp;
+  input output DAE.Exp exp;
   output Boolean cont;
-  output tuple<BackendDAE.Variables,Boolean> outTpl;
+  input output tuple<BackendDAE.Variables,Boolean> tpl;
 algorithm
-  (outExp,cont,outTpl) := match (inExp,inTpl)
+  (exp,cont,tpl) := match (exp,tpl)
     local
-      DAE.Exp cond,t,f,e,e1;
+      DAE.Exp cond,t,f,e1;
       BackendDAE.Variables vars;
       Boolean b;
       Absyn.Path path;
@@ -3445,41 +3443,41 @@ algorithm
         (f,(_,b)) = Expression.traverseExpTopDown(f, varsNotInRelations, (vars,b));
       then (DAE.IFEXP(cond,t,f),false,(vars,b));
 
-    case (e as DAE.CALL(path=Absyn.IDENT(name = "der")),(vars,b))
-      then (e,true,(vars,b));
-    case (e as DAE.CALL(path = Absyn.IDENT(name = "pre")),(vars,b))
-      then (e,false,(vars,b));
-    case (e as DAE.CALL(path = Absyn.IDENT(name = "previous")),(vars,b))
-      then (e,false,(vars,b));
-    case (e as DAE.CALL(expLst=expLst),(vars,b))
+    case (DAE.CALL(path=Absyn.IDENT(name = "der")),_)
+      then (exp,true,tpl);
+    case (DAE.CALL(path = Absyn.IDENT(name = "pre")),_)
+      then (exp,false,tpl);
+    case (DAE.CALL(path = Absyn.IDENT(name = "previous")),_)
+      then (exp,false,tpl);
+    case (DAE.CALL(expLst=expLst),_)
       equation
         // check if vars occurs not in argument list
-        (_,(_,b)) = Expression.traverseExpListTopDown(expLst, BackendDAEUtil.getEqnsysRhsExp2, (vars,b));
-      then (e,false,(vars,b));
-    case (e as DAE.LBINARY(),(vars,b))
+        (_,tpl) = Expression.traverseExpListTopDown(expLst, BackendDAEUtil.getEqnsysRhsExp2, tpl);
+      then (exp,false,tpl);
+    case (DAE.LBINARY(),_)
       equation
         // check if vars not in condition
-        (_,(_,b)) = Expression.traverseExpTopDown(e, BackendDAEUtil.getEqnsysRhsExp2, (vars,b));
-      then (e,false,(vars,b));
-    case (e as DAE.LUNARY(),(vars,b))
+        (_,tpl) = Expression.traverseExpTopDown(exp, BackendDAEUtil.getEqnsysRhsExp2, tpl);
+      then (exp,false,tpl);
+    case (DAE.LUNARY(),tpl)
       equation
         // check if vars not in condition
-        (_,(_,b)) = Expression.traverseExpTopDown(e, BackendDAEUtil.getEqnsysRhsExp2, (vars,b));
-      then (e,false,(vars,b));
-    case (e as DAE.RELATION(),(vars,b))
+        (_,tpl) = Expression.traverseExpTopDown(exp, BackendDAEUtil.getEqnsysRhsExp2, tpl);
+      then (exp,false,tpl);
+    case (DAE.RELATION(),tpl)
       equation
         // check if vars not in condition
-        (_,(_,b)) = Expression.traverseExpTopDown(e, BackendDAEUtil.getEqnsysRhsExp2, (vars,b));
-      then (e,false,(vars,b));
-    case (e as DAE.ASUB(exp=e1,sub=expLst),(vars,b))
+        (_,tpl) = Expression.traverseExpTopDown(exp, BackendDAEUtil.getEqnsysRhsExp2, tpl);
+      then (exp,false,tpl);
+    case (DAE.ASUB(exp=e1,sub=expLst),_)
       equation
         // check if vars not in condition
-        (_,(_,b)) = Expression.traverseExpTopDown(e1, varsNotInRelations, (vars,b));
+        (_,tpl as (_,b)) = Expression.traverseExpTopDown(e1, varsNotInRelations, tpl);
         if b then
-          (_,(_,b)) = Expression.traverseExpListTopDown(expLst, BackendDAEUtil.getEqnsysRhsExp2, (vars,b));
+          (_,tpl) = Expression.traverseExpListTopDown(expLst, BackendDAEUtil.getEqnsysRhsExp2, tpl);
         end if;
-      then (e,false,(vars,b));
-    case (e,(_,b)) then (e,b,inTpl);
+      then (exp,false,tpl);
+    case (_,(_,b)) then (exp,b,tpl);
   end match;
 end varsNotInRelations;
 

--- a/Compiler/FrontEnd/Absyn.mo
+++ b/Compiler/FrontEnd/Absyn.mo
@@ -671,9 +671,14 @@ end Variability;
 
 public
 uniontype Direction "Direction"
-  record INPUT  "direction is input"                                   end INPUT;
-  record OUTPUT "direction is output"                                  end OUTPUT;
-  record BIDIR  "direction is not specified, neither input nor output" end BIDIR;
+  record INPUT "direction is input"
+  end INPUT;
+  record OUTPUT "direction is output"
+  end OUTPUT;
+  record BIDIR  "direction is not specified, neither input nor output"
+  end BIDIR;
+  record INPUT_OUTPUT "direction is both input and output (OM extension; syntactic sugar for functions)"
+  end INPUT_OUTPUT;
 end Direction;
 
 public
@@ -5363,6 +5368,7 @@ algorithm
   isIorO := match(direction)
     case (INPUT()) then true;
     case (OUTPUT()) then true;
+    case (INPUT_OUTPUT()) then true;
     case (BIDIR()) then false;
   end match;
 end isInputOrOutput;
@@ -5373,6 +5379,7 @@ public function isInput
 algorithm
   outIsInput := match(inDirection)
     case INPUT() then true;
+    case INPUT_OUTPUT() then true;
     else false;
   end match;
 end isInput;
@@ -5386,6 +5393,7 @@ algorithm
     case (BIDIR(), BIDIR()) then true;
     case (INPUT(), INPUT()) then true;
     case (OUTPUT(), OUTPUT()) then true;
+    case (INPUT_OUTPUT(), INPUT_OUTPUT()) then true;
     else false;
   end match;
 end directionEqual;

--- a/Compiler/FrontEnd/SCodeUtil.mo
+++ b/Compiler/FrontEnd/SCodeUtil.mo
@@ -58,7 +58,7 @@ import MetaUtil;
 import SCodeDump;
 import System;
 import Util;
-import MetaModelica.Dangerous.listReverseInPlace;
+import MetaModelica.Dangerous;
 
 // Constant expression for AssertionLevel.error.
 protected constant Absyn.Exp ASSERTION_LEVEL_ERROR = Absyn.CREF(Absyn.CREF_FULLYQUALIFIED(
@@ -995,7 +995,7 @@ algorithm
       else ();
     end match;
   end for;
-  outElementLst := listReverseInPlace(l);
+  outElementLst := Dangerous.listReverseInPlace(l);
 end translateEitemlist;
 
 // stefan
@@ -1147,6 +1147,7 @@ algorithm
       SCode.Partial sPar;
       SCode.Visibility vis;
       SCode.ConnectorType ct;
+      SCode.Prefixes prefixes;
       Option<SCode.ConstrainClass> scc;
 
 
@@ -1205,34 +1206,46 @@ algorithm
     case (_,_,_,_,_,Absyn.COMPONENTS(components = {}),_) then {};
 
     case (_,_,_,repl,vis,Absyn.COMPONENTS(attributes =
-      (attr as Absyn.ATTR(flowPrefix = fl,streamPrefix=st,parallelism=parallelism,variability = variability,direction = di,isField = isf,arrayDim = ad)),typeSpec = t,
-      components = (Absyn.COMPONENTITEM(component = Absyn.COMPONENT(name = n,arrayDim = d,modification = m),comment = comment,condition=cond) :: xs)),info)
-      equation
-        // TODO: Improve performance by iterating over all elements at once instead of creating a new Absyn.COMPONENTS in each step...
-        checkTypeSpec(t,info);
-        // fprintln(Flags.TRANSLATE, "translating component: " + n + " final: " + SCode.finalStr(SCode.boolFinal(finalPrefix)));
-        setHasInnerOuterDefinitionsHandler(io); // signal the external flag that we have inner/outer definitions
-        setHasStreamConnectorsHandler(st);      // signal the external flag that we have stream connectors
-        xs_1 = translateElementspec(cc, finalPrefix, io, repl, vis,
-          Absyn.COMPONENTS(attr,t,xs), info);
-        mod = translateMod(m, SCode.NOT_FINAL(), SCode.NOT_EACH(), info);
-        prl1 = translateParallelism(parallelism);
-        var1 = translateVariability(variability);
-        // PR. This adds the arraydimension that may be specified together with the type of the component.
-        tot_dim = listAppend(d, ad);
-        (repl_1, redecl) = translateRedeclarekeywords(repl);
-        (cmt,info) = translateCommentWithLineInfoChanges(comment,info);
-        sFin = SCode.boolFinal(finalPrefix);
-        sRed = SCode.boolRedeclare(redecl);
-        scc = translateConstrainClass(cc);
-        sRep = if repl_1 then SCode.REPLACEABLE(scc) else SCode.NOT_REPLACEABLE();
-        ct = translateConnectorType(fl, st);
-      then
-        (SCode.COMPONENT(n,
-          SCode.PREFIXES(vis,sRed,sFin,io,sRep),
-          SCode.ATTR(tot_dim,ct,prl1,var1,di,isf),
-          t,mod,cmt,cond,info) :: xs_1);
-
+      (attr as Absyn.ATTR(flowPrefix = fl,streamPrefix=st,parallelism=parallelism,variability = variability,direction = di,isField = isf,arrayDim = ad)), typeSpec = t),info)
+      algorithm
+        xs_1 := {};
+        for comp in inElementSpec4.components loop
+          Absyn.COMPONENTITEM(Absyn.COMPONENT(name = n,arrayDim = d,modification = m),comment = comment, condition=cond) := comp;
+          // TODO: Improve performance by iterating over all elements at once instead of creating a new Absyn.COMPONENTS in each step...
+          checkTypeSpec(t,info);
+          // fprintln(Flags.TRANSLATE, "translating component: " + n + " final: " + SCode.finalStr(SCode.boolFinal(finalPrefix)));
+          setHasInnerOuterDefinitionsHandler(io); // signal the external flag that we have inner/outer definitions
+          setHasStreamConnectorsHandler(st);      // signal the external flag that we have stream connectors
+          mod := translateMod(m, SCode.NOT_FINAL(), SCode.NOT_EACH(), info);
+          prl1 := translateParallelism(parallelism);
+          var1 := translateVariability(variability);
+          // PR. This adds the arraydimension that may be specified together with the type of the component.
+          tot_dim := listAppend(d, ad);
+          (repl_1, redecl) := translateRedeclarekeywords(repl);
+          (cmt,info) := translateCommentWithLineInfoChanges(comment,info);
+          sFin := SCode.boolFinal(finalPrefix);
+          sRed := SCode.boolRedeclare(redecl);
+          scc := translateConstrainClass(cc);
+          sRep := if repl_1 then SCode.REPLACEABLE(scc) else SCode.NOT_REPLACEABLE();
+          ct := translateConnectorType(fl, st);
+          prefixes := SCode.PREFIXES(vis,sRed,sFin,io,sRep);
+          xs_1 := match di
+            local
+              SCode.Attributes attr1,attr2;
+              SCode.Mod mod2;
+              String inName;
+            case Absyn.INPUT_OUTPUT() guard not Flags.isSet(Flags.SKIP_INPUT_OUTPUT_SYNTACTIC_SUGAR)
+              algorithm
+                inName := "$in_"+n;
+                attr1 := SCode.ATTR(tot_dim,ct,prl1,var1,Absyn.INPUT(),isf);
+                attr2 := SCode.ATTR(tot_dim,ct,prl1,var1,Absyn.OUTPUT(),isf);
+                mod2 := SCode.MOD(SCode.FINAL(), SCode.NOT_EACH(), {}, SOME(Absyn.CREF(Absyn.CREF_IDENT(inName,{}))), info);
+              then SCode.COMPONENT(n,prefixes,attr2,t,mod2,cmt,cond,info) :: SCode.COMPONENT(inName,prefixes,attr1,t,mod,cmt,cond,info) :: xs_1;
+            else SCode.COMPONENT(n,prefixes,SCode.ATTR(tot_dim,ct,prl1,var1,di,isf),t,mod,cmt,cond,info) :: xs_1;
+          end match;
+        end for;
+        xs_1 := Dangerous.listReverseInPlace(xs_1);
+      then xs_1;
     case (_,_,_,_,vis,Absyn.IMPORT(import_ = imp, info = info),_)
       equation
         // fprintln(Flags.TRANSLATE, "translating import: " + Dump.unparseImportStr(imp));

--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -10120,11 +10120,13 @@ protected function findNamedArg
   output DAE.FuncArg outArg;
 protected
   String id;
+  Boolean haveMM = Config.acceptMetaModelicaGrammar();
+  String inIdent2 = if haveMM then "$in_"+inIdent else "";
 algorithm
   for arg in inArgs loop
     DAE.FUNCARG(name = id) := arg;
 
-    if id == inIdent then
+    if id == inIdent or (haveMM and id == inIdent2) then
       outArg := arg;
       return;
     end if;
@@ -10182,7 +10184,7 @@ algorithm
     SLOT(defaultArg = DAE.FUNCARG(name = fa2)) := slot;
 
     // Check if this slot has the same name as the one we're looking for.
-    if stringEq(fa1, fa2) then
+    if stringEq(fa1, fa2) or stringEq("$in_"+fa1, fa2) /* OM extension input output arguments */ then
       SLOT(defaultArg = DAE.FUNCARG(const = c2, par = prl, defaultBinding = binding),
         slotFilled = filled, idx = idx, evalStatus = ses) := slot;
 

--- a/Compiler/Template/AbsynDumpTV.mo
+++ b/Compiler/Template/AbsynDumpTV.mo
@@ -489,6 +489,7 @@ package Absyn
     record INPUT end INPUT;
     record OUTPUT end OUTPUT;
     record BIDIR end BIDIR;
+    record INPUT_OUTPUT end INPUT_OUTPUT;
   end Direction;
 
   uniontype ForIterator

--- a/Compiler/Template/AbsynDumpTpl.tpl
+++ b/Compiler/Template/AbsynDumpTpl.tpl
@@ -441,6 +441,7 @@ match dir
   case BIDIR() then ""
   case INPUT() then "input "
   case OUTPUT() then "output "
+  case INPUT_OUTPUT() then "input output "
 end dumpDirection;
 
 template dumpElementAttrDim(Absyn.ElementAttributes attr)

--- a/Compiler/Template/SCodeDumpTpl.tpl
+++ b/Compiler/Template/SCodeDumpTpl.tpl
@@ -807,6 +807,7 @@ template dumpDirection(Absyn.Direction direction)
 match direction
   case INPUT(__) then 'input '
   case OUTPUT(__) then 'output '
+  case INPUT_OUTPUT(__) then 'input output '
 end dumpDirection;
 
 template dumpAttributeDim(SCode.Attributes attributes)

--- a/Compiler/Template/SCodeTV.mo
+++ b/Compiler/Template/SCodeTV.mo
@@ -296,6 +296,7 @@ package Absyn
   uniontype Direction
     record INPUT end INPUT;
     record OUTPUT end OUTPUT;
+    record INPUT_OUTPUT end INPUT_OUTPUT;
     record BIDIR end BIDIR;
   end Direction;
 

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -482,7 +482,8 @@ constant DebugFlag FORCE_NLS_ANALYTIC_JACOBIAN = DEBUG_FLAG(156, "forceNLSanalyt
   Util.gettext("Forces calculation analytical jacobian also for non-linear strong components with user-defined functions."));
 constant DebugFlag DUMP_LOOPS = DEBUG_FLAG(157, "dumpLoops", false,
   Util.gettext("Dumps loop equation."));
-
+constant DebugFlag SKIP_INPUT_OUTPUT_SYNTACTIC_SUGAR = DEBUG_FLAG(158, "skipInputOutputSyntacticSugar", false,
+  Util.gettext("Used when bootstrapping to preserve the input output parsing of the code output by the list command."));
 
 // This is a list of all debug flags, to keep track of which flags are used. A
 // flag can not be used unless it's in this list, and the list is checked at
@@ -646,7 +647,8 @@ constant list<DebugFlag> allDebugFlags = {
   DEBUG_ALGLOOP_JACOBIAN,
   DISABLE_JACSCC,
   FORCE_NLS_ANALYTIC_JACOBIAN,
-  DUMP_LOOPS
+  DUMP_LOOPS,
+  SKIP_INPUT_OUTPUT_SYNTACTIC_SUGAR
 };
 
 public

--- a/Compiler/boot/GenerateInterface.mos
+++ b/Compiler/boot/GenerateInterface.mos
@@ -1,4 +1,5 @@
 setCommandLineOptions("+g=MetaModelica");
+setCommandLineOptions("-d=skipInputOutputSyntacticSugar");
 if not loadFile(inFile) then
   print("Failed to load file: " + inFile + "\n" + getErrorString());
   exit(1);

--- a/Parser/Modelica.g
+++ b/Parser/Modelica.g
@@ -117,6 +117,7 @@ goto rule ## func ## Ex; }}
   /* These do not exist in the bootstrapped version, but are returned in a grammar rule. Just do NULL. */
   #define Absyn__FIELD NULL
   #define Absyn__NONFIELD NULL
+  #define Absyn__INPUT_5fOUTPUT NULL
   /* Treat PDE equations as normal equations */
   #define Absyn__EQ_5fPDE(A1,A2,A3) Absyn__EQ_5fEQUALS(A1,A2)
   #else
@@ -535,13 +536,18 @@ component_clause returns [void* ast]
 
 type_prefix returns [void* flow, void* stream, void* parallelism, void* variability, void* direction, void* field]
 @init { fl = 0; st = 0; srd = 0; glb = 0; di = 0; pa = 0; co = 0; in = 0; out = 0; fi = 0; nofi = 0;} :
-  (fl=FLOW|st=STREAM)? (srd=T_LOCAL|glb=T_GLOBAL)? (di=DISCRETE|pa=PARAMETER|co=CONSTANT)? (in=T_INPUT|out=T_OUTPUT)? (fi=FIELD|nofi=NONFIELD)?
+  (fl=FLOW|st=STREAM)? (srd=T_LOCAL|glb=T_GLOBAL)? (di=DISCRETE|pa=PARAMETER|co=CONSTANT)? in=T_INPUT? out=T_OUTPUT? (fi=FIELD|nofi=NONFIELD)?
     {
       $flow = mmc_mk_bcon(fl);
       $stream = mmc_mk_bcon(st);
       $parallelism = srd ? Absyn__PARLOCAL : glb ? Absyn__PARGLOBAL : Absyn__NON_5fPARALLEL;
       $variability = di ? Absyn__DISCRETE : pa ? Absyn__PARAM : co ? Absyn__CONST : Absyn__VAR;
-      $direction = in ? Absyn__INPUT : out ? Absyn__OUTPUT : Absyn__BIDIR;
+      if (in && out) {
+        modelicaParserAssert(metamodelica_enabled(),"Type prefix \"input output\" is not available in Modelica (use either input or output)", type_prefix, $in->line, $in->charPosition+1, $out->line, $out->charPosition+1);
+        $direction = Absyn__INPUT_5fOUTPUT;
+      } else {
+        $direction = in ? Absyn__INPUT : out ? Absyn__OUTPUT : Absyn__BIDIR;
+      }
       $field = fi ? Absyn__FIELD : nofi ? Absyn__NONFIELD : Absyn__NONFIELD;
     }
   ;


### PR DESCRIPTION
Rewrite prefix "input output" to both an input and output variable.
This is a MetaModelica extension and fixes enhancement ticket #3709.