### PR TITLE
remove tuple decompostion-recomposition

### DIFF
--- a/Compiler/BackEnd/BackendEquation.mo
+++ b/Compiler/BackEnd/BackendEquation.mo
@@ -288,12 +288,12 @@ algorithm
       list<Integer> ilst;
 
     // special case for time, it is never part of the equation system
-    case (e as DAE.CREF(componentRef=DAE.CREF_IDENT(ident="time")), (vars, bt))
-    then (e, true, (vars, bt));
+    case (e as DAE.CREF(componentRef=DAE.CREF_IDENT(ident="time")), _)
+    then (e, true, inTuple);
 
     // case for function pointers
-    case (e as DAE.CREF(ty=DAE.T_FUNCTION_REFERENCE_FUNC()), (vars, bt))
-    then (e, true, (vars, bt));
+    case (e as DAE.CREF(ty=DAE.T_FUNCTION_REFERENCE_FUNC()), _)
+    then (e, true, inTuple);
 
     // case for pre vars
     case (e as DAE.CALL(path = Absyn.IDENT(name = "pre")), _)

--- a/Compiler/BackEnd/OnRelaxation.mo
+++ b/Compiler/BackEnd/OnRelaxation.mo
@@ -3196,27 +3196,28 @@ algorithm
       array<Integer> vec1, vec2;
       DAE.Exp e1, e2;
       list<Integer> ds;
+      tuple<Integer, array<Integer>, array<Integer>> tpl;
 
     // array equations
-    case (BackendDAE.ARRAY_EQUATION(dimSize=ds, left=e1, right=e2), _, (id, vec1, vec2))
+    case (BackendDAE.ARRAY_EQUATION(dimSize=ds, left=e1, right=e2), _, _)
       equation
         size = List.fold(ds, intMul, 1);
-        ((id, vec1, vec2)) = vectorMatching1(e1, e2, size, vars, (id, vec1, vec2));
-      then ((id, vec1, vec2));
-    case (BackendDAE.ARRAY_EQUATION(dimSize=ds, left=e2, right=e1), _, (id, vec1, vec2))
+        tpl = vectorMatching1(e1, e2, size, vars, inTpl);
+      then tpl;
+    case (BackendDAE.ARRAY_EQUATION(dimSize=ds, left=e2, right=e1), _, _)
       equation
         size = List.fold(ds, intMul, 1);
-        ((id, vec1, vec2)) = vectorMatching1(e2, e1, size, vars, (id, vec1, vec2));
-      then ((id, vec1, vec2));
+        tpl = vectorMatching1(e2, e1, size, vars, inTpl);
+      then tpl;
     // complex equations
-    case (BackendDAE.COMPLEX_EQUATION(size=size, left=e1, right=e2), _, (id, vec1, vec2))
+    case (BackendDAE.COMPLEX_EQUATION(size=size, left=e1, right=e2), _, _)
       equation
-        ((id, vec1, vec2)) = vectorMatching1(e1, e2, size, vars, (id, vec1, vec2));
-      then ((id, vec1, vec2));
-    case (BackendDAE.COMPLEX_EQUATION(size=size, left=e2, right=e1), _, (id, vec1, vec2))
+        tpl = vectorMatching1(e1, e2, size, vars, inTpl);
+      then tpl;
+    case (BackendDAE.COMPLEX_EQUATION(size=size, left=e2, right=e1), _, _)
       equation
-        ((id, vec1, vec2)) = vectorMatching1(e2, e1, size, vars, (id, vec1, vec2));
-      then ((id, vec1, vec2));
+        tpl = vectorMatching1(e2, e1, size, vars, inTpl);
+      then tpl;
     case (_, _, (id, vec1, vec2))
       equation
         size = BackendEquation.equationSize(eqn);

--- a/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/Compiler/BackEnd/SymbolicJacobian.mo
@@ -3349,11 +3349,11 @@ algorithm
         (_,_) = BackendVariable.getVar(cr, vars);
       then (e,false,(vars,true));
 
