### PR TITLE
Memory leak fixes for sparse solvers.

### DIFF
--- a/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.h
+++ b/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.h
@@ -58,6 +58,9 @@ typedef struct DATA_UMFPACK
 
   double* work;
 
+  int* Wi;
+  double* W;
+
   rtclock_t timeClock;             /* time clock */
   int numberSolving;
 


### PR DESCRIPTION
Fixes for memory leaks in the sparse linear solvers, both umfpack and klu. See ticket:3548.

In umfpack, from everything I've looked at it looks like you must free the Numeric object whenever the matrix changes, which for this application is at every linear solve. I've added this and also changed the solve to wsolve, which uses a workspace to save on some malloc/free calls.

The klu solver also leaked due to a similar issue. However, it has a refactor call that can reuse memory and is a lot faster than factor, but it uses the same pivoting as the previous factor call, which may be unstable as the matrix changes during the simulation. So, I added some logic to check that refactor does ok (via rgrowth) and if not then do a full factor. The questionable thing is what the rgrowth tolerance should be. The guidance from documentation is "If rgrowth is very small, an inaccurate factorization may have been performed." I did some testing and 1e-3 seems fine and probably safe, but it maybe could go lower. Alternatively, condest or rcond could be used.