### PR TITLE
Support for writing Susan text directly to file

### DIFF
--- a/Compiler/Template/CodegenFMU.tpl
+++ b/Compiler/Template/CodegenFMU.tpl
@@ -63,11 +63,10 @@ match simCode
 case sc as SIMCODE(modelInfo=modelInfo as MODELINFO(__)) then
   let guid = getUUIDStr()
   let target  = simulationCodeTarget()
-  let &dummy = buffer ""
   let fileNamePrefixTmpDir = '<%fileNamePrefix%>.fmutmp/sources/<%fileNamePrefix%>'
   let()= textFile(simulationLiteralsFile(fileNamePrefix, literals), '<%fileNamePrefixTmpDir%>_literals.h')
   let()= textFile(simulationFunctionsHeaderFile(fileNamePrefix, modelInfo.functions, recordDecls), '<%fileNamePrefixTmpDir%>_functions.h')
-  let()= textFile(simulationFunctionsFile(fileNamePrefix, modelInfo.functions, dummy), '<%fileNamePrefixTmpDir%>_functions.c')
+  let()= textFile(simulationFunctionsFile(fileNamePrefix, modelInfo.functions), '<%fileNamePrefixTmpDir%>_functions.c')
   let()= textFile(externalFunctionIncludes(sc.externalFunctionIncludes), '<%fileNamePrefixTmpDir%>_includes.h')
   let()= textFile(recordsFile(fileNamePrefix, recordDecls), '<%fileNamePrefixTmpDir%>_records.c')
   let()= textFile(simulationHeaderFile(simCode), '<%fileNamePrefixTmpDir%>_model.h')

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -1265,6 +1265,17 @@ end System;
 
 
 package Tpl
+  function redirectToFile
+    input Text inText;
+    input String inFileName;
+    output Text outText;
+  end redirectToFile;
+
+  function closeFile
+    input Text inText;
+    output Text outText;
+  end closeFile;
+
   function textFile
     input Text inText;
     input String inFileName;

--- a/Compiler/Template/Tpl.mo
+++ b/Compiler/Template/Tpl.mo
@@ -12,9 +12,11 @@ protected import Config;
 protected import ClockIndexes;
 protected import Debug;
 protected import Error;
+protected import File;
 protected import Flags;
 protected import List;
 protected import Print;
+protected import StringUtil;
 protected import System;
 
 // indentation will be implemented through spaces
@@ -28,9 +30,26 @@ uniontype Text
     Tokens tokens; //reversed list of tokens
     list<tuple<Tokens,BlockType>> blocksStack;
   end MEM_TEXT;
+  record FILE_TEXT
+    Option<Integer> opaqueFile;
+    array<Integer> nchars, aind;
+    array<Boolean> isstart;
+    array<list<BlockTypeFileText>> blocksStack;
+  end FILE_TEXT;
 end Text;
 
 public constant Text emptyTxt = MEM_TEXT({}, {});
+
+public
+uniontype BlockTypeFileText
+  record BT_FILE_TEXT
+    BlockType bt "The block type";
+    Integer nchars, aind;
+    Boolean isstart;
+    array<Integer> tell "Usage depends on bt; stores the last file position to know if it is empty or not.";
+    array<Option<StringToken>> septok;
+  end BT_FILE_TEXT;
+end BlockTypeFileText;
 
 public
 uniontype StringToken
@@ -78,7 +97,7 @@ uniontype BlockType
   record BT_ITER "Iteration items block, every token in the block is an item.
                 index0 is the active index during the build phase, then it is the last one + 1."
     IterOptions options;
-    Integer index0;
+    array<Integer> index0;
   end BT_ITER;
 end BlockType;
 
@@ -116,6 +135,7 @@ algorithm
       list<tuple<Tokens,BlockType>> blstack;
       String str;
       Text txt;
+      Integer nchars;
 
     //empty string means nothing
     //to ensure invariant being able to check emptiness only through the tokens (list) emtiness
@@ -131,6 +151,12 @@ algorithm
         -1 = System.stringFind(str, "\n");
       then
         MEM_TEXT(ST_STRING(str) :: toks, blstack);
+
+    case (FILE_TEXT(), str)
+      equation
+        -1 = System.stringFind(str, "\n");
+        stringFile(inText, str, line=false);
+      then inText;
 
     // a new-line is inside
     else
@@ -169,6 +195,11 @@ algorithm
       then
         MEM_TEXT(tok :: toks, blstack);
 
+    case (FILE_TEXT(), tok)
+      algorithm
+        tokFileText(inText, tok);
+      then inText;
+
   end matchcontinue;
 end writeTok;
 
@@ -200,6 +231,17 @@ algorithm
       then
         MEM_TEXT(ST_BLOCK(txttoks, BT_TEXT()) :: toks, blstack);
 
+    case (FILE_TEXT(),
+          MEM_TEXT(
+            tokens = txttoks,
+            blocksStack = {}
+            ))
+      algorithm
+        for tok in listReverse(txttoks) loop
+          writeTok(inText, tok);
+        end for;
+      then inText;
+
     //should not ever happen
     //- when compilation is correct, this is impossible (only completed texts can be accessible to write out)
     else
@@ -210,7 +252,7 @@ algorithm
   end matchcontinue;
 end writeText;
 
-public function writeChars
+protected function writeChars
   input Text inText;
   input list<String> inChars;
 
@@ -253,7 +295,7 @@ algorithm
 end writeChars;
 
 
-public function writeLineOrStr
+protected function writeLineOrStr
   input Text inText;
   input String inStr;
   input Boolean inIsLine;
@@ -287,11 +329,17 @@ algorithm
             ), str, true)
       then
         MEM_TEXT(ST_LINE(str) :: toks, blstack);
+
+    case (FILE_TEXT(), str, _)
+      algorithm
+        stringFile(inText, str, line=inIsLine);
+      then inText;
+
   end match;
 end writeLineOrStr;
 
 
-public function takeLineOrString
+protected function takeLineOrString
   input list<String> inChars;
 
   output list<String> outTillNewLineChars;
@@ -339,21 +387,23 @@ algorithm
       then
         txt;
 
-    //at start of line - nothing
-    case (txt as MEM_TEXT(
-                   tokens = (tok :: _) ))
-      equation
-        isAtStartOfLine(tok);
-      then
-        txt;
+    case (txt as MEM_TEXT(tokens = toks))
+      algorithm
+        //at start of line - nothing
+        if not isAtStartOfLine(txt) then
+          //otherwise put normal new-line
+          txt.tokens := ST_NEW_LINE() :: toks;
+        end if;
+      then txt;
 
-    //otherwise put normal new-line
-    case (MEM_TEXT(
-            tokens = toks,
-            blocksStack = blstack))
-      then
-        MEM_TEXT(ST_NEW_LINE() :: toks, blstack);
-
+    case FILE_TEXT()
+      algorithm
+        //at start of line - nothing
+        if not isAtStartOfLine(inText) then
+          //otherwise put normal new-line
+          newlineFile(inText);
+        end if;
+      then inText;
 
     //should not ever happen
     else
@@ -365,47 +415,54 @@ algorithm
   end matchcontinue;
 end softNewLine;
 
-
-public function isAtStartOfLine
-  input StringToken inTok;
+protected function isAtStartOfLine
+  input Text text;
+  output Boolean b;
 algorithm
-  _ := match (inTok)
+  b := match text
+    local
+      StringToken tok;
+
+    case MEM_TEXT(tokens=tok::_)
+      then isAtStartOfLineTok(tok);
+
+    case FILE_TEXT()
+      then arrayGet(text.isstart,1);
+
+  end match;
+end isAtStartOfLine;
+
+protected function isAtStartOfLineTok
+  input StringToken inTok;
+  output Boolean b;
+algorithm
+  b := match (inTok)
     local
       StringToken tok;
 
     //a new-line at the end
     case ( ST_NEW_LINE() )
