### PR TITLE
Unparse {a for a in as} correctly

### DIFF
--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -1339,7 +1339,10 @@ algorithm
 
     // Figure out the type of the reduction.
     c := exp_const; // Types.constAnd(exp_const, iter_const);
-    fn := Absyn.crefToPath(inReductionFn);
+    fn := match inReductionFn
+      case Absyn.CREF_IDENT("$array",{}) then Absyn.IDENT("array");
+      else Absyn.crefToPath(inReductionFn);
+    end match;
     (outCache, exp, exp_ty, res_ty, v, fn) := reductionType(outCache, inEnv, fn,
       exp, exp_ty, Types.unboxedType(exp_ty), dims, has_guard_exp, inInfo);
     outProperties := DAE.PROP(exp_ty, c);
@@ -1727,6 +1730,7 @@ algorithm
       Absyn.ComponentRef cr, cr1, cr2;
       FCore.Graph env;
 
+    case Absyn.IDENT("$array") then (inEnv, NONE());
     case Absyn.IDENT("array") then (inEnv, NONE());
     case Absyn.IDENT("list") then (inEnv, NONE());
     case Absyn.IDENT("listReverse") then (inEnv, NONE());

--- a/Compiler/Template/AbsynDumpTpl.tpl
+++ b/Compiler/Template/AbsynDumpTpl.tpl
@@ -510,7 +510,7 @@ match eq
     let eq_str = dumpEquation(equation_)
     let cmt_str = dumpCommentOpt(comment)
     '<%eq_str%><%cmt_str%>;'
-  case EQUATIONITEMCOMMENT(__) then System.trimWhitespace(comment)
+  case EQUATIONITEMCOMMENT(__) then (System.trimWhitespace(comment) ; absIndent=0)
 end dumpEquationItem;
 
 template dumpEquationItems(list<Absyn.EquationItem> eql)
@@ -591,7 +591,7 @@ match alg
     let alg_str = dumpAlgorithm(algorithm_)
     let cmt_str = dumpCommentOpt(comment)
     '<%alg_str%><%cmt_str%>;'
-  case ALGORITHMITEMCOMMENT(__) then System.trimWhitespace(comment)
+  case ALGORITHMITEMCOMMENT(__) then (System.trimWhitespace(comment) ; absIndent=0)
 end dumpAlgorithmItem;
 
 template dumpAlgorithm(Absyn.Algorithm alg)
@@ -748,7 +748,7 @@ match exp
   case INTEGER(__) then value
   case REAL(__) then value
   case CREF(__) then dumpCref(componentRef)
-  case STRING(__) then '"<%value%>"'
+  case STRING(__) then ('"<%value ; absIndent=0%>"')
   case BOOL(__) then value
   case e as BINARY(__) then
     let lhs_str = dumpOperand(exp1, e, true)
@@ -774,6 +774,9 @@ match exp
     let op_str = dumpOperator(op)
     '<%lhs_str%> <%op_str%> <%rhs_str%>'
   case IFEXP(__) then dumpIfExp(exp)
+  case CALL(function_=Absyn.CREF_IDENT(name="$array")) then
+    let args_str = dumpFunctionArgs(functionArgs)
+    '{<%args_str%>}'
   case CALL(__) then
     let func_str = dumpCref(function_)
     let args_str = dumpFunctionArgs(functionArgs)

--- a/Examples/BuildModelRecursive.mos
+++ b/Examples/BuildModelRecursive.mos
@@ -15,9 +15,9 @@ settingsStr :=
   "// " + configure + "\n" +
   "// " + systemInfo
   ;
-setCommandLineOptions("+d=nogen");
+setCommandLineOptions("-d=nogen");
 if not regularFileExists("CustomCommands.mos") then
-  customCommands := "setCommandLineOptions(\"+d=nogen,initialization,backenddaeinfo,discreteinfo,stateselection\");
+  customCommands := "setCommandLineOptions(\"-d=nogen,initialization,backenddaeinfo,discreteinfo,stateselection\");
 setMatchingAlgorithm(\"PFPlusExt\");
 setIndexReductionMethod(\"dynamicStateSelection\");";
   writeFile("CustomCommands.mos",customCommands);
@@ -48,7 +48,7 @@ library:=$TypeName(Modelica);
 libraryVersion:="default";
 end if;
 
-setCommandLineOptions({"+g=Modelica","+d=nogen"});
+setCommandLineOptions({"-g=Modelica","-d=nogen"});
 OpenModelica.Scripting.Internal.Time.timerTick(OpenModelica.Scripting.Internal.Time.RT_CLOCK_USER_RESERVED);
 log:="BuildModelRecursive.html";
 default_tolerance:=1e-6;
@@ -417,7 +417,7 @@ system("chmod go+r BuildModelRecursive.tar.gz");
 /* Some useful CustomCommands.mos examples:
 
 // MSL regression testing suite:
-setCommandLineOptions("+d=nogen,initialization,backenddaeinfo,discreteinfo,stateselection");
+setCommandLineOptions("-d=nogen,initialization,backenddaeinfo,discreteinfo,stateselection");
 setMatchingAlgorithm("PFPlusExt");
 setIndexReductionMethod("dynamicStateSelection");
 

--- a/Parser/Modelica.g
+++ b/Parser/Modelica.g
@@ -119,8 +119,10 @@ goto rule ## func ## Ex; }}
   #define Absyn__NONFIELD NULL
   /* Treat PDE equations as normal equations */
   #define Absyn__EQ_5fPDE(A1,A2,A3) Absyn__EQ_5fEQUALS(A1,A2)
+  #define ARRAY_REDUCTION_NAME "array"
   #else
   #define Absyn__ATTR__BOOTSTRAPPING Absyn__ATTR
+  #define ARRAY_REDUCTION_NAME "\$array"
   #endif
 }
 
@@ -1332,7 +1334,7 @@ primary returns [void* ast]
           "Empty array constructors are not valid in Modelica.", primary, $start->line, $start->charPosition+1, LT(1)->line, LT(1)->charPosition);
         $ast = Absyn__ARRAY(for_or_el.ast);
       } else {
-        $ast = Absyn__CALL(Absyn__CREF_5fIDENT(mmc_mk_scon("array"), mmc_mk_nil()),for_or_el.ast);
+        $ast = Absyn__CALL(Absyn__CREF_5fIDENT(mmc_mk_scon(ARRAY_REDUCTION_NAME), mmc_mk_nil()),for_or_el.ast);
       }
     }
   | T_END { $ast = Absyn__END; }


### PR DESCRIPTION
Previously, the parser changed array reductions to array() in the
parser, which meant that they unparsed incorrectly. This can mess up
the diff algorithm and thus editing in OMEdit.