-    case (e as DAE.CALL(path=Absyn.IDENT(name = "pre")),(vars,b))
-      then (e,false,(vars,b));
+    case (e as DAE.CALL(path=Absyn.IDENT(name = "pre")),_)
+      then (e,false,tpl);
 
-    case (e as DAE.CALL(path=Absyn.IDENT(name = "previous")),(vars,b))
-      then (e,false,(vars,b));
+    case (e as DAE.CALL(path=Absyn.IDENT(name = "previous")),_)
+      then (e,false,tpl);
 
     case (e,(_,b)) then (e,not b,tpl);
   end matchcontinue;

--- a/Compiler/FrontEnd/DAEUtil.mo
+++ b/Compiler/FrontEnd/DAEUtil.mo
@@ -3230,14 +3230,14 @@ algorithm
     case (exp as DAE.CREF(ty= DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(_))),(ht,i,j))
       equation
         (e1,true) = Expression.extendArrExp(exp,false);
-        (e1,(ht,i,k)) = Expression.traverseExpBottomUp(e1,evaluateAnnotationTraverse,(ht,i,j));
+        (e1,(ht,i,k)) = Expression.traverseExpBottomUp(e1,evaluateAnnotationTraverse,itpl);
         true = intGt(k,j);
       then (e1,(ht,i,k));
     // Special Case for Arrays
     case (exp as DAE.CREF(ty = DAE.T_ARRAY()),(ht,i,j))
       equation
         (e1,true) = Expression.extendArrExp(exp,false);
-        (e1,(ht,i,k)) = Expression.traverseExpBottomUp(e1,evaluateAnnotationTraverse,(ht,i,j));
+        (e1,(ht,i,k)) = Expression.traverseExpBottomUp(e1,evaluateAnnotationTraverse,itpl);
         true = intGt(k,j);
       then (e1,(ht,i,k));
 
@@ -3746,7 +3746,7 @@ protected function isInvalidFunctionEntry
 algorithm
   b := match tpl
     case ((_,NONE())) then true;
-    case ((_,_)) then false;
+    else false;
   end match;
 end isInvalidFunctionEntry;
 

--- a/Compiler/FrontEnd/SCodeUtil.mo
+++ b/Compiler/FrontEnd/SCodeUtil.mo
@@ -76,7 +76,7 @@ public function translateAbsyn2SCode
 algorithm
   outProgram := match(inProgram)
     local
-      SCode.Program spInitial, spAbsyn, sp;
+      SCode.Program spInitial, sp;
       list<Absyn.Class> inClasses,initialClasses;
 
     case _
@@ -94,8 +94,7 @@ algorithm
         System.setHasStreamConnectors(false);
 
         // translate given absyn to scode.
-        spAbsyn = List.fold(inClasses, translate2, {});
-        sp = listReverse(spAbsyn);
+        sp = list(translateClass(c) for c in inClasses);
 
         // adrpo: note that WE DO NOT NEED to add initial functions to the program
         //        as they are already part of the initialEnv done by Builtin.initialGraph
@@ -103,19 +102,6 @@ algorithm
         sp;
   end match;
 end translateAbsyn2SCode;
-
-public function translate2
-"Folds an Absyn.Program into SCode.Program."
-  input Absyn.Class inClass;
-  input SCode.Program acc;
-  output SCode.Program outAcc;
-protected
-  SCode.Element cl;
-algorithm
-  cl := translateClass(inClass);
-  // print("\n" + SCodeDump.printElementStr(cl) + "\n");
-  outAcc := cl :: acc;
-end translate2;
 
 public function translateClass
   input Absyn.Class inClass;

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -751,40 +751,29 @@ algorithm
   outSubPartitions := inPartition.subPartitions;
 end getSubPartition;
 
-protected type AddTempVarsArg =
-tuple<Integer /*numAlgVars*/, list<SimCodeVar.SimVar> /*algVars*/,
-      Integer /*numIntAlgVars*/, list<SimCodeVar.SimVar> /*intAlgVars*/,
-      Integer /*numBoolAlgVars*/, list<SimCodeVar.SimVar> /*boolAlgVars*/,
-      Integer /*numStringAlgVars*/, list<SimCodeVar.SimVar> /*stringAlgVars*/>;
-
 protected function addTempVars
   input list<SimCodeVar.SimVar> tempVars;
   input SimCode.ModelInfo modelInfo;
   output SimCode.ModelInfo omodelInfo = modelInfo;
 protected
