### PR TITLE
Reorder codegen for patterns

### DIFF
--- a/Compiler/FrontEnd/Patternm.mo
+++ b/Compiler/FrontEnd/Patternm.mo
@@ -716,7 +716,9 @@ algorithm
   end matchcontinue;
 end patternStr;
 
-public function elabMatchExpression
+public
+
+function elabMatchExpression
   input FCore.Cache inCache;
   input FCore.Graph inEnv;
   input Absyn.Exp matchExp;
@@ -793,6 +795,22 @@ algorithm
       then fail();
   end matchcontinue;
 end elabMatchExpression;
+
+function patternAlwaysMatches
+  input DAE.Pattern pattern;
+  output Boolean b;
+algorithm
+  b := match pattern
+    case DAE.PAT_WILD() then true;
+    case DAE.PAT_AS() then patternAlwaysMatches(pattern.pat);
+    case DAE.PAT_AS_FUNC_PTR() then patternAlwaysMatches(pattern.pat);
+    case DAE.PAT_META_TUPLE() then min(patternAlwaysMatches(p) for p in pattern.patterns);
+    case DAE.PAT_CALL_TUPLE() then min(patternAlwaysMatches(p) for p in pattern.patterns);
+    case DAE.PAT_CALL(knownSingleton=true) then min(patternAlwaysMatches(p) for p in pattern.patterns);
+    case DAE.PAT_CALL_NAMED() then min(patternAlwaysMatches(Util.tuple31(tpl)) for tpl in pattern.patterns);
+    else false;
+  end match;
+end patternAlwaysMatches;
 
 protected function optimizeMatchToSwitch
   "match str case 'str1' ... case 'str2' case 'str3' => switch hash(str)...

--- a/Compiler/Template/CodegenCFunctions.tpl
+++ b/Compiler/Template/CodegenCFunctions.tpl
@@ -3829,9 +3829,18 @@ template patternMatch(Pattern pat, Text rhs, Text onPatternFail, Text &varDecls,
         case PAT_WILD(__) then ""
         else
         let tvar = tempDecl("modelica_metatype", &varDecls)
-        <<<%tvar%> = MMC_FETCH(MMC_OFFSET(MMC_UNTAGPTR(<%rhs%>), <%i1%>));
-        <%patternMatch(p,tvar,onPatternFail,&varDecls,&assignments)%>
-        >>; empty /* increase the counter even if no output is produced */)
+        let res1 = '<%tvar%> = MMC_FETCH(MMC_OFFSET(MMC_UNTAGPTR(<%rhs%>), <%i1%>));<%\n%>'
+        /* If there is no structural check in the pattern, delay until we
+         * have checked the structure. What remains is simply assignments.
+         */
+        if patternAlwaysMatches(p) then
+          let &assignments += res1
+          let &inner = buffer ""
+          let &assignments += patternMatch(p,tvar,onPatternFail,&varDecls,&inner)
+          let &assignments += inner
+          ""
+        else (res1+patternMatch(p,tvar,onPatternFail,&varDecls,&assignments))
+      ;empty) /* increase the counter even if no output is produced */
   case PAT_CALL_TUPLE(__)
     then
       // misnomer. Call expressions no longer return tuples using these structs. match-expressions and if-expressions converted to Modelica tuples do
@@ -3862,9 +3871,18 @@ template patternMatch(Pattern pat, Text rhs, Text onPatternFail, Text &varDecls,
         case PAT_WILD(__) then ""
         else
         let tvar = tempDecl("modelica_metatype", &varDecls)
-        <<<%tvar%> = MMC_FETCH(MMC_OFFSET(MMC_UNTAGPTR(<%rhs%>), <%i2%>));
-        <%patternMatch(p,tvar,onPatternFail,&varDecls,&assignments)%>
-        >> ;empty) /* increase the counter even if no output is produced */
+        let res1 = '<%tvar%> = MMC_FETCH(MMC_OFFSET(MMC_UNTAGPTR(<%rhs%>), <%i2%>));<%\n%>'
+        /* If there is no structural check in the pattern, delay until we
+         * have checked the structure. What remains is simply assignments.
+         */
+        if patternAlwaysMatches(p) then
+          let &assignments += res1
+          let &inner = buffer ""
+          let &assignments += patternMatch(p,tvar,onPatternFail,&varDecls,&inner)
+          let &assignments += inner
+          ""
+        else (res1+patternMatch(p,tvar,onPatternFail,&varDecls,&assignments))
+      ;empty) /* increase the counter even if no output is produced */
       %>
       >>
   case p as PAT_AS_FUNC_PTR(__) then

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -3304,6 +3304,10 @@ package Patternm
     input list<DAE.Pattern> inPatterns;
     output list<tuple<DAE.Pattern,Integer>> outPatterns;
   end sortPatternsByComplexity;
+  function patternAlwaysMatches
+    input DAE.Pattern pattern;
+    output Boolean b;
+  end patternAlwaysMatches;
 end Patternm;
 
 package Error


### PR DESCRIPTION
Calculate patterns that do structural checks before patterns that do
not perform any structural checks. (So deconstructing a list is
performed before a simple assignment, etc).

Testing performance after idea from @hkiel 