### PR TITLE
Do not use Option<Name> in FGraph.openScope

### DIFF
--- a/Compiler/FFrontEnd/FGraph.mo
+++ b/Compiler/FFrontEnd/FGraph.mo
@@ -680,7 +680,7 @@ public function openScope
 "Opening a new scope in the graph means adding a new node in the current scope."
   input Graph inGraph;
   input SCode.Encapsulated encapsulatedPrefix;
-  input Option<Name> inName;
+  input Name inName;
   input Option<FCore.ScopeType> inScopeType;
   output Graph outGraph;
 algorithm
@@ -693,7 +693,7 @@ algorithm
       Scope sc;
 
     // see if we have it as a class instance
-    case (g, _, SOME(n), _)
+    case (g, _, n, _)
       equation
         p = lastScopeRef(g);
         r = FNode.child(p, n);
@@ -704,7 +704,7 @@ algorithm
         g;
 
     // see if we have a child with the same name!
-    case (g, _, SOME(n), _)
+    case (g, _, n, _)
       equation
         p = lastScopeRef(g);
         r = FNode.child(p, n);
@@ -715,7 +715,7 @@ algorithm
         g;
 
     // else open a new scope!
-    case (g, _, SOME(n), _)
+    case (g, _, n, _)
       equation
         p = lastScopeRef(g);
         (g, no) = node(g, n, {p}, FCore.ND(inScopeType));
@@ -727,7 +727,7 @@ algorithm
 
     else
       equation
-        Error.addCompilerError("FGraph.openScope: failed to open new scope in scope: " + getGraphNameStr(inGraph) + " name: " + Util.stringOption(inName) + "\n");
+        Error.addCompilerError("FGraph.openScope: failed to open new scope in scope: " + getGraphNameStr(inGraph) + " name: " + inName + "\n");
       then
         fail();
 

--- a/Compiler/FrontEnd/Ceval.mo
+++ b/Compiler/FrontEnd/Ceval.mo
@@ -846,7 +846,7 @@ algorithm
 
     case (cache, env, DAE.REDUCTION(reductionInfo=DAE.REDUCTIONINFO(iterType = iterType, path = path, foldName=foldName, resultName=resultName, foldExp = foldExp, defaultValue = ov, exprType = ty), expr = daeExp, iterators = iterators), impl, stOpt, msg,_)
       equation
-        env = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), SOME(FCore.forScopeName), NONE());
+        env = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), FCore.forScopeName, NONE());
         (cache, valMatrix, names, dims, tys, stOpt) = cevalReductionIterators(cache, env, iterators, impl, stOpt,msg,numIter+1);
         // print("Before:\n");print(stringDelimitList(List.map1(List.mapList(valMatrix, ValuesUtil.valString), stringDelimitList, ","), "\n") + "\n");
         valMatrix = makeReductionAllCombinations(valMatrix,iterType);

--- a/Compiler/FrontEnd/CevalFunction.mo
+++ b/Compiler/FrontEnd/CevalFunction.mo
@@ -1520,7 +1520,7 @@ protected function setupFunctionEnvironment
   output FCore.Graph outEnv;
   output SymbolTable outST;
 algorithm
-  outEnv := FGraph.openScope(inEnv, SCode.NOT_ENCAPSULATED(), SOME(inFuncName), SOME(FCore.FUNCTION_SCOPE()));
+  outEnv := FGraph.openScope(inEnv, SCode.NOT_ENCAPSULATED(), inFuncName, SOME(FCore.FUNCTION_SCOPE()));
   (outCache, outEnv, outST) :=
     extendEnvWithFunctionVars(inCache, outEnv, inFuncParams, inST);
 end setupFunctionEnvironment;

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -589,7 +589,7 @@ algorithm
         isPartialFn = isFn and SCode.partialBool(partialPrefix);
         true = notIsPartial or isPartialFn;
 
