### PR TITLE
Store less information in ElementSource

### DIFF
--- a/Compiler/FrontEnd/InstFunction.mo
+++ b/Compiler/FrontEnd/InstFunction.mo
@@ -123,7 +123,7 @@ algorithm
 
         // set the  of this element
        source = ElementSource.addElementSourcePartOfOpt(DAE.emptyElementSource, FGraph.getScopePath(env));
-       source = ElementSource.addCommentToSource(source, SOME(comment));
+       source = ElementSource.addCommentToSource(source, comment);
        source = ElementSource.addElementSourceFileInfo(source, info);
       then
         (cache,env,ih,DAE.DAE({DAE.EXTOBJECTCLASS(classNameFQ,source)}),ClassInf.EXTERNAL_OBJ(classNameFQ));

--- a/Compiler/FrontEnd/InstSection.mo
+++ b/Compiler/FrontEnd/InstSection.mo
@@ -353,7 +353,7 @@ algorithm
 
         // Set the source of this element.
         source := makeEqSource(info, inEnv, inPrefix, inFlattenOp);
-        source := ElementSource.addCommentToSource(source, SOME(comment));
+        source := ElementSource.addCommentToSource(source, comment);
 
         // Check that the lhs and rhs get along.
         outDae := instEqEquation(lhs_exp, lhs_prop, rhs_exp, rhs_prop, source, inInitial, inImpl);


### PR DESCRIPTION
Most of the information always stored in ElementSource is now only
stored if -d=infoXmlOperations is used.