### PR TITLE
Split up knownVars

### DIFF
--- a/Compiler/BackEnd/BackendDAE.mo
+++ b/Compiler/BackEnd/BackendDAE.mo
@@ -106,6 +106,7 @@ public
 uniontype Shared "Data shared for all equation-systems"
   record SHARED
     Variables knownVars                     "Known variables, i.e. constants and parameters";
+    Variables globalVars                    "Global variables, i.e. time, state, or input dependent";
     Variables externalObjects               "External object variables";
     Variables aliasVars                     "Data originating from removed simple equations needed to build
                                              variables' lookup table (in C output).

--- a/Compiler/BackEnd/BackendDAECreate.mo
+++ b/Compiler/BackEnd/BackendDAECreate.mo
@@ -95,8 +95,8 @@ public function lower "This function translates a DAE, which is the result from 
   input BackendDAE.ExtraInfo inExtraInfo;
   output BackendDAE.BackendDAE outBackendDAE;
 protected
-  list<BackendDAE.Var> varlst, knvarlst, extvarlst;
-  BackendDAE.Variables vars, knvars, vars_1, extVars, aliasVars;
+  list<BackendDAE.Var> varlst, knvarlst, glvarlst, extvarlst;
+  BackendDAE.Variables vars, knvars, glvars, vars_1, extVars, aliasVars;
   list<BackendDAE.Equation> eqns, reqns, ieqns, algeqns, algeqns1, ialgeqns, multidimeqns, imultidimeqns, eqns_1, ceeqns, iceeqns;
   list<DAE.Constraint> constrs;
   list<DAE.ClassAttributes> clsAttrs;
@@ -116,10 +116,11 @@ algorithm
   functionTree := FCore.getFunctionTree(inCache);
   //deactivated because of some codegen errors: functionTree := renameFunctionParameter(functionTree);
   (DAE.DAE(elems), functionTree, timeEvents) := processBuiltinExpressions(lst, functionTree);
-  (varlst, knvarlst, extvarlst, eqns, reqns, ieqns, constrs, clsAttrs, extObjCls, aliaseqns, _) :=
+  (varlst, knvarlst, glvarlst, extvarlst, eqns, reqns, ieqns, constrs, clsAttrs, extObjCls, aliaseqns, _) :=
     lower2(listReverse(elems), functionTree, HashTableExpToExp.emptyHashTable());
   vars := BackendVariable.listVar(varlst);
   knvars := BackendVariable.listVar(knvarlst);
+  glvars := BackendVariable.listVar(glvarlst);
   extVars := BackendVariable.listVar(extvarlst);
   aliasVars := BackendVariable.emptyVars();
   if Flags.isSet(Flags.VECTORIZE) then
