### PR TITLE
Improve instantiation caching.

### DIFF
--- a/Compiler/FrontEnd/PrefixUtil.mo
+++ b/Compiler/FrontEnd/PrefixUtil.mo
@@ -1291,6 +1291,16 @@ algorithm
   end matchcontinue;
 end prefixDimensions;
 
+public function isPrefix
+  input Prefix.Prefix prefix;
+  output Boolean isPrefix;
+algorithm
+  isPrefix := match prefix
+    case Prefix.PREFIX() then true;
+    else false;
+  end match;
+end isPrefix;
+
 public function isNoPrefix
   input Prefix.Prefix inPrefix;
   output Boolean outIsEmpty;


### PR DESCRIPTION
- Only call Inst.generateCachePath once in instClassIn2 and
  partialInstClassIn, instead of twice for each class not found
  in the cache.
- Don't store unused things in the cache.
- Some code clean up.