### PR TITLE
Avoid buffers when generating constant literals

### DIFF
--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -5077,18 +5077,15 @@ end equationIfEquationAssign;
   "Generates the content of the C file for literals in the simulation case.
   used in Compiler/Template/CodegenFMU.tpl"
 ::=
-  let &preLit = buffer ""
-  let res = literals |> literal hasindex i0 fromindex 0 =>
-    (if typeinfo() then '/* <%Util.escapeModelicaStringToCString(printExpStr(literal))%> */<%\n%>') +
-    literalExpConst(literal,i0, &preLit)
-    ; separator="\n";empty
   <<
   #ifdef __cplusplus
   extern "C" {
   #endif
 
-  <%preLit%>
-  <%res%>
+  <%literals |> literal hasindex i0 fromindex 0 =>
+    (if typeinfo() then '/* <%Util.escapeModelicaStringToCString(printExpStr(literal))%> */<%\n%>') +
+    literalExpConst(literal,i0)
+    ; separator="\n"; empty %>
 
   #ifdef __cplusplus
   }


### PR DESCRIPTION
This is used to test future enhancements in ticket:3356. One of the
limitations for writing directly to files is that no temporary buffers
or texts are created.