@@ -137,6 +138,7 @@ algorithm
   symjacs := {(NONE(), ({}, {}, ({}, {}), -1), {}), (NONE(), ({}, {}, ({}, {}), -1), {}), (NONE(), ({}, {}, ({}, {}), -1), {}), (NONE(), ({}, {}, ({}, {}), -1), {})};
   outBackendDAE := BackendDAE.DAE(BackendDAEUtil.createEqSystem(vars_1, eqnarr, {}, BackendDAE.UNKNOWN_PARTITION(), reqnarr)::{},
                                   BackendDAE.SHARED(knvars,
+                                                    glvars,
                                                     extVars,
                                                     aliasVars,
                                                     ieqnarr,
@@ -164,6 +166,7 @@ protected function lower2
   input HashTableExpToExp.HashTable inInlineHT "Workaround to speed up inlining of array parameters.";
   input list<BackendDAE.Var> inVars = {};
   input list<BackendDAE.Var> inKnVars = {};
+  input list<BackendDAE.Var> inGlVars = {};
   input list<BackendDAE.Var> inExVars = {};
   input list<BackendDAE.Equation> inEqns = {};
   input list<BackendDAE.Equation> inREqns = {};
@@ -174,6 +177,7 @@ protected function lower2
   input list<DAE.Element> inAliasEqns = {};
   output list<BackendDAE.Var> outVars = inVars "Time dependent variables.";
   output list<BackendDAE.Var> outKnVars = inKnVars "Time independent variables.";
+  output list<BackendDAE.Var> outGlVars = inGlVars "Time, inputs, states dependent variables.";
   output list<BackendDAE.Var> outExVars = inExVars "External variables.";
   output list<BackendDAE.Equation> outEqns  = inEqns "Dynamic equations/algorithms.";
   output list<BackendDAE.Equation> outREqns = inREqns "Algebraic equations.";
@@ -208,8 +212,8 @@ algorithm
       // variables
       case DAE.VAR()
         algorithm
-          (outVars, outKnVars, outExVars, outEqns, outREqns, outInlineHT) :=
-            lowerVar(el, inFunctions, outVars, outKnVars, outExVars, outEqns, outREqns, outInlineHT);
+          (outVars, outKnVars, outGlVars, outExVars, outEqns, outREqns, outInlineHT) :=
+            lowerVar(el, inFunctions, outVars, outKnVars, outGlVars, outExVars, outEqns, outREqns, outInlineHT);
         then
           ();
 
@@ -284,9 +288,9 @@ algorithm
             (outEqns, outVars, eq_attrs) := createWhenClock(whenClkCnt, e, outEqns, outVars);
             whenClkCnt := whenClkCnt + 1;
 
-            ( outVars, outKnVars, outExVars, eqns, reqns, outIEqns, outConstraints, outClassAttributes,
+            ( outVars, outKnVars, outGlVars, outExVars, eqns, reqns, outIEqns, outConstraints, outClassAttributes,
               outExtObjClasses, outAliasEqns, outInlineHT ) :=
-                  lower2( dae_elts, inFunctions, outInlineHT, outVars, outKnVars, outExVars, {}, {}, outIEqns,
+                  lower2( dae_elts, inFunctions, outInlineHT, outVars, outKnVars, outGlVars, outExVars, {}, {}, outIEqns,
                           outConstraints, outClassAttributes, outExtObjClasses, outAliasEqns );
 
             outEqns := listAppend(List.map1(eqns, BackendEquation.setEquationAttributes, eq_attrs), outEqns);
@@ -332,10 +336,10 @@ algorithm
       // flat class / COMP
       case DAE.COMP(dAElist = dae_elts)
         algorithm
-          (outVars, outKnVars, outExVars, outEqns, outREqns, outIEqns, outConstraints,
+          (outVars, outKnVars, outGlVars, outExVars, outEqns, outREqns, outIEqns, outConstraints,
            outClassAttributes, outExtObjClasses, outAliasEqns, outInlineHT)
           := lower2(listReverse(dae_elts), inFunctions, outInlineHT, outVars,
-            outKnVars, outExVars, outEqns, outREqns, outIEqns, outConstraints,
+            outKnVars, outGlVars, outExVars, outEqns, outREqns, outIEqns, outConstraints,
             outClassAttributes, outExtObjClasses, outAliasEqns);
         then
           ();
@@ -471,13 +475,15 @@ end transformBuiltinExpression;
 public function lowerVars
   input list<DAE.Element> inElements;
   input DAE.FunctionTree functionTree;
-  input list<BackendDAE.Var> inVars = {} "The time depend Variables";
-  input list<BackendDAE.Var> inKnVars = {} "The time independend Variables";
+  input list<BackendDAE.Var> inVars = {} "The time depend variables";
+  input list<BackendDAE.Var> inKnVars = {} "The time independend variables";
+  input list<BackendDAE.Var> inGlVars = {} "The time, state, and input dependend variables";
   input list<BackendDAE.Var> inExVars = {} "The external Variables";
   input list<BackendDAE.Equation> inEqns = {} "The dynamic Equations/Algoritms";
   input list<BackendDAE.Equation> inREqns = {};
   output list<BackendDAE.Var> outVars = inVars;
   output list<BackendDAE.Var> outKnVars = inKnVars;
+  output list<BackendDAE.Var> outGlVars = inGlVars;
   output list<BackendDAE.Var> outExVars = inExVars;
   output list<BackendDAE.Equation> outEqns = inEqns;
   output list<BackendDAE.Equation> outREqns = inREqns;
@@ -494,11 +500,11 @@ algorithm
       crefs := ComponentReference.expandCref(cr, false);
       el := DAEUtil.replaceTypeInVar(arr_ty, el);
       new_vars := list(DAEUtil.replaceCrefInVar(c, el) for c in crefs);
-      (outVars, outKnVars, outExVars, outEqns, outREqns) :=
-        lowerVars(new_vars, functionTree, outVars, outKnVars, outExVars, outEqns, outREqns);
+      (outVars, outKnVars, outGlVars, outExVars, outEqns, outREqns) :=
+        lowerVars(new_vars, functionTree, outVars, outKnVars, outGlVars, outExVars, outEqns, outREqns);
     else
-      (outVars, outKnVars, outExVars, outEqns, outREqns) := lowerVar(el, functionTree,
-        outVars, outKnVars, outExVars, outEqns, outREqns, inline_ht);
+      (outVars, outKnVars, outGlVars, outExVars, outEqns, outREqns) := lowerVar(el, functionTree,
+        outVars, outKnVars, outGlVars, outExVars, outEqns, outREqns, inline_ht);
     end try;
   end for;
 end lowerVars;
@@ -508,12 +514,14 @@ protected function lowerVar
   input DAE.FunctionTree inFunctions;
   input list<BackendDAE.Var> inVars;
   input list<BackendDAE.Var> inKnVars;
+  input list<BackendDAE.Var> inGlVars;
   input list<BackendDAE.Var> inExVars;
   input list<BackendDAE.Equation> inEqns;
   input list<BackendDAE.Equation> inREqns;
   input HashTableExpToExp.HashTable inInlineHT;
   output list<BackendDAE.Var> outVars = inVars;
   output list<BackendDAE.Var> outKnVars = inKnVars;
+  output list<BackendDAE.Var> outGlVars = inGlVars;
   output list<BackendDAE.Var> outExVars = inExVars;
   output list<BackendDAE.Equation> outEqns = inEqns;
   output list<BackendDAE.Equation> outREqns = inREqns;
@@ -555,11 +563,10 @@ algorithm
         ();
 
     // known variables: parameters and constants
+    // global variables: top-level inputs
     case DAE.VAR()
       algorithm
-        (var, outInlineHT, outREqns) :=
-          lowerKnownVar(inElement, inFunctions, outInlineHT, outREqns);
-        outKnVars := var :: outKnVars;
+        (outInlineHT, outREqns, outKnVars, outGlVars) := lowerKnownAndGlobalVar(inElement, inFunctions, outInlineHT, outREqns, outKnVars, outGlVars);
       then
         ();
 
@@ -641,17 +648,18 @@ algorithm
   end match;
 end lowerDynamicVar;
 
-protected function lowerKnownVar
+protected function lowerKnownAndGlobalVar
 "Helper function to lower2"
   input DAE.Element inElement;
   input DAE.FunctionTree functionTree;
   input HashTableExpToExp.HashTable iInlineHT "workaround to speed up inlining of array parameters";
   input list<BackendDAE.Equation> assrtEqIn;
-  output BackendDAE.Var outVar;
   output HashTableExpToExp.HashTable oInlineHT "workaround to speed up inlining of array parameters";
   output list<BackendDAE.Equation> assrtEqOut;
+  input output list<BackendDAE.Var> knVars;
+  input output list<BackendDAE.Var> glVars;
 algorithm
-  (outVar,oInlineHT,assrtEqOut) := matchcontinue (inElement)
+  (oInlineHT,assrtEqOut) := matchcontinue (inElement)
     local
       list<DAE.Dimension> dims;
       DAE.ComponentRef name;
@@ -664,7 +672,7 @@ algorithm
       DAE.ConnectorType ct;
       DAE.ElementSource source;
       Option<DAE.VariableAttributes> dae_var_attr;
-    Option<BackendDAE.TearingSelect> ts;
+      Option<BackendDAE.TearingSelect> ts;
       Option<SCode.Comment> comment;
       DAE.Type t;
       DAE.VarVisibility protection;
@@ -675,6 +683,8 @@ algorithm
       list<DAE.Statement> assrtLst;
       list<BackendDAE.Equation> eqLst;
       Absyn.InnerOuter io;
+      BackendDAE.Var var;
+
      case DAE.VAR(componentRef = name,
                   kind = kind,
                   direction = dir,
@@ -689,7 +699,7 @@ algorithm
                   comment = comment,
                   innerOuter = io)
       equation
-        kind_1 = lowerKnownVarkind(kind, name, dir, ct);
+        kind_1 = lowerKnownAndGlobalVarkind(kind, name, dir, ct);
         // bind = fixParameterStartBinding(bind, t, dae_var_attr, kind_1);
         tp = lowerType(t);
         b = DAEUtil.boolVarVisibility(protection);
@@ -701,17 +711,24 @@ algorithm
         eqLst = buildAssertAlgorithms(assrtLst,source,assrtEqIn);
         // building an algorithm of the assert
         (dae_var_attr, source, _) = Inline.inlineStartAttribute(dae_var_attr, source, fnstpl);
-    ts = NONE();
-      then
-        (BackendDAE.VAR(name, kind_1, dir, prl, tp, bind1, NONE(), dims, source, dae_var_attr, ts, comment, ct, DAEUtil.toDAEInnerOuter(io), false), inlineHT, eqLst);
+        ts = NONE();
 
-    else
-      equation
-        str = "BackendDAECreate.lowerKnownVar failed for " + DAEDump.dumpElementsStr({inElement});
-        Error.addMessage(Error.INTERNAL_ERROR, {str});
-      then fail();
+        var = BackendDAE.VAR(name, kind_1, dir, prl, tp, bind1, NONE(), dims, source, dae_var_attr, ts, comment, ct, DAEUtil.toDAEInnerOuter(io), false);
+
+        if DAEUtil.topLevelInput(name, dir, ct) then
+          glVars = var :: glVars;
+        else
+          knVars = var :: knVars;
+        end if;
+      then
+        (inlineHT, eqLst);
+
+    else equation
+      str = "BackendDAECreate.lowerKnownAndGlobalVar failed for " + DAEDump.dumpElementsStr({inElement});
+      Error.addMessage(Error.INTERNAL_ERROR, {str});
+    then fail();
   end matchcontinue;
-end lowerKnownVar;
+end lowerKnownAndGlobalVar;
 
 
 protected function buildAssertAlgorithms "builds BackendDAE.ALGORITHM out of the given assert statements
@@ -927,9 +944,9 @@ algorithm
   end match;
 end lowerVarkind;
 
-protected function lowerKnownVarkind
-"Helper function to lowerKnownVar.
-  NOTE: Fails for everything but parameters and constants and top level inputs"
+protected function lowerKnownAndGlobalVarkind
+"Helper function to lowerKnownAndGlobalVar.
+  NOTE: Fails for everything but parameters and constants"
   input DAE.VarKind inVarKind;
   input DAE.ComponentRef inComponentRef;
   input DAE.VarDirection inVarDirection;
@@ -951,11 +968,11 @@ algorithm
     //    BackendDAE.VARIABLE();
     else
       equation
-        Error.addInternalError("function lowerKnownVarkind failed", sourceInfo());
+        Error.addInternalError("function lowerKnownAndGlobalVarkind failed", sourceInfo());
       then
         fail();
   end matchcontinue;
-end lowerKnownVarkind;
+end lowerKnownAndGlobalVarkind;
 
 protected function lowerType
 "Transforms a DAE.Type to Type"

--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -8214,7 +8214,7 @@ protected
   BackendDAE.EquationArray emptyEqs = BackendEquation.emptyEqns();
   DAE.FunctionTree functions = DAEUtil.avlTreeNew();
 algorithm
-  shared := BackendDAE.SHARED( emptyVars, emptyVars, emptyVars, emptyEqs, emptyEqs, {}, {}, cache, graph,
+  shared := BackendDAE.SHARED( emptyVars, emptyVars, emptyVars, emptyVars, emptyEqs, emptyEqs, {}, {}, cache, graph,
                                DAEUtil.avlTreeNew(), emptyEventInfo(), {}, backendDAEType, {}, ei,
                                emptyPartitionsInfo() );
 end createEmptyShared;
@@ -8452,6 +8452,14 @@ public function setSharedKnVars
 algorithm
   outShared.knownVars := knownVars;
 end setSharedKnVars;
+
+public function setSharedGlobalVars
+  input BackendDAE.Shared inShared;
+  input BackendDAE.Variables globalVars;
+  output BackendDAE.Shared outShared = inShared;
+algorithm
+  outShared.globalVars := globalVars;
+end setSharedGlobalVars;
 
 public function setSharedAliasVars
   input BackendDAE.Shared inShared;

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -257,7 +257,8 @@ algorithm
   printBackendDAEType(inShared.backendDAEType);
   print("\n\n");
 
-  dumpVariables(inShared.knownVars, "Known Variables (constants)");
+  dumpVariables(inShared.knownVars, "Known Variables (dependent on constants or parameters)");
+  dumpVariables(inShared.globalVars, "Global Variables (dependent on time, states, inputs)");
   dumpVariables(inShared.externalObjects, "External Objects");
   dumpExternalObjectClasses(inShared.extObjClasses, "Classes of External Objects");
   dumpVariables(inShared.aliasVars, "Alias Variables");

--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -2536,6 +2536,16 @@ algorithm
   outShared := BackendDAEUtil.setSharedKnVars(inShared, addVar(inVar, inShared.knownVars));
 end addKnVarDAE;
 
+public function addGlobalVarDAE "author: lochel
+  Add a variable to globalVars of a Shared object.
+  If the variable already exists, the function updates the variable."
+  input BackendDAE.Var inVar;
+  input BackendDAE.Shared inShared;
+  output BackendDAE.Shared outShared;
+algorithm
+  outShared := BackendDAEUtil.setSharedGlobalVars(inShared, addVar(inVar, inShared.knownVars));
+end addGlobalVarDAE;
+
 public function addNewKnVarDAE
 "author: Frenkel TUD 2011-04
   Add a variable to Variables of a BackendDAE.

--- a/Compiler/BackEnd/Differentiate.mo
+++ b/Compiler/BackEnd/Differentiate.mo
@@ -3027,12 +3027,11 @@ protected function lowerVarsElementVars
   output list< BackendDAE.Equation> eqnsLst;
   output list< BackendDAE.Equation> reqnsLst;
 protected
-  list<BackendDAE.Var> vars, knvars, exvars;
+  list<BackendDAE.Var> vars, knvars, glvars, exvars;
 algorithm
   try
-    (vars, knvars, exvars, eqnsLst, reqnsLst) :=
-      BackendDAECreate.lowerVars(inElementLstVars, functions);
-    varsLst := listAppend(exvars, listAppend(vars, knvars));
+    (vars, knvars, glvars, exvars, eqnsLst, reqnsLst) := BackendDAECreate.lowerVars(inElementLstVars, functions);
+    varsLst := listAppend(exvars, listAppend(vars, listAppend(knvars, glvars)));
   else
     true := Flags.isSet(Flags.FAILTRACE);
     Debug.traceln("- Differentiate.lowerVarsElementVars failed.");

--- a/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/Compiler/BackEnd/SymbolicJacobian.mo
@@ -1451,11 +1451,11 @@ algorithm
     local
       BackendDAE.BackendDAE backendDAE,backendDAE2,emptyBDAE;
 
-      list<BackendDAE.Var>  varlst, knvarlst,  states, inputvars, inputvars2, outputvars, paramvars, states_inputs, conVarsList, fconVarsList, object;
+      list<BackendDAE.Var>  varlst, knvarlst, glvarlst, states, inputvars, inputvars2, outputvars, paramvars, states_inputs, conVarsList, fconVarsList, object;
       list<DAE.ComponentRef> comref_states, comref_inputvars, comref_outputvars, comref_vars, comref_knvars;
       DAE.ComponentRef leftcref;
 
-      BackendDAE.Variables v,kv,statesarr,inputvarsarr,paramvarsarr,outputvarsarr, optimizer_vars, conVars;
+      BackendDAE.Variables v,knownVars,globalVars,statesarr,inputvarsarr,paramvarsarr,outputvarsarr, optimizer_vars, conVars;
       BackendDAE.EquationArray e;
 
       BackendDAE.SymbolicJacobians linearModelMatrices;
@@ -1476,17 +1476,18 @@ algorithm
         backendDAE2 = BackendDAEUtil.copyBackendDAE(backendDAE);
         backendDAE2 = BackendDAEOptimize.collapseIndependentBlocks(backendDAE2);
         backendDAE2 = BackendDAEUtil.transformBackendDAE(backendDAE2,SOME((BackendDAE.NO_INDEX_REDUCTION(),BackendDAE.EXACT())),NONE(),NONE());
-        BackendDAE.DAE({BackendDAE.EQSYSTEM(orderedVars = v)}, BackendDAE.SHARED(knownVars = kv, functionTree = functionTree, cache=cache, graph=graph, info=ei)) = backendDAE2;
+        BackendDAE.DAE({BackendDAE.EQSYSTEM(orderedVars = v)}, BackendDAE.SHARED(knownVars=knownVars, globalVars=globalVars, functionTree = functionTree, cache=cache, graph=graph, info=ei)) = backendDAE2;
 
 
         emptyBDAE = BackendDAE.DAE({BackendDAEUtil.createEqSystem(BackendVariable.emptyVars(), BackendEquation.emptyEqns())}, BackendDAEUtil.createEmptyShared(BackendDAE.JACOBIAN(), ei, cache, graph));
         // Prepare all needed variables
         varlst = BackendVariable.varList(v);
-        knvarlst = BackendVariable.varList(kv);
+        knvarlst = BackendVariable.varList(knownVars);
+        glvarlst = BackendVariable.varList(globalVars);
         states = BackendVariable.getAllStateVarFromVariables(v);
-        inputvars = List.select(knvarlst,BackendVariable.isInput);
+        inputvars = List.select(glvarlst,BackendVariable.isInput);
         paramvars = List.select(knvarlst, BackendVariable.isParam);
-        inputvars2 = List.select(knvarlst,BackendVariable.isVarOnTopLevelAndInput);
+        inputvars2 = List.select(glvarlst,BackendVariable.isVarOnTopLevelAndInput);
         outputvars = List.select(varlst, BackendVariable.isVarOnTopLevelAndOutput);
 
         statesarr = BackendVariable.listVar1(states);
@@ -1517,15 +1518,16 @@ algorithm
         backendDAE2 = BackendDAEUtil.copyBackendDAE(backendDAE);
         backendDAE2 = BackendDAEOptimize.collapseIndependentBlocks(backendDAE2);
         backendDAE2 = BackendDAEUtil.transformBackendDAE(backendDAE2,SOME((BackendDAE.NO_INDEX_REDUCTION(),BackendDAE.EXACT())),NONE(),NONE());
-        BackendDAE.DAE({BackendDAE.EQSYSTEM(orderedVars = v)}, BackendDAE.SHARED(knownVars = kv)) = backendDAE2;
+        BackendDAE.DAE({BackendDAE.EQSYSTEM(orderedVars = v)}, BackendDAE.SHARED(knownVars=knownVars, globalVars=globalVars)) = backendDAE2;
 
         // Prepare all needed variables
         varlst = BackendVariable.varList(v);
-        knvarlst = BackendVariable.varList(kv);
+        knvarlst = BackendVariable.varList(knownVars);
+        glvarlst = BackendVariable.varList(globalVars);
         states = BackendVariable.getAllStateVarFromVariables(v);
-        inputvars = List.select(knvarlst,BackendVariable.isInput);
+        inputvars = List.select(glvarlst,BackendVariable.isInput);
         paramvars = List.select(knvarlst, BackendVariable.isParam);
-        inputvars2 = List.select(knvarlst,BackendVariable.isVarOnTopLevelAndInput);
+        inputvars2 = List.select(glvarlst,BackendVariable.isVarOnTopLevelAndInput);
         outputvars = List.select(varlst, BackendVariable.isVarOnTopLevelAndOutput);
 
         statesarr = BackendVariable.listVar1(states);
@@ -1580,15 +1582,16 @@ algorithm
         backendDAE2 = BackendDAEUtil.copyBackendDAE(backendDAE);
         backendDAE2 = BackendDAEOptimize.collapseIndependentBlocks(backendDAE2);
         backendDAE2 = BackendDAEUtil.transformBackendDAE(backendDAE2,SOME((BackendDAE.NO_INDEX_REDUCTION(),BackendDAE.EXACT())),NONE(),NONE());
-        BackendDAE.DAE({BackendDAE.EQSYSTEM(orderedVars = v)}, BackendDAE.SHARED(knownVars = kv)) = backendDAE2;
+        BackendDAE.DAE({BackendDAE.EQSYSTEM(orderedVars = v)}, BackendDAE.SHARED(knownVars=knownVars, globalVars=globalVars)) = backendDAE2;
 
         // Prepare all needed variables
         varlst = BackendVariable.varList(v);
-        knvarlst = BackendVariable.varList(kv);
+        knvarlst = BackendVariable.varList(knownVars);
+        glvarlst = BackendVariable.varList(globalVars);
         states = BackendVariable.getAllStateVarFromVariables(v);
-        inputvars = List.select(knvarlst,BackendVariable.isInput);
+        inputvars = List.select(glvarlst,BackendVariable.isInput);
         paramvars = List.select(knvarlst, BackendVariable.isParam);
-        inputvars2 = List.select(knvarlst,BackendVariable.isVarOnTopLevelAndInputNoDerInput); // without der(u)
+        inputvars2 = List.select(glvarlst,BackendVariable.isVarOnTopLevelAndInputNoDerInput); // without der(u)
         outputvars = List.select(varlst, BackendVariable.isVarOnTopLevelAndOutput);
         conVarsList = List.select(varlst, BackendVariable.isRealOptimizeConstraintsVars);
         fconVarsList = List.select(varlst, BackendVariable.isRealOptimizeFinalConstraintsVars); // ToDo: FinalCon

--- a/Compiler/BackEnd/XMLDump.mo
+++ b/Compiler/BackEnd/XMLDump.mo
@@ -172,6 +172,7 @@ protected import System;        // for stringReplace
 
   protected constant String ORDERED  = "ordered";
   protected constant String KNOWN    = "known";
+  protected constant String GLOBAL   = "global";
   protected constant String EXTERNAL = "external";
   protected constant String ALIAS = "alias";
   protected constant String CLASSES  = "classes";
@@ -973,7 +974,7 @@ the relative tag is not printed.
 algorithm
   _ := matchcontinue (inBackendDAE,addOriginalIncidenceMatrix,addSolvingInfo,addMathMLCode,dumpResiduals,dumpSolvedEquations)
     local
-      list<BackendDAE.Var> vars,knvars,extvars,aliasvars;
+      list<BackendDAE.Var> vars,knvars,glvars,extvars,aliasvars;
 
       //Ordered Variables: state & algebraic variables.
       //VARIABLES record for vars.
@@ -985,6 +986,9 @@ algorithm
       BackendDAE.VariableArray varArr_knownVars;
       Integer bucketSize_knownVars;
       Integer numberOfVars_knownVars;
+
+      BackendDAE.Variables vars_globalVars;
+      array<list<BackendDAE.CrefIndex>> crefIdxLstArr_globalVars;
 
       //External Object: external variables.
       BackendDAE.Variables vars_externalObject;
@@ -1024,6 +1028,7 @@ algorithm
     case (BackendDAE.DAE(systs,
                  BackendDAE.SHARED(
                  vars_knownVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_knownVars),
+                 vars_globalVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_globalVars),
                  vars_externalObject as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_externalObject),
                  vars_aliasVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_aliasVars),
                  ieqns,_,constrs,_,_,_,funcs,eventInfo,
@@ -1031,6 +1036,7 @@ algorithm
       equation
 
         knvars  = BackendVariable.varList(vars_knownVars);
+        glvars  = BackendVariable.varList(vars_globalVars);
         extvars = BackendVariable.varList(vars_externalObject);
         aliasvars = BackendVariable.varList(vars_aliasVars);
 
@@ -1043,6 +1049,7 @@ algorithm
         vars = List.fold(systs,getOrderedVars,{});
         dumpVars(vars,arrayCreate(1,{}),stringAppend(ORDERED,VARIABLES_),addMML);
         dumpVars(knvars,crefIdxLstArr_knownVars,stringAppend(KNOWN,VARIABLES_),addMML);
+        dumpVars(glvars,crefIdxLstArr_globalVars,stringAppend(GLOBAL,VARIABLES_),addMML);
         dumpVars(extvars,crefIdxLstArr_externalObject,stringAppend(EXTERNAL,VARIABLES_),addMML);
         dumpVars(aliasvars,crefIdxLstArr_aliasVars,stringAppend(ALIAS,VARIABLES_),addMML);
         dumpExtObjCls(extObjCls,stringAppend(EXTERNAL,CLASSES_));
@@ -1066,6 +1073,7 @@ algorithm
     case (BackendDAE.DAE(systs,
                  BackendDAE.SHARED(
                  vars_knownVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_knownVars),
+                 vars_globalVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_globalVars),
                  vars_externalObject as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_externalObject),
                  vars_aliasVars as BackendDAE.VARIABLES(crefIndices=crefIdxLstArr_aliasVars),
                  ieqns,_,constrs,_,_,_,funcs,eventInfo,
@@ -1073,6 +1081,7 @@ algorithm
       equation
 
         knvars  = BackendVariable.varList(vars_knownVars);
+        glvars  = BackendVariable.varList(vars_globalVars);
         extvars = BackendVariable.varList(vars_externalObject);
         aliasvars = BackendVariable.varList(vars_aliasVars);
 
@@ -1085,6 +1094,7 @@ algorithm
         vars = List.fold(systs,getOrderedVars,{});
         dumpVars(vars,arrayCreate(1,{}),stringAppend(ORDERED,VARIABLES_),addMML);
         dumpVars(knvars,crefIdxLstArr_knownVars,stringAppend(KNOWN,VARIABLES_),addMML);
+        dumpVars(glvars,crefIdxLstArr_globalVars,stringAppend(GLOBAL,VARIABLES_),addMML);
         dumpVars(extvars,crefIdxLstArr_externalObject,stringAppend(EXTERNAL,VARIABLES_),addMML);
         dumpVars(aliasvars,crefIdxLstArr_aliasVars,stringAppend(ALIAS,VARIABLES_),addMML);
         dumpExtObjCls(extObjCls,stringAppend(EXTERNAL,CLASSES_));

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -630,7 +630,7 @@ algorithm
     end for;
     for i in 1:BackendVariable.varsSize(syst.orderedVars) loop
       var := BackendVariable.getVarAt(syst.orderedVars, i);
-      simVar := dlowvarToSimvar(var, SOME(inShared.aliasVars), inShared.knownVars);
+      simVar := dlowvarToSimvar(var, SOME(inShared.aliasVars), inShared.globalVars);
       prevClockedVars := (simVar, isPrevVar[i])::prevClockedVars;
       clockedVars := simVar::clockedVars;
       if isPrevVar[i] then
@@ -2730,7 +2730,7 @@ algorithm
     local
       list<BackendDAE.Equation> eqn_lst,  disc_eqn;
       list<BackendDAE.Var> var_lst,  disc_var, var_lst_1;
-      BackendDAE.Variables vars_1, vars, knvars, exvars;
+      BackendDAE.Variables vars_1, vars, glvars, exvars;
       BackendDAE.EquationArray eqns_1, eqns;
       Option<list<tuple<Integer, Integer, BackendDAE.Equation>>> jac;
       BackendDAE.JacobianType jac_tp;
@@ -2766,7 +2766,7 @@ algorithm
 
     // EQUATIONSYSTEM: continuous system of equations
     case (BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns),
-          BackendDAE.SHARED(knownVars=knvars, functionTree=funcs, info = ei),
+          BackendDAE.SHARED(globalVars=glvars, functionTree=funcs, info = ei),
           comp as BackendDAE.EQUATIONSYSTEM(eqns=eqIdcs,jac=jacobian,jacType=jac_tp, mixedSystem=mixedSystem))
       equation
         if Flags.isSet(Flags.FAILTRACE) then
@@ -2786,7 +2786,7 @@ algorithm
         var_lst_1 = List.map(var_lst, BackendVariable.transformXToXd);
         vars_1 = BackendVariable.listVar1(var_lst_1);
         eqns_1 = BackendEquation.listEquation(eqn_lst);
-        (equations_, uniqueEqIndex, tempvars) = createOdeSystem2(false, vars_1, knvars, eqns_1, jacobian, jac_tp, funcs, vars, iuniqueEqIndex, ei, mixedSystem, itempvars);
+        (equations_, uniqueEqIndex, tempvars) = createOdeSystem2(false, vars_1, glvars, eqns_1, jacobian, jac_tp, funcs, vars, iuniqueEqIndex, ei, mixedSystem, itempvars);
         uniqueEqIndexMapping = uniqueEqIndex-1; //a system with this index is created that contains all the equations with the indeces from iuniqueEqIndex to uniqueEqIndex-2
         //tmpEqSccMapping = List.fold1(List.intRange2(iuniqueEqIndex, uniqueEqIndex - 1), appendSccIdx, isccIndex, ieqSccMapping);
         tmpEqSccMapping = List.fold1(List.intRange2(uniqueEqIndexMapping, uniqueEqIndex - 1), appendSccIdx, isccIndex, ieqSccMapping);
@@ -2817,7 +2817,7 @@ end createOdeSystem;
 protected function createOdeSystem2
   input Boolean mixedEvent "true if generating the mixed system event code";
   input BackendDAE.Variables inVars;
-  input BackendDAE.Variables inKnVars;
+  input BackendDAE.Variables inGlVars;
   input BackendDAE.EquationArray inEquationArray;
   input BackendDAE.Jacobian inJacobian;
   input BackendDAE.JacobianType inJacobianType;
@@ -2858,7 +2858,7 @@ algorithm
       if Flags.isSet(Flags.FAILTRACE) then
         Debug.trace("function createOdeSystem2 create linear system(const jacobian).\n");
       end if;
-      ((simVars, _)) = BackendVariable.traverseBackendDAEVars(inVars, traversingdlowvarToSimvar, ({}, inKnVars));
+      ((simVars, _)) = BackendVariable.traverseBackendDAEVars(inVars, traversingdlowvarToSimvar, ({}, inGlVars));
       simVars = listReverse(simVars);
       (beqs, sources) = BackendDAEUtil.getEqnSysRhs(inEquationArray, inVars, SOME(inFuncs));
       beqs = listReverse(beqs);
@@ -2877,7 +2877,7 @@ algorithm
       if Flags.isSet(Flags.FAILTRACE) then
         Debug.trace("function createOdeSystem2 create linear system with jacobian.\n");
       end if;
-      ((simVars, _)) = BackendVariable.traverseBackendDAEVars(inVars, traversingdlowvarToSimvar, ({}, inKnVars));
+      ((simVars, _)) = BackendVariable.traverseBackendDAEVars(inVars, traversingdlowvarToSimvar, ({}, inGlVars));
       simVars = listReverse(simVars);
       (beqs, sources) = BackendDAEUtil.getEqnSysRhs(inEquationArray, inVars, SOME(inFuncs));
       beqs = listReverse(beqs);
@@ -3006,7 +3006,7 @@ algorithm
      local
        list<BackendDAE.Var> tvars, ovarsLst;
        list<BackendDAE.Equation> reqns, otherEqnsLst;
-       BackendDAE.Variables vars, kv, diffVars, ovars;
+       BackendDAE.Variables vars, globalVars, diffVars, ovars;
        BackendDAE.EquationArray eqns, oeqns;
        list<SimCodeVar.SimVar> tempvars, simVars;
        list<SimCode.SimEqSystem> simequations, resEqs;
@@ -3077,12 +3077,12 @@ algorithm
          (simequations, uniqueEqIndex, tempvars);
 */
      // CASE: linear
-     case(true, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns), BackendDAE.SHARED(knownVars=kv)) equation
+     case(true, BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns), BackendDAE.SHARED(globalVars=globalVars)) equation
        BackendDAE.TEARINGSET(tearingvars=tearingVars, residualequations=residualEqns, innerEquations=innerEquations, jac=inJacobian) = strictTearingSet;
        // get tearing vars
        tvars = List.map1r(tearingVars, BackendVariable.getVarAt, vars);
        tvars = List.map(tvars, BackendVariable.transformXToXd);
-       ((simVars, _)) = List.fold(tvars, traversingdlowvarToSimvarFold, ({}, kv));
+       ((simVars, _)) = List.fold(tvars, traversingdlowvarToSimvarFold, ({}, globalVars));
        simVars = listReverse(simVars);
 
        // get residual eqns
@@ -3102,7 +3102,7 @@ algorithm
          // get tearing vars
          tvars = List.map1r(tearingVars, BackendVariable.getVarAt, vars);
          tvars = List.map(tvars, BackendVariable.transformXToXd);
-         ((simVars, _)) = List.fold(tvars, traversingdlowvarToSimvarFold, ({}, kv));
+         ((simVars, _)) = List.fold(tvars, traversingdlowvarToSimvarFold, ({}, globalVars));
          simVars = listReverse(simVars);
 
          // get residual eqns
@@ -4380,7 +4380,7 @@ algorithm
   evarLst := BackendVariable.varList(evars);
   evarLst := orderExtVars(evarLst);
   //evarLst := listReverse(evarLst);
-  (simvars, aliases) := extractExtObjInfo2(evarLst, evars);
+  (simvars, aliases) := extractExtObjInfo2(evarLst, evars /* ??? */);
   extObjInfo := SimCode.EXTOBJINFO(simvars, aliases);
 end createExtObjInfo;
 
@@ -4412,7 +4412,7 @@ end orderExtVars;
 
 protected function extractExtObjInfo2
   input list<BackendDAE.Var> varLst;
-  input BackendDAE.Variables evars;
+  input BackendDAE.Variables globalVars;
   output list<SimCodeVar.SimVar> vars = {};
   output list<SimCode.ExtAlias> aliases = {};
 algorithm
@@ -4427,7 +4427,7 @@ algorithm
         then ();
       else
         equation
-          sv = dlowvarToSimvar(bv, NONE(), evars);
+          sv = dlowvarToSimvar(bv, NONE(), globalVars);
           vars = sv::vars;
         then ();
       end match;
@@ -6252,14 +6252,15 @@ protected function createVars
   output SimCodeVar.SimVars outVars;
 protected
   BackendDAE.Variables knvars1, knvars2;
+  BackendDAE.Variables glvars1, glvars2;
   BackendDAE.Variables extvars1, extvars2;
   BackendDAE.Variables aliasVars1, aliasVars2;
   BackendDAE.EqSystems systs1, systs2;
   DAE.FunctionTree funcTree;
   HashSet.HashSet hs = HashSet.emptyHashSet();
 algorithm
-  BackendDAE.DAE(eqs=systs1, shared=BackendDAE.SHARED(knownVars=knvars1, externalObjects=extvars1, aliasVars=aliasVars1, functionTree=funcTree)) := inSimDAE;
-  BackendDAE.DAE(eqs=systs2, shared=BackendDAE.SHARED(knownVars=knvars2, externalObjects=extvars2, aliasVars=aliasVars2)) := inInitDAE;
+  BackendDAE.DAE(eqs=systs1, shared=BackendDAE.SHARED(knownVars=knvars1, globalVars=glvars1, externalObjects=extvars1, aliasVars=aliasVars1, functionTree=funcTree)) := inSimDAE;
+  BackendDAE.DAE(eqs=systs2, shared=BackendDAE.SHARED(knownVars=knvars2, globalVars=glvars2, externalObjects=extvars2, aliasVars=aliasVars2)) := inInitDAE;
 
   systs1 := List.filterOnFalse(systs1, BackendDAEUtil.isClockedSyst);
   systs2 := List.filterOnFalse(systs2, BackendDAEUtil.isClockedSyst);
@@ -6267,35 +6268,42 @@ algorithm
   if not Flags.isSet(Flags.NO_START_CALC) then
     (systs1) := List.map2(systs1, preCalculateStartValues, knvars1, funcTree);
     (knvars1, _) := BackendVariable.traverseBackendDAEVarsWithUpdate(knvars1, evaluateStartValues, funcTree);
+    //TODO handle globalVars as well?
     //systs2 := List.map1(systs2, preCalculateStartValues, knvars2);
   end if;
 
   // ### simulation ###
   // Extract from variable list
-  ((outVars, _, _, hs)) := List.fold1(List.map(systs1, BackendVariable.daeVars), BackendVariable.traverseBackendDAEVars, extractVarsFromList, (SimCodeVar.emptySimVars, aliasVars1, knvars1, hs));
+  ((outVars, _, _, _, hs)) := List.fold1(List.map(systs1, BackendVariable.daeVars), BackendVariable.traverseBackendDAEVars, extractVarsFromList, (SimCodeVar.emptySimVars, aliasVars1, knvars1, glvars1, hs));
 
   // Extract from known variable list
-  ((outVars, _, _, hs)) := BackendVariable.traverseBackendDAEVars(knvars1, extractVarsFromList, (outVars, aliasVars1, knvars1, hs));
+  ((outVars, _, _, _, hs)) := BackendVariable.traverseBackendDAEVars(knvars1, extractVarsFromList, (outVars, aliasVars1, knvars1, glvars1, hs));
+
+  // Extract from global variable list
+  ((outVars, _, _, _, hs)) := BackendVariable.traverseBackendDAEVars(glvars1, extractVarsFromList, (outVars, aliasVars1, knvars1, glvars1, hs));
 
   // Extract from removed variable list
-  ((outVars, _, _, hs)) := BackendVariable.traverseBackendDAEVars(aliasVars1, extractVarsFromList, (outVars, aliasVars1, knvars1, hs));
+  ((outVars, _, _, _, hs)) := BackendVariable.traverseBackendDAEVars(aliasVars1, extractVarsFromList, (outVars, aliasVars1, knvars1, glvars1, hs));
 
   // Extract from external object list
-  ((outVars, _, _, hs)) := BackendVariable.traverseBackendDAEVars(extvars1, extractVarsFromList, (outVars, aliasVars1, knvars1, hs));
+  ((outVars, _, _, _, hs)) := BackendVariable.traverseBackendDAEVars(extvars1, extractVarsFromList, (outVars, aliasVars1, knvars1, glvars1, hs));
 
 
   // ### initialization ###
   // Extract from variable list
-  ((outVars, _, _, hs)) := List.fold1(List.map(systs2, BackendVariable.daeVars), BackendVariable.traverseBackendDAEVars, extractVarsFromList, (outVars, aliasVars2, knvars2, hs));
+  ((outVars, _, _, _, hs)) := List.fold1(List.map(systs2, BackendVariable.daeVars), BackendVariable.traverseBackendDAEVars, extractVarsFromList, (outVars, aliasVars2, knvars2, glvars2, hs));
 
   // Extract from known variable list
-  ((outVars, _, _, hs)) := BackendVariable.traverseBackendDAEVars(knvars2, extractVarsFromList, (outVars, aliasVars2, knvars2, hs));
+  ((outVars, _, _, _, hs)) := BackendVariable.traverseBackendDAEVars(knvars2, extractVarsFromList, (outVars, aliasVars2, knvars2, glvars2, hs));
+
+  // Extract from global variable list
+  ((outVars, _, _, _, hs)) := BackendVariable.traverseBackendDAEVars(glvars2, extractVarsFromList, (outVars, aliasVars2, knvars2, glvars2, hs));
 
   // Extract from removed variable list
-  ((outVars, _, _, hs)) := BackendVariable.traverseBackendDAEVars(aliasVars2, extractVarsFromList, (outVars, aliasVars2, knvars2, hs));
+  ((outVars, _, _, _, hs)) := BackendVariable.traverseBackendDAEVars(aliasVars2, extractVarsFromList, (outVars, aliasVars2, knvars2, glvars2, hs));
 
   // Extract from external object list
-  ((outVars, _, _, hs)) := BackendVariable.traverseBackendDAEVars(extvars2, extractVarsFromList, (outVars, aliasVars2, knvars2, hs));
+  ((outVars, _, _, _, hs)) := BackendVariable.traverseBackendDAEVars(extvars2, extractVarsFromList, (outVars, aliasVars2, knvars2, glvars2, hs));
 
   //BaseHashSet.printHashSet(hs);
 
@@ -6420,24 +6428,24 @@ end getRecordPathFromCref;
 
 protected function extractVarsFromList
   input BackendDAE.Var inVar;
-  input tuple<SimCodeVar.SimVars, BackendDAE.Variables, BackendDAE.Variables, HashSet.HashSet /*all processed crefs*/> inTpl;
+  input tuple<SimCodeVar.SimVars, BackendDAE.Variables, BackendDAE.Variables, BackendDAE.Variables, HashSet.HashSet /*all processed crefs*/> inTpl;
   output BackendDAE.Var outVar = inVar;
-  output tuple<SimCodeVar.SimVars, BackendDAE.Variables, BackendDAE.Variables, HashSet.HashSet /*all processed crefs*/> outTpl;
+  output tuple<SimCodeVar.SimVars, BackendDAE.Variables, BackendDAE.Variables, BackendDAE.Variables, HashSet.HashSet /*all processed crefs*/> outTpl;
 protected
   SimCodeVar.SimVars vars;
-  BackendDAE.Variables aliasVars, v;
+  BackendDAE.Variables aliasVars, knownVars, globalVars;
   HashSet.HashSet hs;
 algorithm
-  (vars, aliasVars, v, hs) := inTpl;
+  (vars, aliasVars, knownVars, globalVars, hs) := inTpl;
 
   if not BaseHashSet.has(inVar.varName, hs) and not ComponentReference.isPreCref(inVar.varName) then
-    (vars, hs) := extractVarFromVar(inVar, aliasVars, v, vars, hs);
+    (vars, hs) := extractVarFromVar(inVar, aliasVars, knownVars, globalVars, vars, hs);
   //  print("Added  " + ComponentReference.printComponentRefStr(inVar.varName) + "\n");
   //else
   //  print("Skiped " + ComponentReference.printComponentRefStr(inVar.varName) + "\n");
   end if;
 
-  outTpl := (vars, aliasVars, v, hs);
+  outTpl := (vars, aliasVars, knownVars, globalVars, hs);
 end extractVarsFromList;
 
 // one dlow var can result in multiple simvars: input and output are a subset
@@ -6445,7 +6453,8 @@ end extractVarsFromList;
 protected function extractVarFromVar
   input BackendDAE.Var dlowVar;
   input BackendDAE.Variables inAliasVars;
-  input BackendDAE.Variables inVars;
+  input BackendDAE.Variables inKnownVars;
+  input BackendDAE.Variables inGlobalVars;
   input SimCodeVar.SimVars varsIn;
   input HashSet.HashSet inHS "all processed crefs";
   output SimCodeVar.SimVars varsOut;
@@ -6489,7 +6498,7 @@ algorithm
     stringAlgVars, stringParamVars, stringAliasVars, extObjVars, constVars, intConstVars, boolConstVars, stringConstVars, jacobianVars, seedVars, realOptimizeConstraintsVars, realOptimizeFinalConstraintsVars, mixedArrayVars) := varsIn;
 
   // extract the sim var
-  simvar := dlowvarToSimvar(dlowVar, SOME(inAliasVars), inVars);
+  simvar := dlowvarToSimvar(dlowVar, SOME(inAliasVars), inGlobalVars);
   derivSimvar := derVarFromStateVar(simvar);
   isalias := isAliasVar(simvar);
 
@@ -7767,10 +7776,10 @@ end getVectorizedCrefFromExp;
 protected function dlowvarToSimvar
   input BackendDAE.Var dlowVar;
   input Option<BackendDAE.Variables> optAliasVars;
-  input BackendDAE.Variables inVars;
+  input BackendDAE.Variables inGlobalVars;
   output SimCodeVar.SimVar simVar;
 algorithm
-  simVar := match (dlowVar, optAliasVars, inVars)
+  simVar := match (dlowVar)
     local
       DAE.ComponentRef cr;
       BackendDAE.VarKind kind;
@@ -7790,18 +7799,17 @@ algorithm
       Option<DAE.ComponentRef> arrayCref;
       SimCodeVar.AliasVariable aliasvar;
       DAE.ElementSource source;
-      BackendDAE.Variables vars;
       SimCodeVar.Causality caus;
       Boolean isProtected;
       Boolean hideResult;
 
-    case ((BackendDAE.VAR(varName = cr,
+    case (BackendDAE.VAR(varName = cr,
       varKind = kind as BackendDAE.PARAM(),
       arryDim = inst_dims,
       values = dae_var_attr,
       comment = comment,
       varType = tp,
-      source = source)), _, vars)
+      source = source))
       equation
         commentStr = unparseCommentOptionNoAnnotationNoQuote(comment);
         (unit, displayUnit) = extractVarUnit(dae_var_attr);
@@ -7816,7 +7824,7 @@ algorithm
         isDiscrete = BackendVariable.isVarDiscrete(dlowVar);
         arrayCref = ComponentReference.getArrayCref(cr);
         aliasvar = getAliasVar(dlowVar, optAliasVars);
-        caus = getCausality(dlowVar, vars);
+        caus = getCausality(dlowVar, inGlobalVars);
         numArrayElement = List.map(inst_dims, ExpressionDump.dimensionIntString);
         // print("name: " + ComponentReference.printComponentRefStr(cr) + "indx: " + intString(indx) + "\n");
         // check if the variable has changeable value
@@ -7830,13 +7838,13 @@ algorithm
         minValue, maxValue, initVal, nomVal, isFixed, type_, isDiscrete, arrayCref, aliasvar, source, caus, NONE(), numArrayElement, isValueChangeable, isProtected, hideResult, NONE());
 
     // Start value of states may be changeable