-        env_1 = FGraph.openScope(env, encflag, SOME(n), FGraph.restrictionToScopeType(r));
+        env_1 = FGraph.openScope(env, encflag, n, FGraph.restrictionToScopeType(r));
 
         ci_state = ClassInf.start(r,FGraph.getGraphName(env_1));
         csets = ConnectUtil.newSet(pre, inSets);
@@ -693,7 +693,7 @@ algorithm
 
     case (cache,env,ih,store,mod,pre,(c as SCode.CLASS(name = n,encapsulatedPrefix = encflag,restriction = r)),inst_dims,impl,_,_) /* impl */
       equation
-        env_1 = FGraph.openScope(env, encflag, SOME(n), FGraph.restrictionToScopeType(r));
+        env_1 = FGraph.openScope(env, encflag, n, FGraph.restrictionToScopeType(r));
         ci_state = ClassInf.start(r, FGraph.getGraphName(env_1));
         c_1 = SCode.classSetPartial(c, SCode.NOT_PARTIAL());
         (cache,env_3,ih,store,dae1,csets,ci_state_1,tys,bc_ty,_,_,_)
@@ -791,7 +791,7 @@ algorithm
         FCore.CL(status = FCore.CLS_INSTANCE(n)) = FNode.refData(FGraph.lastScopeRef(inEnv));
         (env, _) = FGraph.stripLastScopeRef(inEnv);
 
-        env = FGraph.openScope(env, encflag, SOME(n), FGraph.restrictionToScopeType(r));
+        env = FGraph.openScope(env, encflag, n, FGraph.restrictionToScopeType(r));
         ci_state = ClassInf.start(r,FGraph.getGraphName(env));
 
         // lookup in IH
@@ -1630,7 +1630,6 @@ algorithm
       equation
         true = Flags.isSet(Flags.CACHE);
         instHash = getGlobalRoot(Global.instHashIndex);
-        _ = SCode.className(c);
 
         fullEnvPathPlusClass = generateCachePath(inEnv, c, pre, InstTypes.INNER_CALL());
 
@@ -2325,7 +2324,7 @@ algorithm
           Lookup.lookupClass(cache, env, cn, SOME(info));
 
         // keep the old behaviour
-        env3 = FGraph.openScope(cenv, enc2, SOME(cn2), SOME(FCore.CLASS_SCOPE()));
+        env3 = FGraph.openScope(cenv, enc2, cn2, SOME(FCore.CLASS_SCOPE()));
         ci_state2 = ClassInf.start(r, FGraph.getGraphName(env3));
         new_ci_state = ClassInf.start(r, FGraph.getGraphName(env3));
 
@@ -2368,7 +2367,7 @@ algorithm
         Util.setStatefulBoolean(stopInst, not valid_connector);
         true = valid_connector;
 
-        cenv_2 = FGraph.openScope(cenv, enc2, SOME(cn2), FGraph.classInfToScopeType(ci_state));
+        cenv_2 = FGraph.openScope(cenv, enc2, cn2, FGraph.classInfToScopeType(ci_state));
         new_ci_state = ClassInf.start(r, FGraph.getGraphName(cenv_2));
 
         // chain the redeclares
@@ -2439,7 +2438,7 @@ algorithm
         // not a basic type, change class name!
         false = InstUtil.checkDerivedRestriction(re, r, cn2);
 
-        cenv_2 = FGraph.openScope(cenv, enc2, SOME(className), FGraph.classInfToScopeType(ci_state));
+        cenv_2 = FGraph.openScope(cenv, enc2, className, FGraph.classInfToScopeType(ci_state));
         new_ci_state = ClassInf.start(r, FGraph.getGraphName(cenv_2));
 
         c = SCode.setClassName(className, c);
@@ -3033,7 +3032,7 @@ algorithm
         if is_basic_type or has_dims then
           scope_ty := if is_basic_type then FGraph.restrictionToScopeType(der_re) else
                                             FGraph.classInfToScopeType(inState);
