### PR TITLE
Make a special case for derived classes

### DIFF
--- a/Compiler/FrontEnd/Absyn.mo
+++ b/Compiler/FrontEnd/Absyn.mo
@@ -6766,5 +6766,35 @@ algorithm
   end match;
 end isEmptyClassPart;
 
+public function isInvariantExpNoTraverse "For use with traverseExp"
+  input output Absyn.Exp e;
+  input output Boolean b;
+algorithm
+  if not b then
+    return;
+  end if;
+  b := match e
+    case INTEGER() then true;
+    case REAL() then true;
+    case STRING() then true;
+    case BOOL() then true;
+    case BINARY() then true;
+    case UNARY() then true;
+    case LBINARY() then true;
+    case LUNARY() then true;
+    case RELATION() then true;
+    case IFEXP() then true;
+    // case CREF(CREF_FULLYQUALIFIED()) then true;
+    case CALL(function_=CREF_FULLYQUALIFIED()) then true;
+    case PARTEVALFUNCTION(function_=CREF_FULLYQUALIFIED()) then true;
+    case ARRAY() then true;
+    case MATRIX() then true;
+    case RANGE() then true;
+    case CONS() then true;
+    case LIST() then true;
+    else false;
+  end match;
+end isInvariantExpNoTraverse;
+
 annotation(__OpenModelica_Interface="frontend");
 end Absyn;

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -757,7 +757,7 @@ public constant Message MISSING_INNER_CLASS = MESSAGE(532, TRANSLATION(), WARNIN
 public constant Message RECURSION_DEPTH_WARNING = MESSAGE(533, TRANSLATION(), ERROR(),
   Util.gettext("The maximum recursion depth of %s was reached when evaluating expression %s in scope %s. Translation may still succeed but you are recommended to fix the problem."));
 public constant Message RECURSION_DEPTH_DERIVED = MESSAGE(534, TRANSLATION(), ERROR(),
-  Util.gettext("The maximum recursion depth of %s was reached when instantiating a derived class. Current class %s in scope %s."));
+  Util.gettext("The maximum recursion depth of was reached when instantiating a derived class. Current class %s in scope %s."));
 public constant Message EVAL_EXTERNAL_OBJECT_CONSTRUCTOR = MESSAGE(535, TRANSLATION(), WARNING(),
   Util.gettext("OpenModelica requires that all external objects input arguments are possible to evaluate before initialization in order to avoid odd run-time failures, but %s is a variable."));
 public constant Message CLASS_ANNOTATION_DOES_NOT_EXIST = MESSAGE(536, SCRIPTING(), ERROR(),


### PR DESCRIPTION
Handle derived class declarations with simple modifications special:
do not translate them using extends, but rather by directly using
the base class + modifiers.