-    case ((BackendDAE.VAR(varName = cr,
+    case (BackendDAE.VAR(varName = cr,
       varKind = kind as BackendDAE.STATE(),
       arryDim = inst_dims,
       values = dae_var_attr,
       comment = comment,
       varType = tp,
-      source = source)), _, vars)
+      source = source))
       equation
         commentStr = unparseCommentOptionNoAnnotationNoQuote(comment);
         (unit, displayUnit) = extractVarUnit(dae_var_attr);
@@ -7851,20 +7859,20 @@ algorithm
         isDiscrete = BackendVariable.isVarDiscrete(dlowVar);
         arrayCref = ComponentReference.getArrayCref(cr);
         aliasvar = getAliasVar(dlowVar, optAliasVars);
-        caus = getCausality(dlowVar, vars);
+        caus = getCausality(dlowVar, inGlobalVars);
         numArrayElement = List.map(inst_dims, ExpressionDump.dimensionIntString);
         // print("name: " + ComponentReference.printComponentRefStr(cr) + "indx: " + intString(indx) + "\n");
       then
         SimCodeVar.SIMVAR(cr, kind, commentStr, unit, displayUnit, -1 /* use -1 to get an error in simulation if something failed */,
         minValue, maxValue, initVal, nomVal, isFixed, type_, isDiscrete, arrayCref, aliasvar, source, caus, NONE(), numArrayElement, true, isProtected, hideResult, NONE());
 
