### PR TITLE
Use a single shared HashTable for Inline.mo

### DIFF
--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -2737,7 +2737,8 @@ algorithm
 
     // use the inlined function to analyze the ocuring variables
     case (DAE.CALL(), tpl as (_, _, SOME(functionTree))) equation
-      (e1,(_, true, _)) = Inline.forceInlineCall(inExp, ((SOME(functionTree), {DAE.NORM_INLINE(),DAE.DEFAULT_INLINE()}),false,{}));
+      (e1,_) = Inline.forceInlineCall(inExp, {}, (SOME(functionTree), {DAE.NORM_INLINE(),DAE.DEFAULT_INLINE()}));
+      false = referenceEq(inExp,e1);
       (_, tpl) = Expression.traverseExpTopDown(e1, traversingincidenceRowExpSolvableFinder, tpl);
     then (inExp, false, tpl);
 

--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -10331,7 +10331,7 @@ algorithm
       DAE.ReductionIterator iter;
       DAE.ReductionIterators iters;
 
-    case ({},_,arg) then ({},arg);
+    case ({},_,arg) then (inIters,arg);
     case (iter::iters,_,arg)
       equation
         (iter, arg) = traverseReductionIteratorTopDown(iter, func, arg);
@@ -10373,11 +10373,9 @@ algorithm
 end traverseReductionIterator;
 
 protected function traverseReductionIterators
-  input DAE.ReductionIterators inIters;
+  input output DAE.ReductionIterators iters;
   input FuncExpType func;
-  input Type_a inArg;
-  output DAE.ReductionIterators outIters;
-  output Type_a outArg;
+  input output Type_a arg;
 
   partial function FuncExpType
     input DAE.Exp inExp;
@@ -10387,18 +10385,17 @@ protected function traverseReductionIterators
   end FuncExpType;
   replaceable type Type_a subtypeof Any;
 algorithm
-  (outIters,outArg) := match (inIters,func,inArg)
+  (iters,arg) := match iters
     local
       DAE.ReductionIterator iter,iter1;
-      DAE.ReductionIterators iters,iters1;
-      Type_a arg;
+      DAE.ReductionIterators rest,iters1;
 
-    case ({},_,arg) then ({},arg);
-    case (iter::iters,_,arg)
+    case {} then (iters,arg);
+    case iter::rest
       equation
         (iter1, arg) = traverseReductionIterator(iter, func, arg);
-        (iters1, arg) = traverseReductionIterators(iters, func, arg);
-        iters = if referenceEq(iter,iter1) and referenceEq(iters,iters1) then inIters else (iter1::iters1);
+        (iters1, arg) = traverseReductionIterators(rest, func, arg);
+        iters = if referenceEq(iter,iter1) and referenceEq(rest,iters1) then iters else (iter1::iters1);
       then (iters, arg);
   end match;
 end traverseReductionIterators;

--- a/Compiler/FrontEnd/Inline.mo
+++ b/Compiler/FrontEnd/Inline.mo
@@ -691,7 +691,7 @@ algorithm
       then (e_1,source,true);
     case (e,fns,source)
       equation
-        (e_1,_) = Expression.Expression.traverseExpBottomUp(e,function forceInlineCall(fns=fns),{});
+        (e_1,_) = Expression.traverseExpBottomUp(e,function forceInlineCall(fns=fns),{});
         false = referenceEq(e, e_1);
         source = DAEUtil.addSymbolicTransformation(source,DAE.OP_INLINE(DAE.PARTIAL_EQUATION(e),DAE.PARTIAL_EQUATION(e_1)));
         (DAE.PARTIAL_EQUATION(e_2),source) = ExpressionSimplify.simplifyAddSymbolicOperation(DAE.PARTIAL_EQUATION(e_1), source);
@@ -821,9 +821,9 @@ algorithm
           // add noEvent to avoid events as usually for functions
           // MSL 3.2.1 need GenerateEvents to disable this
           newExp = Expression.addNoEventToRelationsAndConds(newExp);
-          (newExp,(_,_,true)) = Expression.Expression.traverseExpBottomUp(newExp,replaceArgs,(argmap,checkcr,true));
+          (newExp,(_,_,true)) = Expression.traverseExpBottomUp(newExp,replaceArgs,(argmap,checkcr,true));
           // for inlinecalls in functions
-          (newExp1,assrtLst) = Expression.Expression.traverseExpBottomUp(newExp,function inlineCall(fns=fns),assrtLst);
+          (newExp1,assrtLst) = Expression.traverseExpBottomUp(newExp,function inlineCall(fns=fns),assrtLst);
         else // normal Modelica
           // get inputs, body and output
           (crefs,lst_cr,stmts,repl) = getFunctionInputsOutputBody(fn,{},{},{},repl);
@@ -842,9 +842,9 @@ algorithm
             // MSL 3.2.1 need GenerateEvents to disable this
             generateEvents = hasGenerateEventsAnnotation(comment);
             newExp = if not generateEvents then Expression.addNoEventToRelationsAndConds(newExp) else newExp;