-          cenv := FGraph.openScope(cenv, enc, SOME(class_name), scope_ty);
+          cenv := FGraph.openScope(cenv, enc, class_name, scope_ty);
           outState := ClassInf.start(der_re, FGraph.getGraphName(cenv));
           (outCache, outEnv, outIH, outState, outVars) :=
             partialInstClassIn(outCache, cenv, inIH, mod, inPrefix, outState, cls,
@@ -5484,7 +5483,7 @@ algorithm
         true = Flags.isSet(Flags.CACHE);
         instHash = getGlobalRoot(Global.instHashIndex);
         FCore.CL(e2 as SCode.CLASS(restriction = restr, encapsulatedPrefix=encflag), pre2, m2, _, _) = FNode.refData(inRef);
-        env = FGraph.openScope(inEnv, encflag, SOME(inName), FGraph.restrictionToScopeType(restr));
+        env = FGraph.openScope(inEnv, encflag, inName, FGraph.restrictionToScopeType(restr));
         fullEnvPathPlusClass = generateCachePath(env, e2, pre2, InstTypes.INNER_CALL());
 
         // print("Try cached instance: " + Absyn.pathString(fullEnvPathPlusClass) + "\n");
@@ -5512,8 +5511,8 @@ algorithm
         true = Flags.isSet(Flags.CACHE);
         _ = getGlobalRoot(Global.instHashIndex);
         FCore.CL(e2 as SCode.CLASS(restriction = restr, encapsulatedPrefix=encflag), pre2, _, _, _) = FNode.refData(inRef);
-        env = FGraph.openScope(inEnv, encflag, SOME(inName), FGraph.restrictionToScopeType(restr));
-        _ = generateCachePath(env, e2, pre2, InstTypes.INNER_CALL());
+        env = FGraph.openScope(inEnv, encflag, inName, FGraph.restrictionToScopeType(restr));
+        // _ = generateCachePath(env, e2, pre2, InstTypes.INNER_CALL());
 
         // print("Could not get the cached instance: " + Absyn.pathString(fullEnvPathPlusClass) + "\n");
         env = FGraph.pushScopeRef(inEnv, inRef);

--- a/Compiler/FrontEnd/InstExtends.mo
+++ b/Compiler/FrontEnd/InstExtends.mo
@@ -168,7 +168,7 @@ algorithm
           // Fully qualify modifiers in extends in the extends environment.
           (outCache, emod) := fixModifications(outCache, inEnv, emod, {ht});
 
-          cenv := FGraph.openScope(cenv, encf, SOME(cn), FGraph.classInfToScopeType(inState));
+          cenv := FGraph.openScope(cenv, encf, cn, FGraph.classInfToScopeType(inState));
 
           // Add classdefs and imports to env, so e.g. imports from baseclasses can be found.
           (import_els, cdef_els, clsext_els, rest_els) :=
@@ -957,7 +957,7 @@ algorithm
         // lookup as it might have been redeclared!!!
         (SCode.CLASS(prefixes = prefixes, partialPrefix = partialPrefix, restriction = restriction,
                      cmt = comment, info = info,classDef=classDef),_) = Lookup.lookupClassLocal(env, name);
-        env = FGraph.openScope(env, SCode.ENCAPSULATED(), SOME(name), FGraph.restrictionToScopeType(restriction));
+        env = FGraph.openScope(env, SCode.ENCAPSULATED(), name, FGraph.restrictionToScopeType(restriction));
         (cache,classDef) = fixClassdef(cache,env,classDef,ht);
       then
         (cache,SCode.CLASS(name, prefixes, SCode.ENCAPSULATED(), partialPrefix, restriction, classDef, comment, info));
@@ -966,7 +966,7 @@ algorithm
     case (cache,env,SCode.CLASS(name, prefixes, SCode.ENCAPSULATED(), partialPrefix, restriction, classDef, comment, info),ht)
       equation
         //fprintln(Flags.DEBUG,"fixClassdef " + name);
-        env = FGraph.openScope(env, SCode.ENCAPSULATED(), SOME(name), FGraph.restrictionToScopeType(restriction));
+        env = FGraph.openScope(env, SCode.ENCAPSULATED(), name, FGraph.restrictionToScopeType(restriction));
         (cache,classDef) = fixClassdef(cache,env,classDef,ht);
       then
         (cache,SCode.CLASS(name, prefixes, SCode.ENCAPSULATED(), partialPrefix, restriction, classDef, comment, info));
@@ -979,7 +979,7 @@ algorithm
         (SCode.CLASS(prefixes = prefixes, partialPrefix = partialPrefix, restriction = restriction,
                      cmt = comment, info = info,classDef=classDef),_) = Lookup.lookupClassLocal(env, name);
 
-        env = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), SOME(name), FGraph.restrictionToScopeType(restriction));
+        env = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), name, FGraph.restrictionToScopeType(restriction));
         (cache,classDef) = fixClassdef(cache,env,classDef,ht);
       then
         (cache,SCode.CLASS(name, prefixes, SCode.NOT_ENCAPSULATED(), partialPrefix, restriction, classDef, comment, info));