-    case ((BackendDAE.VAR(varName = cr,
+    case (BackendDAE.VAR(varName = cr,
       varKind = kind,
       arryDim = inst_dims,
       values = dae_var_attr,
       comment = comment,
       varType = tp,
-      source = source)), _, vars)
+      source = source))
       equation
         commentStr = unparseCommentOptionNoAnnotationNoQuote(comment);
         (unit, displayUnit) = extractVarUnit(dae_var_attr);
@@ -7879,7 +7887,7 @@ algorithm
         isDiscrete = BackendVariable.isVarDiscrete(dlowVar);
         arrayCref = ComponentReference.getArrayCref(cr);
         aliasvar = getAliasVar(dlowVar, optAliasVars);
-        caus = getCausality(dlowVar, vars);
+        caus = getCausality(dlowVar, inGlobalVars);
         numArrayElement = List.map(inst_dims, ExpressionDump.dimensionIntString);
         // print("name: " + ComponentReference.printComponentRefStr(cr) + "indx: " + intString(indx) + "\n");
       then
@@ -7916,25 +7924,26 @@ end dlowvarToSimvar;
 
 protected function getCausality
   input BackendDAE.Var dlowVar;
-  input BackendDAE.Variables inVars;
+  input BackendDAE.Variables inGlobalVars;
   output SimCodeVar.Causality caus;
 algorithm
