### PR TITLE
New data type for inner equations of tearing set

### DIFF
--- a/Compiler/BackEnd/BackendDAE.mo
+++ b/Compiler/BackEnd/BackendDAE.mo
@@ -532,10 +532,27 @@ uniontype TearingSet
   record TEARINGSET
     list<Integer> tearingvars;
     list<Integer> residualequations;
-    list<tuple<Integer,list<Integer>>> otherEqnVarTpl "list of tuples of indexes for Equation and Variable solved in the equation, in the order they have to be solved";
+    InnerEquations innerEquations "list of matched equations and variables; these will be solved explicitly in the given order";
     Jacobian jac;
   end TEARINGSET;
 end TearingSet;
+
+type InnerEquations = list<InnerEquation>;
+
+public
+uniontype InnerEquation
+  record INNEREQUATION
+    Integer eqn;
+    list<Integer> vars;
+  end INNEREQUATION;
+
+  record INNEREQUATIONCONSTRAINTS
+    Integer eqn;
+    list<Integer> vars;
+    Constraints cons;
+  end INNEREQUATIONCONSTRAINTS;
+end InnerEquation;
+
 
 public
 type StateSets = list<StateSet> "List of StateSets";
@@ -611,7 +628,7 @@ type IncidenceMatrixT = IncidenceMatrix
  contain the state variable and not the derivative have a negative index.";
 
 public
-type AdjacencyMatrixElementEnhancedEntry = tuple<Integer,Solvability>;
+type AdjacencyMatrixElementEnhancedEntry = tuple<Integer,Solvability,Constraints>;
 
 public
 type AdjacencyMatrixElementEnhanced = list<AdjacencyMatrixElementEnhancedEntry>;
@@ -641,6 +658,9 @@ uniontype Solvability
   record SOLVABILITY_SOLVABLE "It is possible to solve the equation for the variable, it is not considered
                      how the variable occurs in the equation." end SOLVABILITY_SOLVABLE;
 end Solvability;
+
+public
+type Constraints = list<.DAE.Constraint> "Constraints needed for proper Dynamic Tearing";
 
 public
 uniontype IndexType

--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -3980,7 +3980,7 @@ end adjacencyMatrixDispatchEnhanced;
 protected function fillincAdjacencyMatrixTEnhanced
 "@author: Frenkel TUD 2011-04
   helper for adjacencyMatrixDispatchEnhanced.
-  Inserts the rows in the transposed adiacenca matrix."
+  Inserts the rows in the transposed adjacency matrix."
   input BackendDAE.AdjacencyMatrixElementEnhanced eqns;
   input list<Integer> eqnsindxs;
   input BackendDAE.AdjacencyMatrixTEnhanced inIncidenceArrayT;
@@ -3992,28 +3992,29 @@ algorithm
       Integer v,vabs;
       BackendDAE.AdjacencyMatrixTEnhanced mT;
       BackendDAE.Solvability solva;
+      BackendDAE.Constraints cons;
       list<Integer> eqnsindxs1;
 
     case ({},_,_) then inIncidenceArrayT;
 
-    case ((v,solva)::rest,_,_)
+    case ((v,solva,cons)::rest,_,_)
       equation
         true = intLt(0, v);
         row = inIncidenceArrayT[v];
-        newrow = List.map1(eqnsindxs,Util.makeTuple,solva);
+        newrow = List.map2(eqnsindxs,Util.make3Tuple,solva,cons);
         newrow = listAppend(newrow,row);
         // put it in the array
         mT = arrayUpdate(inIncidenceArrayT, v, newrow);
       then
         fillincAdjacencyMatrixTEnhanced(rest, eqnsindxs, mT);
 
-    case ((v,solva)::rest,_,_)
+    case ((v,solva,cons)::rest,_,_)
       equation
         false = intLt(0, v);
         vabs = intAbs(v);
         row = inIncidenceArrayT[vabs];
         eqnsindxs1 = List.map(eqnsindxs,intNeg);
-        newrow = List.map1(eqnsindxs1,Util.makeTuple,solva);
+        newrow = List.map2(eqnsindxs1,Util.make3Tuple,solva,cons);
         // put it in the array
         newrow = listAppend(newrow,row);
         mT = arrayUpdate(inIncidenceArrayT, vabs, newrow);
@@ -4145,10 +4146,11 @@ algorithm
         row1 = adjacencyRowEnhanced1(lst,DAE.RCONST(0.0),DAE.RCONST(0.0),vars,kvars,mark,rowmark,{},trytosolve);
 
         (row, size) = adjacencyRowEnhancedEqnLst(eqnselse, vars, mark, rowmark, kvars, trytosolve);
-        lst = List.map(row,Util.tuple21);
+        lst = List.map(row,Util.tuple31);
+
         (lst, row, size) = List.fold5(eqnslst, adjacencyRowEnhancedEqnLstIfBranches, vars, mark, rowmark, kvars, trytosolve, (lst, row, size));
 
-        lstall = List.map(row, Util.tuple21);
+        lstall = List.map(row, Util.tuple31);
         (_, lst, _) = List.intersection1OnTrue(lstall, lst, intEq);
         _ = List.fold1(lst, markNegativ, rowmark, mark);
         row = listAppend(row1,row);
@@ -4182,7 +4184,7 @@ algorithm
   (inLstAllBranch,iRow,iSize) := intpl;
   for eqn in iEqns loop
     (row,size) := adjacencyRowEnhanced(inVariables, eqn, mark, rowmark, kvars, trytosolve);
-    lst := List.map(row,Util.tuple21);
+    lst := List.map(row,Util.tuple31);
     inLstAllBranch := List.intersectionOnTrue(lst, inLstAllBranch,intEq);
     iSize := iSize + size;
     iRow := listAppend(row,iRow);
@@ -4256,7 +4258,7 @@ algorithm
       equation
         arrayUpdate(rowmark,i,mark);
       then
-        adjacencyRowAlgorithmOutputs1(rest,mark,rowmark,(i,BackendDAE.SOLVABILITY_SOLVED())::iRow);
+        adjacencyRowAlgorithmOutputs1(rest,mark,rowmark,(i,BackendDAE.SOLVABILITY_SOLVED(),{})::iRow);
   end match;
 end adjacencyRowAlgorithmOutputs1;
 
@@ -4308,7 +4310,7 @@ algorithm
         false = intEq(intAbs(rowmark[i]),mark);
         arrayUpdate(rowmark,i,-mark);
       then
-        adjacencyRowAlgorithmInputs1(rest,mark,rowmark,(i,BackendDAE.SOLVABILITY_UNSOLVABLE())::iRow);
+        adjacencyRowAlgorithmInputs1(rest,mark,rowmark,(i,BackendDAE.SOLVABILITY_UNSOLVABLE(),{})::iRow);
     case (i::rest,_,_,_)
       equation
         // not allready handled
@@ -4403,6 +4405,7 @@ algorithm
       Absyn.Path path,path1;
       list<DAE.Exp> explst,crexplst, explst2;
       Boolean b,solved,derived;