-            (newExp,(_,_,true)) = Expression.Expression.traverseExpBottomUp(newExp,replaceArgs,(argmap,checkcr,true));
+            (newExp,(_,_,true)) = Expression.traverseExpBottomUp(newExp,replaceArgs,(argmap,checkcr,true));
             // for inlinecalls in functions
-            (newExp1,assrtLst) = Expression.Expression.traverseExpBottomUp(newExp,function inlineCall(fns=fns),assrtLst);
+            (newExp1,assrtLst) = Expression.traverseExpBottomUp(newExp,function inlineCall(fns=fns),assrtLst);
           else // assert detected
             true = listLength(assrtStmts) == 1;
             assrt = listHead(assrtStmts);
@@ -859,10 +859,10 @@ algorithm
             // MSL 3.2.1 need GenerateEvents to disable this
             generateEvents = hasGenerateEventsAnnotation(comment);
             newExp = if not generateEvents then Expression.addNoEventToRelationsAndConds(newExp) else newExp;
-            (newExp,(_,_,true)) = Expression.Expression.traverseExpBottomUp(newExp,replaceArgs,(argmap,checkcr,true));
+            (newExp,(_,_,true)) = Expression.traverseExpBottomUp(newExp,replaceArgs,(argmap,checkcr,true));
             assrt = inlineAssert(assrt,fns,argmap,checkcr);
             // for inlinecalls in functions
-            (newExp1,assrtLst) = Expression.Expression.traverseExpBottomUp(newExp,function inlineCall(fns=fns),assrt::assrtLst);
+            (newExp1,assrtLst) = Expression.traverseExpBottomUp(newExp,function inlineCall(fns=fns),assrt::assrtLst);
           end if;
         end if;
       then
@@ -886,11 +886,12 @@ protected
   DAE.Exp cond, msg, level;
 algorithm
   DAE.STMT_ASSERT(cond=cond, msg=msg, level=level, source=source) := assrtIn;
-  (cond,_,_,_) := inlineExp(cond,fns,source);
-  (cond,(_,_,true)) := Expression.Expression.traverseExpBottomUp(cond,replaceArgs,(argmap,checkcr,true));
+  (cond,(_,_,true)) := Expression.traverseExpBottomUp(cond,replaceArgs,(argmap,checkcr,true));
   //print("ASSERT inlined: "+ExpressionDump.printExpStr(cond)+"\n");
-  (msg,_,_,_) := inlineExp(msg,fns,source);
-  (msg,(_,_,true)) := Expression.Expression.traverseExpBottomUp(msg,replaceArgs,(argmap,checkcr,true));
+  (msg,(_,_,true)) := Expression.traverseExpBottomUp(msg,replaceArgs,(argmap,checkcr,true));
+  // These clear checkcr/repl and need to be performed last
+  // (cond,_,_,_) := inlineExp(cond,fns,source);
+  // (msg,_,_,_) := inlineExp(msg,fns,source);
   assrtOut := DAE.STMT_ASSERT(cond, msg, level, source);
 end inlineAssert;
 
@@ -965,7 +966,7 @@ algorithm
         // MSL 3.2.1 need GenerateEvents to disable this
         generateEvents = hasGenerateEventsAnnotation(comment);
         newExp = if not generateEvents then Expression.addNoEventToRelationsAndConds(newExp) else newExp;
-        (newExp,(_,_,true)) = Expression.Expression.traverseExpBottomUp(newExp,replaceArgs,(argmap,checkcr,true));
+        (newExp,(_,_,true)) = Expression.traverseExpBottomUp(newExp,replaceArgs,(argmap,checkcr,true));
         // for inlinecalls in functions
         (newExp1,assrtLst) = Expression.traverseExpBottomUp(newExp,function forceInlineCall(fns=fns),assrtLst);
       then (newExp1,assrtLst);
@@ -1599,7 +1600,7 @@ algorithm
       list<DAE.Statement> assrtLst;
     case DAE.PARTIAL_EQUATION(e)
       equation
-        (e_1,_) = Expression.Expression.traverseExpBottomUp(e,fn,{});
+        (e_1,_) = Expression.traverseExpBottomUp(e,fn,{});
         changed = not referenceEq(e, e_1);
         eq2 = DAE.PARTIAL_EQUATION(e_1);
         source = DAEUtil.condAddSymbolicTransformation(changed,inSource,DAE.OP_INLINE(inExp,eq2));
@@ -1607,7 +1608,7 @@ algorithm
       then (eq2,source);
     case DAE.RESIDUAL_EXP(e)
       equation
-        (e_1,_) = Expression.Expression.traverseExpBottomUp(e,fn,{});
+        (e_1,_) = Expression.traverseExpBottomUp(e,fn,{});
         changed = not referenceEq(e, e_1);
         eq2 = DAE.RESIDUAL_EXP(e_1);
         source = DAEUtil.condAddSymbolicTransformation(changed,inSource,DAE.OP_INLINE(inExp,eq2));
