### PR TITLE
Fix name of OPC UA aliases

### DIFF
--- a/SimulationRuntime/opc/ua/omc_opc_ua.c
+++ b/SimulationRuntime/opc/ua/omc_opc_ua.c
@@ -381,6 +381,11 @@ static inline omc_opc_ua_state* addAliasVars(omc_opc_ua_state *state, var_kind_t
     int inputIndex;
     int isState = 0;
 
+    if (aliases[i].aliasType != 0) {
+      /* We only alias non-parameter/time variables in OPC */
+      continue;
+    }
+
     switch (varKind) {
     case VARKIND_REAL:
     {
@@ -390,8 +395,8 @@ static inline omc_opc_ua_state* addAliasVars(omc_opc_ua_state *state, var_kind_t
         continue; /* Because we did not add discrete reals, etc. yet */
       }
       inputIndex = realVarsData[index].info.inputIndex;
-      nameStr = (char*) realVarsData[index].info.name;
-      commentStr = (char*) realVarsData[index].info.comment;
+      nameStr = (char*) aliases[i].info.name;
+      commentStr = (char*) aliases[i].info.comment;
       isState = i < modelData->nStates;
       dataSource = (UA_DataSource) {.handle = state, .read = readReal, .write = inputIndex >= 0 || isState ? writeReal : NULL};
       break;


### PR DESCRIPTION
Previously, we put the name of the actual variable instead of the alias.
Also, we added aliases for parameters even though parameters are not
added in the OPC UA interface.