-  AddTempVarsArg arg;
   SimCode.VarInfo varInfo;
   SimCodeVar.SimVars vars;
-  Integer numAlgVars, numIntAlgVars, numBoolAlgVars, numStringAlgVars;
-  list<SimCodeVar.SimVar> algVars, intAlgVars, boolAlgVars, stringAlgVars;
 algorithm
   varInfo := omodelInfo.varInfo;
   vars := omodelInfo.vars;
 
-  arg := (varInfo.numAlgVars, listReverse(vars.algVars), varInfo.numIntAlgVars, listReverse(vars.intAlgVars),
-          varInfo.numBoolAlgVars, listReverse(vars.boolAlgVars), varInfo.numStringAlgVars, listReverse(vars.stringAlgVars));
-  arg := List.fold(tempVars, addTempVars1, arg);
-  (numAlgVars, algVars, numIntAlgVars, intAlgVars, numBoolAlgVars, boolAlgVars, numStringAlgVars, stringAlgVars) := arg;
+  vars.algVars := listReverse(vars.algVars);
+  vars.intAlgVars := listReverse(vars.intAlgVars);
+  vars.boolAlgVars := listReverse(vars.boolAlgVars);
+  vars.stringAlgVars := listReverse(vars.stringAlgVars);
+  for e in tempVars loop
+    (vars, varInfo) := addTempVars1(e, vars, varInfo);
+  end for;
 
-  vars.algVars := listReverse(algVars);
-  vars.intAlgVars := listReverse(intAlgVars);
-  vars.boolAlgVars := listReverse(boolAlgVars);
-  vars.stringAlgVars := listReverse(stringAlgVars);
-
-  varInfo.numAlgVars := numAlgVars;
-  varInfo.numIntAlgVars := numIntAlgVars;
-  varInfo.numBoolAlgVars := numBoolAlgVars;
-  varInfo.numStringAlgVars := numStringAlgVars;
+  vars.algVars := listReverse(vars.algVars);
+  vars.intAlgVars := listReverse(vars.intAlgVars);
+  vars.boolAlgVars := listReverse(vars.boolAlgVars);
+  vars.stringAlgVars := listReverse(vars.stringAlgVars);
 
   omodelInfo.vars := vars;
   omodelInfo.varInfo := varInfo;
@@ -792,39 +781,46 @@ end addTempVars;
 
 protected function addTempVars1
   input SimCodeVar.SimVar inVar;
-  input AddTempVarsArg inArg;
-  output AddTempVarsArg outArg;
+  input output SimCodeVar.SimVars vars;
+  input output SimCode.VarInfo varInfo;
 protected
-  Integer numAlgVars, numIntAlgVars, numBoolAlgVars, numStringAlgVars;
-  list<SimCodeVar.SimVar> algVars, intAlgVars, boolAlgVars, stringAlgVars;
   SimCodeVar.SimVar var = inVar;
 algorithm
-  (numAlgVars, algVars, numIntAlgVars, intAlgVars, numBoolAlgVars, boolAlgVars, numStringAlgVars, stringAlgVars) := inArg;
-  outArg := match inVar.type_
+  _ := match inVar.type_
     case DAE.T_INTEGER()
-      equation var.index = numIntAlgVars;
-      then
-        (numAlgVars, algVars, numIntAlgVars+1, var::intAlgVars, numBoolAlgVars, boolAlgVars, numStringAlgVars, stringAlgVars);
+      equation
+        var.index = varInfo.numIntAlgVars;
+        varInfo.numIntAlgVars = varInfo.numIntAlgVars+1;
+        vars.intAlgVars = var::vars.intAlgVars;
+        then ();
 
     case DAE.T_ENUMERATION()