@@ -988,7 +988,7 @@ algorithm
     case (cache,env,SCode.CLASS(name, prefixes, SCode.NOT_ENCAPSULATED(), partialPrefix, restriction, classDef, comment, info),ht)
       equation
         //fprintln(Flags.DEBUG,"fixClassdef " + name + str);
-        env = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), SOME(name), FGraph.restrictionToScopeType(restriction));
+        env = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), name, FGraph.restrictionToScopeType(restriction));
         (cache,classDef) = fixClassdef(cache,env,classDef,ht);
       then
         (cache,SCode.CLASS(name, prefixes, SCode.NOT_ENCAPSULATED(), partialPrefix, restriction, classDef, comment, info));
@@ -1598,7 +1598,7 @@ algorithm
         (denv,id) = lookupVarNoErrorMessage(cache,env,cref_);
         //fprintln(Flags.DEBUG,"Got env " + intString(listLength(env)));
         // isOutside = FGraph.graphPrefixOf(denv, env);
-        denv = FGraph.openScope(denv,SCode.ENCAPSULATED(),SOME(id),NONE());
+        denv = FGraph.openScope(denv,SCode.ENCAPSULATED(),id,NONE());
         cref = Absyn.crefReplaceFirstIdent(cref,FGraph.getGraphName(denv));
         // cref = if_(isOutside, cref, FGraph.crefStripGraphScopePrefix(cref, env, false));
         cref = FGraph.crefStripGraphScopePrefix(cref, env, false);
@@ -1614,7 +1614,7 @@ algorithm
         // id might come from named import, make sure you use the actual class name!
         id = SCode.getElementName(c);
         //fprintln(Flags.DEBUG,"Got env " + intString(listLength(env)));
-        denv = FGraph.openScope(denv,SCode.ENCAPSULATED(),SOME(id),NONE());
+        denv = FGraph.openScope(denv,SCode.ENCAPSULATED(),id,NONE());
         cref = Absyn.crefReplaceFirstIdent(cref,FGraph.getGraphName(denv));
         // cref = if_(isOutside, cref, FGraph.crefStripGraphScopePrefix(cref, env, false));
         cref = FGraph.crefStripGraphScopePrefix(cref, env, false);

--- a/Compiler/FrontEnd/InstSection.mo
+++ b/Compiler/FrontEnd/InstSection.mo
@@ -1230,7 +1230,7 @@ algorithm
     Values.ARRAY(valueLst = values) := inValue;
 
     for val in values loop
