### PR TITLE
Make error messages consume less memory

### DIFF
--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -3226,7 +3226,7 @@ algorithm
     (outCache, outEnv, outIH, outStore, DAE.DAE(outDae), outSets, outState, outVars, outGraph, outFieldDomOpt) :=
       instElement(outCache, outEnv, outIH, outStore, inMod, inPrefix, outState, elt, inInstDims,
         inImplicit, inCallingScope, outGraph, inSets);
-    Error.updateCurrentComponent("", Absyn.dummyInfo);
+    Error.updateCurrentComponent(Prefix.NOPRE(), "", Absyn.dummyInfo, PrefixUtil.identAndPrefixToPath);
     ErrorExt.delCheckpoint("instElement2");
   else // Instantiation failed, fail or skip the element depending on inStopOnError.
     if inStopOnError then

--- a/Compiler/FrontEnd/InstVar.mo
+++ b/Compiler/FrontEnd/InstVar.mo
@@ -571,8 +571,7 @@ protected
   DAE.ElementSource source;
 algorithm
   try
-    comp_name := Absyn.pathString(PrefixUtil.prefixPath(Absyn.IDENT(inName), inPrefix));
-    Error.updateCurrentComponent(comp_name, inInfo);
+    Error.updateCurrentComponent(inPrefix, inName, inInfo, PrefixUtil.identAndPrefixToPath);
 
     (outCache, dims, cls, type_mods) :=
       InstUtil.getUsertypeDimensions(inCache, inEnv, inIH, inPrefix, inClass, inInstDims, inImpl);
@@ -604,9 +603,9 @@ algorithm
     outCache := InstFunction.addRecordConstructorFunction(outCache, inEnv,
       Types.arrayElementType(outType), SCode.elementInfo(inClass));
 
-    Error.updateCurrentComponent("", Absyn.dummyInfo);
+    Error.updateCurrentComponent(Prefix.NOPRE(), "", Absyn.dummyInfo, PrefixUtil.identAndPrefixToPath);
   else
-    Error.updateCurrentComponent("", Absyn.dummyInfo);
+    Error.updateCurrentComponent(Prefix.NOPRE(), "", Absyn.dummyInfo, PrefixUtil.identAndPrefixToPath);
     fail();
   end try;
 end instVar_dispatch;

--- a/Compiler/FrontEnd/PrefixUtil.mo
+++ b/Compiler/FrontEnd/PrefixUtil.mo
@@ -307,6 +307,14 @@ algorithm
   end match;
 end prefixToPath;
 
+public function identAndPrefixToPath "Convert a Ident/Prefix to a String"
+  input String ident;
+  input Prefix.Prefix inPrefix;
+  output String str;
+algorithm
+  str := Absyn.pathString(PrefixUtil.prefixPath(Absyn.IDENT(ident),inPrefix));
+end identAndPrefixToPath;
+
 protected function componentPrefixToPath "Convert a Prefix to a Path"
   input Prefix.ComponentPrefix pre;
   output Absyn.Path path;

--- a/Compiler/Global/Global.mo
+++ b/Compiler/Global/Global.mo
@@ -58,6 +58,7 @@ constant Integer rewriteRulesIndex = 18;
 constant Integer stackoverFlowIndex = 19;
 constant Integer gcProfilingIndex = 20;
 constant Integer inlineHashTable = 21; // TODO: Should be a local root?
+constant Integer currentInstVar = 22;
 
 // indexes in System.tick
 // ----------------------
@@ -80,6 +81,7 @@ algorithm
   setGlobalRoot(rewriteRulesIndex,  NONE());
   setGlobalRoot(stackoverFlowIndex, NONE());
   setGlobalRoot(inlineHashTable, NONE());
+  setGlobalRoot(currentInstVar, NONE());
 end initialize;
 
 annotation(__OpenModelica_Interface="util");

--- a/Compiler/Util/ErrorExt.mo
+++ b/Compiler/Util/ErrorExt.mo
@@ -49,27 +49,6 @@ function registerModelicaFormatError
 </html>"),Library = "omcruntime");
 end registerModelicaFormatError;
 
-function updateCurrentComponent
-  input String str;
-  input Boolean writeable;
-  input String fileName;
-  input Integer rowstart;
-  input Integer rowend;
-  input Integer colstart;
-  input Integer colend;
-  external "C" ErrorImpl__updateCurrentComponent(OpenModelica.threadData(),str,writeable,fileName,rowstart,rowend,colstart,colend) annotation(Library = "omcruntime");
-end updateCurrentComponent;
-
-function addMessage
-  input Error.ErrorID id;
-  input Error.MessageType msg_type;
-  input Error.Severity msg_severity;
-  input String msg;
-  input list<String> msg_tokens;
-
-  external "C" Error_addMessage(OpenModelica.threadData(),id,msg_type,msg_severity,msg,msg_tokens) annotation(Library = "omcruntime");
-end addMessage;
-
 function addSourceMessage
   input Error.ErrorID id;
   input Error.MessageType msg_type;