-      then
-        ();
+      then true;
 
     //a new-line at the end
     case ( ST_LINE() )
-      then
-        ();
+      then true;
 
     //a new-line at the end
     case ( ST_STRING_LIST(lastHasNewLine = true) )
-      then
-        ();
+      then true;
 
     //recursively in the last block
     case ( ST_BLOCK(
              tokens = (tok :: _) ))
-      equation
-        isAtStartOfLine(tok);
-      then
-        ();
+      then isAtStartOfLineTok(tok);
 
-    //this should not ever happen - tokens should have at least one element, ... but for sure and completness
-    case ( ST_BLOCK(
-             tokens = {} ))
-      then
-        ();
 
   // otherwise fail - not at the start
+    else false;
 
   end match;
-end isAtStartOfLine;
+end isAtStartOfLineTok;
 
 
 public function newLine
@@ -419,35 +476,70 @@ algorithm
 
     case (MEM_TEXT(tokens = toks,blocksStack = blstack))
       then MEM_TEXT(ST_NEW_LINE() :: toks, blstack);
+
+    case FILE_TEXT()
+      algorithm
+        newlineFile(inText);
+      then inText;
   end match;
 end newLine;
 
 
 public function pushBlock
-  input Text inText;
+  input output Text txt;
   input BlockType inBlockType;
-
-  output Text outText;
 algorithm
-  outText := match (inText, inBlockType)
+  txt := match txt
     local
       Tokens toks;
       list<tuple<Tokens,BlockType>> blstack;
       BlockType blType;
+      Integer nchars, aind, w;
+      Boolean isstart;
 
-    case (MEM_TEXT(
+    case MEM_TEXT(
             tokens = toks,
             blocksStack = blstack
-            ), blType)
+            )
       then
         MEM_TEXT(
           {},
-          (toks, blType) :: blstack
+          (toks, inBlockType) :: blstack
         );
 
+    case FILE_TEXT()
+      algorithm
+        nchars := arrayGet(txt.nchars,1);
+        aind := arrayGet(txt.aind,1);
+        isstart := arrayGet(txt.isstart,1);
+        arrayUpdate(txt.blocksStack, 1, BT_FILE_TEXT(inBlockType, nchars, aind, isstart, arrayCreate(1, textFileTell(txt)), arrayCreate(1, NONE()))::arrayGet(txt.blocksStack, 1));
+        _ := match inBlockType
+          case BT_INDENT(width = w)
+          algorithm
+            arrayUpdate(txt.nchars, 1, nchars+w);
+            arrayUpdate(txt.aind, 1, aind+w);
+          then ();
+          case BT_ABS_INDENT(width = w)
+          algorithm
+            if isstart then
+              arrayUpdate(txt.nchars, 1, 0);
+            end if;
+            arrayUpdate(txt.aind, 1, w);
+          then ();
+          case BT_REL_INDENT(offset = w)
+          algorithm
+            arrayUpdate(txt.aind, 1, aind + w);
+          then ();
+          case BT_ANCHOR(offset = w)
+          algorithm
+            arrayUpdate(txt.aind, 1, nchars + w);
+          then ();
+          else ();
+        end match;
+      then txt;
 
     //should not ever happen
-    case (_, _)
+    else
       equation
         true = Flags.isSet(Flags.FAILTRACE); Debug.trace("-!!!Tpl.pushBlock failed \n");
       then
@@ -458,16 +550,18 @@ end pushBlock;
 
 
 public function popBlock
-  input Text inText;
-  output Text outText;
+  input output Text txt;
 algorithm
-  outText := match (inText)
+  txt := match txt
     local
       Tokens toks, stacktoks;
       list<tuple<Tokens,BlockType>> blstack;
       BlockType blType;
+      list<BlockTypeFileText> rest;
+      BlockTypeFileText blk;
+      Boolean oldisstart;
 
-    //when nothig was put, just pop tokens from the stack and no block output
+    //when nothing was put, just pop tokens from the stack and no block output
     case (MEM_TEXT(
             tokens = {},
             blocksStack = ( (stacktoks,_) :: blstack )
@@ -484,6 +578,48 @@ algorithm
           ST_BLOCK(toks, blType) :: stacktoks,
           blstack);
 
+    case FILE_TEXT()
+      algorithm
+        blk::rest := arrayGet(txt.blocksStack, 1);
+        arrayUpdate(txt.blocksStack, 1, rest);
+        _ := match blk.bt
+          case BT_INDENT()
+            algorithm
+              if arrayGet(txt.isstart,1) then
+                arrayUpdate(txt.nchars, 1, blk.nchars);
+              end if;
+              arrayUpdate(txt.aind, 1, blk.aind);
+            then ();
+          case _ guard match blk.bt
+            // All these have the same cases
+            case BT_ABS_INDENT() then true;
+            case BT_REL_INDENT() then true;
+            case BT_ANCHOR() then true;
+            end match
+            algorithm
+              oldisstart := arrayGet(txt.isstart,1);
+              if oldisstart then
+                if textFileTell(txt)==arrayGet(blk.tell,1) then
+                  // No update, restore nchars
+                  arrayUpdate(txt.nchars, 1, blk.nchars);
+                else
+                  // Update; restore depends on if we are at start of line
+                  if arrayGet(txt.isstart,1) then
+                    arrayUpdate(txt.nchars, 1, blk.aind);
+                  end if;
+                end if;
+              else
+                // Was not at start of line before
+                if arrayGet(txt.isstart,1) then
+                  arrayUpdate(txt.nchars, 1, blk.aind);
+                end if;
+              end if;
+              arrayUpdate(txt.aind, 1, blk.aind);
+            then ();
+          else ();
+        end match;
+      then txt;
+
     //should not ever happen
     //- when compilation is correct, this is impossible (pushs and pops should be balanced)
     case (_)
@@ -496,12 +632,10 @@ end popBlock;
 
 
 public function pushIter
-  input Text inText;
+  input output Text txt;
   input IterOptions inIterOptions;
-
-  output Text outText;
 algorithm
-  outText := match (inText, inIterOptions)
+  txt := match (txt, inIterOptions)
     local
       Tokens toks;
       list<tuple<Tokens,BlockType>> blstack;
@@ -517,7 +651,21 @@ algorithm
       then //let the existing tokens on stack in the text block and start iterating
         MEM_TEXT(
           {},
-          ({}, BT_ITER(iopts, i0)) :: (toks, BT_TEXT()) :: blstack);
+          ({}, BT_ITER(iopts, arrayCreate(1,i0))) :: (toks, BT_TEXT()) :: blstack);
+
+    case (FILE_TEXT(),
+          iopts as ITER_OPTIONS(
+            startIndex0 = i0))
+      algorithm
+        _ := match iopts
+          case ITER_OPTIONS(alignNum=0, wrapWidth=0) then ();
+          else
+            algorithm
+              Error.addInternalError("Tpl.mo FILE_TEXT does not support aligning or wrapping elements", sourceInfo());
+            then fail();
+        end match;
+        pushBlock(txt, BT_ITER(inIterOptions, arrayCreate(1,i0)));
+      then txt;
 
     //should not ever happen
     case (_ , _)
@@ -530,10 +678,9 @@ end pushIter;
 
 
 public function popIter
-  input Text inText;
-  output Text outText;
+  input output Text txt;
 algorithm
-  outText := match (inText)
+  txt := match txt
     local
       Tokens  stacktoks, itertoks;
       list<tuple<Tokens,BlockType>> blstack;
@@ -556,6 +703,11 @@ algorithm
             ST_BLOCK(itertoks, blType) :: stacktoks,
             blstack);
 
