### PR TITLE
Flag to deactivate tearing for certain components

### DIFF
--- a/Compiler/BackEnd/Tearing.mo
+++ b/Compiler/BackEnd/Tearing.mo
@@ -106,7 +106,6 @@ algorithm
 
     // get method function and traverse systems
     case(_) equation
-
       methodString = Config.getTearingMethod();
       BackendDAE.SHARED(backendDAEType=DAEtype) = inDAE.shared;
       false = stringEqual(methodString, "shuffleTearing") and stringEq("simulation",BackendDump.printBackendDAEType2String(DAEtype));
@@ -269,7 +268,14 @@ algorithm
       equality(jacType = BackendDAE.JAC_LINEAR());
       maxSize = Flags.getConfigInt(Flags.MAX_SIZE_LINEAR_TEARING);
       if intGt(listLength(vindx),maxSize) then
-        Error.addMessage(Error.MAX_TEARING_SIZE, {intString(listLength(vindx)),"linear",intString(maxSize)});
+        Error.addMessage(Error.MAX_TEARING_SIZE, {intString(strongComponentIndexOut), intString(listLength(vindx)),"linear",intString(maxSize)});
+        fail();
+      end if;
+      if listMember(strongComponentIndexOut,Flags.getConfigIntList(Flags.NO_TEARING_FOR_COMPONENT)) then
+        if Flags.isSet(Flags.TEARING_DUMP) or Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
+          print("\nTearing deactivated by user.\n");
+        end if;
+        Error.addMessage(Error.NO_TEARING_FOR_COMPONENT, {intString(strongComponentIndexOut)});
         fail();
       end if;
       if Flags.isSet(Flags.TEARING_DUMP) or Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
@@ -293,7 +299,14 @@ algorithm
       failure(equality(jacType = BackendDAE.JAC_LINEAR()));
       maxSize = Flags.getConfigInt(Flags.MAX_SIZE_NONLINEAR_TEARING);
       if intGt(listLength(vindx),maxSize) then
-        Error.addMessage(Error.MAX_TEARING_SIZE, {intString(listLength(vindx)),"nonlinear",intString(maxSize)});
+        Error.addMessage(Error.MAX_TEARING_SIZE, {intString(strongComponentIndexOut), intString(listLength(vindx)),"nonlinear",intString(maxSize)});
+        fail();
+      end if;
+      if listMember(strongComponentIndexOut,Flags.getConfigIntList(Flags.NO_TEARING_FOR_COMPONENT)) then
+        if Flags.isSet(Flags.TEARING_DUMP) or Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
+          print("\nTearing deactivated by user.\n");
+        end if;
+        Error.addMessage(Error.NO_TEARING_FOR_COMPONENT, {intString(strongComponentIndexOut)});
         fail();
       end if;
       if Flags.isSet(Flags.TEARING_DUMP) or Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
@@ -4429,26 +4442,6 @@ algorithm
     print("order: " + stringDelimitList(List.map(order,intString),",") + "\n\n");
   end for;
 end dumpMatchingList;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 annotation(__OpenModelica_Interface="backend");
 end Tearing;

--- a/Compiler/Global/Global.mo
+++ b/Compiler/Global/Global.mo
@@ -72,6 +72,8 @@ constant Integer backendDAE_jacobianSeq = 21;
 constant Integer fgraph_nextId = 22;
 // csevar name
 constant Integer backendDAE_cseIndex = 23;
+// strong component index
+constant Integer strongComponent_index = 24;
 
 // ----------------------
 

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -837,7 +837,9 @@ public constant Message EXEC_STAT = MESSAGE(572, TRANSLATION(), NOTIFICATION(),
 public constant Message EXEC_STAT_GC = MESSAGE(573, TRANSLATION(), NOTIFICATION(),
   Util.gettext("Performance of %s: time %s/%s, GC stats:%s"));
 public constant Message MAX_TEARING_SIZE = MESSAGE(574, SYMBOLIC(), NOTIFICATION(),
-  Util.gettext("Tearing is skipped because system size of %s exceeds maximum system size for tearing of %s systems (%s)\nTo adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>\n"));
+  Util.gettext("Tearing is skipped for strong component %s because system size of %s exceeds maximum system size for tearing of %s systems (%s).\nTo adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.\n"));
+public constant Message NO_TEARING_FOR_COMPONENT = MESSAGE(575, SYMBOLIC(), NOTIFICATION(),
+  Util.gettext("Tearing is skipped for strong component %s because of activated compiler flag 'noTearingForComponent=%1'.\n"));
 
 public constant Message MATCH_SHADOWING = MESSAGE(5001, TRANSLATION(), ERROR(),
   Util.gettext("Local variable '%s' shadows another variable."));


### PR DESCRIPTION
this is related to [ticket:3830](https://trac.openmodelica.org/OpenModelica/ticket/3830)
Usage: '--noTearingForComponent=<value>', where values is list<Integer>