### PR TITLE
Implement MetaModelica.Dangerous.listAppendTail()

### DIFF
--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -2044,20 +2044,17 @@ end listVar1;
 public function equationSystemsVarsLst
   input BackendDAE.EqSystems systs;
   input list<BackendDAE.Var> inVars;
-  output list<BackendDAE.Var> outVars;
+  output list<BackendDAE.Var> outVars = {};
+protected
+  list<BackendDAE.Var> tail = {};
+  BackendDAE.Variables v;
+  list<BackendDAE.Var> vars;
 algorithm
-  outVars := match (systs)
-    local
-      BackendDAE.EqSystems rest;
-      list<BackendDAE.Var> vars, vars1;
-      BackendDAE.Variables v;
-
-    case {} then inVars;
-    case BackendDAE.EQSYSTEM(orderedVars=v)::rest equation
-      vars = varList(v);
-      vars1 = listAppend(inVars,vars);
-    then equationSystemsVarsLst(rest,vars1);
-  end match;
+  for vs in inVars loop
+    BackendDAE.EQSYSTEM(orderedVars=v) := vs;
+    vars := varList(v);
+    (vars1,tail) := listAppendTail(inVars,tail,vars);
+  end for;
 end equationSystemsVarsLst;
 
 public function daeVars "returns orderedVars"

--- a/Compiler/BackEnd/EvaluateFunctions.mo
+++ b/Compiler/BackEnd/EvaluateFunctions.mo
@@ -56,6 +56,7 @@ protected import List;
 protected import RemoveSimpleEquations;
 protected import SCode;
 protected import Util;
+protected import MetaModelica.Dangerous;
 
 
 // =============================================================================
@@ -2620,7 +2621,7 @@ algorithm
       DAE.Subscript sub;
       list<DAE.Dimension> rest;
       list<DAE.Subscript> subs;
-      list<list<DAE.Subscript>> subsLst, subsLst1, subFold = {};
+      list<list<DAE.Subscript>> subsLst, subsLst1, subFold = {}, tail = {};
   case(dim::rest,_)
     algorithm
       size := Expression.dimensionSize(dim);
@@ -2629,7 +2630,7 @@ algorithm
       subsLst := List.map(subs,List.create);
       for sub in subsIn loop
         subsLst1 := List.map1r(subsLst,listAppend,sub);
-        subFold := listAppend(subFold,subsLst1);
+        (subFold, tail) := Dangerous.listAppendTail(subFold,{},subsLst1);
       end for;
       if listEmpty(subsIn) then subFold := subsLst; end if;
     then expandDimension(rest,subFold);

--- a/Compiler/FrontEnd/MetaModelicaBuiltin.mo
+++ b/Compiler/FrontEnd/MetaModelicaBuiltin.mo
@@ -901,6 +901,14 @@ function listReverseInPlace<A> "O(n). A destructive listReverse. May cause segme
 external "builtin";
 end listReverseInPlace;
 
+function listAppendTail<A> "O(length(lst1)), O(1) if either list is empty"
+  input List<A> lst1;
+  input List<A> tail;
+  input List<A> lst2 = {};
+  output List<A> lst;
+  output List<A> outTail;
+external "builtin";
+end listAppendTail;
 end Dangerous;
 
 end MetaModelica;

--- a/SimulationRuntime/c/meta/meta_modelica_builtin.h
+++ b/SimulationRuntime/c/meta/meta_modelica_builtin.h
@@ -98,6 +98,7 @@ extern modelica_metatype listReverse(modelica_metatype);
 extern modelica_metatype listReverseInPlace(modelica_metatype);
 extern modelica_boolean listMember(modelica_metatype, modelica_metatype);
 extern modelica_metatype listAppend(modelica_metatype,modelica_metatype);
+extern modelica_metatype listAppendTail(modelica_metatype,modelica_metatype,modelica_metatype,modelica_metatype *);
 extern modelica_integer listLength(modelica_metatype);
 #define listGet(X,Y) boxptr_listGet(threadData,X,mmc_mk_icon(Y))
 #define listEmpty(LST) MMC_NILTEST(LST)


### PR DESCRIPTION
it is a fast and not memory consuming alternative to construct lists using "listAppend" method.
Sample implementation of some functions given.

Should be able to improve [ticket 3685](https://trac.openmodelica.org/OpenModelica/ticket/3685)