+      BackendDAE.Constraints cons;
     case({},_,_,_,_,_,_,_) then inRow;
 /*    case(r::rest,_,_,_,_,_,_,_)
       equation
@@ -4420,7 +4423,7 @@ algorithm
         true = ComponentReference.crefEqualNoStringCompare(cr, cr1);
         false = Expression.expHasDerCref(e2,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,_,DAE.CALL(path= Absyn.IDENT("der"),expLst={DAE.CREF(componentRef = cr)}),_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4431,7 +4434,7 @@ algorithm
         true = ComponentReference.crefEqualNoStringCompare(cr, cr1);
         false = Expression.expHasDerCref(e1,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,DAE.CREF(componentRef=cr),_,_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4442,7 +4445,7 @@ algorithm
         true = ComponentReference.crefEqualNoStringCompare(cr, cr1);
         false = Expression.expHasCrefNoPreorDer(e2,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,DAE.CREF(componentRef=cr),_,_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4454,7 +4457,7 @@ algorithm
         true = ComponentReference.crefEqualNoStringCompare(cr, crarr);
         false = Expression.expHasCrefNoPreorDer(e2,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,DAE.LUNARY(operator=DAE.NOT(_),exp=DAE.CREF(componentRef=cr)),_,_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4465,7 +4468,7 @@ algorithm
         true = ComponentReference.crefEqualNoStringCompare(cr, cr1);
         false = Expression.expHasCrefNoPreorDer(e2,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,DAE.UNARY(operator=DAE.UMINUS(_),exp=DAE.CREF(componentRef=cr)),_,_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4476,7 +4479,7 @@ algorithm
         true = ComponentReference.crefEqualNoStringCompare(cr, cr1);
         false = Expression.expHasCrefNoPreorDer(e2,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,DAE.UNARY(operator=DAE.UMINUS_ARR(_),exp=DAE.CREF(componentRef=cr)),_,_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4488,7 +4491,7 @@ algorithm
         true = ComponentReference.crefEqualNoStringCompare(cr, crarr);
         false = Expression.expHasCrefNoPreorDer(e2,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,_,DAE.CREF(componentRef=cr),_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4499,7 +4502,7 @@ algorithm
         true = ComponentReference.crefEqualNoStringCompare(cr, cr1);
         false = Expression.expHasCrefNoPreorDer(e1,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,_,DAE.CREF(componentRef=cr),_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4511,7 +4514,7 @@ algorithm
         true = ComponentReference.crefEqualNoStringCompare(cr, crarr);
         false = Expression.expHasCrefNoPreorDer(e1,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,_,DAE.LUNARY(operator=DAE.NOT(_),exp=DAE.CREF(componentRef=cr)),_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4522,7 +4525,7 @@ algorithm
         true = ComponentReference.crefEqualNoStringCompare(cr, cr1);
         false = Expression.expHasCrefNoPreorDer(e1,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,_,DAE.UNARY(operator=DAE.UMINUS(_),exp=DAE.CREF(componentRef=cr)),_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4533,7 +4536,7 @@ algorithm
         true = ComponentReference.crefEqualNoStringCompare(cr, cr1);
         false = Expression.expHasCrefNoPreorDer(e1,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,_,DAE.UNARY(operator=DAE.UMINUS_ARR(_),exp=DAE.CREF(componentRef=cr)),_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4545,7 +4548,7 @@ algorithm
         true = ComponentReference.crefEqualNoStringCompare(cr, crarr);
         false = Expression.expHasCrefNoPreorDer(e1,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,DAE.CREF(componentRef=cr),_,_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4556,7 +4559,7 @@ algorithm
         true = ComponentReference.crefPrefixOf(cr, cr1);
         false = Expression.expHasCrefNoPreorDer(e2,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,_,DAE.CREF(componentRef=cr),_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4567,7 +4570,7 @@ algorithm
         true = ComponentReference.crefPrefixOf(cr, cr1);
         false = Expression.expHasCrefNoPreorDer(e1,cr);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,DAE.CALL(path=path,expLst=explst,attr=DAE.CALL_ATTR(ty= DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(path1)))),_,_,_,_,_,_)
       equation
         true = Absyn.pathEqual(path,path1);
@@ -4579,7 +4582,7 @@ algorithm
         true = expCrefLstHasCref(explst,cr1);
         false = Expression.expHasCrefNoPreorDer(e2,cr1);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,_,DAE.CALL(path=path,expLst=explst,attr=DAE.CALL_ATTR(ty= DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(path1)))),_,_,_,_,_)
       equation
         true = Absyn.pathEqual(path,path1);
@@ -4591,7 +4594,7 @@ algorithm
         true = expCrefLstHasCref(explst,cr1);
         false = Expression.expHasCrefNoPreorDer(e1,cr1);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,DAE.TUPLE(PR=explst),DAE.CALL(),_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4606,7 +4609,7 @@ algorithm
         true = expCrefLstHasCref(crexplst,cr1);
         false = Expression.expHasCrefNoPreorDer(e2,cr1);
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve);
     case(r::rest,_,_,_,_,_,_,_)
       // case: state derivative
       equation
@@ -4619,7 +4622,7 @@ algorithm
         e = Expression.crefExp(cr);
         ((e,_)) = Expression.replaceExp(Expression.expSub(e1,e2), DAE.CALL(Absyn.IDENT("der"),{e},DAE.callAttrBuiltinReal), Expression.crefExp(cr1));
         e_derAlias = Expression.traverseExpDummy(e, replaceDerCall);
-        (de,solved,derived) = tryToSolveOrDerive(e_derAlias, cr1, NONE(),trytosolve);
+        (de,solved,derived,cons) = tryToSolveOrDerive(e_derAlias, cr1, vars, NONE(),trytosolve);
         if not solved then
           (de,_) = ExpressionSimplify.simplify(de);
           (_,crlst) = Expression.traverseExpBottomUp(de, Expression.traversingComponentRefFinder, {});
@@ -4635,7 +4638,7 @@ algorithm
           end if;
         end if;
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,solvab)::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,solvab,cons)::inRow,trytosolve);
     case(r::rest,_,_,_,_,_,_,_)
       equation
         rabs = intAbs(r);
@@ -4645,7 +4648,7 @@ algorithm
         BackendDAE.VAR(varName=cr) = BackendVariable.getVarAt(vars, rabs);
         e = Expression.expSub(e1,e2);
         e_derAlias = Expression.traverseExpDummy(e, replaceDerCall);
-        (de,solved,derived) = tryToSolveOrDerive(e_derAlias, cr, NONE(),trytosolve);
+        (de,solved,derived,cons) = tryToSolveOrDerive(e_derAlias, cr, vars, NONE(),trytosolve);
         if not solved then
           (de,_) = ExpressionSimplify.simplify(de);
           (_,crlst) = Expression.traverseExpTopDown(de, Expression.traversingComponentRefFinderNoPreDer, {});
@@ -4655,17 +4658,16 @@ algorithm
             (de,_) = ExpressionSimplify.simplify(de);
             (_,crlst) = Expression.traverseExpTopDown(de, Expression.traversingComponentRefFinderNoPreDer, {});
             solvab = adjacencyRowEnhanced2(cr,de,crlst,vars,kvars);
-             // print("\nvorher:\n" + BackendDump.dumpSolvability(solvab) + "\n");
             solvab = transformSolvabilityForCasualTearingSet(solvab);
           else
             solvab = BackendDAE.SOLVABILITY_SOLVABLE();
           end if;
         end if;
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,solvab)::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,solvab,cons)::inRow,trytosolve);
     case(r::rest,_,_,_,_,_,_,_)
       then
-        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_UNSOLVABLE())::inRow,trytosolve);
+        adjacencyRowEnhanced1(rest,e1,e2,vars,kvars,mark,rowmark,(r,BackendDAE.SOLVABILITY_UNSOLVABLE(),{})::inRow,trytosolve);
   end matchcontinue;
 end adjacencyRowEnhanced1;
 
@@ -4704,19 +4706,22 @@ end replaceDerCall;
 protected function tryToSolveOrDerive
   input DAE.Exp e;
   input DAE.ComponentRef cr "x";
+  input BackendDAE.Variables vars;
   input Option<DAE.FunctionTree> functions;
   input Boolean trytosolve1 "if true, try to solve the expression for the variable, even if flag 'advanceTearing' is not set";
   output DAE.Exp f;
   output Boolean solved=false "true if equation is solved for the variable with ExpressionSolve.solve2, false if equation is differentiated";
   output Boolean derived=false;
+  output BackendDAE.Constraints outCons={};
 protected
   DAE.Type tp = Expression.typeof(e);
   Boolean trytosolve2 = Flags.isSet(Flags.ADVANCE_TEARING);
-  DAE.Exp one;
+  DAE.Exp one,solvedExp;
 algorithm
   if trytosolve1 or trytosolve2 then
     try // try to solve for x (1*x = f(y))
-      _ := ExpressionSolve.solve2(e, Expression.makeConstZero(tp),Expression.crefExp(cr), functions, SOME(-1));
+      (solvedExp,_,_,_) := ExpressionSolve.solve2(e, Expression.makeConstZero(tp),Expression.crefExp(cr), functions, SOME(-1));
+      (_,(outCons,_)) := Expression.traverseExpTopDown(solvedExp, getConstraints, ({},vars));
       solved := true;
     else end try;
   end if;
@@ -4740,6 +4745,59 @@ algorithm
    end if;
    true := solved or derived;
 end tryToSolveOrDerive;
+
+
+protected function getConstraints "
+author: ptaeuber
+Function to find the constraints for Dynamic Tearing."
+  input DAE.Exp inExp;
+  input tuple<BackendDAE.Constraints,BackendDAE.Variables> inTpl;
+  output DAE.Exp outExp;
+  output Boolean cont;
+  output tuple<BackendDAE.Constraints,BackendDAE.Variables> outTpl;
+protected
+  BackendDAE.Constraints inCons;
+  BackendDAE.Variables vars;
+algorithm
+  (inCons,vars) := inTpl;
+  (outExp,cont,outTpl) := match(inExp)
+    local
+      DAE.Exp e1, e2;
+      DAE.Exp rel;
+      DAE.Constraint con;
+      list<DAE.ComponentRef> crlst;
+      Boolean localCon;
+    case DAE.BINARY(exp1=e1, operator=DAE.DIV(), exp2=e2)
+      equation
+        rel = DAE.RELATION(e2,DAE.NEQUAL(DAE.T_UNKNOWN(DAE.emptyTypeSource)),DAE.RCONST(0.0),-1,NONE());
+        (_,crlst) = Expression.traverseExpTopDown(rel, Expression.traversingComponentRefFinderNoPreDer, {});
+        localCon = containAnyVar(crlst,vars);
+        con = DAE.CONSTRAINT_DT(rel,localCon);
+     then (inExp,true,(con::inCons,vars));
+    else
+     then (inExp,true,inTpl);
+  end match;
+end getConstraints;
+
+
+public function getEqnAndVarsFromInnerEquation
+  "author: ptaeuber
+   Returns the equation and the variables from BackendDAE record INNEREQUATION
+   or the equation, variables and constraints from INNEREQUATIONCONSTRAINTS."
+  input BackendDAE.InnerEquation innerEquation;
+  output Integer outEqn;
+  output list<Integer> outVars;
+  output BackendDAE.Constraints outCons;
+algorithm
+  (outEqn,outVars,outCons) := match(innerEquation)
+    local
+      Integer eqn;
+      list<Integer> vars;
+      BackendDAE.Constraints cons;
+    case(BackendDAE.INNEREQUATION(eqn=eqn, vars=vars)) then (eqn,vars,{});
+    case(BackendDAE.INNEREQUATIONCONSTRAINTS(eqn=eqn, vars=vars, cons=cons)) then (eqn,vars,cons);
+  end match;
+end getEqnAndVarsFromInnerEquation;
 
 
 protected function transformSolvabilityForCasualTearingSet
@@ -7834,7 +7892,7 @@ end collectAlgorithms;
 
 public function getConditionList "author: lochel
   This function extracts all when-conditions. A when-condition can only be a
-  ComponentRef or initial()-call. If one condion is equal to >initial()<, the
+  ComponentRef or initial()-call. If one condition is equal to >initial()<, the
   second output becomes true."
   input DAE.Exp inCondition;
   output list<DAE.ComponentRef> outConditionVarList;
@@ -8131,6 +8189,7 @@ algorithm
   BackendDAE.DAE(shared=BackendDAE.SHARED(knownVars=outKnownVars)) := inDAE;
 end getKnownVars;
 
+
 public function setVars
   input BackendDAE.BackendDAE inDAE;
   input BackendDAE.Variables inVars;
@@ -8410,7 +8469,7 @@ algorithm
     local
       Integer i1,i2, j1,j2;
       list<Integer> l1,l2,k1,k2;
-      list<tuple<Integer,list<Integer>>> l3,k3;
+      BackendDAE.InnerEquations l3,k3;
   case(BackendDAE.SINGLEEQUATION(eqn=i1,var=i2),BackendDAE.SINGLEEQUATION(eqn=j1,var=j2))
   then intEq(i1,j1) and intEq(i2,j2);
 
@@ -8432,28 +8491,29 @@ algorithm
   case(BackendDAE.SINGLEIFEQUATION(eqn=i1,vars=l1),BackendDAE.SINGLEIFEQUATION(eqn=j1,vars=k1))
   then intEq(i1,j1) and List.isEqualOnTrue(l1,k1,intEq);
 
-  case(BackendDAE.TORNSYSTEM(strictTearingSet=BackendDAE.TEARINGSET(tearingvars=l1,residualequations=l2,otherEqnVarTpl=l3)),BackendDAE.TORNSYSTEM(strictTearingSet=BackendDAE.TEARINGSET(tearingvars=k1,residualequations=k2,otherEqnVarTpl=k3)))
-  then List.isEqualOnTrue(l1,k1,intEq) and List.isEqualOnTrue(l2,k2,intEq) and List.isEqualOnTrue(l3,k3,otherEqnVarTplEqual);
+  case(BackendDAE.TORNSYSTEM(strictTearingSet=BackendDAE.TEARINGSET(tearingvars=l1,residualequations=l2,innerEquations=l3)),BackendDAE.TORNSYSTEM(strictTearingSet=BackendDAE.TEARINGSET(tearingvars=k1,residualequations=k2,innerEquations=k3)))
+  then List.isEqualOnTrue(l1,k1,intEq) and List.isEqualOnTrue(l2,k2,intEq) and List.isEqualOnTrue(l3,k3,innerEquationsEqual);
   else false;
   end matchcontinue;
 end componentsEqual;
 
-protected function otherEqnVarTplEqual"compares 2 tpls from otherEqnVarTpl in TearingSets"
-  input tuple<Integer,list<Integer>> tpl1;
-  input tuple<Integer,list<Integer>> tpl2;
+protected function innerEquationsEqual"compares 2 innerEquations from innerEquations in TearingSets"
+  input BackendDAE.InnerEquation innerEquation1;
+  input BackendDAE.InnerEquation innerEquation2;
   output Boolean isEqual;
 algorithm
-  isEqual := matchcontinue(tpl1,tpl2)
+  isEqual := matchcontinue(innerEquation1,innerEquation2)
     local
       Integer i1,i2;
       list<Integer> l1,l2;
-  case((i1,l1),(i2,l2))
-  then intEq(i1,i2) and List.isEqualOnTrue(l1,l2,intEq);
-
-  else
-    false;
+    case(BackendDAE.INNEREQUATION(eqn=i1,vars=l1),BackendDAE.INNEREQUATION(eqn=i2,vars=l2))
+     then intEq(i1,i2) and List.isEqualOnTrue(l1,l2,intEq);
+    case(BackendDAE.INNEREQUATIONCONSTRAINTS(eqn=i1,vars=l1),BackendDAE.INNEREQUATIONCONSTRAINTS(eqn=i2,vars=l2))
+     then intEq(i1,i2) and List.isEqualOnTrue(l1,l2,intEq);
+    else
+     false;
   end matchcontinue;
-end otherEqnVarTplEqual;
+end innerEquationsEqual;
 
 
 public function causalizeVarBindSystem"causalizes a system of variables and their binding-equations.
@@ -8495,12 +8555,13 @@ algorithm
   (varsOut,varIdxs,eqsOut,eqIdcxs) := matchcontinue(comp,varArr,eqArr)
     local
       Integer vidx,eidx;
-      list<Integer> vidxs,eidxs;
+      list<Integer> vidxs,eidxs, otherEqns, otherVars;
+      list<list<Integer>> otherVarsLst;
       BackendDAE.Equation eq;
       BackendDAE.Var var;
       list<BackendDAE.Equation> eqs;
       list<BackendDAE.Var> vars;
-      list<tuple<Integer,list<Integer>>> otherEqnVarTpl;
+      BackendDAE.InnerEquations innerEquations;
   case(BackendDAE.SINGLEEQUATION(eqn=eidx,var=vidx),_,_)
     equation
       var = BackendVariable.getVarAt(varArr,vidx);
@@ -8536,10 +8597,12 @@ algorithm
       vars = List.map1(vidxs,BackendVariable.getVarAtIndexFirst,varArr);
       eq = BackendEquation.equationNth1(eqArr,eidx);
     then (vars,vidxs,{eq},{eidx});
-  case(BackendDAE.TORNSYSTEM(strictTearingSet = BackendDAE.TEARINGSET(residualequations=eidxs,tearingvars=vidxs, otherEqnVarTpl=otherEqnVarTpl)),_,_)
+  case(BackendDAE.TORNSYSTEM(strictTearingSet = BackendDAE.TEARINGSET(residualequations=eidxs,tearingvars=vidxs, innerEquations=innerEquations)),_,_)
     equation
-      eidxs = listAppend(List.map(otherEqnVarTpl,Util.tuple21),eidxs);
-      vidxs = listAppend(List.flatten(List.map(otherEqnVarTpl,Util.tuple22)),vidxs);
+      (otherEqns,otherVarsLst,_) = List.map_3(innerEquations, BackendDAEUtil.getEqnAndVarsFromInnerEquation);
+      otherVars = List.flatten(otherVarsLst);
+      eidxs = listAppend(otherEqns,eidxs);
+      vidxs = listAppend(otherVars,vidxs);
       vars = List.map1(vidxs,BackendVariable.getVarAtIndexFirst,varArr);
       eqs = BackendEquation.getEqns(eidxs,eqArr);
     then (vars,vidxs,eqs,eidxs);

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -965,6 +965,7 @@ algorithm
     local
       Integer e,v;
       list<Integer> elst,vlst,vlst1,elst1,vlst2,elst2;
+      list<list<Integer>> vlst1Lst;
       BackendDAE.StrongComponent comp;
       BackendDAE.StrongComponents rest;
       BackendDAE.Var var;
@@ -972,7 +973,7 @@ algorithm
       list<BackendDAE.Var> varlst;
       list<BackendDAE.Equation> eqnlst;
       BackendDAE.JacobianType jacType;
-      list<tuple<Integer,list<Integer>>> eqnsvartpllst,eqnsvartpllst2;
+      BackendDAE.InnerEquations innerEquations,innerEquations2;
       Boolean b;
       String s;
       Option<list<tuple<Integer, Integer, BackendDAE.Equation>>> jac;
@@ -1057,12 +1058,12 @@ algorithm
       then
         ();
     // no dynamic tearing
-    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=vlst,residualequations=elst,otherEqnVarTpl=eqnsvartpllst),NONE(),linear=b)::rest,_,_)
+    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=vlst,residualequations=elst,innerEquations=innerEquations),NONE(),linear=b)::rest,_,_)
       equation
         s = if b then "linear" else "nonlinear";
         print("torn " + s + " Equationsystem:\n");
-        vlst1 = List.flatten(List.map(eqnsvartpllst,Util.tuple22));
-        elst1 = List.map(eqnsvartpllst,Util.tuple21);
+        (elst1,vlst1Lst,_) = List.map_3(innerEquations, BackendDAEUtil.getEqnAndVarsFromInnerEquation);
+        vlst1 = List.flatten(vlst1Lst);
         varlst = List.map1r(vlst1, BackendVariable.getVarAt, vars);
         print("\ninternal vars\n");
         printVarList(varlst);
@@ -1080,12 +1081,12 @@ algorithm
       then
         ();
     // dynamic tearing
-    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=vlst,residualequations=elst,otherEqnVarTpl=eqnsvartpllst),SOME(BackendDAE.TEARINGSET(tearingvars=vlst2,residualequations=elst2,otherEqnVarTpl=eqnsvartpllst2)),linear=b)::rest,_,_)
+    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=vlst,residualequations=elst,innerEquations=innerEquations),SOME(BackendDAE.TEARINGSET(tearingvars=vlst2,residualequations=elst2,innerEquations=innerEquations2)),linear=b)::rest,_,_)
       equation
         s = if b then "linear" else "nonlinear";
         print("Strict torn " + s + " Equationsystem:\n");
-        vlst1 = List.flatten(List.map(eqnsvartpllst,Util.tuple22));
-        elst1 = List.map(eqnsvartpllst,Util.tuple21);
+        (elst1,vlst1Lst,_) = List.map_3(innerEquations, BackendDAEUtil.getEqnAndVarsFromInnerEquation);
+        vlst1 = List.flatten(vlst1Lst);
         varlst = List.map1r(vlst1, BackendVariable.getVarAt, vars);
         printVarList(varlst);
         varlst = List.map1r(vlst, BackendVariable.getVarAt, vars);
@@ -1099,8 +1100,8 @@ algorithm
         print("\n");
         dumpEqnsSolved2(rest,eqns,vars);
         print("Casual torn " + s + " Equationsystem:\n");
-        vlst1 = List.flatten(List.map(eqnsvartpllst2,Util.tuple22));
-        elst1 = List.map(eqnsvartpllst2,Util.tuple21);
+        (elst1,vlst1Lst,_) = List.map_3(innerEquations2, BackendDAEUtil.getEqnAndVarsFromInnerEquation);
+        vlst1 = List.flatten(vlst1Lst);
         varlst = List.map1r(vlst1, BackendVariable.getVarAt, vars);
         printVarList(varlst);
         varlst = List.map1r(vlst2, BackendVariable.getVarAt, vars);
@@ -1281,7 +1282,7 @@ algorithm
       String s,s2,s3,s4;
       BackendDAE.JacobianType jacType;
       BackendDAE.StrongComponent comp;
-      list<tuple<Integer,list<Integer>>> eqnvartpllst,eqnvartpllst2;
+      BackendDAE.InnerEquations innerEquations,innerEquations2;
       Boolean b;
     case BackendDAE.SINGLEEQUATION(eqn=i,var=v)
       equation
@@ -1326,9 +1327,9 @@ algorithm
         s = stringDelimitList(ls, ", ");
         tmpStr = "WhenEquation " + " {" + intString(i) + ":" + s + "}\n";
       then tmpStr;
-    case BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(residualequations=ilst,tearingvars=vlst,otherEqnVarTpl=eqnvartpllst),NONE(),linear=b)
+    case BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(residualequations=ilst,tearingvars=vlst,innerEquations=innerEquations),NONE(),linear=b)
       equation
-        ls = List.map(eqnvartpllst, tupleString);
+        ls = List.map(innerEquations, innerEquationString);
         s = stringDelimitList(ls, ", ");
         ls = List.map(ilst, intString);
         s2 = stringDelimitList(ls, ", ");
@@ -1337,9 +1338,9 @@ algorithm
         s4 = if b then "linear" else "nonlinear";
         tmpStr = "{{" + s + "}\n,{" + s2 + ":" + s3 + "}} Size: " + intString(listLength(vlst)) + " " + s4 + "\n";
       then tmpStr;
-    case BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(residualequations=ilst,tearingvars=vlst,otherEqnVarTpl=eqnvartpllst),SOME(BackendDAE.TEARINGSET(residualequations=ilst2,tearingvars=vlst2,otherEqnVarTpl=eqnvartpllst2)),linear=b)
+    case BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(residualequations=ilst,tearingvars=vlst,innerEquations=innerEquations),SOME(BackendDAE.TEARINGSET(residualequations=ilst2,tearingvars=vlst2,innerEquations=innerEquations2)),linear=b)
       equation
-        ls = List.map(eqnvartpllst, tupleString);
+        ls = List.map(innerEquations, innerEquationString);
         s = stringDelimitList(ls, ", ");
         ls = List.map(ilst, intString);
         s2 = stringDelimitList(ls, ", ");
@@ -1347,7 +1348,7 @@ algorithm
         s3 = stringDelimitList(ls, ", ");
         s4 = if b then "linear" else "nonlinear";
         tmpStr = "{{" + s + "}\n,{" + s2 + ":" + s3 + "}} Size: " + intString(listLength(vlst)) + " " + s4 + " (strict tearing set)\n";
-        ls = List.map(eqnvartpllst2, tupleString);
+        ls = List.map(innerEquations2, innerEquationString);
         s = stringDelimitList(ls, ", ");
         ls = List.map(ilst2, intString);
         s2 = stringDelimitList(ls, ", ");
@@ -1380,7 +1381,7 @@ algorithm
       String s,s1,s2,sl,sj;
       BackendDAE.JacobianType jacType;
       BackendDAE.StrongComponent comp;
-      list<tuple<Integer,list<Integer>>> eqnvartpllst;
+      BackendDAE.InnerEquations innerEquations;
       Boolean b;
     case BackendDAE.SINGLEEQUATION(eqn=i,var=v)
       equation
@@ -1439,9 +1440,9 @@ algorithm
         s2 = stringAppendList({"WhenEquation ",sl," {",s,"}"});
       then
         s2;
-   case BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(residualequations=ilst,tearingvars=vlst,otherEqnVarTpl=eqnvartpllst),linear=b)
+   case BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(residualequations=ilst,tearingvars=vlst,innerEquations=innerEquations),linear=b)
       equation
-        ls = List.map(eqnvartpllst, tupleString);
+        ls = List.map(innerEquations, innerEquationString);
         s = stringDelimitList(ls, ", ");
         ls = List.map(ilst, intString);
         s1 = stringDelimitList(ls, ", ");
@@ -2857,20 +2858,31 @@ public function dumpAdjacencyRowEnhanced
 algorithm
   _ := match (inRow)
     local
-      String s,s1;
+      String s,s1,s2;
       Integer x;
       BackendDAE.Solvability solva;
       BackendDAE.AdjacencyMatrixElementEnhanced xs;
+      BackendDAE.Constraints cons;
     case ({})
       equation
         print("\n");
       then
         ();
-    case (((x,solva) :: xs))
+    case (((x,solva,{}) :: xs))
       equation
         s = intString(x);
         s1 = dumpSolvability(solva);
         print("(" + s + "," + s1 + ")");
+        print(" ");
+        dumpAdjacencyRowEnhanced(xs);
+      then
+        ();
+    case (((x,solva,cons) :: xs))
+      equation
+        s = intString(x);
+        s1 = dumpSolvability(solva);
+        s2 = ExpressionDump.constraintDTlistToString(cons,",");
+        print("(" + s + "," + s1 + s2 +")");
         print(" ");
         dumpAdjacencyRowEnhanced(xs);
       then
@@ -3245,17 +3257,17 @@ algorithm
   end matchcontinue;
 end bltdump;
 
-protected function tupleString
-  input tuple<Integer, list<Integer>> iTpl;
+protected function innerEquationString
+  input BackendDAE.InnerEquation innerEquation;
   output String s;
 protected
   Integer e;
   list<Integer> v;
 algorithm
-  (e,v) := iTpl;
+  (e,v) := BackendDAEUtil.getEqnAndVarsFromInnerEquation(innerEquation);
   s := stringDelimitList(List.map(v,intString), ", ");
   s := "{"+intString(e)+":"+s+"}";
-end tupleString;
+end innerEquationString;
 
 protected type DumpCompShortSystemsTpl = tuple<list<Integer>,list<tuple<Integer,Integer>>,list<Integer>,list<Integer>>;
 protected type DumpCompShortMixedTpl = tuple<list<Integer>,list<Integer>,list<Integer>,list<Integer>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>>;
@@ -3542,7 +3554,7 @@ algorithm
       list<tuple<Integer, Integer, BackendDAE.Equation>> jac;
       tuple<list<Integer>,list<Integer>,list<Integer>,list<Integer>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>> meqsys;
       tuple<list<tuple<Integer,Integer,Integer>>,list<tuple<Integer,Integer>>> teqsys,teqsys2;
-      list<tuple<Integer,list<Integer>>> eqnvartpllst,eqnvartpllst2;
+      BackendDAE.InnerEquations innerEquations,innerEquations2;
       list<tuple< .DAE.ComponentRef, list< .DAE.ComponentRef>>> patternLst;
 
     case (BackendDAE.SINGLEEQUATION(),(seq,salg,sarr,sce,swe,sie,eqsys,meqsys,teqsys,teqsys2))
@@ -3586,29 +3598,29 @@ algorithm
     then ((seq,salg,sarr,sce,swe,sie,(e_jc,e_jt,e_jn,e::e_nj),meqsys,teqsys,teqsys2));
 
     // no dynamic tearing
-    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=ilst,otherEqnVarTpl=eqnvartpllst,jac=BackendDAE.GENERIC_JACOBIAN(_,(_,_,_,nnz),_)),NONE(),linear=true),(seq,salg,sarr,sce,swe,sie,eqsys,meqsys,(te_l,te_nl),(te_l2,te_nl2))) equation
+    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=ilst,innerEquations=innerEquations,jac=BackendDAE.GENERIC_JACOBIAN(_,(_,_,_,nnz),_)),NONE(),linear=true),(seq,salg,sarr,sce,swe,sie,eqsys,meqsys,(te_l,te_nl),(te_l2,te_nl2))) equation
       d = listLength(ilst);
-      e = listLength(eqnvartpllst);
+      e = listLength(innerEquations);
     then ((seq,salg,sarr,sce,swe,sie,eqsys,meqsys,((d,e,nnz)::te_l,te_nl),((0,0,0)::te_l2,te_nl2)));
 
-    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=ilst,otherEqnVarTpl=eqnvartpllst),NONE(),linear=false),(seq,salg,sarr,sce,swe,sie,eqsys,meqsys,(te_l,te_nl),(te_l2,te_nl2))) equation
+    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=ilst,innerEquations=innerEquations),NONE(),linear=false),(seq,salg,sarr,sce,swe,sie,eqsys,meqsys,(te_l,te_nl),(te_l2,te_nl2))) equation
       d = listLength(ilst);
-      e = listLength(eqnvartpllst);
+      e = listLength(innerEquations);
     then ((seq,salg,sarr,sce,swe,sie,eqsys,meqsys,(te_l,(d,e)::te_nl),(te_l2,(0,0)::te_nl2)));
 
     // dynamic tearing
-    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=ilst,otherEqnVarTpl=eqnvartpllst,jac=BackendDAE.GENERIC_JACOBIAN(_,(_,_,_,nnz),_)),SOME(BackendDAE.TEARINGSET(tearingvars=ilst2,otherEqnVarTpl=eqnvartpllst2,jac=BackendDAE.GENERIC_JACOBIAN(_,(_,_,_,nnz2),_))),linear=true),(seq,salg,sarr,sce,swe,sie,eqsys,meqsys,(te_l,te_nl),(te_l2,te_nl2))) equation
+    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=ilst,innerEquations=innerEquations,jac=BackendDAE.GENERIC_JACOBIAN(_,(_,_,_,nnz),_)),SOME(BackendDAE.TEARINGSET(tearingvars=ilst2,innerEquations=innerEquations2,jac=BackendDAE.GENERIC_JACOBIAN(_,(_,_,_,nnz2),_))),linear=true),(seq,salg,sarr,sce,swe,sie,eqsys,meqsys,(te_l,te_nl),(te_l2,te_nl2))) equation
       d = listLength(ilst);
-      e = listLength(eqnvartpllst);
+      e = listLength(innerEquations);
       d2 = listLength(ilst2);
-      e2 = listLength(eqnvartpllst2);
+      e2 = listLength(innerEquations2);
     then ((seq,salg,sarr,sce,swe,sie,eqsys,meqsys,((d,e,nnz)::te_l,te_nl),((d2,e2,nnz2)::te_l2,te_nl2)));
 
-    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=ilst,otherEqnVarTpl=eqnvartpllst),SOME(BackendDAE.TEARINGSET(tearingvars=ilst2,otherEqnVarTpl=eqnvartpllst2)),linear=false),(seq,salg,sarr,sce,swe,sie,eqsys,meqsys,(te_l,te_nl),(te_l2,te_nl2))) equation
+    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=ilst,innerEquations=innerEquations),SOME(BackendDAE.TEARINGSET(tearingvars=ilst2,innerEquations=innerEquations2)),linear=false),(seq,salg,sarr,sce,swe,sie,eqsys,meqsys,(te_l,te_nl),(te_l2,te_nl2))) equation
       d = listLength(ilst);
-      e = listLength(eqnvartpllst);
+      e = listLength(innerEquations);
       d2 = listLength(ilst2);
-      e2 = listLength(eqnvartpllst2);
+      e2 = listLength(innerEquations2);
     then ((seq,salg,sarr,sce,swe,sie,eqsys,meqsys,(te_l,(d,e)::te_nl),(te_l2,(d2,e2)::te_nl2)));
 
     else equation
@@ -3790,7 +3802,8 @@ algorithm
       list<Boolean> tornInfo;
       list<String> addInfo;
       list<Integer> eqIdcs,varIdcs,tVarIdcs,rEqIdcs, tVarIdcsNew, rEqIdcsNew;
-      list<tuple<Integer,list<Integer>>> otherEqnVarTplIdcs;
+      list<list<Integer>> varIdcsLst;
+      BackendDAE.InnerEquations innerEquations;
       list<tuple<Boolean,String>> varAtts,eqAtts;
       BackendDAE.EquationArray compEqs;
       BackendDAE.Variables compVars;
@@ -3813,12 +3826,12 @@ algorithm
       eqAtts = List.threadMap(List.fill(false,numEqs),List.fill("",numEqs),Util.makeTuple);
       dumpBipartiteGraphStrongComponent2(compVars,compEqs,m,varAtts,eqAtts,"rL_eqSys_"+graphName);
     then ();
-  case((BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(residualequations=rEqIdcs,tearingvars=tVarIdcs,otherEqnVarTpl=otherEqnVarTplIdcs))),_,_,_,_)
+  case((BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(residualequations=rEqIdcs,tearingvars=tVarIdcs,innerEquations=innerEquations))),_,_,_,_)
     equation
       //gather equations ans variables
-      eqIdcs = List.map(otherEqnVarTplIdcs,Util.tuple21);
+      (eqIdcs,varIdcsLst,_) = List.map_3(innerEquations, BackendDAEUtil.getEqnAndVarsFromInnerEquation);
+      varIdcs = List.flatten(varIdcsLst);
       eqIdcs = listAppend(eqIdcs, rEqIdcs);
-      varIdcs = List.flatten(List.map(otherEqnVarTplIdcs,Util.tuple22));
       varIdcs = listAppend(varIdcs, tVarIdcs);
       compEqLst = List.map1(eqIdcs,List.getIndexFirst,eqsIn);
       compVarLst = List.map1(varIdcs,List.getIndexFirst,varsIn);

--- a/Compiler/BackEnd/IndexReduction.mo
+++ b/Compiler/BackEnd/IndexReduction.mo
@@ -3258,17 +3258,17 @@ end incidenceMatrixElementfromEnhanced2;
 protected function incidenceMatrixElementElementfromEnhanced2
 "author: Frenkel TUD 2012-11
   converts an AdjacencyMatrix entry into a IncidenceMatrix entry"
-  input tuple<Integer, BackendDAE.Solvability> inTpl;
+  input tuple<Integer, BackendDAE.Solvability, BackendDAE.Constraints> inTpl;
   input BackendDAE.Variables vars;
   input list<Integer> iRow;
   output list<Integer> oRow;
 algorithm
   oRow := match(inTpl,vars,iRow)
     local Integer i;
-    case ((i,BackendDAE.SOLVABILITY_SOLVED()),_,_) then i::iRow;
-    case ((i,BackendDAE.SOLVABILITY_CONSTONE()),_,_) then i::iRow;
-    case ((i,BackendDAE.SOLVABILITY_CONST()),_,_) then i::iRow;
-    case ((i,BackendDAE.SOLVABILITY_PARAMETER(b=true)),_,_) then i::iRow;
+    case ((i,BackendDAE.SOLVABILITY_SOLVED(),_),_,_) then i::iRow;
+    case ((i,BackendDAE.SOLVABILITY_CONSTONE(),_),_,_) then i::iRow;
+    case ((i,BackendDAE.SOLVABILITY_CONST(),_),_,_) then i::iRow;
+    case ((i,BackendDAE.SOLVABILITY_PARAMETER(b=true),_),_,_) then i::iRow;
 //    case ((i,BackendDAE.SOLVABILITY_PARAMETER(b=false)),_,_) then incidenceMatrixElementElementfromEnhanced2_1(i,vars,iRow);
 //    case ((i,BackendDAE.SOLVABILITY_LINEAR(b=_)),_,_) then incidenceMatrixElementElementfromEnhanced2_1(i,vars,iRow);
 //    case ((i,BackendDAE.SOLVABILITY_NONLINEAR()),_,_) then incidenceMatrixElementElementfromEnhanced2_1(i,vars,iRow);

--- a/Compiler/BackEnd/Initialization.mo
+++ b/Compiler/BackEnd/Initialization.mo
@@ -1488,13 +1488,13 @@ algorithm
     //case (id, BackendDAE.SOLVABILITY_SOLVED())::elem guard intEq(id, inVarID)
     //then false;
 
-    case (id, BackendDAE.SOLVABILITY_UNSOLVABLE())::_ guard intEq(id, inVarID)
+    case (id, BackendDAE.SOLVABILITY_UNSOLVABLE(),_)::_ guard intEq(id, inVarID)
     then false;
 
-    case (id, BackendDAE.SOLVABILITY_NONLINEAR())::_ guard intEq(id, inVarID)
+    case (id, BackendDAE.SOLVABILITY_NONLINEAR(),_)::_ guard intEq(id, inVarID)
     then false;
 
-    case (_, _)::elem equation
+    case (_, _, _)::elem equation
       b = isVarExplicitSolvable(elem, inVarID);
     then b;
   end match;

--- a/Compiler/BackEnd/RemoveSimpleEquations.mo
+++ b/Compiler/BackEnd/RemoveSimpleEquations.mo
@@ -660,7 +660,8 @@ algorithm
       BackendDAE.StrongComponents rest;
       BackendDAE.Equation eqn;
       list<BackendDAE.Equation> eqnlst, eqnlst1;
-      list<tuple<Integer, list<Integer>>> eqnvartpllst;
+      BackendDAE.InnerEquations innerEquations;
+      BackendDAE.InnerEquation innerEquation;
       Type_a arg;
     case ({}, _, _, _) then inTypeA;
     case (BackendDAE.SINGLEEQUATION(eqn=e)::rest, _, _, _)
@@ -705,11 +706,11 @@ algorithm
         arg = inFunc({eqn}, inTypeA);
       then
         traverseComponents(rest, iEqns, inFunc, arg);
-    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(residualequations=elst, otherEqnVarTpl=eqnvartpllst))::rest, _, _, _)
+    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(residualequations=elst, innerEquations=innerEquations))::rest, _, _, _)
       equation
-        // collect alle equations
+        // collect all equations
         eqnlst = BackendEquation.getEqns(elst, iEqns);
-        elst = List.map(eqnvartpllst, Util.tuple21);
+        (elst,_,_) = List.map_3(innerEquations, BackendDAEUtil.getEqnAndVarsFromInnerEquation);
         eqnlst1 = BackendEquation.getEqns(elst, iEqns);
         eqnlst = listAppend(eqnlst, eqnlst1);
         arg = inFunc(eqnlst, inTypeA);

--- a/Compiler/BackEnd/ResolveLoops.mo
+++ b/Compiler/BackEnd/ResolveLoops.mo
@@ -1893,9 +1893,9 @@ protected function getEqPairs
 protected
   list<Integer> vars,eqs;
 algorithm
-  vars := List.map(arrayGet(me,eq),Util.tuple21);
+  vars := List.map(arrayGet(me,eq),Util.tuple31);
           //print("vars: \n"+stringDelimitList(List.map(vars,intString)," / ")+"\n");
-  eqs := List.map(List.flatten(List.map1(vars,Array.getIndexFirst,meT)),Util.tuple21);
+  eqs := List.map(List.flatten(List.map1(vars,Array.getIndexFirst,meT)),Util.tuple31);
           //print("eqs: \n"+stringDelimitList(List.map(eqs,intString)," / ")+"\n");
   eqs := getDoublicates(eqs);
           //print("eqs: \n"+stringDelimitList(List.map(eqs,intString)," / ")+"\n");
@@ -1911,9 +1911,9 @@ protected
   list<Integer> vars,eqs,numEqs;
   list<list<Integer>> eqLst;
 algorithm
-  vars := List.map(row,Util.tuple21);
+  vars := List.map(row,Util.tuple31);
   b1 := intEq(listLength(row),2);  // only two variables
-  eqLst := List.mapList((List.map1(vars,Array.getIndexFirst,meT)),Util.tuple21);
+  eqLst := List.mapList((List.map1(vars,Array.getIndexFirst,meT)),Util.tuple31);
   numEqs := List.map(eqLst,listLength);
   b3 := List.fold(List.map1(numEqs,intEq,2),boolOr,false);  // at least one adjacent variable hast only 2 adj equations
   eqs := List.flatten(eqLst);
@@ -1980,8 +1980,8 @@ algorithm
         // start resolving the first 2 equations
         nextEq::rest = rest;
         //BackendDump.dumpIncidenceMatrix(m);
-        vars1 = List.map(arrayGet(me,startEq),Util.tuple21);
-        vars2 = List.map(arrayGet(me,nextEq),Util.tuple21);
+        vars1 = List.map(arrayGet(me,startEq),Util.tuple31);
+        vars2 = List.map(arrayGet(me,nextEq),Util.tuple31);
         vars1 = List.intersectionOnTrue(vars1,vars2,intEq);
         numEqs = List.map(List.map1(vars1,Array.getIndexFirst,meT),listLength);
         (_,vars1) = List.filter1OnTrueSync(numEqs,intEq,2,vars1);

--- a/Compiler/BackEnd/Tearing.mo
+++ b/Compiler/BackEnd/Tearing.mo
@@ -452,46 +452,46 @@ algorithm
       BackendDAE.AdjacencyMatrixElementEnhanced rest;
       Boolean b1;
     case ({}) then true;
-    case ((e,BackendDAE.SOLVABILITY_SOLVED())::rest)
+    case ((e,BackendDAE.SOLVABILITY_SOLVED(),_)::rest)
       equation
         b1 = intLe(e,0);
         b1 = if b1 then unsolvable(rest) else false;
       then
         b1;
-    case ((e,BackendDAE.SOLVABILITY_CONSTONE())::rest)
+    case ((e,BackendDAE.SOLVABILITY_CONSTONE(),_)::rest)
       equation
         b1 = intLe(e,0);
         b1 = if b1 then unsolvable(rest) else false;
       then
         b1;
-    case ((e,BackendDAE.SOLVABILITY_CONST())::rest)
+    case ((e,BackendDAE.SOLVABILITY_CONST(),_)::rest)
       equation
         b1 = intLe(e,0);
         b1 = if b1 then unsolvable(rest) else false;
       then
         b1;
-    case ((_,BackendDAE.SOLVABILITY_PARAMETER(b=false))::rest)
+    case ((_,BackendDAE.SOLVABILITY_PARAMETER(b=false),_)::rest)
       then
         unsolvable(rest);
-    case ((e,BackendDAE.SOLVABILITY_PARAMETER(b=true))::rest)
+    case ((e,BackendDAE.SOLVABILITY_PARAMETER(b=true),_)::rest)
       equation
         b1 = intLe(e,0);
         b1 = if b1 then unsolvable(rest) else false;
       then
         b1;
-    case ((_,BackendDAE.SOLVABILITY_LINEAR(b=false))::rest)
+    case ((_,BackendDAE.SOLVABILITY_LINEAR(b=false),_)::rest)
       then
         unsolvable(rest);
-    case ((_,BackendDAE.SOLVABILITY_LINEAR(b=true))::rest)
+    case ((_,BackendDAE.SOLVABILITY_LINEAR(b=true),_)::rest)
       then
         unsolvable(rest);
-    case ((_,BackendDAE.SOLVABILITY_NONLINEAR())::rest)
+    case ((_,BackendDAE.SOLVABILITY_NONLINEAR(),_)::rest)
       then
         unsolvable(rest);
-    case ((_,BackendDAE.SOLVABILITY_UNSOLVABLE())::rest)
+    case ((_,BackendDAE.SOLVABILITY_UNSOLVABLE(),_)::rest)
       then
         unsolvable(rest);
-    case ((e,BackendDAE.SOLVABILITY_SOLVABLE())::rest)
+    case ((e,BackendDAE.SOLVABILITY_SOLVABLE(),_)::rest)
       equation
         b1 = intLe(e,0);
         b1 = if b1 then unsolvable(rest) else false;
@@ -872,10 +872,10 @@ protected function findVareqns
   input CompFunc inCompFunc;
   input BackendDAE.AdjacencyMatrixTEnhanced mt;
   input list<Integer> tSel_alwaysIn;
-  output list<tuple<Integer,BackendDAE.Solvability>> vareqnsOut = {};
+  output list<tuple<Integer,BackendDAE.Solvability,BackendDAE.Constraints>> vareqnsOut = {};
   partial function CompFunc
     input array<Integer> inValue;
-    input tuple<Integer,BackendDAE.Solvability> inElement;
+    input tuple<Integer,BackendDAE.Solvability,BackendDAE.Constraints> inElement;
     output Boolean outIsEqual;
   end CompFunc;
 algorithm
@@ -1057,10 +1057,9 @@ protected function removeMatched
   output BackendDAE.AdjacencyMatrixElementEnhanced oAcc = {};
 protected
   Integer e;
-  BackendDAE.Solvability s;
 algorithm
   for el in elem loop
-    (e,s) := el;
+    (e,_,_) := el;
     if intLt(ass2[e],0) then
       oAcc := el::oAcc;
     end if;
@@ -1095,7 +1094,7 @@ end calcSolvabilityWeight;
 protected function solvabilityWeightsnoStates
 "helper function for calcSolvabilityWeight, giving points for solvability
   author: Frenkel TUD 2012-05"
-  input tuple<Integer,BackendDAE.Solvability> inTpl;
+  input tuple<Integer,BackendDAE.Solvability,BackendDAE.Constraints> inTpl;
   input array<Integer> ass;
   input Integer iW;
   output Integer oW;
@@ -1104,7 +1103,7 @@ algorithm
     local
       BackendDAE.Solvability s;
       Integer eq,w;
-    case((eq,s),_,_)
+    case((eq,s,_),_,_)
       guard
         intGt(eq,0) and
         not intGt(ass[eq], 0)
@@ -1155,7 +1154,7 @@ algorithm
      case (_,_,_,_)
        equation
          // finds equations with exact two variables (v1,v2)
-         ((v1,_)::(v2,_)::{}) = List.removeOnTrue(ass1, isAssignedSaveEnhanced, m[e]);
+         ((v1,_,_)::(v2,_,_)::{}) = List.removeOnTrue(ass1, isAssignedSaveEnhanced, m[e]);
          points = arrayUpdate(iPoints,v1,iPoints[v1]+5);
          points = arrayUpdate(iPoints,v2,points[v2]+5);
        then
@@ -1169,13 +1168,13 @@ end addEqnWeights;
 protected function isAssignedSaveEnhanced " returns true if var/eqn is already assigned
   author: Frenkel TUD 2012-05"
   input array<Integer> ass;
-  input tuple<Integer,BackendDAE.Solvability> inTpl;
+  input tuple<Integer,BackendDAE.Solvability,BackendDAE.Constraints> inTpl;
   output Boolean outB;
 algorithm
   outB := match(ass,inTpl)
     local
       Integer i;
-    case (_,(i,_)) guard intGt(i,0)
+    case (_,(i,_,_)) guard intGt(i,0)
       then
         intGt(ass[i],0);
     else
@@ -1256,7 +1255,7 @@ algorithm
         tearingBFS(newqueue,m,mt,mapEqnIncRow,mapIncRowEqn,size,ass1,ass2,{});
       then
         ();
-    case((c,_)::rest,_,_,_,_,_,_,_,_)
+    case((c,_,_)::rest,_,_,_,_,_,_,_,_)
       equation
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("Queue:\n");
@@ -1312,7 +1311,7 @@ protected
   Integer r;
   BackendDAE.AdjacencyMatrixElementEnhanced row;
 algorithm
-  (r,_) := entry;
+  (r,_,_) := entry;
   row := m[r];
   hasnonlinear := hasnonlinearVars1(row);
 end hasnonlinearVars;
@@ -1326,7 +1325,7 @@ algorithm
     local
       BackendDAE.AdjacencyMatrixElementEnhanced rest;
     case ( {}) then false;
-    case ((_,BackendDAE.SOLVABILITY_NONLINEAR())::_)
+    case ((_,BackendDAE.SOLVABILITY_NONLINEAR(),_)::_)
       then
         true;
     case (_::rest)
@@ -1385,7 +1384,7 @@ protected
   BackendDAE.Solvability s;
 algorithm
   for r in rows loop
-    (_,s) := r;
+    (_,s,_) := r;
     if not solvable(s) then
       solvable := false;
       return;
@@ -1430,7 +1429,7 @@ algorithm
       BackendDAE.Solvability s;
       BackendDAE.AdjacencyMatrixElementEnhanced rest,vareqns,newqueue;
     case ({},_,_,_,_,_) then inNextQueue;
-    case ((r,_)::rest,c::ilst,_,_,_,_)
+    case ((r,_,_)::rest,c::ilst,_,_,_,_)
       equation
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
            print("Assignment: Eq " + intString(c) + " - Var " + intString(r) + "\n");
@@ -1512,7 +1511,7 @@ algorithm
     matchcontinue (jacType,isyst,ishared,subsyst,tvars,residual,ass1,ass2,othercomps,eindex,vindx,mapEqnIncRow,mapIncRowEqn,columark,mark,mixedSystem)
     local
       list<Integer> ores,residual1,ovars;
-      list<tuple<Integer,list<Integer>>> eqnvartpllst;
+      BackendDAE.InnerEquations innerEquations;
       array<Integer> eindxarr,varindxarr;
       Boolean linear;
     case (_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_)
@@ -1527,10 +1526,10 @@ algorithm
         ores = List.map1r(residual1,arrayGet,eindxarr);
         varindxarr = listArray(vindx);
         ovars = List.map1r(tvars,arrayGet,varindxarr);
-        eqnvartpllst = omcTearing4_1(othercomps,ass2,mapIncRowEqn,eindxarr,varindxarr,columark,mark);
+        innerEquations = omcTearing4_1(othercomps,ass2,mapIncRowEqn,eindxarr,varindxarr,columark,mark);
         linear = getLinearfromJacType(jacType);
       then
-        (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(ovars, ores, eqnvartpllst, BackendDAE.EMPTY_JACOBIAN()), NONE(), linear,mixedSystem),true);
+        (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(ovars, ores, innerEquations, BackendDAE.EMPTY_JACOBIAN()), NONE(), linear,mixedSystem),true);
     case (_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_)
       then
         (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET({}, {}, {}, BackendDAE.EMPTY_JACOBIAN()), NONE(), false,mixedSystem),false);
@@ -1539,7 +1538,7 @@ end omcTearing4;
 
 
 protected function omcTearing4_1
-" creates otherEqnVarTpl for TORNSYSTEM
+" creates innerEquations for TearingSet
   author: Frenkel TUD 2012-09"
   input list<list<Integer>> othercomps;
   input array<Integer> ass2;
@@ -1548,9 +1547,9 @@ protected function omcTearing4_1
   input array<Integer> varindxarr;
   input array<Integer> columark;
   input Integer mark;
-  output list<tuple<Integer,list<Integer>>> oEqnVarTplLst;
+  output BackendDAE.InnerEquations outInnerEquations;
 algorithm
-  oEqnVarTplLst := list(
+  outInnerEquations := list(
     match x
       local
         list<Integer> vlst,clst,elst;
@@ -1562,19 +1561,19 @@ algorithm
           e = eindxarr[e];
           v = ass2[c];
           v = varindxarr[v];
-      then
-        (e,{v});
+       then
+        BackendDAE.INNEREQUATION(eqn=e,vars={v});
 
-    case clst
-      equation
-        elst = List.map1r(clst,arrayGet,mapIncRowEqn);
-        elst = List.fold2(elst,uniqueIntLst,mark,columark,{});
-        {e} = elst;
-        e = eindxarr[e];
-        vlst = List.map1r(clst,arrayGet,ass2);
-        vlst = List.map1r(vlst,arrayGet,varindxarr);
-      then
-        (e,vlst);
+      case clst
+        equation
+          elst = List.map1r(clst,arrayGet,mapIncRowEqn);
+          elst = List.fold2(elst,uniqueIntLst,mark,columark,{});
+          {e} = elst;
+          e = eindxarr[e];
+          vlst = List.map1r(clst,arrayGet,ass2);
+          vlst = List.map1r(vlst,arrayGet,varindxarr);
+       then
+        BackendDAE.INNEREQUATION(eqn=e,vars=vlst);
     end match
   for x in othercomps);
 end omcTearing4_1;
@@ -1605,7 +1604,7 @@ end getLinearfromJacType;
 // =============================================================================
 
 protected function CellierTearing " tearing method based on the method from book of Cellier
-author: ptaeuber FHB 2013-2015"
+author: ptaeuber FHB 2013-2016"
   input BackendDAE.EqSystem isyst;
   input BackendDAE.Shared ishared;
   input list<Integer> eindex;
@@ -1620,7 +1619,7 @@ protected
   array<Integer> ass1,ass2,mapIncRowEqn;
   array<list<Integer>> mapEqnIncRow;
   list<Integer> OutTVars,residual,residual_coll,order,unsolvables,discreteVars,unsolvableDiscretes,tSel_always,tSel_prefer,tSel_avoid,tSel_never;
-  list<tuple<Integer,list<Integer>>> otherEqnVarTpl;
+  BackendDAE.InnerEquations innerEquations;
   BackendDAE.EqSystem subsyst;
   BackendDAE.Variables vars;
   BackendDAE.EquationArray eqns;
@@ -1755,11 +1754,11 @@ algorithm
      print("*\n* =====\n* resEq: "+ stringDelimitList(List.map(residual,intString),",") + "\n* =====\n" + BORDER + "\n\n");
   end if;
 
-  // assign otherEqnVarTpl:
-  otherEqnVarTpl := assignOtherEqnVarTpl(order,eindex,vindx,ass2,mapEqnIncRow);
+  // assign innerEquations:
+  innerEquations := assignInnerEquations(order,eindex,vindx,ass2,mapEqnIncRow,NONE());
 
   // Create BackendDAE.TearingSet for strict set
-  strictTearingSet := BackendDAE.TEARINGSET(OutTVars,residual,otherEqnVarTpl,BackendDAE.EMPTY_JACOBIAN());
+  strictTearingSet := BackendDAE.TEARINGSET(OutTVars,residual,innerEquations,BackendDAE.EMPTY_JACOBIAN());
 
 
   // Determine casual tearing set if dynamic tearing is enabled
@@ -1843,11 +1842,11 @@ algorithm
          print("\nNote:\n=====\n" + s + " dynamic tearing for this strong component in model:\n" + modelName + "\n\n");
       end if;
 
-      // assign otherEqnVarTpl:
-      otherEqnVarTpl := assignOtherEqnVarTpl(order,eindex,vindx,ass2,mapEqnIncRow);
+      // assign innerEquations:
+      innerEquations := assignInnerEquations(order,eindex,vindx,ass2,mapEqnIncRow,SOME(me));
 
       // Create BackendDAE.TearingSet for casual set
-      casualTearingSet := SOME(BackendDAE.TEARINGSET(OutTVars,residual,otherEqnVarTpl,BackendDAE.EMPTY_JACOBIAN()));
+      casualTearingSet := SOME(BackendDAE.TEARINGSET(OutTVars,residual,innerEquations,BackendDAE.EMPTY_JACOBIAN()));
     else
       if Flags.isSet(Flags.TEARING_DUMP) or Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
         print("\n" + BORDER + "\n* TEARING RESULTS (CASUAL SET):\n*\n* No of equations in strong Component: "+intString(size)+"\n");
@@ -3030,7 +3029,7 @@ algorithm
    local
      Integer v,count,maxi;
      list<Integer> rest,newPotentials1,counts;
-   BackendDAE.AdjacencyMatrixElementEnhanced elem;
+     BackendDAE.AdjacencyMatrixElementEnhanced elem;
    case({},_,_,_,_,_)
      then (newPotentials,inCounts,max);
    case(v::rest,_,_,_,_,_)
@@ -3057,7 +3056,7 @@ protected
   BackendDAE.Solvability s;
 algorithm
   for e in elem loop
-    (_,s) := e;
+    (_,s,_) := e;
     if not solvable(s) then
       outCount := outCount + 1;
     end if;
@@ -3297,26 +3296,64 @@ algorithm
 end makeAssignment;
 
 
-protected function assignOtherEqnVarTpl " assigns otherEqnVarTpl for TORNSYSTEM
+protected function assignInnerEquations " assigns innerEquations for TearingSet
   author: ptaeuber FHB 2013-08"
-  input list<Integer> inEqns,eindex,vindx;
+  input list<Integer> inEqns "order of equations with local numbering";
+  input list<Integer> eindex "equation indexes with global numbering";
+  input list<Integer> vindex "variable indexes with global numbering";
   input array<Integer> ass2;
   input array<list<Integer>> mapEqnIncRow;
-  output list<tuple<Integer,list<Integer>>> outOtherEqnVarTpl;
+  input Option<BackendDAE.AdjacencyMatrixEnhanced> meOpt;
+  output BackendDAE.InnerEquations outInnerEquations;
 algorithm
-  outOtherEqnVarTpl := list(
-    match eqn
+  outInnerEquations := list(
+    match (eqn,meOpt)
       local
         Integer eq,otherEqn;
-        list<Integer> vars,otherVars,rest;
-      case eq
+        list<Integer> eqns,vars,otherVars,rest;
+        BackendDAE.InnerEquation innerEquation;
+        BackendDAE.Constraints constraints;
+        BackendDAE.AdjacencyMatrixEnhanced me;
+      case (eq,NONE())
         equation
           vars = List.map1r(mapEqnIncRow[eq],arrayGet,ass2);
           otherEqn = listGet(eindex,eq);
-          otherVars = selectFromList_rev(vindx,vars);
-      then (otherEqn,otherVars);
+          otherVars = selectFromList_rev(vindex,vars);
+      then BackendDAE.INNEREQUATION(eqn=otherEqn, vars=otherVars);
+      case (eq,SOME(me))
+        equation
+          eqns = mapEqnIncRow[eq];
+          vars = List.map1r(eqns,arrayGet,ass2);
+          otherEqn = listGet(eindex,eq);
+          otherVars = selectFromList_rev(vindex,vars);
+          constraints = findConstraintForInnerEquation(me[listHead(eqns)],listHead(vars));
+          if listEmpty(constraints) then
+            innerEquation = BackendDAE.INNEREQUATION(eqn=otherEqn, vars=otherVars);
+          else
+            innerEquation = BackendDAE.INNEREQUATIONCONSTRAINTS(eqn=otherEqn, vars=otherVars, cons=constraints);
+          end if;
+      then (innerEquation);
   end match for eqn in inEqns);
-end assignOtherEqnVarTpl;
+end assignInnerEquations;
+
+
+protected function findConstraintForInnerEquation
+  input BackendDAE.AdjacencyMatrixElementEnhanced meRow;
+  input Integer searchIndex;
+  output BackendDAE.Constraints constraints={};
+protected
+  Integer index;
+  BackendDAE.AdjacencyMatrixElementEnhancedEntry meElem;
+  BackendDAE.Constraints cons;
+algorithm
+  for meElem in meRow loop
+    (index,_,cons) := meElem;
+    if intEq(index,searchIndex) then
+      constraints := cons;
+      break;
+    end if;
+  end for;
+end findConstraintForInnerEquation;
 
 
 protected function getpossibleEqn " finds equation that can be matched
@@ -3643,11 +3680,11 @@ protected
   BackendDAE.StateSets stateSets;
   BackendDAE.BaseClockPartitionKind partitionKind;
 
-  list<tuple<Integer,list<Integer>>> otherEqnVarTpl;
-  tuple<Integer,list<Integer>> tpl;
+  BackendDAE.InnerEquations innerEquations;
+  BackendDAE.InnerEquation innerEquation;
   Integer eqindex, vindex;
   list<Integer> residualequations;
-  list<Integer> tearingvars;
+  list<Integer> tearingvars, othervars;
   list<BackendDAE.Var> var_lst;
   BackendDAE.Var var;
   array<DAE.ComponentRef> tear_cr;
@@ -3674,8 +3711,8 @@ algorithm
     for comp in comps loop
       if isTornsystem(comp, true, false) then
         // -----
-        BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(otherEqnVarTpl = otherEqnVarTpl, residualequations= residualequations, tearingvars=tearingvars)) := comp;
-        n := listLength(otherEqnVarTpl);
+        BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(innerEquations = innerEquations, residualequations= residualequations, tearingvars=tearingvars)) := comp;
+        n := listLength(innerEquations);
         m := listLength(residualequations);
         if maxSizeOne and m > 1 then
           continue;
@@ -3688,8 +3725,8 @@ algorithm
         update := true;
         tmp_update := true;
         // -----
-        for tpl in otherEqnVarTpl loop
-          (eqindex, {vindex}) := tpl;
+        for innerEquation in innerEquations loop
+          (eqindex, {vindex}, _) := BackendDAEUtil.getEqnAndVarsFromInnerEquation(innerEquation);
           (var as BackendDAE.VAR(varName = cr)) := BackendVariable.getVarAt(vars, vindex);
           all_vars := cr :: all_vars;
           arrayUpdate(indx_var,i,vindex);
@@ -3706,7 +3743,7 @@ algorithm
           if Flags.isSet(Flags.DUMP_RTEARING) then
             print("INeqn => " + BackendDump.equationString(eqn) +  "[" + intString(i-1) + "]\n");
           end if;
-        end for; //otherEqnVarTpl
+        end for; //innerEquations
 
         // -----
         var_lst := list(BackendVariable.getVarAt(vars, i) for i in tearingvars);

--- a/Compiler/BackEnd/XMLDump.mo
+++ b/Compiler/BackEnd/XMLDump.mo
@@ -1186,13 +1186,14 @@ algorithm
     local
       Integer e,v;
       list<Integer> elst,vlst,vlst1,elst1;
+      list<list<Integer>> vlst1Lst;
       BackendDAE.StrongComponent comp;
       BackendDAE.StrongComponents rest;
       BackendDAE.Var var;
       BackendDAE.Equation eqn;
       list<BackendDAE.Var> inAccumVars, varlst, varlst1;
       list<BackendDAE.Equation> inAccumEqns, eqnlst, eqnlst1;
-      list<tuple<Integer,list<Integer>>> eqnsvartpllst;
+      BackendDAE.InnerEquations innerEquations;
       tuple<list<BackendDAE.Equation>, list<BackendDAE.Var>> eqnsVars;
       list<tuple<list<BackendDAE.Equation>, list<BackendDAE.Var>>> result;
     case ({},_,_,_)  then inAccum;
@@ -1252,13 +1253,13 @@ algorithm
         result = getOrderedEqs2(rest,eqns,vars,result);
       then
         result;
-    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=vlst,residualequations=elst,otherEqnVarTpl=eqnsvartpllst))::rest,_,_,_)
+    case (BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=vlst,residualequations=elst,innerEquations=innerEquations))::rest,_,_,_)
       equation
-        vlst1 = List.flatten(List.map(eqnsvartpllst,Util.tuple22));
+        (elst1,vlst1Lst,_) = List.map_3(innerEquations, BackendDAEUtil.getEqnAndVarsFromInnerEquation);
+        vlst1 = List.flatten(vlst1Lst);
         varlst1 = List.map1r(vlst1, BackendVariable.getVarAt, vars);
         varlst = List.map1r(vlst, BackendVariable.getVarAt, vars);
         varlst = listAppend(varlst1,varlst);
-        elst1 = List.map(eqnsvartpllst,Util.tuple21);
         eqnlst1 = BackendEquation.getEqns(elst1,eqns);
         eqnlst = BackendEquation.getEqns(elst,eqns);
         eqnlst = listAppend(eqnlst1,eqnlst);

--- a/Compiler/FrontEnd/DAE.mo
+++ b/Compiler/FrontEnd/DAE.mo
@@ -598,6 +598,10 @@ uniontype Constraint "Optimica extension: The `Constraints\' type corresponds to
     list<Exp> constraintLst;
   end CONSTRAINT_EXPS;
 
+  record CONSTRAINT_DT "Constraints needed for proper Dynamic Tearing"
+    Exp constraint;
+    Boolean localCon "local or global constraint; local constraints depend on variables that are computed within the algebraic loop itself";
+  end CONSTRAINT_DT;
 end Constraint;
 
 public

--- a/Compiler/FrontEnd/ExpressionDump.mo
+++ b/Compiler/FrontEnd/ExpressionDump.mo
@@ -1805,5 +1805,37 @@ algorithm
   end match;
 end clockKindString;
 
+
+public function constraintDTtoString "
+author: ptaeuber
+Converts DAE.CONSTRAINT_DT to string."
+  input DAE.Constraint con;
+  output String str;
+protected
+  DAE.Exp c;
+  Boolean localCon;
+algorithm
+  DAE.CONSTRAINT_DT(constraint = c, localCon = localCon) := con;
+  str := printExpStr(c);
+  str := if localCon then str + " (local)" else str + " (global)";
+end constraintDTtoString;
+
+
+public function constraintDTlistToString "
+author: ptaeuber
+Converts list of DAE.CONSTRAINT_DT to string."
+  input list<DAE.Constraint> cons;
+  input String delim;
+  output String str="";
+protected
+  DAE.Exp c;
+  Boolean localCon;
+  DAE.Constraint con;
+algorithm
+  for con in cons loop
+    str := str + delim + constraintDTtoString(con);
+  end for;
+end constraintDTlistToString;
+
 annotation(__OpenModelica_Interface="frontend");
 end ExpressionDump;


### PR DESCRIPTION
- save the inner equations in BackendDAE.InnerEquations
  instead of in list<tupel<Integer,list<Integer>>>
- introduced record INNEREQUATIONCONSTRAINTS for constraints
  on the inner equations of the casual set (Dynamic Tearing)