### PR TITLE
Make error messages less verbose for performance

### DIFF
--- a/Compiler/FrontEnd/InstVar.mo
+++ b/Compiler/FrontEnd/InstVar.mo
@@ -571,8 +571,8 @@ protected
   DAE.ElementSource source;
 algorithm
   try
-    comp_name := Absyn.pathString(PrefixUtil.prefixPath(Absyn.IDENT(inName), inPrefix));
-    Error.updateCurrentComponent(comp_name, inInfo);
+    // comp_name := Absyn.pathString(PrefixUtil.prefixPath(Absyn.IDENT(inName), inPrefix));
+    Error.updateCurrentComponent(inName, inInfo);
 
     (outCache, dims, cls, type_mods) :=
       InstUtil.getUsertypeDimensions(inCache, inEnv, inIH, inPrefix, inClass, inInstDims, inImpl);


### PR DESCRIPTION
Do not create a prefixed path to string for every single variable that
is instantiated. Possibility: use a debugging flag to turn on more
diagnostics. This *should* be OK since we pass along SourceInfo to most
of the functions in the compiler, which is the main task of
Error.updateCurrentComponent. Also getting the full instance name
should be a minor detail.