-      env := FGraph.openScope(inEnv, SCode.NOT_ENCAPSULATED(), SOME(FCore.forScopeName), NONE());
+      env := FGraph.openScope(inEnv, SCode.NOT_ENCAPSULATED(), FCore.forScopeName, NONE());
       // The iterator is not constant but the range is constant.
       env := FGraph.addForIterator(env, inIdent, inIteratorType,
         DAE.VALBOUND(val, DAE.BINDING_FROM_DEFAULT_VALUE()), SCode.CONST(), SOME(DAE.C_CONST()));
@@ -1263,7 +1263,7 @@ protected function addForLoopScope
   input Option<DAE.Const> constOfForIteratorRange;
   output FCore.Graph newEnv;
 algorithm
-  newEnv := FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), SOME(FCore.forScopeName), NONE());
+  newEnv := FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), FCore.forScopeName, NONE());
   newEnv := FGraph.addForIterator(newEnv, iterName, iterType, DAE.UNBOUND(), iterVariability, constOfForIteratorRange);
 end addForLoopScope;
 
@@ -1279,7 +1279,7 @@ protected function addParForLoopScope
   input Option<DAE.Const> constOfForIteratorRange;
   output FCore.Graph newEnv;
 algorithm
-  newEnv := FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), SOME(FCore.parForScopeName), NONE());
+  newEnv := FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), FCore.parForScopeName, NONE());
   newEnv := FGraph.addForIterator(newEnv, iterName, iterType, DAE.UNBOUND(), iterVariability, constOfForIteratorRange);
 end addParForLoopScope;
 
@@ -2597,7 +2597,7 @@ algorithm
       equation
         dim = dim-1;
         dims = dim::dims;
-        env_1 = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), SOME(FCore.forScopeName),NONE());
+        env_1 = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), FCore.forScopeName,NONE());
         // the iterator is not constant but the range is constant
         env_2 = FGraph.addForIterator(env_1, i, DAE.T_INTEGER_DEFAULT, DAE.VALBOUND(fst, DAE.BINDING_FROM_DEFAULT_VALUE()), SCode.CONST(), SOME(DAE.C_CONST()));
         /* use instEEquation*/

--- a/Compiler/FrontEnd/Lookup.mo
+++ b/Compiler/FrontEnd/Lookup.mo
@@ -206,7 +206,7 @@ algorithm
     // lookup of an enumeration type
     case (cache,env_1,path,c as SCode.CLASS(name=id,encapsulatedPrefix=encflag,restriction=r as SCode.R_ENUMERATION()))
       equation
-        env_2 = FGraph.openScope(env_1, encflag, SOME(id), SOME(FCore.CLASS_SCOPE()));
+        env_2 = FGraph.openScope(env_1, encflag, id, SOME(FCore.CLASS_SCOPE()));
         ci_state = ClassInf.start(r, FGraph.getGraphName(env_2));
         // fprintln(Flags.INST_TRACE, "LOOKUP TYPE ICD: " + FGraph.printGraphPathStr(env_1) + " path:" + Absyn.pathString(path));
         mod = Mod.getClassModifier(env_1, id);
@@ -603,7 +603,7 @@ algorithm
 
     case (cache,env,_,SCode.CLASS(name=id,encapsulatedPrefix=encflag,restriction=restr),NONE(),_)
       equation