@@ -1615,8 +1616,8 @@ algorithm
       then (eq2,source);
     case DAE.EQUALITY_EXPS(e1,e2)
       equation
-        (e1_1,_) = Expression.Expression.traverseExpBottomUp(e1,fn,{});
-        (e2_1,_) = Expression.Expression.traverseExpBottomUp(e2,fn,{});
+        (e1_1,_) = Expression.traverseExpBottomUp(e1,fn,{});
+        (e2_1,_) = Expression.traverseExpBottomUp(e2,fn,{});
         changed = not (referenceEq(e1, e1_1) and referenceEq(e2, e2_1));
         eq2 = DAE.EQUALITY_EXPS(e1_1,e2_1);
         source = DAEUtil.condAddSymbolicTransformation(changed,inSource,DAE.OP_INLINE(inExp,eq2));

--- a/Compiler/FrontEnd/Inline.mo
+++ b/Compiler/FrontEnd/Inline.mo
@@ -655,7 +655,7 @@ algorithm
 
     case (e,fns,source)
       equation
-        (e_1,assrtLst) = Expression.Expression.traverseExpBottomUp(e,function inlineCall(fns=fns),{});
+        (e_1,assrtLst) = Expression.traverseExpBottomUp(e,function inlineCall(fns=fns),{});
         false = referenceEq(e, e_1);
         source = DAEUtil.addSymbolicTransformation(source,DAE.OP_INLINE(DAE.PARTIAL_EQUATION(e),DAE.PARTIAL_EQUATION(e_1)));
         (DAE.PARTIAL_EQUATION(e_2),source) = ExpressionSimplify.simplifyAddSymbolicOperation(DAE.PARTIAL_EQUATION(e_1), source);

--- a/Compiler/Global/Global.mo
+++ b/Compiler/Global/Global.mo
@@ -57,6 +57,7 @@ constant Integer builtinGraphIndex = 17;
 constant Integer rewriteRulesIndex = 18;
 constant Integer stackoverFlowIndex = 19;
 constant Integer gcProfilingIndex = 20;
+constant Integer inlineHashTable = 21; // TODO: Should be a local root?
 
 // indexes in System.tick
 // ----------------------
@@ -78,6 +79,7 @@ algorithm
   setGlobalRoot(instOnlyForcedFunctions,  NONE());
   setGlobalRoot(rewriteRulesIndex,  NONE());
   setGlobalRoot(stackoverFlowIndex, NONE());
+  setGlobalRoot(inlineHashTable, NONE());
 end initialize;
 
 annotation(__OpenModelica_Interface="util");

--- a/Compiler/Util/BaseHashTable.mo
+++ b/Compiler/Util/BaseHashTable.mo
@@ -612,5 +612,59 @@ algorithm
   outCopy := (hv, (vs, ve, vae), bs, ft);
 end copy;
 
+public function clear
+  "Makes a copy of a hashtable."
+  input output HashTable ht;
+protected
+  HashVector hv;
+  Integer bs, sz, vs, ve, hash_idx;
+  FuncsTuple ft;
+  FuncHash hashFunc;
+  Key key;
+  array<Option<HashEntry>> vae;
+algorithm
+  (hv, (vs, ve, vae), bs, ft as (hashFunc,_,_,_)) := ht;
+  for i in 1:vs loop
+    _ := match arrayGet(vae, i)
+      case SOME((key,_))
+        algorithm
+          hash_idx := hashFunc(key, bs) + 1;
+          arrayUpdate(hv, hash_idx, {});
+          arrayUpdate(vae, i, NONE());
+        then ();
+      else ();
+    end match;
+  end for;
+  ht := (hv, (0, ve, vae), bs, ft);
+end clear;
+
+public function clearAssumeNoDelete
+  "Clears a HashTable that has not been properly stored, but was known to never delete an element (making the values sequential SOME() for as long as there are elements). NOTE: Does not handle arrays that were expanded?"
+  input HashTable ht;
+protected
+  HashVector hv;
+  Integer bs, sz, vs, ve, hash_idx;
+  FuncsTuple ft;
+  FuncHash hashFunc;
+  Key key;
+  array<Option<HashEntry>> vae;
+algorithm
+  (hv, (vs, ve, vae), bs, ft as (hashFunc,_,_,_)) := ht;
+  for i in 1:ve loop
+    _ := match arrayGet(vae, i)
+      case SOME((key,_))
+        algorithm
+          hash_idx := hashFunc(key, bs) + 1;
+          arrayUpdate(hv, hash_idx, {});
+          arrayUpdate(vae, i, NONE());
+        then ();
+      else
+        algorithm
+          return;
+        then ();
+    end match;
+  end for;
+end clearAssumeNoDelete;
+
 annotation(__OpenModelica_Interface="util");
 end BaseHashTable;


### PR DESCRIPTION
Add HashTable+VarTransform to the global roots in order to allocate a
single HashTable in Inline.mo that only needs to clear the previously
added elements before use (typically 3-4 instead of 4000 before, while
also reducing the stress on GC).