### PR TITLE
Create symbolic Jacobian faster

### DIFF
--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -2130,6 +2130,18 @@ algorithm
   outVariables := List.fold(inVarLst,addVar,emptyVarsSized(size));
 end listVar1;
 
+public function listVar2 "author: Frenkel TUD 2012-05
+  ToDo: replace all listVar calls with this function, tailrecursive implementation
+  Takes BackendDAE.Var list and creates a BackendDAE.Variables structure, see also var_list."
+  input list<BackendDAE.Var> inVarLst1,inVarLst2;
+  output BackendDAE.Variables outVariables;
+protected
+  Integer size;
+algorithm
+  size := listLength(inVarLst1)+listLength(inVarLst2);
+  outVariables := List.fold(inVarLst2,addVar,List.fold(inVarLst1,addVar,emptyVarsSized(size)));
+end listVar2;
+
 public function equationSystemsVarsLst
   input BackendDAE.EqSystems systs;
   output list<BackendDAE.Var> outVars = {};
@@ -3006,6 +3018,7 @@ public function mergeVariables
    precedence over the second set."
   input BackendDAE.Variables inVariables1;
   input BackendDAE.Variables inVariables2;
+  input Boolean copy=true;
   output BackendDAE.Variables outVariables;
 protected
   Integer num_vars;
@@ -3015,8 +3028,10 @@ algorithm
   if varsLoadFactor(inVariables1, num_vars) > 1 then
     outVariables := emptyVarsSized(varsSize(inVariables1) + num_vars);
     outVariables := addVariables(inVariables1, outVariables);
-  else
+  elseif copy then
     outVariables := copyVariables(inVariables1);
+  else
+    outVariables := inVariables1;
   end if;
 
   outVariables := addVariables(inVariables2, outVariables);

--- a/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/Compiler/BackEnd/SymbolicJacobian.mo
@@ -2555,7 +2555,7 @@ algorithm
 
       BackendDAE.Variables emptyVars, dependentVars, independentVars, knvars, allvars;
       BackendDAE.EquationArray emptyEqns, eqns;
-      list<BackendDAE.Var> knvarLst, independentVarsLst, dependentVarsLst,  otherVarsLst;
+      list<BackendDAE.Var> knvarLst1, knvarLst2, independentVarsLst, dependentVarsLst,  otherVarsLst;
       list<BackendDAE.Equation> residual_eqnlst;
       list<DAE.ComponentRef> independentComRefs, dependentVarsComRefs,  otherVarsLstComRefs;
 
@@ -2591,12 +2591,6 @@ algorithm
         otherVarsLst = BackendVariable.varList(inotherVars);
         otherVarsLstComRefs = List.map(otherVarsLst, BackendVariable.varCref);
 
-        // all vars since the inVars are inputs for the jacobian
-        allvars = BackendVariable.copyVariables(inAllVars);
-        allvars = BackendVariable.removeCrefs(independentComRefs, allvars);
-        allvars = BackendVariable.removeCrefs(otherVarsLstComRefs, allvars);
-        knvars = BackendVariable.mergeVariables(knvars, allvars);
-
         if Flags.isSet(Flags.JAC_DUMP2) then
           print("\n---+++ known variables +++---\n");
           BackendDump.printVariables(knvars);
@@ -2615,8 +2609,13 @@ algorithm
         end if;
 
         // create known variables
-        knvarLst = BackendEquation.equationsVars(eqns, knvars);
-        knvars = BackendVariable.listVar1(knvarLst);
+        knvarLst1 = BackendEquation.equationsVars(eqns, knvars);
+        knvarLst2 = BackendEquation.equationsVars(eqns, inAllVars);
+        // Create a list of known variables true *only* for this shared system
+        knvars = BackendVariable.listVar2(knvarLst1,knvarLst2);
+        // Remove inputs for the jacobian
+        knvars = BackendVariable.removeCrefs(independentComRefs, knvars);
+        knvars = BackendVariable.removeCrefs(otherVarsLstComRefs, knvars);
 
         if Flags.isSet(Flags.JAC_DUMP2) then
           print("\n---+++ known variables +++---\n");


### PR DESCRIPTION
Avoid copying and merging variable sets when creating the known
variables for the symbolic Jacobian.