### PR TITLE
Do not allocate tables for DSS using uode

### DIFF
--- a/Compiler/BackEnd/BackendDAE.mo
+++ b/Compiler/BackEnd/BackendDAE.mo
@@ -474,6 +474,8 @@ uniontype StateOrder
     HashTableCG.HashTable hashTable "x -> dx";
     HashTable3.HashTable invHashTable "dx -> {x,y,z}";
   end STATEORDER;
+  record NOSTATEORDER "Index reduction disabled; don't need big hashtables"
+  end NOSTATEORDER;
 end StateOrder;
 
 public

--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -3159,6 +3159,13 @@ algorithm
   v_lst := traverseBackendDAEVars(inVariables,traversingisStateVarFinder,{});
 end getAllStateVarFromVariables;
 
+public function getNumStateVarFromVariables
+  input BackendDAE.Variables inVariables;
+  output Integer count;
+algorithm
+  count := traverseBackendDAEVars(inVariables,traversingisStateCount,0);
+end getNumStateVarFromVariables;
+
 protected function traversingisStateVarFinder
   input BackendDAE.Var inVar;
   input list<BackendDAE.Var> inVars;
@@ -3168,6 +3175,15 @@ algorithm
   v := inVar;
   v_lst := List.consOnTrue(isStateVar(v),v,inVars);
 end traversingisStateVarFinder;
+
+protected function traversingisStateCount
+  input output BackendDAE.Var v;
+  input output Integer count;
+algorithm
+  if isStateVar(v) then
+    count := count + 1;
+  end if;
+end traversingisStateCount;
 
 public function getAllStateDerVarIndexFromVariables
   input BackendDAE.Variables inVariables;

--- a/Compiler/BackEnd/Matching.mo
+++ b/Compiler/BackEnd/Matching.mo
@@ -6308,7 +6308,7 @@ algorithm
   end matchcontinue;
 end testMatchingAlgorithms1;
 
-public function testMatchingAlgorithm
+protected function testMatchingAlgorithm
 "function testMatchingAlgorithm, tests a specific matching algorithm
  author: Frenkel TUD 2012-04"
   input Integer index;


### PR DESCRIPTION
This commit disables allocating of large hash tables for dynamic state
selection when using uode (no DSS), and sizes the hash tables based on
the number of states if we do use DSS.