+    case FILE_TEXT()
+      algorithm
+        arrayUpdate(txt.blocksStack, 1, listRest(arrayGet(txt.blocksStack, 1)));
+      then txt;
+
     //should not ever happen
     //- when compilation is correct, this is impossible (pushs and pops should be balanced)
     case (_)
@@ -568,17 +720,20 @@ end popIter;
 
 
 public function nextIter
-  input Text inText;
-  output Text outText;
+  input output Text txt;
 algorithm
-  outText := matchcontinue (inText)
+  txt := match txt
     local
       Tokens toks, itertoks;
       StringToken tok, emptok;
       list<tuple<Tokens,BlockType>> blstack;
       IterOptions iopts;
-      Integer i0;
-      Text txt;
+      array<Integer> i0, tell;
+      BlockType bt;
+      Integer tellpos, curIndex;
+      Text txt2;
+      Boolean haveToken;
+      array<Option<StringToken>> septok;
 
     //empty iteration segment and 'empty' option is NONE(), so do nothing
     case (txt as MEM_TEXT(
@@ -591,58 +746,89 @@ algorithm
     //empty iteration segment, but 'empty' option is specified, so put the value
     case (MEM_TEXT(
             tokens = {},
-            blocksStack = (itertoks, BT_ITER(
+            blocksStack = (itertoks, bt as BT_ITER(
                                        options = iopts as ITER_OPTIONS(
                                                             empty = SOME(emptok)),
                                        index0 = i0)) :: blstack
             ))
       equation
-        i0 = i0 + 1;
+        arrayUpdate(i0, 1, arrayGet(i0,1) + 1);
       then
         MEM_TEXT(
           {},
-          (emptok :: itertoks, BT_ITER(iopts, i0)) :: blstack
+          (emptok :: itertoks, bt) :: blstack
         );
 
 
     //one token, put it as it is
     case (MEM_TEXT(
             tokens = {tok},
-            blocksStack = (itertoks, BT_ITER(
-                                        options = iopts,
-                                        index0 = i0)) :: blstack
+            blocksStack = (itertoks, bt as BT_ITER(index0 = i0)) :: blstack
             ))
       equation
-        i0 = i0 + 1;
+        arrayUpdate(i0, 1, arrayGet(i0,1) + 1);
       then
         MEM_TEXT(
           {},
-          (tok :: itertoks, BT_ITER(iopts, i0)) :: blstack
+          (tok :: itertoks, bt) :: blstack
         );
 
     //more tokens, put them as a text block
     case (MEM_TEXT(
             tokens = toks /* as (_::_) */,
-            blocksStack = (itertoks, BT_ITER(
-                                        options = iopts,
-                                        index0 = i0)) :: blstack
+            blocksStack = (itertoks, bt as BT_ITER(index0 = i0)) :: blstack
             ))
       equation
-        i0 = i0 + 1;
+        arrayUpdate(i0, 1, arrayGet(i0,1) + 1);
       then
         MEM_TEXT(
           {},
-          (ST_BLOCK(toks,BT_TEXT()) :: itertoks, BT_ITER(iopts, i0)) :: blstack
+          (ST_BLOCK(toks,BT_TEXT()) :: itertoks, bt) :: blstack
         );
 
+    case FILE_TEXT()
+      algorithm
+        _ := match listGet(arrayGet(txt.blocksStack,1),1)
+        case BT_FILE_TEXT(bt=BT_ITER(options = iopts, index0=i0), tell=tell, septok=septok)
+        algorithm
+          // Either the iterator always increments, or the file position changed
+          tellpos := textFileTell(txt);
+          if arrayGet(tell,1)<>tellpos then
+            // Update file position and increment i0. Else, we are at the same position and state as before.
+            arrayUpdate(tell, 1, tellpos);
+            txt2 := txt;
+            haveToken := true;
+          else
+            // File position did not change, but we might have the empty specifier
+            txt2 := match iopts.empty
+            case NONE()
+              algorithm
+                haveToken := false;
+              then txt;
+            case SOME(emptok)
+              algorithm
+                arrayUpdate(i0, 1, arrayGet(i0,1) + 1);
+                haveToken := true;
+              then writeTok(txt, emptok);
+            end match;
+          end if;
+          if haveToken then
+            // Handle separator
+            curIndex := arrayGet(i0,1);
+            arrayUpdate(septok, 1, iopts.separator);
+            arrayUpdate(i0, 1, curIndex + 1);
+          end if;
+        then ();
+        end match;
+      then txt2;
 
     //should not ever happen
     else
       equation
-        true = Flags.isSet(Flags.FAILTRACE); Debug.trace("-!!!Tpl.nextIter failed - nextIter was called in a non-iteration context ? \n");
+        Error.addInternalError("-!!!Tpl.nextIter failed - nextIter was called in a non-iteration context?", sourceInfo());
       then
         fail();
-  end matchcontinue;
+  end match;
 end nextIter;
 
 
@@ -652,13 +838,16 @@ public function getIteri_i0
 algorithm
   outI0 := match (inText)
     local
-      Integer i0;
+      array<Integer> i0;
 
     case (MEM_TEXT(
             blocksStack = (_, BT_ITER(index0 = i0)) :: _
             ))
       then
-        i0;
+        arrayGet(i0,1);
+
+    case FILE_TEXT()
+      then match listGet(arrayGet(inText.blocksStack,1),1) case BT_FILE_TEXT(bt=BT_ITER(index0=i0)) then arrayGet(i0,1); end match;
 
     //should not ever happen
     case (_ )
@@ -668,31 +857,6 @@ algorithm
         fail();
   end match;
 end getIteri_i0;
-
-
-public function getIteri_i1
-  input Text inText;
-  output Integer outI1;
-algorithm
-  outI1 := match (inText)
-    local
-      Integer i0;
-
-    case (MEM_TEXT(
-            blocksStack = (_, BT_ITER(index0 = i0)) :: _
-            ))
-      then
-        i0 + 1;
-
-    //should not ever happen
-    case (_ )
-      equation
-        true = Flags.isSet(Flags.FAILTRACE); Debug.trace("-!!!Tpl.getIter_i1 failed - getIter_i1 was called in a non-iteration context ? \n");
-      then
-        fail();
-  end match;
-end getIteri_i1;
-
 
 public function textString "function: textString:
 This function renders a (memory-)text to string."
@@ -756,7 +920,7 @@ algorithm
   end match;
 end textStringBuf;
 
-public function tokensString
+protected function tokensString
   input Tokens inTokens;
   input output Integer actualPositionOnLine;
   input output Boolean atStartOfLine;
@@ -767,8 +931,19 @@ algorithm
   end for;
 end tokensString;
 
+protected function tokensFile
+  input File.File file;
+  input Tokens inTokens;
+  input output Integer actualPositionOnLine;
+  input output Boolean atStartOfLine;
+  input output Integer afterNewLineIndent;
+algorithm
+  for tok in inTokens loop
+    (actualPositionOnLine, atStartOfLine, afterNewLineIndent) := tokFile(file, tok, actualPositionOnLine, atStartOfLine, afterNewLineIndent);
+  end for;
+end tokensFile;
 
-public function tokString
+protected function tokString
   input StringToken inStringToken;
   input Integer inActualPositionOnLine;
   input Boolean inAtStartOfLine;
@@ -851,8 +1026,96 @@ algorithm
   end match;
 end tokString;
 
+protected function tokFileText
+  input Text inText;
+  input StringToken inStringToken;
+  input Boolean doHandleTok=true;
+protected
+  File.File file = File.File(getTextOpaqueFile(inText));
+  Integer nchars, aind;
+  Boolean isstart;
+algorithm
+  if doHandleTok then
+    handleTok(inText);
+  end if;
+  _ := match inText
+    case FILE_TEXT()
+    algorithm
+      nchars := arrayGet(inText.nchars, 1);
+      aind := arrayGet(inText.aind, 1);
+      isstart := arrayGet(inText.isstart, 1);
+      (nchars, isstart, aind) := tokFile(file, inStringToken, nchars, isstart, aind);
+      arrayUpdate(inText.nchars, 1, nchars);
+      arrayUpdate(inText.aind, 1, aind);
+      arrayUpdate(inText.isstart, 1, isstart);
+    then ();
+  end match;
+end tokFileText;
 
-public function stringListString
+protected function tokFile
+  input File.File file;
+  input StringToken inStringToken;
+  input output Integer nchars;
+  input output Boolean isstart;
+  input output Integer aind;
+algorithm
+  (nchars, isstart, aind) := match (inStringToken, nchars, isstart, aind)
+    local
+      Tokens toks;
+      BlockType bt;
+      String str;
+      list<String> strLst;
+
+    case (ST_NEW_LINE(), _, _, aind)
+      equation
+        File.write(file, "\n");
+      then (aind, true, aind);
+
+    case (ST_STRING(value = str), nchars, true, aind)
+      equation
+        File.writeSpace(file, nchars);
+        File.write(file, str);
+      then
+        (nchars+stringLength(str), false, aind);
+
+    case (ST_STRING(value = str), nchars, false, aind)
+      equation
+        File.write(file, str);
+      then
+        (nchars + stringLength(str), false, aind);
+
+    case (ST_LINE(line = str), nchars, true, aind)
+      equation
+        File.writeSpace(file, nchars);
+        File.write(file, str);
+      then
+        (aind, true, aind);
+
+    case (ST_LINE(line = str), _, false, aind)
+      equation
+        File.write(file, str);
+      then
+        (aind, true, aind);
+
+    case (ST_STRING_LIST( strList = strLst ), nchars, isstart, aind)
+      equation
+        (nchars, isstart, aind)
+          = stringListFile(file, strLst, nchars, isstart, aind);
+      then
+        (nchars, isstart, aind);
+
+    case (ST_BLOCK(
+           tokens = toks,
+           blockType = bt), nchars, isstart, aind)
+      equation
+        (nchars, isstart, aind)
+          = blockFile(file, bt, listReverse(toks), nchars, isstart, aind);
+      then
+        (nchars, isstart, aind);
+  end match;
+end tokFile;
+
+protected function stringListString
   input list<String> inStringList;
   input Integer inActualPositionOnLine;
   input Boolean inAtStartOfLine;
@@ -863,13 +1126,12 @@ public function stringListString
   output Integer outAfterNewLineIndent;
 algorithm
   (outActualPositionOnLine, outAtStartOfLine, outAfterNewLineIndent)
-   := matchcontinue (inStringList, inActualPositionOnLine, inAtStartOfLine, inAfterNewLineIndent)
+   := match (inStringList, inActualPositionOnLine, inAtStartOfLine, inAfterNewLineIndent)
     local
       String str;
       list<String> strLst;
       Integer nchars, aind, blen;
       Boolean isstart, hasNL;
-
 
     case ({}, _, isstart, aind)
       then
@@ -894,26 +1156,8 @@ algorithm
         hasNL = Print.hasBufNewLineAtEnd();
         nchars = if hasNL then aind else blen;
         (nchars, isstart, aind) = stringListString(strLst, nchars, hasNL, aind);
-
-        //"\n" = stringGetStringChar(str, stringLength(str));
-        //accstr = accstr + (spaceStr(nchars) + str); //indent is actually stored in nchars when on start of the line
-        //(str, nchars, isstart, aind)
-        // = stringListString(strLst, aind, true, aind, accstr);
       then
         (nchars, isstart, aind);
-
-
-    //at start, no new line
-    //case (str :: strLst, nchars, true, aind, accstr)
-    //  equation
-    //    //failure("\n" = stringGetStringChar(str, stringLength(str)));
-    //    accstr = accstr + (spaceStr(nchars) + str); //indent is actually stored in nchars when on start of the line
-    //    nchars = nchars + stringLength(str);
-    //    (str, nchars, isstart, aind)
-    //     = stringListString(strLst, nchars, false, aind, accstr);
-    //  then
-    //    (str, nchars, isstart, aind);
-
 
     //not at start, new line or no new line
     case (str :: strLst, nchars, false, aind)
@@ -924,24 +1168,8 @@ algorithm
         hasNL = Print.hasBufNewLineAtEnd();
         nchars = if hasNL then aind else nchars+blen;
         (nchars, isstart, aind) = stringListString(strLst, nchars, hasNL, aind);
-
-        //"\n" = stringGetStringChar(str, stringLength(str));
-        //accstr = accstr + str;
-        //(str, nchars, isstart, aind)
-        // = stringListString(strLst, aind, true, aind, accstr);
       then
         (nchars, isstart, aind);
-
-    //not at start, no new line
-    //case (str :: strLst, nchars, true, aind, accstr)
-    //  equation
-    //    //failure("\n" = stringGetStringChar(str, stringLength(str)));
-    //    accstr = accstr + str;
-    //    nchars = nchars + stringLength(str);
-    //    (str, nchars, isstart, aind)
-    //     = stringListString(strLst, nchars, false, aind, accstr);
-    // then
-    //    (str, nchars, isstart, aind);
 
     //should not ever happen
     else
@@ -949,10 +1177,67 @@ algorithm
         true = Flags.isSet(Flags.FAILTRACE); Debug.trace("-!!!Tpl.stringListString failed.\n");
       then
         fail();
-  end matchcontinue;
+  end match;
 end stringListString;
 
-public function blockString
+protected function stringListFile
+  input File.File file;
+  input list<String> inStringList;
+  input output Integer nchars;
+  input output Boolean isstart;
+  input output Integer aind;
+algorithm
+  (nchars, isstart, aind)
+   := match (inStringList, nchars, isstart, aind)
+    local
+      String str;
+      list<String> strLst;
+      Boolean hasNL;
+
+    case ({}, _, isstart, aind)
+      then
+        (aind, isstart, aind);
+
+    //empty string ... for sure -> it can be a special case when allowed; when let for the case at start of a line, it would output an indent
+    case ("" :: strLst, nchars, isstart, aind)
+      equation
+        (nchars, isstart, aind)
+         = stringListFile(file, strLst, nchars, isstart, aind);
+      then
+        (nchars, isstart, aind);
+
+
+    //at start, new line or no new line
+    case (str :: strLst, nchars, true, aind)
+      equation
+        File.writeSpace(file, nchars);
+        File.write(file, str);
+        hasNL = StringUtil.endsWithNewline(str);
+        nchars = if hasNL then aind else (nchars+stringLength(str));
+        (nchars, isstart, aind) = stringListFile(file, strLst, nchars, hasNL, aind);
+      then
+        (nchars, isstart, aind);
+
+    //not at start, new line or no new line
+    case (str :: strLst, nchars, false, aind)
+      equation
+        File.write(file, str);
+        hasNL = StringUtil.endsWithNewline(str);
+        nchars = if hasNL then aind else (nchars+stringLength(str));
+        (nchars, isstart, aind) = stringListFile(file, strLst, nchars, hasNL, aind);
+      then
+        (nchars, isstart, aind);
+
+    //should not ever happen
+    else
+      equation
+        true = Flags.isSet(Flags.FAILTRACE); Debug.trace("-!!!Tpl.stringListFile failed.\n");
+      then
+        fail();
+  end match;
+end stringListFile;
+
+protected function blockString
   input BlockType inBlockType;
   input Tokens inTokens;
   input Integer inActualPositionOnLine;
@@ -1121,7 +1406,7 @@ algorithm
 end blockString;
 
 
-public function iterSeparatorString
+protected function iterSeparatorString
   input Tokens inTokens;
   input StringToken inSeparator;
   input Integer inActualPositionOnLine;
@@ -1154,7 +1439,7 @@ algorithm
 end iterSeparatorString;
 
 
-public function iterSeparatorAlignWrapString
+protected function iterSeparatorAlignWrapString
   input Tokens inTokens;
   input StringToken inSeparator;
   input Integer inActualIndex;
@@ -1196,7 +1481,7 @@ algorithm
 end iterSeparatorAlignWrapString;
 
 
-public function iterAlignWrapString
+protected function iterAlignWrapString
   input Tokens inTokens;
   input Integer inActualIndex;
   input Integer inAlignNum;
@@ -1269,7 +1554,7 @@ algorithm
 end iterAlignWrapString;
 
 
-public function tryWrapString
+protected function tryWrapString
   input Integer inWrapWidth;
   input StringToken inWrapSeparator;
   input Integer inActualPositionOnLine;
@@ -1300,15 +1585,357 @@ algorithm
 end tryWrapString;
 
 
-public function booleanString
-  input Boolean inBoolean;
-  output String outString;
+protected function blockFile
+  input File.File file;
+  input BlockType inBlockType;
+  input Tokens inTokens;
+  input Integer inActualPositionOnLine;
+  input Boolean inAtStartOfLine;
+  input Integer inAfterNewLineIndent;
+
+  output Integer outActualPositionOnLine;
+  output Boolean outAtStartOfLine;
+  output Integer outAfterNewLineIndent;
 algorithm
-  outString := match inBoolean
-    case (false) then "false";
-    case (true)  then "true";
+  (outActualPositionOnLine, outAtStartOfLine, outAfterNewLineIndent)
+   := match (inBlockType, inTokens, inActualPositionOnLine, inAtStartOfLine, inAfterNewLineIndent)
+    local
+      Tokens toks;
+      StringToken septok, tok, asep, wsep;
+      Integer nchars, tsnchars,   aind, w, aoffset, anum, wwidth, blen;
+      Boolean isstart;
+
+    case (BT_TEXT(), toks, nchars, isstart, aind)
+      equation
+        (nchars, isstart, aind)
+          = tokensFile(file, toks, nchars, isstart, aind);
+      then
+        (nchars, isstart, aind);
+
+    case (BT_INDENT(width = w), toks, nchars, true, aind)
+      equation
+        (tsnchars, isstart)
+          = tokensFile(file, toks, w + nchars, true, w + aind);
+        nchars = if isstart then nchars else tsnchars; //pop indent when at the start of a line
+      then
+        (nchars, isstart, aind);
+
+    case (BT_INDENT(width = w), toks, nchars, false, aind)
+      equation
+        File.writeSpace(file, w);
+        (tsnchars, isstart)
+          = tokensFile(file, toks, w + nchars, false, w + aind);
+        nchars = if isstart then aind else tsnchars; //pop indent when at the start of a line - there were a new line, so use the aind
+      then
+        (nchars, isstart, aind);
+
+    case (BT_ABS_INDENT(width = w), toks, nchars, true, aind)
+      equation
+        blen = File.tell(file);
+        (tsnchars, isstart)
+          = tokensFile(file, toks, 0, true, w); //discard an indent when at the start of a line
+        blen = File.tell(file) - blen;
+        nchars = if blen == 0 then nchars else (if isstart then aind else tsnchars); //when no chars -> pop indent; when something written -> aind for the start of a line otherwise actual position
+      then
+        (nchars, isstart, aind);
+
+    case (BT_ABS_INDENT(width = w), toks, nchars, false, aind)
+      equation
+        (tsnchars, isstart)
+          = tokensFile(file, toks, nchars, false, w);
+        nchars = if isstart then aind else tsnchars; //pop indent when at the start of a line - there were a new line, so use the aind
+      then
+        (nchars, isstart, aind);
+
+    case (BT_REL_INDENT(offset = w), toks, nchars, true, aind)
+      equation
+        blen = File.tell(file);
+        (tsnchars, isstart)
+          = tokensFile(file, toks, nchars, true, aind + w);
+        blen = File.tell(file) - blen;
+        nchars = if blen == 0 then nchars else (if isstart then aind else tsnchars); //when no chars -> pop indent; when something written -> aind for the start of a line otherwise actual position
+      then
+        (nchars, isstart, aind);
+
+    case (BT_REL_INDENT(offset = w), toks, nchars, false, aind)
+      equation
+        (tsnchars, isstart)
+          = tokensFile(file, toks, nchars, false, aind + w);
+        nchars = if isstart then aind else tsnchars; //pop indent when at the start of a line - there were a new line, so use the aind
+      then
+        (nchars, isstart, aind);
+
+    case (BT_ANCHOR(offset = w), toks, nchars, true, aind)
+      equation
+        blen = File.tell(file);
+        (tsnchars, isstart)
+          = tokensFile(file, toks, nchars, true, nchars + w);
+        blen = File.tell(file) - blen;
+        nchars = if blen == 0 then nchars else (if isstart then aind else tsnchars); //when no chars -> pop indent; when something written -> aind for the start of a line otherwise actual position
+      then
+        (nchars, isstart, aind);
+
+    case (BT_ANCHOR(offset = w), toks, nchars, false, aind)
+      equation
+        (tsnchars, isstart)
+          = tokensFile(file, toks, nchars, false, nchars + w);
+        nchars = if isstart then aind else tsnchars; //pop indent when at the start of a line - there were a new line, so use the aind
+      then
+        (nchars, isstart, aind);
+
+
+    //iter block, no tokens ... should be impossible, but ...
+    case (BT_ITER(), {}, nchars, isstart, aind)
+      then
+        (nchars, isstart, aind);
+
+    //concat ... i.e. text
+    case (BT_ITER(options = ITER_OPTIONS(
+                              separator = NONE(),
+                              alignNum = 0,
+                              wrapWidth = 0)), toks, nchars, isstart, aind)
+      equation
+        (nchars, isstart, aind)
+          = tokensFile(file,toks, nchars, isstart, aind);
+      then
+        (nchars, isstart, aind);
+
+
+    //separator only ...
+    case (BT_ITER(options = ITER_OPTIONS(
+                              separator = SOME(septok),
+                              alignNum = 0,
+                              wrapWidth = 0)), tok :: toks, nchars, isstart, aind)
+      equation
+        // put the first token, all the others with separator
+        (nchars, isstart, aind) = tokFile(file, tok, nchars, isstart, aind);
+        (nchars, isstart)
+          = iterSeparatorFile(file, toks, septok, nchars, isstart, aind);
+      then
+        (nchars, isstart, aind);
+
+    //separator and alignment and/or wrapping
+    case (BT_ITER(options = ITER_OPTIONS(
+                              separator = SOME(septok),
+                              alignNum = anum,
+                              alignOfset = aoffset,
+                              alignSeparator = asep,
+                              wrapWidth = wwidth,
+                              wrapSeparator = wsep)), tok :: toks, nchars, isstart, aind)
+      equation
+        // put the first token, all the others with separator
+        (nchars, isstart, aind) = tokFile(file, tok, nchars, isstart, aind);
+        (nchars, isstart)
+          = iterSeparatorAlignWrapFile(file, toks, septok, 1 + aoffset, anum, asep, wwidth, wsep, nchars, isstart, aind);
+      then
+        (nchars, isstart, aind);
+
+    //no separator and alignment and/or wrapping
+    case (BT_ITER(options = ITER_OPTIONS(
+                              separator = NONE(),
+                              alignNum = anum,
+                              alignOfset = aoffset,
+                              alignSeparator = asep,
+                              wrapWidth = wwidth,
+                              wrapSeparator = wsep)), toks, nchars, isstart, aind)
+      equation
+        (nchars, isstart)
+          = iterAlignWrapFile(file, toks, aoffset, anum, asep, wwidth, wsep, nchars, isstart, aind);
+      then
+        (nchars, isstart, aind);
+
+
+    //should not ever happen
+    else
+      equation
+        true = Flags.isSet(Flags.FAILTRACE); Debug.trace("-!!!Tpl.tokString failed.\n");
+      then
+        fail();
   end match;
-end booleanString;
+end blockFile;
+
+protected function iterSeparatorFile
+  input File.File file;
+  input Tokens inTokens;
+  input StringToken inSeparator;
+  input Integer inActualPositionOnLine;
+  input Boolean inAtStartOfLine;
+  input Integer inAfterNewLineIndent;
+
+  output Integer outActualPositionOnLine;
+  output Boolean outAtStartOfLine;
+algorithm
+  (outActualPositionOnLine, outAtStartOfLine) := match (inTokens, inSeparator, inActualPositionOnLine, inAtStartOfLine, inAfterNewLineIndent)
+    local
+      Tokens toks;
+      StringToken tok, septok;
+      Integer pos, aind;
+      Boolean isstart;
+
+    case ({}, _, pos, isstart, _)
+      then
+        (pos, isstart);
+
+    case (tok :: toks, septok, pos, isstart, aind)
+      equation
+        (pos, isstart, aind) = tokFile(file, septok, pos, isstart, aind);
+        (pos, isstart, aind) = tokFile(file, tok, pos, isstart, aind);
+        (pos, isstart)
+         = iterSeparatorFile(file, toks, septok, pos, isstart, aind);
+      then
+        (pos, isstart);
+  end match;
+end iterSeparatorFile;
+
+
+protected function iterSeparatorAlignWrapFile
+  input File.File file;
+  input Tokens inTokens;
+  input StringToken inSeparator;
+  input Integer inActualIndex;
+  input Integer inAlignNum;
+  input StringToken inAlignSeparator;
+  input Integer inWrapWidth;
+  input StringToken inWrapSeparator;
+  input Integer inActualPositionOnLine;
+  input Boolean inAtStartOfLine;
+  input Integer inAfterNewLineIndent;
+
+  output Integer outActualPositionOnLine;
+  output Boolean outAtStartOfLine;
+protected
+  Tokens toks = inTokens;
+  StringToken tok;
+  StringToken septok = inSeparator;
+  Integer idx = inActualIndex;
+  Integer anum = inAlignNum;
+  StringToken asep = inAlignSeparator;
+  Integer wwidth = inWrapWidth;
+  StringToken wsep = inWrapSeparator;
+  Integer pos = inActualPositionOnLine;
+  Boolean isstart = inAtStartOfLine;
+  Integer aind = inAfterNewLineIndent;
+algorithm
+  while (boolNot(listEmpty(toks))) loop
+    tok::toks := toks;
+    if((idx > 0) and (intMod(idx,anum) == 0)) then
+      (pos, isstart, aind) := tokFile(file, asep, pos, isstart, aind);
+    else
+      (pos, isstart, aind) := tokFile(file, septok, pos, isstart, aind);
+    end if;
+    (pos, isstart, aind) := tryWrapFile(file, wwidth, wsep, pos, isstart, aind);
+    (pos, isstart, aind) := tokFile(file, tok, pos, isstart, aind);
+    idx := idx + 1;
+  end while;
+  (outActualPositionOnLine, outAtStartOfLine) := (pos, isstart);
+end iterSeparatorAlignWrapFile;
+
+
+protected function iterAlignWrapFile
+  input File.File file;
+  input Tokens inTokens;
+  input Integer inActualIndex;
+  input Integer inAlignNum;
+  input StringToken inAlignSeparator;
+  input Integer inWrapWidth;
+  input StringToken inWrapSeparator;
+  input Integer inActualPositionOnLine;
+  input Boolean inAtStartOfLine;
+  input Integer inAfterNewLineIndent;
+
+  output Integer outActualPositionOnLine;
+  output Boolean outAtStartOfLine;
+algorithm
+  (outActualPositionOnLine, outAtStartOfLine)
+   := matchcontinue (inTokens, inActualIndex, inAlignNum, inAlignSeparator, inWrapWidth, inWrapSeparator, inActualPositionOnLine, inAtStartOfLine, inAfterNewLineIndent)
+    local
+      Tokens toks;
+      StringToken tok,  asep, wsep;
+      Integer pos, aind, idx, anum, wwidth;
+      Boolean isstart;
+
+    case ({}, _,_,_,_,_, pos, isstart, _)
+      then
+        (pos, isstart);
+
+    //align and try wrap
+    case (tok :: toks, idx, anum, asep, wwidth, wsep, pos, isstart, aind)
+      equation
+        true = (idx > 0) and (intMod(idx,anum) == 0);
+        (pos, isstart, aind) = tokFile(file, asep, pos, isstart, aind);
+        (pos, isstart, aind) = tryWrapFile(file, wwidth, wsep, pos, isstart, aind);
+        (pos, isstart, aind) = tokFile(file, tok, pos, isstart, aind);
+        (pos, isstart)
+         = iterAlignWrapFile(file, toks, idx + 1, anum, asep, wwidth, wsep,
+                pos, isstart, aind);
+      then
+        (pos, isstart);
+    //wrap
+    case (tok :: toks, idx, anum, asep, wwidth, wsep, pos, isstart, aind)
+      equation
+        //false = (idx > 0) and (intMod(idx,anum) == 0);
+        true = (wwidth > 0) and (pos >= wwidth); //check wwidth for the invariant that should be always true here
+        (pos, isstart, aind) = tokFile(file, wsep, pos, isstart, aind);
+        (pos, isstart, aind) = tokFile(file, tok, pos, isstart, aind);
+        (pos, isstart)
+          = iterAlignWrapFile(file, toks, idx + 1, anum, asep, wwidth, wsep,
+                pos, isstart, aind);
+      then
+        (pos, isstart);
+
+    //item only
+    case (tok :: toks, idx, anum, asep, wwidth, wsep, pos, isstart, aind)
+      equation
+        //false = (idx > 0) and (intMod(idx,anum) == 0);
+        //false = (wwidth > 0) and (pos >= wwidth); //check wwidth for the invariant that should be always true here
+        (pos, isstart, aind) = tokFile(file, tok, pos, isstart, aind);
+        (pos, isstart)
+         = iterAlignWrapFile(file, toks, idx + 1, anum, asep, wwidth, wsep,
+              pos, isstart, aind);
+      then
+        (pos, isstart);
+
+    //should not ever happen
+    else
+      equation
+        true = Flags.isSet(Flags.FAILTRACE); Debug.trace("-!!!Tpl.iterAlignWrapString failed.\n");
+      then
+        fail();
+  end matchcontinue;
+end iterAlignWrapFile;
+
+
+protected function tryWrapFile
+  input File.File file;
+  input Integer inWrapWidth;
+  input StringToken inWrapSeparator;
+  input Integer inActualPositionOnLine;
+  input Boolean inAtStartOfLine;
+  input Integer inAfterNewLineIndent;
+
+  output Integer outActualPositionOnLine;
+  output Boolean outAtStartOfLine;
+  output Integer outAfterNewLineIndent;
+algorithm
+  (outActualPositionOnLine, outAtStartOfLine, outAfterNewLineIndent)
+   := matchcontinue (inWrapWidth, inWrapSeparator, inActualPositionOnLine, inAtStartOfLine, inAfterNewLineIndent)
+    local
+      Integer pos, aind, wwidth;
+      Boolean isstart;
+      StringToken wsep;
+
+    //wrap
+    case (wwidth, wsep, pos, isstart, aind)
+      equation
+        true = (wwidth > 0) and (pos >= wwidth); //check wwidth for the invariant that should be always true here
+        (pos, isstart, aind) = tokFile(file, wsep, pos, isstart, aind);
+      then
+        (pos, isstart, aind);
+
+    else (inActualPositionOnLine, inAtStartOfLine, inAfterNewLineIndent);
+  end matchcontinue;
+end tryWrapFile;
+
 
 public function strTokText
   input StringToken inStringToken;
@@ -1363,7 +1990,7 @@ algorithm
   outString := textString( MEM_TEXT({inStringToken},{}) );
 end strTokString;
 
-protected function failIfTrue
+public function failIfTrue
   input Boolean istrue;
 algorithm
   _ := match istrue
@@ -1374,7 +2001,7 @@ end failIfTrue;
 
 public function tplCallWithFailErrorNoArg
   input Tpl_Fun inFun;
-  output Text txt;
+  input output Text txt = emptyTxt;
 
   partial function Tpl_Fun
     input Text in_txt;
@@ -1382,9 +2009,9 @@ public function tplCallWithFailErrorNoArg
   end Tpl_Fun;
 algorithm
   try
-    txt := inFun(emptyTxt);
+    txt := inFun(txt);
   else
-    addTemplateError("A template call failed (a call with 0 parameters: " + System.dladdr(inFun) +"). One possible reason could be that a template imported function call failed (which should not happen for functions called from within template code; templates preserve pure 'match'/non-failing semantics).");
+    addTemplateErrorFunc(0, inFun);
     fail();
   end try;
 end tplCallWithFailErrorNoArg;
@@ -1410,7 +2037,7 @@ algorithm
       then txt;
     else
       equation
-        addTemplateError("A template call failed (a call with 1 parameter: " + System.dladdr(inFun) +"). One possible reason could be that a template imported function call failed (which should not happen for functions called from within template code; templates preserve pure 'match'/non-failing semantics).");
+        addTemplateErrorFunc(1, inFun);
       then fail();
   end matchcontinue;
 end tplCallWithFailError;
@@ -1441,7 +2068,7 @@ algorithm
       then txt;
     else
       equation
-        addTemplateError("A template call failed (a call with 2 parameters: " + System.dladdr(inFun) + "). One possible reason could be that a template imported function call failed (which should not happen for functions called from within template code; templates preserve pure 'match'/non-failing semantics).");
+        addTemplateErrorFunc(2, inFun);
       then fail();
   end matchcontinue;
 end tplCallWithFailError2;
@@ -1473,7 +2100,7 @@ algorithm
       then txt;
     else
       equation
-        addTemplateError("A template call failed (a call with 3 parameters: " + System.dladdr(inFun) +"). One possible reason could be that a template imported function call failed (which should not happen for functions called from within template code; templates preserve pure 'match'/non-failing semantics).");
+        addTemplateErrorFunc(3, inFun);
       then fail();
   end matchcontinue;
 end tplCallWithFailError3;
@@ -1498,7 +2125,7 @@ algorithm
   try
     txt := func(emptyTxt, argA, argB, argC, argD);
   else
-    addTemplateError("A template call failed (a call with 4 parameters: " + System.dladdr(func) +"). One possible reason could be that a template imported function call failed (which should not happen for functions called from within template code; templates preserve pure 'match'/non-failing semantics).");
+    addTemplateErrorFunc(4, func);
     fail();
   end try;
 end tplCallWithFailError4;
@@ -1824,12 +2451,194 @@ algorithm
 end addSourceTemplateError;
 
 //for completeness
+protected function addTemplateErrorFunc<T>
+ "Wraps call to Error.addMessage() funtion with Error.TEMPLATE_ERROR and one MessageToken."
+  input Integer numArg;
+  input T func;
+algorithm
+  Error.addMessage(Error.TEMPLATE_ERROR_FUNC, {String(numArg), System.dladdr(func)});
+end addTemplateErrorFunc;
+
 public function addTemplateError
  "Wraps call to Error.addMessage() funtion with Error.TEMPLATE_ERROR and one MessageToken."
-  input String inErrMsg;
+  input String msg;
 algorithm
-  Error.addMessage(Error.TEMPLATE_ERROR, {inErrMsg});
+  Error.addMessage(Error.TEMPLATE_ERROR, {msg});
 end addTemplateError;
+
+public function redirectToFile
+"Magic sourceInfo() function implementation"
+  input output Text text;
+  input String fileName;
+protected
+  File.File file = File.File();
+algorithm
+  File.open(file, fileName, File.Mode.Write);
+  text := writeText(FILE_TEXT(File.getReference(file), arrayCreate(1, 0), arrayCreate(1, 0), arrayCreate(1, true), arrayCreate(1, {})), text);
+end redirectToFile;
+
+public function closeFile
+"Magic sourceInfo() function implementation"
+  input output Text text;
+protected
+  File.File file = File.File(getTextOpaqueFile(text));
+algorithm
+  File.releaseReference(file);
+  text := emptyTxt;
+end closeFile;
+
+public function booleanString // TODO: Remove me
+  input Boolean b;
+  output String s;
+algorithm
+  s := String(b);
+end booleanString;
+
+protected function getTextOpaqueFile
+  input Text text;
+  output Option<Integer> opaqueFile;
+algorithm
+  opaqueFile := match text
+    case FILE_TEXT() then text.opaqueFile;
+    else
+    algorithm
+      Error.addInternalError("tokFile got non-file text input", sourceInfo());
+    then fail();
+  end match;
+end getTextOpaqueFile;
+
+protected function stringFile "Like ST_STRING or ST_LINE"
+  input Text inText;
+  input String str;
+  input Boolean line;
+  input Boolean recurseSeparator=true;
+protected
+  File.File file = File.File(getTextOpaqueFile(inText));
+  Integer nchars;
+  IterOptions iopts;
+  StringToken septok;
+algorithm
+  _ := match inText
+  case FILE_TEXT()
+  algorithm
+    handleTok(inText);
+    nchars := arrayGet(inText.nchars, 1);
+    if not line then
+      if arrayGet(inText.isstart,1) then
+        File.writeSpace(file, nchars);
+        File.write(file, str);
+        arrayUpdate(inText.nchars, 1, nchars+stringLength(str));
+        arrayUpdate(inText.isstart, 1, false);
+      else
+        File.write(file, str);
+        arrayUpdate(inText.nchars, 1, nchars+stringLength(str));
+      end if;
+    else
+      if arrayGet(inText.isstart,1) then
+        File.writeSpace(file, nchars);
+      else
+        arrayUpdate(inText.isstart,1,true);
+      end if;
+      File.write(file, str);
+      arrayUpdate(inText.nchars,1,arrayGet(inText.aind,1));
+    end if;
+  then ();
+  end match;
+end stringFile;
+
+protected function newlineFile "Like ST_NEWLINE"
+  input Text inText;
+protected
+  File.File file = File.File(getTextOpaqueFile(inText));
+  Integer nchars;
+algorithm
+  _ := match inText
+  case FILE_TEXT()
+  algorithm
+    File.write(file, "\n");
+    arrayUpdate(inText.nchars, 1, arrayGet(inText.aind, 1));
+    arrayUpdate(inText.isstart, 1, true);
+  then ();
+  end match;
+end newlineFile;
+
+protected function textFileTell
+  input Text inText;
+  output Integer tell;
+protected
+  File.File file = File.File(getTextOpaqueFile(inText));
+algorithm
+  tell := File.tell(file);
+end textFileTell;
+
+protected function handleTok "Handle a new token, for example separators"
+  input Text txt;
+protected
+  // File.File file = File.File(getTextOpaqueFile(inText));
+  StringToken septok;
+  array<Option<StringToken>> aseptok;
+algorithm
+  _ := match txt
+  case FILE_TEXT()
+  algorithm
+    _ := match arrayGet(txt.blocksStack, 1)
+      case (BT_FILE_TEXT(bt=BT_ITER(), septok=aseptok)::_)
+      algorithm
+        _ := match arrayGet(aseptok,1)
+        case SOME(septok)
+        algorithm
+          arrayUpdate(aseptok,1,NONE());
+          tokFileText(txt, septok, doHandleTok=false);
+        then ();
+        else ();
+        end match;
+      then ();
+      else ();
+    end match;
+  then ();
+  end match;
+end handleTok;
+
+/*
+protected function handleSeparatorTextFile
+  input Text txt;
+  input IterOptions iopts;
+protected
+  File.File file = File.File(getTextOpaqueFile(inText));
+  Integer nchars, aind;
+  Boolean isstart;
+algorithm
+  _ := match inText
+    case FILE_TEXT()
+    algorithm
+      nchars := arrayGet(inText.nchars, 1);
+      aind := arrayGet(inText.aind, 1);
+      isstart := arrayGet(inText.isstart, 1);
+      (nchars, isstart, aind) := handleSeparatorFile(file, iopts, nchars, isstart, aind);
+      arrayUpdate(inText.nchars, 1, nchars);
+      arrayUpdate(inText.aind, 1, aind);
+      arrayUpdate(inText.isstart, 1, isstart);
+    then ();
+  end match;
+end handleSeparatorTextFile;
+
+protected function handleSeparatorFile
+  input File.File file;
+  input IterOptions iopts;
+  input output Integer nchars;
+  input output Boolean isstart;
+  input output Integer aind;
+algorithm
+  (nchars,isstart,aind) := match (iopts.separator, iopts.alignNum, iopts.wrapWidth)
+    case (NONE(),_,_) then (nchars,isstart,aind);
+    case (SOME(septok),0,0) then (nchars,isstart,aind);
+    else
+    algorithm
+      Error.addInternalError("haveSeparatorFile failed", sourceInfo());
+    then fail();
+  end match;
+end handleSeparatorFile;
+*/
 
 annotation(__OpenModelica_Interface="susan");
 end Tpl;

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -941,7 +941,7 @@ public constant Message COMPILER_NOTIFICATION_SCRIPTING = MESSAGE(6002, SCRIPTIN
 public constant Message SUSAN_ERROR = MESSAGE(7000, TRANSLATION(), ERROR(),
   Util.notrans("%s"));
 public constant Message TEMPLATE_ERROR = MESSAGE(7001, TRANSLATION(), ERROR(),
-  Util.gettext("Template error: %s"));
+  Util.gettext("Template error: %s."));
 public constant Message OPERATOR_OVERLOADING_WARNING = MESSAGE(7002, TRANSLATION(), WARNING(),
   Util.gettext("Operator Overloading: %s."));
 public constant Message OPERATOR_OVERLOADING_ERROR = MESSAGE(7003, TRANSLATION(), ERROR(),
@@ -967,6 +967,8 @@ public constant Message SUSAN_NOTIFY = MESSAGE(7012, TRANSLATION(), NOTIFICATION
   Util.notrans("%s"));
 public constant Message PDEModelica_ERROR = MESSAGE(7013, TRANSLATION(), ERROR(),
   Util.gettext("PDEModelica: %s"));
+public constant Message TEMPLATE_ERROR_FUNC = MESSAGE(7014, TRANSLATION(), ERROR(),
+  Util.gettext("Template error: A template call failed (a call with %s parameters: %s). One possible reason could be that a template imported function call failed (which should not happen for functions called from within template code; templates preserve pure 'match'/non-failing semantics)."));
 
 protected import ErrorExt;
 

--- a/Compiler/Util/StringUtil.mo
+++ b/Compiler/Util/StringUtil.mo
@@ -43,6 +43,7 @@ protected import System;
 protected import MetaModelica.Dangerous.{listReverseInPlace, stringGetNoBoundsChecking};
 
 public constant Integer NO_POS = 0;
+protected constant Integer CHAR_NL = 10;
 protected constant Integer CHAR_SPACE = 32;
 protected constant Integer CHAR_DASH = 45;
 
@@ -369,6 +370,13 @@ algorithm
   c := c + stringLength(str6);
   str := System.stringAllocatorResult(sb,str1);
 end stringAppend6;
+
+function endsWithNewline
+  input String str;
+  output Boolean b;
+algorithm
+  b := CHAR_NL == MetaModelica.Dangerous.stringGetNoBoundsChecking(str, stringLength(str));
+end endsWithNewline;
 
 annotation(__OpenModelica_Interface="util");
 end StringUtil;

--- a/Compiler/runtime/systemimpl.c
+++ b/Compiler/runtime/systemimpl.c
@@ -2906,7 +2906,7 @@ int SystemImpl__covertTextFileToCLiteral(const char *textFile, const char *outFi
       j = 0;
       /* adrpo: encode each char */
       for (i=0; i<n; i++) {
-	    fputc('\'', fout);
+      fputc('\'', fout);
 
         switch (buffer[i]) {
         case '\n':
@@ -2921,11 +2921,11 @@ int SystemImpl__covertTextFileToCLiteral(const char *textFile, const char *outFi
           fputc('\\', fout);
           fputc('\\', fout);
           break;
-		case '"':
+    case '"':
           fputc('\\', fout);
           fputc('\"', fout);
           break;
-		case '\'':
+    case '\'':
           fputc('\\', fout);
           fputc('\'', fout);
           break;
@@ -2996,12 +2996,13 @@ void SystemImpl__dladdr(void *symbol, const char **file, const char **name)
   *name = "not available on Windows";
 #else
   Dl_info info;
-  if (0 == dladdr((MMC_FETCH(MMC_OFFSET(MMC_UNTAGPTR(symbol), 1))), &info)) {
+  void *ptr = (MMC_FETCH(MMC_OFFSET(MMC_UNTAGPTR(symbol), 1)));
+  if (0 == dladdr(ptr, &info)) {
     *file = "dladdr failed";
     *name = "";
   } else {
-    *file = omc_alloc_interface.malloc_strdup(info.dli_fname);
-    *name = omc_alloc_interface.malloc_strdup(info.dli_sname);
+    *file = info.dli_fname ? omc_alloc_interface.malloc_strdup(info.dli_fname) : "(null)";
+    *name = info.dli_sname ? omc_alloc_interface.malloc_strdup(info.dli_sname) : "(null)";
   }
 #endif
 }


### PR DESCRIPTION
This partially resolves ticket:3356 (separators with alignment and
wrapping was not yet implemented for direct file output). It is now
possible to make a Tpl.Text bound to a file. Such a file needs to be
explicitly closed because the Susan engine does not know what it is.
It is simply a Tpl.mo function that changes the internal structure
of the Text and writes its output directly to file. This is only
possible because it knows that it cannot be read. You could write in
the template that you want to append a FILE_TEXT to a MEM_TEXT, but
this would just result in errors.

There are a few ways to use this new functionality.

From MetaModelica:

```mo
Tpl.closeFile(somTplFunc,Tpl.redirectToFile(Tpl.emptyTxt, file));
```

From Susan:

```
let &literalsFile = buffer ""
let &literalsFile += redirectToFile('<%fileNamePrefix%>_literals.h')
let &literalsFile += simulationLiteralsFile(fileNamePrefix, literals)
let &literalsFile += closeFile()
```

Susan alternative:
```
redirectToFile('<%fileNamePrefix%>_literals.h') +
simulationLiteralsFile(fileNamePrefix, literals)
closeFile()
```

Note that fully taking advantage of FILE_TEXT requires using as few let-
expressions as possible and as few impure external functions as
possible. The reason is that let-expressions need to be stored in memory
and that writing the expressions directly in the template in order is
very hard with impure functions.