-        env = FGraph.openScope(env, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
+        env = FGraph.openScope(env, encflag, id, FGraph.restrictionToScopeType(restr));
         ci_state = ClassInf.start(restr, FGraph.getGraphName(env));
         // fprintln(Flags.INST_TRACE, "LOOKUP CLASS QUALIFIED PARTIALICD: " + FGraph.printGraphPathStr(env) + " path: " + Absyn.pathString(path) + " class: " + SCodeDump.shortElementStr(c));
         mod = Mod.getClassModifier(inEnv, id);
@@ -942,7 +942,7 @@ algorithm
       equation
         env = FGraph.topScope(env);
         (cache,(c as SCode.CLASS(name=id,encapsulatedPrefix=encflag,restriction=restr)),env_1) = lookupClass(cache, env, path);
-        env2 = FGraph.openScope(env_1, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
+        env2 = FGraph.openScope(env_1, encflag, id, FGraph.restrictionToScopeType(restr));
         ci_state = ClassInf.start(restr, FGraph.getGraphName(env2));
         // fprintln(Flags.INST_TRACE, "LOOKUP MORE UNQUALIFIED IMPORTED ICD: " + FGraph.printGraphPathStr(env) + "." + ident);
         mod = Mod.getClassModifier(env_1, id);
@@ -1004,7 +1004,7 @@ algorithm
         (cache,(c as
                 SCode.CLASS(name=id,encapsulatedPrefix=encflag,restriction=restr)),env_1,prevFrames)
         = lookupClass2(cache,env3,path,prevFrames,Util.makeStatefulBoolean(false),inInfo);
-        env2 = FGraph.openScope(env_1, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
+        env2 = FGraph.openScope(env_1, encflag, id, FGraph.restrictionToScopeType(restr));
         ci_state = ClassInf.start(restr, FGraph.getGraphName(env2));
         // fprintln(Flags.INST_TRACE, "LOOKUP UNQUALIFIED IMPORTED ICD: " + FGraph.printGraphPathStr(env) + "." + ident);
         mod = Mod.getClassModifier(env_1, id);
@@ -1376,7 +1376,7 @@ algorithm
               then
                 (cache, env5) = Inst.getCachedInstance(cache, env2, id, rr);
               else // not an instance, instantiate it - lookup of constants on form A.B in packages. instantiate package and look inside.
-                env3 = FGraph.openScope(env2, encflag, SOME(n), FGraph.restrictionToScopeType(r));
+                env3 = FGraph.openScope(env2, encflag, n, FGraph.restrictionToScopeType(r));
                 ci_state = ClassInf.start(r, FGraph.getGraphName(env3));
                 // fprintln(Flags.INST_TRACE, "LOOKUP VAR IN PACKAGES ICD: " + FGraph.printGraphPathStr(env3) + " var: " + ComponentReference.printComponentRefStr(cref));
                 mod = Mod.getClassModifier(env2, n);
@@ -1815,7 +1815,7 @@ algorithm
         then
           (cache, env2) = Inst.getCachedInstance(cache, env_1, str, r);
         else
-          env2 = FGraph.openScope(env_1, encflag, SOME(str), FGraph.restrictionToScopeType(restr));
+          env2 = FGraph.openScope(env_1, encflag, str, FGraph.restrictionToScopeType(restr));
           ci_state = ClassInf.start(restr, FGraph.getGraphName(env2));
           // fprintln(Flags.INST_TRACE, "LOOKUP FUNCTIONS IN ENV QUAL ICD: " + FGraph.printGraphPathStr(env2) + "." + str);
           mod = Mod.getClassModifier(env_1, str);
@@ -2215,7 +2215,7 @@ algorithm
     case (cache,env,SCode.CLASS(name = name,info = info),_)
       equation
         (cache,env,_,elts,_,_,_,_,_) = InstExtends.instDerivedClasses(cache,env,InnerOuter.emptyInstHierarchy,DAE.NOMOD(),Prefix.NOPRE(),cl,true,info);
-        env = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), SOME(name), SOME(FCore.CLASS_SCOPE()));
+        env = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), name, SOME(FCore.CLASS_SCOPE()));
         fpath = FGraph.getGraphName(env);
         (cdefelts,classExtendsElts,extendsElts,compElts) = InstUtil.splitElts(elts);
         (cache,env,_,_,eltsMods,_,_,_,_) = InstExtends.instExtendsAndClassExtendsList(cache, env, InnerOuter.emptyInstHierarchy, DAE.NOMOD(), Prefix.NOPRE(), extendsElts, classExtendsElts, elts, ClassInf.RECORD(fpath), name, true, false);
