### PR TITLE
Fix for ticket:3842.

### DIFF
--- a/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -1361,7 +1361,7 @@ algorithm
             true = arrayLength(marr) > 1;
             simplifySymmetric(marr, arrayLength(marr)-1, arrayLength(marr));
             mexpl = List.map(arrayList(marr), arrayList);
-            tp1 = Types.unliftArray(tp);
+            tp1 = Expression.unliftArray(tp);
             es = List.map2(mexpl, Expression.makeArray, tp1, not Types.isArray(tp1));
             e = Expression.makeArray(es, tp, false);
           then e;


### PR DESCRIPTION
- Use Expression.unliftArray instead of Types.unliftArray when
  simplifying symmetric.