### PR TITLE
Make Compiler/runtime shared to avoid C++ issues

### DIFF
--- a/Compiler/boot/Makefile.common
+++ b/Compiler/boot/Makefile.common
@@ -34,12 +34,12 @@ PATCH_SOURCES=$(SED) -i 's/ = omc_assert_function/__attribute__((noreturn)) = om
 PATCHES := $(patsubst %.patch.xz,%.patch,$(wildcard patches/*.patch.xz))
 
 ifeq ($(BOOTSTRAP_STAGE_1),1)
-OMCRUNTIMEAR=../runtime/libomcruntime-boot.a
+OMCRUNTIMEAR=../runtime/libomcruntime-boot$(SHREXT)
 OMPARSEAR=../../Parser/libomparse-boot.a
 LOMPARSE=$(OMPARSEAR)
-LCOMPILERRUNTIME=$(OMCRUNTIMEAR)
+LCOMPILERRUNTIME=$(abspath $(OMCRUNTIMEAR))
 else
-OMCRUNTIMEAR=$(OMHOME)/$(LIB_OMC)/libomcruntime.a
+OMCRUNTIMEAR=$(OMHOME)/$(LIB_OMC)/libomcruntime$(SHREXT)
 OMPARSEAR=$(OMHOME)/$(LIB_OMC)/libomparse.a
 LOMPARSE=-lomparse
 LCOMPILERRUNTIME=-lomcruntime
@@ -177,13 +177,13 @@ $(GEN_DIR)_main_static.o: $(GEN_DIR)_main_static.c
 
 $(OMHOME)/$(LIB_OMC)/libOpenModelicaCompiler$(SHREXT): $(ALL_OBJECTS) $(OMCRUNTIMEAR) $(OMPARSEAR) $(GEN_DIR)_main_omc.o
 	@test ! -z "`echo $(ALL_OBJECTS)`" || (echo Empty dependencies for $@ ; false)
-	$(CC) -shared $(RPATH) $(INSTALL_NAME) -o $@ $^ $(LDFLAGS)
+	$(CC) -shared $(RPATH) $(INSTALL_NAME) -o $@ $(ALL_OBJECTS) $(GEN_DIR)_main_omc.o $(LDFLAGS)
 	test ! "$(SHREXT)" = ".dylib" || install_name_tool -id @rpath/libOpenModelicaCompiler.dylib $@
 
 ifeq (${STATIC},)
 #shared
 $(GEN_DIR)omc$(EXE_SUFFIX)$(EXE_EXT): $(OMHOME)/$(LIB_OMC)/libOpenModelicaCompiler$(SHREXT) $(GEN_DIR)_main_omc.o $(GEN_DIR)_main.o
-	$(CC) $(GEN_DIR)_main.o $(RPATH) $(CFLAGS) $(CPPFLAGS) -o $@ $(LDFLAGS) -lOpenModelicaCompiler
+	$(CC) $(GEN_DIR)_main.o $(RPATH) $(CFLAGS) $(CPPFLAGS) -o $@ $(LDFLAGS_SHARED_MAIN) -lOpenModelicaCompiler
 install: $(GEN_DIR)omc$(EXE_SUFFIX)$(EXE_EXT) install-interface
 	cp -a $< $(OMHOME)/bin/
 	test ! "$(SHREXT)" = ".dll" || cp -a $(OMHOME)/$(LIB_OMC)/libOpenModelicaCompiler$(SHREXT) $(OMHOME)/bin/

--- a/Compiler/boot/Makefile.in
+++ b/Compiler/boot/Makefile.in
@@ -13,6 +13,7 @@ EXE_SUFFIX=
 
 LIB_OMC=lib/@host_short@/omc
 LDFLAGS=-L.  -L$(GEN_DIR) -L"$(OMHOME)/$(LIB_OMC)" $(LOMPARSE) $(LCOMPILERRUNTIME) -lOpenModelicaRuntimeC -lModelicaExternalC -lomantlr3 $(CORBALIBS) $(FMILIB) $(GSLIB) @RT_LDFLAGS@ @LIBSOCKET@ @LIBLPSOLVE55@ @OMC_LIBS@ @GRAPHLIB@ -lexpat @LD_LAPACK@
+LDFLAGS_SHARED_MAIN=-L"$(OMHOME)/$(LIB_OMC)" @RT_LDFLAGS_SHARED@
 ifeq (@WITH_FMIL@,yes)
 FMILIB = -L$(TOP_DIR)/3rdParty/FMIL/install/lib -lfmilib
 endif

--- a/Compiler/runtime/Makefile.common
+++ b/Compiler/runtime/Makefile.common
@@ -33,8 +33,8 @@ OMC_OBJ = $(OMC_OBJ_BOOT) Print_omc.o  Settings_omc.o serializer.o \
 
 all: install
 .PHONY: all install
-install: libomcruntime.a
-	cp libomcruntime.a $(builddir_lib)/$(TRIPLE)/omc/
+install: libomcruntime$(SHREXT)
+	cp libomcruntime$(SHREXT) $(builddir_lib)/$(TRIPLE)/omc/
 OBJEXT=.o
 BOOTH=../OpenModelicaBootstrappingHeader.h
 ifeq ($(BOOTSTRAPPING),1)
@@ -42,7 +42,7 @@ ifeq ($(wildcard $(OMC)),)
 OBJEXT=.boot.o
 BOOTH=../boot/tarball-include/OpenModelicaBootstrappingHeader.h
 CPPFLAGS += -I../boot/tarball-include
-install_bootstrapping: libomcruntime-boot.a
+install_bootstrapping: libomcruntime-boot$(SHREXT)
 else
 install_bootstrapping:
 	@echo "Skipping libomcruntime-boot.a since we already have an OMC executable"
@@ -56,6 +56,22 @@ libomcruntime.a : $(OMC_OBJ)
 libomcruntime-boot.a : $(OMC_OBJ)
 	rm -f $@
 	$(AR) -s -r $@ $(OMC_OBJ)
+
+libomcruntime.dylib : $(OMC_OBJ)
+	rm -f $@
+	$(CXX) -shared $(RPATH) -install_name @rpath/$@ -o $@ $(OMC_OBJ) $(LDFLAGS)
+
+libomcruntime-boot.dylib : $(OMC_OBJ)
+	rm -f $@
+	$(CXX) -shared $(RPATH) -install_name @rpath/$@ -o $@ $(OMC_OBJ) $(LDFLAGS)
+
+libomcruntime.so : $(OMC_OBJ)
+	rm -f $@
+	$(CXX) -shared $(RPATH) -o $@ $(OMC_OBJ) $(LDFLAGS)
+
+libomcruntime-boot.so : $(OMC_OBJ)
+	rm -f $@
+	$(CXX) -shared $(RPATH) -o $@ $(OMC_OBJ) $(LDFLAGS)
 
 omc_communication.cc : omc_communication.idl
 	$(IDL) omc_communication.idl

--- a/Compiler/runtime/Makefile.in
+++ b/Compiler/runtime/Makefile.in
@@ -33,6 +33,9 @@ IDLPYTHON = @IDLPYTHONCMD@
 CXXFLAGS = $(CFLAGS) @CXXFLAGS@
 CPPFLAGS = @CPPFLAGS@ -I$(top_builddir)/SimulationRuntime/c -I$(top_builddir)/SimulationRuntime/c/simulation/results -I$(top_builddir)/SimulationRuntime/c/util -I$(top_builddir)/SimulationRuntime/c/meta -I$(top_builddir)/SimulationRuntime/c/meta/gc -I. $(CORBAINCL) -I$(FMIINCLUDE) -I$(top_builddir)/3rdParty/gc/include -I$(GRAPHSTREAMINCLUDE) -I$(GRAPHINCLUDE) -I$(CJSONINCLUDE)
 TRIPLE=@host_short@
+SHREXT=@SHREXT@
+RPATH=@RPATH@
+LDFLAGS = -L "$(builddir_lib)/$(TRIPLE)/omc/"  -lOpenModelicaRuntimeC
 
 include Makefile.common
 

--- a/Compiler/runtime/Makefile.omdev.mingw
+++ b/Compiler/runtime/Makefile.omdev.mingw
@@ -26,7 +26,7 @@ OMBUILDDIR = ../../build
 LPSOLVEINCLUDE = ../../3rdParty/lpsolve/build/include/
 SQLITE3INCLUDE = ../../3rdParty/sqlite3/build/include/
 OMC=$(OMBUILDDIR)/bin/omc
-
+SHREXT=.a
 OMPCC = gcc -fopenmp
 
 # We always compile with corba on OMDev-mingw

--- a/Makefile.common
+++ b/Makefile.common
@@ -53,7 +53,7 @@ mkbuilddirs:
 
 release: omc
 
-bootstrap-dependencies: graphstream $(BOOTSTRAP_FMIL_DEP) $(MINGW_EXTRA_LIBS)
+bootstrap-dependencies: graphstream $(BOOTSTRAP_FMIL_DEP) $(MINGW_EXTRA_LIBS) interactive
 	$(MAKE) -f $(defaultMakefileTarget) -C Compiler/runtime install_bootstrapping BOOTSTRAPPING=1 OMBUILDDIR=$(OMBUILDDIR)
 	$(MAKE) -f $(defaultMakefileTarget) -C Compiler builtin OMBUILDDIR=$(OMBUILDDIR)
 	$(MAKE) -f $(defaultMakefileTarget) -C Parser install_bootstrapping OMBUILDDIR=$(OMBUILDDIR)

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ AC_SUBST(RT_LDFLAGS_SIM_OPTIONAL)
 AC_SUBST(RT_LDFLAGS_GENERATED_CODE)
 AC_SUBST(RT_LDFLAGS_GENERATED_CODE_SIM)
 AC_SUBST(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU)
+AC_SUBST(RT_LDFLAGS_SHARED)
 AC_SUBST(SUNDIALS_LDFLAGS)
 AC_SUBST(IPOPT_LDFLAGS)
 AC_SUBST(IPOPT_CFLAGS)
@@ -628,6 +629,7 @@ if test "$DARWIN" = "1"; then
   RT_LDFLAGS_GENERATED_CODE="$LDFLAGS -lOpenModelicaRuntimeC $LD_LAPACK -lm"
   RT_LDFLAGS_GENERATED_CODE_SIM="$LDFLAGS -lSimulationRuntimeC $LD_LAPACK -lm -lomcgc"
   RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS $LD_LAPACK -lm$LD_NOUNDEFINED"
+  RT_LDFLAGS_SHARED=
   LINK="cp -fr"
   RPATH="-Wl,-rpath,'@loader_path/../lib/$host_short/omc/'"
   RPATH_QMAKE="-Wl,-rpath,'@loader_path/../../../../lib/$host_short/omc',-rpath,'@loader_path/../../../../lib/',-rpath,'$PREFIX/lib/$host_short/omc',-rpath,'$PREFIX/lib/'"
@@ -697,6 +699,8 @@ else
   RT_LDFLAGS_GENERATED_CODE_SIM="$LDFLAGS -lSimulationRuntimeC $LD_LAPACK -lm -lomcgc -lpthread -rdynamic$LD_NOUNDEFINED"
   RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS $LD_LAPACK -lm -lpthread -rdynamic$LD_NOUNDEFINED"
   LINK="cp -frl"
+  LDFLAGS="$LDFLAGS -Wl,-rpath-link,$OMBUILDDIR/lib/$host_short/omc"
+  RT_LDFLAGS_SHARED="-Wl,-rpath-link,$OMBUILDDIR/lib/$host_short/omc"
   RPATH="-Wl,-z,origin -Wl,-rpath,'\$\$ORIGIN/../lib/$host_short/omc' -Wl,-rpath,'\$\$ORIGIN'"
   RPATH_QMAKE="-Wl,-z,origin -Wl,-rpath,\\'\\\$\$ORIGIN/../lib/$host_short/omc\\' -Wl,-rpath,\\'\\\$\$ORIGIN\\'"
   OS_TARGET="linux"


### PR DESCRIPTION
This hopefully fixes OSX where there are multiple competing full C++
ABI's.