-      equation var.index = numIntAlgVars;
-      then
-        (numAlgVars, algVars, numIntAlgVars+1, var::intAlgVars, numBoolAlgVars, boolAlgVars, numStringAlgVars, stringAlgVars);
+      equation
+        var.index = varInfo.numIntAlgVars;
+        varInfo.numIntAlgVars = varInfo.numIntAlgVars+1;
+        vars.intAlgVars = var::vars.intAlgVars;
+        then ();
 
     case DAE.T_BOOL()
-      equation var.index = numBoolAlgVars;
-      then
-        (numAlgVars, algVars, numIntAlgVars, intAlgVars, numBoolAlgVars+1, var::boolAlgVars, numStringAlgVars, stringAlgVars);
+      equation
+        var.index = varInfo.numBoolAlgVars;
+        varInfo.numBoolAlgVars = varInfo.numBoolAlgVars+1;
+        vars.boolAlgVars = var::vars.boolAlgVars;
+      then ();
 
     case DAE.T_STRING()
-      equation var.index = numStringAlgVars;
-      then
-        (numAlgVars, algVars, numIntAlgVars, intAlgVars, numBoolAlgVars, boolAlgVars, numStringAlgVars+1, var::stringAlgVars);
+      equation
+        var.index = varInfo.numStringAlgVars;
+        varInfo.numStringAlgVars = varInfo.numStringAlgVars+1;
+        vars.stringAlgVars = var::vars.stringAlgVars;
+      then ();
 
     else
-      equation var.index = numAlgVars;
-      then
-        (numAlgVars+1, var::algVars, numIntAlgVars, intAlgVars, numBoolAlgVars, boolAlgVars, numStringAlgVars, stringAlgVars);
+      equation
+        var.index = varInfo.numAlgVars;
+        varInfo.numAlgVars = varInfo.numAlgVars+1;
+        vars.algVars = var::vars.algVars;
+      then ();
   end match;
 end addTempVars1;
 
@@ -1815,7 +1811,7 @@ algorithm
     list<Integer> occurEquLst;
     list<BackendDAE.ZeroCrossing> rest;
 
-   case ({}, _, _) then listReverse(iAccum);
+   case ({}, _, _) then Dangerous.listReverseInPlace(iAccum);
 
    case (BackendDAE.ZERO_CROSSING(relation_=exp, occurEquLst=occurEquLst)::rest, _, _)
      equation
@@ -2433,7 +2429,7 @@ algorithm
           var := SimCodeVar.SIMVAR(cr, BackendDAE.VARIABLE(), "", "", "", 0, NONE(), NONE(), NONE(), NONE(), false, ty, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, true, false, NONE());
           ttmpvars := var::ttmpvars;
         end for;
-        ttmpvars := listReverse(ttmpvars);
+        ttmpvars := Dangerous.listReverseInPlace(ttmpvars);
         ttmpvars := listAppend(itempvars,ttmpvars);
       then createTempVars(rest, inCrefPrefix, ttmpvars);
 
@@ -4019,7 +4015,7 @@ algorithm
       newCref := Differentiate.createSeedCrefName(oldCref, inMatrixName);
       outSimVars := replaceSimVarName(newCref, v)::outSimVars;
   end for;
-  outSimVars := listReverse(outSimVars);
+  outSimVars := Dangerous.listReverseInPlace(outSimVars);
 end replaceSeedVarsName;
 
 protected function sortBackVarWithSimVarsOrder
@@ -4347,7 +4343,7 @@ algorithm
   evarLst := BackendVariable.varList(evars);
   evarLst := orderExtVars(evarLst);
   //evarLst := listReverse(evarLst);
-  (simvars, aliases) := extractExtObjInfo2(evarLst, evars, {}, {});
+  (simvars, aliases) := extractExtObjInfo2(evarLst, evars);
   extObjInfo := SimCode.EXTOBJINFO(simvars, aliases);
 end createExtObjInfo;
 
@@ -4380,28 +4376,27 @@ end orderExtVars;
 protected function extractExtObjInfo2
   input list<BackendDAE.Var> varLst;
   input BackendDAE.Variables evars;
-  input list<SimCodeVar.SimVar> ivars;
-  input list<SimCode.ExtAlias> ialiases;
-  output list<SimCodeVar.SimVar> vars;
-  output list<SimCode.ExtAlias> aliases;
+  output list<SimCodeVar.SimVar> vars = {};
+  output list<SimCode.ExtAlias> aliases = {};
 algorithm