-  caus := matchcontinue (dlowVar, inVars)
+  caus := matchcontinue (dlowVar)
     local
       DAE.ComponentRef cr;
-      BackendDAE.Variables knvars;
-    case (BackendDAE.VAR(varName = cr, varDirection = DAE.OUTPUT()), _) then SimCodeVar.OUTPUT();
-    case (BackendDAE.VAR(varName = cr, varDirection = DAE.INPUT()), knvars)
-      equation
-        (_, _) = BackendVariable.getVar(cr, knvars);
-      then SimCodeVar.INPUT();
+    case (BackendDAE.VAR(varName=cr, varDirection=DAE.OUTPUT()))
+    then SimCodeVar.OUTPUT();
+
+    case (BackendDAE.VAR(varName=cr, varDirection=DAE.INPUT())) equation
+      (_, _) = BackendVariable.getVar(cr, inGlobalVars);
+    then SimCodeVar.INPUT();
+
     else SimCodeVar.INTERNAL();
   end matchcontinue;
 end getCausality;
 
 protected function traversingdlowvarToSimvarFold
   input BackendDAE.Var v;
-  input tuple<list<SimCodeVar.SimVar>, BackendDAE.Variables> inTpl;
+  input tuple<list<SimCodeVar.SimVar>, BackendDAE.Variables /*globalVars*/> inTpl;
   output tuple<list<SimCodeVar.SimVar>, BackendDAE.Variables> outTpl;
 algorithm
   (_, outTpl) := traversingdlowvarToSimvar(v, inTpl);
