### PR TITLE
Do not generate function code for constants

### DIFF
--- a/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -1478,7 +1478,7 @@ algorithm
       DAE.VarDirection vd;
     case DAE.VAR(kind=vk, direction=vd)
       guard
-        isVarVarOrConstant(vk) and
+        isVarKindVarOrParameter(vk) and
         isDirectionNotInput(vd)
       then true;
     else false;
@@ -1497,14 +1497,14 @@ algorithm
       DAE.VarDirection vd;
     case DAE.VAR(kind=vk, direction=vd)
       guard
-        isVarVarOrConstant(vk) and
+        isVarKindVarOrParameter(vk) and
         isDirectionNotInputNotOutput(vd)
       then true;
     else false;
   end match;
 end isVarNotInputNotOutput;
 
-protected function isVarVarOrConstant
+protected function isVarKindVarOrParameter
   input DAE.VarKind inVarKind;
   output Boolean outB;
 algorithm
@@ -1514,7 +1514,7 @@ algorithm
     case DAE.CONST() then true;
     else false;
   end match;
-end isVarVarOrConstant;
+end isVarKindVarOrParameter;
 
 protected function isDirectionNotInput
   input DAE.VarDirection inVarDirection;


### PR DESCRIPTION
Constants are replaced by values and do not need to be duplicated in
functions. Currently, if evaluation of the constant fails, we get the
same constant that cannot be evaluated in the function prologue.