-  (vars, aliases) := match (varLst, evars, ivars, ialiases)
-    local
-      BackendDAE.Var bv;
-      SimCodeVar.SimVar sv;
-      list<BackendDAE.Var> vs;
-      DAE.ComponentRef cr, name;
-    case ({}, _, _, _) then (listReverse(ivars), listReverse(ialiases));
-    case (BackendDAE.VAR(varName=name, bindExp=SOME(DAE.CREF(cr, _)), varKind=BackendDAE.EXTOBJ(_))::vs, _, _, _)
-      equation
-        (vars, aliases) = extractExtObjInfo2(vs, evars, ivars, (name, cr)::ialiases);
-      then (vars, aliases);
-    case (bv::vs, _, _, _)
-      equation
-        sv = dlowvarToSimvar(bv, NONE(), evars);
-        (vars, aliases) = extractExtObjInfo2(vs, evars, sv::ivars, ialiases);
-      then (vars, aliases);
-  end match;
+  for bv in varLst loop
+    _ := match bv
+      local
+        DAE.ComponentRef cr, name;
+        SimCodeVar.SimVar sv;
+      case BackendDAE.VAR(varName=name, bindExp=SOME(DAE.CREF(cr, _)), varKind=BackendDAE.EXTOBJ(_))
+        equation
+          aliases = (name, cr)::aliases;
+        then ();
+      else
+        equation
+          sv = dlowvarToSimvar(bv, NONE(), evars);
+          vars = sv::vars;
+        then ();
+      end match;
+  end for;
+  vars := Dangerous.listReverseInPlace(vars);
+  aliases := Dangerous.listReverseInPlace(aliases);
 end extractExtObjInfo2;
 
 protected function createAlgorithmAndEquationAsserts
@@ -7327,27 +7322,17 @@ end fixIndex;
 protected function rewriteIndex
   input list<SimCodeVar.SimVar> inVars;
   input Integer iindex;
-  output list<SimCodeVar.SimVar> outVars;
+  output list<SimCodeVar.SimVar> outVars = {};
+protected
+  Integer index = iindex;
 algorithm
-  outVars := rewriteIndexWork(inVars, iindex, {});
+  for var in inVars loop
+    var.index := index;
+    outVars := var::outVars;
+    index := index+1;
+  end for;
+  outVars := Dangerous.listReverseInPlace(outVars);
 end rewriteIndex;
-
-protected function rewriteIndexWork
-  input list<SimCodeVar.SimVar> inVars;
-  input Integer iindex;
-  input list<SimCodeVar.SimVar> inAcc;
-  output list<SimCodeVar.SimVar> outVars;
-algorithm
-  outVars := match inVars
-    local
-      SimCodeVar.SimVar var;
-      list<SimCodeVar.SimVar> rest;
-    case {} then listReverse(inAcc);
-    case var::rest
-      equation var.index = iindex;
-      then rewriteIndexWork(rest, iindex + 1, var::inAcc);
-  end match;
-end rewriteIndexWork;
 
 protected function setVariableIndex
   input SimCodeVar.SimVars inSimVars;
@@ -11480,7 +11465,7 @@ algorithm
   allEqs := List.fold(odeEquations, getDaeEqsNotPartOfOdeSystem2, allEqs);
   tmpEqs := {};
   tmpEqs := Array.fold(allEqs, getDaeEqsNotPartOfOdeSystem4, tmpEqs);
-  oEqs := listReverse(tmpEqs);
+  oEqs := Dangerous.listReverseInPlace(tmpEqs);
 end getDaeEqsNotPartOfOdeSystem;
 
 protected function getDaeEqsNotPartOfOdeSystem0 "Add the given equation system object to the mapping list (simEqIdx -> SimEqSystem).


### PR DESCRIPTION
Fix the following code pattern to save memory
```
(a,b,c) := tpl;
(a,b,c) := funcWithTupleParam( (a,b,c) );
tpl := (a,b,c);
```