### PR TITLE
Use a new key for InstCache

### DIFF
--- a/Compiler/FFrontEnd/FNode.mo
+++ b/Compiler/FFrontEnd/FNode.mo
@@ -2008,5 +2008,21 @@ algorithm
   outName := extendsPrefix + Absyn.pathString(inPath);
 end mkExtendsName;
 
+public function scopeHashWork
+  input Scope scope;
+  input output Integer hash;
+algorithm
+  for r in scope loop
+    hash := 31*hash + stringHashDjb2(FNode.refName(r));
+  end for;
+end scopeHashWork;
+
+public function scopePathEq
+  input Scope scope1,scope2;
+  output Boolean eq;
+algorithm
+  eq := min(FNode.refName(r1)==FNode.refName(r2) threaded for r1 in scope1, r2 in scope2);
+end scopePathEq;
+
 annotation(__OpenModelica_Interface="frontend");
 end FNode;

--- a/Compiler/FrontEnd/PrefixUtil.mo
+++ b/Compiler/FrontEnd/PrefixUtil.mo
@@ -315,7 +315,7 @@ algorithm
   str := Absyn.pathString(PrefixUtil.prefixPath(Absyn.IDENT(ident),inPrefix));
 end identAndPrefixToPath;
 
-protected function componentPrefixToPath "Convert a Prefix to a Path"
+public function componentPrefixToPath "Convert a Prefix to a Path"
   input Prefix.ComponentPrefix pre;
   output Absyn.Path path;
 algorithm
@@ -1376,6 +1376,38 @@ algorithm
     else Absyn.dummyInfo;
   end match;
 end getPrefixInfo;
+
+public function prefixHashWork
+  input Prefix.ComponentPrefix inPrefix;
+  input output Integer hash;
+algorithm
+  hash := match inPrefix
+    case Prefix.PRE() then prefixHashWork(inPrefix.next, 31*hash + stringHashDjb2(inPrefix.prefix));
+    else hash;
+  end match;
+end prefixHashWork;
+
+public function componentPrefixPathEqual
+  input Prefix.ComponentPrefix pre1,pre2;
+  output Boolean eq;
+algorithm
+  eq := match (pre1,pre2)
+    case (Prefix.PRE(),Prefix.PRE())
+      then if pre1.prefix==pre2.prefix then componentPrefixPathEqual(pre1.next, pre2.next) else false;
+    case (Prefix.NOCOMPPRE(),Prefix.NOCOMPPRE()) then true;
+    else false;
+  end match;
+end componentPrefixPathEqual;
+
+public function componentPrefix
+  input Prefix.Prefix inPrefix;
+  output Prefix.ComponentPrefix outPrefix;
+algorithm
+  outPrefix := match inPrefix
+    case Prefix.PREFIX() then inPrefix.compPre;
+    else Prefix.NOCOMPPRE();
+  end match;
+end componentPrefix;
 
 annotation(__OpenModelica_Interface="frontend");
 end PrefixUtil;

--- a/Compiler/FrontEnd/SCode.mo
+++ b/Compiler/FrontEnd/SCode.mo
@@ -1205,6 +1205,7 @@ algorithm
     // BTH
     case (R_PREDEFINED_CLOCK(),R_PREDEFINED_CLOCK()) then true;
     case (R_PREDEFINED_ENUMERATION(),R_PREDEFINED_ENUMERATION()) then true;
+    case (R_UNIONTYPE(),R_UNIONTYPE()) then min(t1==t2 threaded for t1 in restr1.typeVars, t2 in restr2.typeVars);
     else false;
    end match;
 end restrictionEqual;


### PR DESCRIPTION
The new key for InstCache is a tuple of the parts that previously
created an Absyn.Path by converting the individual elements to
strings or paths. Now, we hash each tuple element individually.