### PR TITLE
Configure ANTLR with CXX

### DIFF
--- a/Parser/Makefile.common
+++ b/Parser/Makefile.common
@@ -21,7 +21,7 @@ install_bootstrapping: $(ANTLR_LIB) libomparse-boot.a
 	cp $(ANTLR_LIB) $(OMBUILDDIR)/$(LIB_OMC)/
 
 $(ANTLR)/antlr3config.h: $(ANTLR)/antlr3config.h.in $(ANTLR)/configure
-	(cd $(ANTLR) && ./configure $(ANTLR64) $(ANTLRDEBUG) $(host) CC="$(CC)" LDFLAGS="" CFLAGS="$(CFLAGS)" CPPFLAGS="")
+	(cd $(ANTLR) && ./configure $(ANTLR64) $(ANTLRDEBUG) $(host) CC="$(CC)" CXX="$(CXX)" LDFLAGS="" CFLAGS="$(CFLAGS)" CPPFLAGS="")
 libomantlr3.a: $(ANTLR)/src/*.c $(ANTLR)/include/*.h $(ANTLR)/antlr3config.h
 	# build the library
 	$(CC) ${CFLAGS} ${CPPFLAGS} -c $(ANTLR)/src/*.c -I$(ANTLR)/include -I$(ANTLR)


### PR DESCRIPTION
CXX is actually unused, but may put g++ in the config.log even though it
is unused.