### PR TITLE
Move conditional component info to environment.

### DIFF
--- a/Compiler/FFrontEnd/FCore.mo
+++ b/Compiler/FFrontEnd/FCore.mo
@@ -293,6 +293,9 @@ and finally instantiated to produce the DAE. These three states are indicated by
                   between typed variables without DAE to know when to skip multiply declared dae elements"
   end VAR_DAE;
 
+  record VAR_DELETED "A conditional variable that was deleted."
+  end VAR_DELETED;
+
   record CLS_UNTYPED "just added to the env"
   end CLS_UNTYPED;
 
@@ -705,6 +708,18 @@ algorithm
     else true;
   end match;
 end isTyped;
+
+public function isDeletedComp
+  "Returns true if the status indicates a deleted conditional component,
+   otherwise false."
+  input Status status;
+  output Boolean isDeleted;
+algorithm
+  isDeleted := match status
+    case VAR_DELETED() then true;
+    else false;
+  end match;
+end isDeletedComp;
 
 public function getCachedInitialGraph "get the initial environment from the cache"
   input Cache cache;

--- a/Compiler/FrontEnd/Connect.mo
+++ b/Compiler/FrontEnd/Connect.mo
@@ -115,12 +115,6 @@ public uniontype SetTrieNode
       variable, if the leaf represents a stream variable.";
     Integer connectCount "How many times this connector has been connected.";
   end SET_TRIE_LEAF;
-
-  record SET_TRIE_DELETED
-    "Represents a connector which has been deleted, i.e. a conditional component
-     with condition = false."
-    String name;
-  end SET_TRIE_DELETED;
 end SetTrieNode;
 
 public type SetTrie = SetTrieNode "A trie, a.k.a. prefix tree, that maps crefs to sets.";

--- a/Compiler/FrontEnd/DAEUtil.mo
+++ b/Compiler/FrontEnd/DAEUtil.mo
@@ -6194,50 +6194,49 @@ end showCacheFuncs;
 
 public function setAttrVariability "
   Sets the variability attribute in an Attributes record."
-  input DAE.Attributes inAttr;
-  input SCode.Variability inVar;
-  output DAE.Attributes outAttr;
-protected
-  SCode.ConnectorType ct;
-  SCode.Parallelism prl;
-  Absyn.Direction dir;
-  Absyn.InnerOuter io;
-  SCode.Visibility vis;
+  input output DAE.Attributes attr;
+  input SCode.Variability var;
+  annotation(__OpenModelica_EarlyInline = true);
 algorithm
-  DAE.ATTR(ct, prl, _, dir, io, vis) := inAttr;
-  outAttr := DAE.ATTR(ct, prl, inVar, dir, io, vis);
+  attr.variability := var;
 end setAttrVariability;
 
 public function getAttrVariability "
   Get the variability attribute in an Attributes record."
-  input DAE.Attributes inAttr;
-  output SCode.Variability outVar;
-algorithm
-  DAE.ATTR(variability = outVar) := inAttr;
+  input DAE.Attributes attr;
+  output SCode.Variability var = attr.variability;
+  annotation(__OpenModelica_EarlyInline = true);
 end getAttrVariability;
 
 public function setAttrDirection
   "Sets the direction attribute in an Attributes record."
-  input DAE.Attributes inAttr;
-  input Absyn.Direction inDir;
-  output DAE.Attributes outAttr;
-protected
-  SCode.ConnectorType ct;
-  SCode.Parallelism prl;
-  SCode.Variability var;
-  Absyn.InnerOuter io;
-  SCode.Visibility vis;
+  input output DAE.Attributes attr;
+  input Absyn.Direction dir;
+  annotation(__OpenModelica_EarlyInline = true);
 algorithm
-  DAE.ATTR(ct, prl, var, _, io, vis) := inAttr;
-  outAttr := DAE.ATTR(ct, prl, var, inDir, io, vis);
+  attr.direction := dir;
 end setAttrDirection;
 
 public function getAttrDirection
-  input DAE.Attributes inAttr;
-  output Absyn.Direction outDir;
-algorithm
-  DAE.ATTR(direction = outDir) := inAttr;
+  input DAE.Attributes attr;
+  output Absyn.Direction dir = attr.direction;
+  annotation(__OpenModelica_EarlyInline = true);
 end getAttrDirection;
+
+public function setAttrInnerOuter
+  "Sets the innerOuter attribute in an Attributes record."
+  input output DAE.Attributes attr;
+  input Absyn.InnerOuter io;
+  annotation(__OpenModelica_EarlyInline = true);
+algorithm
+  attr.innerOuter := io;
+end setAttrInnerOuter;
+
+public function getAttrInnerOuter
+  input DAE.Attributes attr;
+  output Absyn.InnerOuter io = attr.innerOuter;
+  annotation(__OpenModelica_EarlyInline = true);
+end getAttrInnerOuter;
 
 public function translateSCodeAttrToDAEAttr
   input SCode.Attributes inAttributes;

--- a/Compiler/FrontEnd/SCode.mo
+++ b/Compiler/FrontEnd/SCode.mo
@@ -3790,17 +3790,10 @@ algorithm
 end prefixesInnerOuter;
 
 public function prefixesSetInnerOuter
-  input Prefixes inPrefixes;
-  input Absyn.InnerOuter inInnerOuter;
-  output Prefixes outPrefixes;
-protected
-  Visibility v;
-  Redeclare rd;
-  Final f;
-  Replaceable rp;
+  input output Prefixes prefixes;
+  input Absyn.InnerOuter innerOuter;
 algorithm
-  PREFIXES(v, rd, f, _, rp) := inPrefixes;
-  outPrefixes := PREFIXES(v, rd, f, inInnerOuter, rp);
+  prefixes.innerOuter := innerOuter;
 end prefixesSetInnerOuter;
 
 public function removeAttributeDimensions
@@ -3818,18 +3811,10 @@ algorithm
 end removeAttributeDimensions;
 
 public function setAttributesDirection
-  input Attributes inAttributes;
-  input Absyn.Direction inDirection;
-  output Attributes outAttributes;
-protected
-  Absyn.ArrayDim ad;
-  ConnectorType ct;
-  Parallelism p;
-  Variability v;
-  Absyn.IsField isf;
+  input output Attributes attributes;
+  input Absyn.Direction direction;
 algorithm
-  ATTR(ad, ct, p, v, _, isf) := inAttributes;
-  outAttributes := ATTR(ad, ct, p, v, inDirection, isf);
+  attributes.direction := direction;
 end setAttributesDirection;
 
 public function attrVariability
@@ -3842,6 +3827,13 @@ algorithm
     case  ATTR(variability = v) then v;
   end match;
 end attrVariability;
+
+public function setAttributesVariability
+  input output Attributes attributes;
+  input Variability variability;
+algorithm
+  attributes.variability := variability;
+end setAttributesVariability;
 
 public function isDerivedClassDef
   input ClassDef inClassDef;


### PR DESCRIPTION
- Move the information about deleted conditional components to
  FCore.Graph instead of Connect.Sets, to make it more efficient
  and simplify the connection handling.