--- a/Compiler/boot/tarball-include/OpenModelicaBootstrappingHeader.h
+++ b/Compiler/boot/tarball-include/OpenModelicaBootstrappingHeader.h
@@ -2,6 +2,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#define OPENMODELICA_BOOTSTRAPPING_STAGE_1
+
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef FMI_Info_INFO__desc_added
 #define FMI_Info_INFO__desc_added

--- a/Compiler/runtime/Error_omc.cpp
+++ b/Compiler/runtime/Error_omc.cpp
@@ -49,20 +49,6 @@ void Error_registerModelicaFormatError()
   OpenModelica_ModelicaVFormatError = OpenModelica_ErrorModule_ModelicaVFormatError;
 }
 
-void Error_addMessage(threadData_t *threadData,int errorID, void *msg_type, void *severity, const char* message, modelica_metatype tokenlst)
-{
-  ErrorMessage::TokenList tokens;
-  while (MMC_GETHDR(tokenlst) != MMC_NILHDR) {
-    const char* token = MMC_STRINGDATA(MMC_CAR(tokenlst));
-    tokens.push_back(string(token));
-    tokenlst=MMC_CDR(tokenlst);
-  }
-  add_message(threadData,errorID,
-              (ErrorType) (MMC_HDRCTOR(MMC_GETHDR(msg_type))-Error__SYNTAX_3dBOX0),
-              (ErrorLevel) (MMC_HDRCTOR(MMC_GETHDR(severity))-Error__INTERNAL_3dBOX0),
-              message,tokens);
-}
-
 extern void* Error_getMessages(threadData_t *threadData)
 {
   return listReverse(ErrorImpl__getMessages(threadData));
@@ -79,6 +65,22 @@ extern const char* Error_printMessagesStr(threadData_t *threadData,int warningsA
   std::string res = ErrorImpl__printMessagesStr(threadData,warningsAsErrors);
   return omc_alloc_interface.malloc_strdup(res.c_str());
 }
+
+#if defined(OPENMODELICA_BOOTSTRAPPING_STAGE_1)
+extern void Error_addMessage(threadData_t *threadData,int errorID, void *msg_type, void *severity, const char* message, modelica_metatype tokenlst)
+{
+  ErrorMessage::TokenList tokens;
+  while (MMC_GETHDR(tokenlst) != MMC_NILHDR) {
+    const char* token = MMC_STRINGDATA(MMC_CAR(tokenlst));
+    tokens.push_back(string(token));
+    tokenlst=MMC_CDR(tokenlst);
+  }
+  add_source_message(threadData,errorID,
+              (ErrorType) (MMC_HDRCTOR(MMC_GETHDR(msg_type))-Error__SYNTAX_3dBOX0),
+              (ErrorLevel) (MMC_HDRCTOR(MMC_GETHDR(severity))-Error__INTERNAL_3dBOX0),
+              message,tokens,0,0,0,0,0,"");
+}
+#endif
 
 extern void Error_addSourceMessage(threadData_t *threadData,int _id, void *msg_type, void *severity, int _sline, int _scol, int _eline, int _ecol, int _read_only, const char* _filename, const char* _msg, void* tokenlst)
 {

--- a/SimulationRuntime/fmi/export/buildproject/configure.ac
+++ b/SimulationRuntime/fmi/export/buildproject/configure.ac
@@ -30,7 +30,7 @@ AC_MSG_CHECKING([for cross-compilation flags])
 if test "$host_short" = "$build_short"; then
   # Not cross-compiling or found a good tool; don't need special flags
   AC_MSG_RESULT([not cross-compiling])
-elif echo "$CC" | grep -q "$host_short" || echo "$CC" | grep -q "$host"; then
+elif echo "$CC" | grep -q "$host_short" || echo "$CC" | grep -q "$host" || echo "$CC" | grep -q "$host_cpu"; then
   AC_MSG_RESULT([not needed; $CC contains the prefix])
 elif test "$host_os" = "$build_os" && test "$host_short" = "x86_64"; then
   CFLAGS_BEFORE="$CFLAGS"


### PR DESCRIPTION
This implements ticket:3824 by making updateCurrentComponent store the
Prefix instead of always making a String out of it. This should result
in a big performance gain without changing the behaviour of OMC.