@@ -3173,7 +3173,7 @@ protected
   list<String> typeVars;
 algorithm
   SCode.CLASS(name=id,restriction=SCode.R_METARECORD(name=utPath,index=index,singleton=singleton,typeVars=typeVars),classDef=SCode.PARTS(elementLst = els)) := cdef;
-  env := FGraph.openScope(inEnv, SCode.NOT_ENCAPSULATED(), SOME(id), SOME(FCore.CLASS_SCOPE()));
+  env := FGraph.openScope(inEnv, SCode.NOT_ENCAPSULATED(), id, SOME(FCore.CLASS_SCOPE()));
   // print("buildMetaRecordType " + id + " in scope " + FGraph.printGraphPathStr(env) + "\n");
   (cache,utPath) := Inst.makeFullyQualified(inCache,env,utPath);
   path := Absyn.joinPaths(utPath, Absyn.IDENT(id));

--- a/Compiler/FrontEnd/Patternm.mo
+++ b/Compiler/FrontEnd/Patternm.mo
@@ -2514,7 +2514,7 @@ algorithm
       then (cache,SOME((env,DAE.emptyDae,declsTree)));
     case (cache,env,ld,_,_,_)
       equation
-        env2 = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), SOME(scopeName),NONE());
+        env2 = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), scopeName,NONE());
 
         // Tranform declarations such as Real x,y; to Real x; Real y;
         ld2 = SCodeUtil.translateEitemlist(ld, SCode.PROTECTED());

--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -1324,7 +1324,7 @@ protected
 algorithm
   try
     env := FGraph.openScope(inEnv, SCode.NOT_ENCAPSULATED(),
-      SOME(FCore.forIterScopeName), NONE());
+      FCore.forIterScopeName, NONE());
 
     // Elaborate the iterators.
     (outCache, env, reduction_iters, dims, iter_const, has_guard_exp, outST) :=
@@ -8956,7 +8956,7 @@ algorithm
   // Create a new implicit scope with the needed parameters on top of the
   // current env so we can find the bindings if needed. We need an implicit
   // scope so comp1.comp2 can be looked up without package constant restriction.
-  env := FGraph.openScope(inEnv, SCode.NOT_ENCAPSULATED(), SOME(FCore.forScopeName), NONE());
+  env := FGraph.openScope(inEnv, SCode.NOT_ENCAPSULATED(), FCore.forScopeName, NONE());
 
   // Add variables to the environment.
   env := makeDummyFuncEnv(env, vars, dummy_var);

--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -1677,7 +1677,7 @@ algorithm
         (sp, st) = GlobalScriptUtil.symbolTableToSCode(st);
         (cache, env) = Inst.makeEnvFromProgram(sp);
         (cache,(cl as SCode.CLASS(name=name,encapsulatedPrefix=encflag,restriction=restr)),env) = Lookup.lookupClass(cache, env, classpath, NONE());
-        env = FGraph.openScope(env, encflag, SOME(name), FGraph.restrictionToScopeType(restr));
+        env = FGraph.openScope(env, encflag, name, FGraph.restrictionToScopeType(restr));
         (_, env) = Inst.partialInstClassIn(cache, env, InnerOuter.emptyInstHierarchy, DAE.NOMOD(), Prefix.NOPRE(),
           ClassInf.start(restr, FGraph.getGraphName(env)), cl, SCode.PUBLIC(), {}, 0);
         valsLst = list(getComponentInfo(c, env, isProtected=false) for c in Interactive.getPublicComponentsInClass(absynClass));

--- a/Compiler/Script/Interactive.mo
+++ b/Compiler/Script/Interactive.mo
@@ -3997,7 +3997,7 @@ algorithm
         p_1 = SCodeUtil.translateAbsyn2SCode(p);
         (cache,env) = Inst.makeEnvFromProgram(p_1);
         (cache,(cl as SCode.CLASS(name=id,encapsulatedPrefix=encflag,restriction=restr)),env_1) = Lookup.lookupClass(cache,env, p_class);