@@ -7942,7 +7951,7 @@ end traversingdlowvarToSimvarFold;
 
 protected function traversingdlowvarToSimvar
   input BackendDAE.Var inVar;
-  input tuple<list<SimCodeVar.SimVar>, BackendDAE.Variables> inTpl;
+  input tuple<list<SimCodeVar.SimVar>, BackendDAE.Variables /*globalVars*/> inTpl;
   output BackendDAE.Var outVar;
   output tuple<list<SimCodeVar.SimVar>, BackendDAE.Variables> outTpl;
 algorithm
@@ -7951,11 +7960,11 @@ algorithm
       BackendDAE.Var v;
       list<SimCodeVar.SimVar> sv_lst;
       SimCodeVar.SimVar sv;
-      BackendDAE.Variables vars;
-    case (v, (sv_lst, vars))
+      BackendDAE.Variables globalVars;
+    case (v, (sv_lst, globalVars))
       equation
-        sv = dlowvarToSimvar(v, NONE(), vars);
-      then (v, (sv::sv_lst, vars));
+        sv = dlowvarToSimvar(v, NONE(), globalVars);
+      then (v, (sv::sv_lst, globalVars));
     else (inVar,inTpl);
   end match;
 end traversingdlowvarToSimvar;


### PR DESCRIPTION
`knownVars` should only contain those variables, that are constant for the entire simulation.
The newly introduced `globalVars` can be used for variables that are somehow known but not constant for the entire simulation.