### PR TITLE
Add new instCacheSize flag.

### DIFF
--- a/Compiler/Util/BaseHashTable.mo
+++ b/Compiler/Util/BaseHashTable.mo
@@ -397,11 +397,20 @@ public function dumpHashTable
 protected
   FuncKeyString printKey;
   FuncValString printValue;
+  Key k;
+  Value v;
 algorithm
   (_, _, _, _, (_, _, printKey, printValue)) := t;
   print("HashTable:\n");
-  print(stringDelimitList(List.map2(hashTableList(t), dumpTuple, printKey, printValue), "\n"));
-  print("\n");
+
+  for entry in hashTableList(t) loop
+    (k, v) := entry;
+    print("{");
+    print(printKey(k));
+    print(",{");
+    print(printValue(v));
+    print("}}\n");
+  end for;
 end dumpHashTable;
 
 protected function dumpTuple

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -1227,10 +1227,14 @@ constant ConfigFlag HETS = CONFIG_FLAG(88, "hets",
     ("none", Util.gettext("do nothing")),
     ("derCalls", Util.gettext("sort terms based on der-calls"))
     })),
-  Util.gettext("heuristic euqtion terms sort"));
+  Util.gettext("Heuristic equation terms sort"));
 constant ConfigFlag DEFAULT_CLOCK_PERIOD = CONFIG_FLAG(89, "defaultClockPeriod",
   NONE(), INTERNAL(), REAL_FLAG(1.0), NONE(),
   Util.gettext("Sets the default clock period (in seconds) for state machines (default: 1.0)."));
+constant ConfigFlag INST_CACHE_SIZE = CONFIG_FLAG(90, "instCacheSize",
+  NONE(), EXTERNAL(), INT_FLAG(250007), NONE(),
+  Util.gettext("Sets the size of the internal hash table used for instantiation caching."));
+
 
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
@@ -1325,7 +1329,8 @@ constant list<ConfigFlag> allConfigFlags = {
   INIT_OPT_MODULES_SUB,
   PERMISSIVE,
   HETS,
-  DEFAULT_CLOCK_PERIOD
+  DEFAULT_CLOCK_PERIOD,
+  INST_CACHE_SIZE
 };
 
 public function new


### PR DESCRIPTION
- Added new instCacheSize flag that can be used to change the size
  of the instantiation cache.
- Increased the default size of the instantiation cache to better
  handle large models.