-        env2 = FGraph.openScope(env_1, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
+        env2 = FGraph.openScope(env_1, encflag, id, FGraph.restrictionToScopeType(restr));
         ci_state = ClassInf.start(restr, FGraph.getGraphName(env2));
         (_,env_2,_,_,_) =
           Inst.partialInstClassIn(cache,env2,InnerOuter.emptyInstHierarchy,
@@ -9214,7 +9214,7 @@ algorithm
     /* If that fails, instantiate, which takes more time */
     case ((c as SCode.CLASS(name = id,encapsulatedPrefix = encflag,restriction = restr)),cdef,env)
       equation
-        env2 = FGraph.openScope(env, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
+        env2 = FGraph.openScope(env, encflag, id, FGraph.restrictionToScopeType(restr));
         ci_state = ClassInf.start(restr, FGraph.getGraphName(env2));
         (_,env_2,_,_,_) =
           Inst.partialInstClassIn(FCore.emptyCache(),env2,InnerOuter.emptyInstHierarchy,
@@ -9588,7 +9588,7 @@ algorithm
     /* If that fails, instantiate, which takes more time */
     case ((c as SCode.CLASS(name = id,encapsulatedPrefix = encflag,restriction = restr)),cdef,n,env)
       equation
-        env2 = FGraph.openScope(env, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
+        env2 = FGraph.openScope(env, encflag, id, FGraph.restrictionToScopeType(restr));
         ci_state = ClassInf.start(restr, FGraph.getGraphName(env2));
         (_,env_2,_,_,_) =
           Inst.partialInstClassIn(FCore.emptyCache(),env2,InnerOuter.emptyInstHierarchy,
@@ -9777,7 +9777,7 @@ algorithm
 
     case ((c as SCode.CLASS(name = id,encapsulatedPrefix = encflag,restriction = restr)),cdef,n,env)
       equation
-        env2 = FGraph.openScope(env, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
+        env2 = FGraph.openScope(env, encflag, id, FGraph.restrictionToScopeType(restr));
         ci_state = ClassInf.start(restr, FGraph.getGraphName(env2));
         (_,env_2,_,_,_) =
           Inst.partialInstClassIn(FCore.emptyCache(),env2,InnerOuter.emptyInstHierarchy,
@@ -9878,7 +9878,7 @@ algorithm
         (p_1,st) = GlobalScriptUtil.symbolTableToSCode(st);
         (cache,env) = Inst.makeEnvFromProgram(p_1);
         (cache,(c as SCode.CLASS(name=id,encapsulatedPrefix=encflag,restriction=restr)),env_1) = Lookup.lookupClass(cache,env, modelpath);
-        env2 = FGraph.openScope(env_1, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
+        env2 = FGraph.openScope(env_1, encflag, id, FGraph.restrictionToScopeType(restr));
         ci_state = ClassInf.start(restr, FGraph.getGraphName(env2));
         permissive = Flags.getConfigBool(Flags.PERMISSIVE);
         Flags.setConfigBool(Flags.PERMISSIVE, true);
@@ -18006,7 +18006,7 @@ protected
 algorithm
   (cache, (cl as SCode.CLASS(name = id, encapsulatedPrefix = encflag, restriction = restr)), env) :=
     Lookup.lookupClass(FCore.emptyCache(), inEnv, inClassPath);
-  env := FGraph.openScope(env, encflag, SOME(id), FGraph.restrictionToScopeType(restr));
+  env := FGraph.openScope(env, encflag, id, FGraph.restrictionToScopeType(restr));
   ci_state := ClassInf.start(restr, FGraph.getGraphName(env));
 
   // First try partial instantiation


### PR DESCRIPTION
All calls to openScope were using SOME(id), which allocates a SOME-cell
for every single call to openScope. While easy to collect, it still
causes some extra work for the GC, so it has been refactored away.