### PR TITLE
Make special case for BackendVariable.getVarSingle

### DIFF
--- a/Compiler/BackEnd/BackendDAECreate.mo
+++ b/Compiler/BackEnd/BackendDAECreate.mo
@@ -2673,17 +2673,17 @@ algorithm
       Integer i;
     case(_, _, _, _)
       equation
-        (v::{}, i::{}) = BackendVariable.getVar(cr, iVars);
+        (v, i) = BackendVariable.getVarSingle(cr, iVars);
       then
         (v, i, 1);
     case(_, _, _, _)
       equation
-        (v::{}, i::{}) = BackendVariable.getVar(cr, iKnVars);
+        (v, i) = BackendVariable.getVarSingle(cr, iKnVars);
       then
         (v, i, 2);
     case(_, _, _, _)
       equation
-        (v::{}, i::{}) = BackendVariable.getVar(cr, iExtVars);
+        (v, i) = BackendVariable.getVarSingle(cr, iExtVars);
       then
         (v, i, 3);
   end matchcontinue;

--- a/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -172,17 +172,17 @@ algorithm
       Boolean negate;
 
     case (DAE.CALL(path=Absyn.IDENT(name="der"), expLst={DAE.CREF(componentRef=cr, ty=tp)}), (knvars, aliasvars, _)) equation
-      (var::{}, _) = BackendVariable.getVar(cr, knvars);
+      (var, _) = BackendVariable.getVarSingle(cr, knvars);
       false = BackendVariable.isVarOnTopLevelAndInput(var);
       (zero, _) = Expression.makeZeroExpression(Expression.arrayDimension(tp));
     then (zero, (knvars, aliasvars, true));
 
     case (DAE.CALL(path=Absyn.IDENT(name="pre"), expLst={e as DAE.CREF(componentRef=cr)}), (knvars, aliasvars, _)) equation
-      (_::{}, _) = BackendVariable.getVar(cr, knvars);
+      (_, _) = BackendVariable.getVarSingle(cr, knvars);
     then(e, (knvars, aliasvars, true));
 
     case (DAE.CALL(path=Absyn.IDENT(name="previous"), expLst={e as DAE.CREF(componentRef=cr)}), (knvars, aliasvars, _)) equation
-      (_::{}, _) = BackendVariable.getVar(cr, knvars);
+      (_, _) = BackendVariable.getVarSingle(cr, knvars);
     then(e, (knvars, aliasvars, true));
 
     case (DAE.CALL(path=Absyn.IDENT(name="pre"), expLst={e as DAE.CREF(componentRef=DAE.CREF_IDENT(ident="time"))}), (knvars, aliasvars, _))
@@ -198,7 +198,7 @@ algorithm
     then (e, (knvars, aliasvars, true));
 
     case (DAE.CALL(path=Absyn.IDENT(name="pre"), expLst={DAE.CREF(componentRef=cr, ty=tp)}, attr=attr), (knvars, aliasvars, _)) equation
-      (var::{}, _) = BackendVariable.getVar(cr, aliasvars);
+      (var, _) = BackendVariable.getVarSingle(cr, aliasvars);
       (cr, negate) = BackendVariable.getAlias(var);
       e = DAE.CREF(cr, tp);
       e = if negate then Expression.negate(e) else e;
@@ -207,7 +207,7 @@ algorithm
     then (e, (knvars, aliasvars, true));
 
     case (DAE.CALL(path=Absyn.IDENT(name="previous"), expLst={DAE.CREF(componentRef=cr, ty=tp)}, attr=attr), (knvars, aliasvars, _)) equation
-      (var::{}, _) = BackendVariable.getVar(cr, aliasvars);
+      (var, _) = BackendVariable.getVarSingle(cr, aliasvars);
       (cr, negate) = BackendVariable.getAlias(var);
       e = DAE.CREF(cr, tp);
       e = if negate then Expression.negate(e) else e;
@@ -229,7 +229,7 @@ algorithm
     then (DAE.BCONST(false), (knvars, aliasvars, true));
 
     case (DAE.CALL(path=Absyn.IDENT(name="change"), expLst={DAE.CREF(componentRef=cr, ty=tp)}, attr=attr), (knvars, aliasvars, _)) equation
-      (var::{}, _) = BackendVariable.getVar(cr, aliasvars);
+      (var, _) = BackendVariable.getVarSingle(cr, aliasvars);
       (cr, negate) = BackendVariable.getAlias(var);
       e = DAE.CREF(cr, tp);
       e = if negate then Expression.negate(e) else e;
@@ -238,7 +238,7 @@ algorithm
     then (e, (knvars, aliasvars, true));
 
     case (DAE.CALL(path=Absyn.IDENT(name="edge"), expLst={DAE.CREF(componentRef=cr, ty=tp)}), (knvars, aliasvars, _)) equation
-      (_::{}, _) = BackendVariable.getVar(cr, knvars);
+      (_, _) = BackendVariable.getVarSingle(cr, knvars);
       zero = Expression.arrayFill(Expression.arrayDimension(tp), DAE.BCONST(false));
     then (zero, (knvars, aliasvars, true));
 
@@ -246,7 +246,7 @@ algorithm
     then (DAE.BCONST(false), (knvars, aliasvars, true));
 
     case (DAE.CALL(path=Absyn.IDENT(name="edge"), expLst={DAE.CREF(componentRef=cr, ty=tp)}, attr=attr), (knvars, aliasvars, _)) equation
-      (var::{}, _) = BackendVariable.getVar(cr, aliasvars);
+      (var, _) = BackendVariable.getVarSingle(cr, aliasvars);
       (cr, negate) = BackendVariable.getAlias(var);
       e = DAE.CREF(cr, tp);
       e = if negate then Expression.negate(e) else e;
@@ -2323,7 +2323,7 @@ algorithm
       DAE.Exp e;
     case (DAE.CREF(componentRef = cr),(knvars,_))
       equation
-        (v::{},_::{}) = BackendVariable.getVar(cr,knvars);
+        (v,_) = BackendVariable.getVarSingle(cr,knvars);
         true = BackendVariable.isFinalVar(v);
         e = BackendVariable.varBindExpStartValue(v);
       then (e,(knvars,true));
@@ -3810,7 +3810,7 @@ algorithm
       then (exp,vars);
     case (e1 as DAE.CALL(path=Absyn.IDENT(name = "der"), expLst={DAE.CREF(componentRef=cr)}))
       equation
-        ({v}, _) = BackendVariable.getVar(cr, vars);
+        (v, _) = BackendVariable.getVarSingle(cr, vars);
         (vars, e1) = updateStatesVar(vars, v, e1);
       then (e1, vars);
     case (e1 as DAE.CALL(path=Absyn.IDENT(name = "der"), expLst={DAE.CREF(componentRef=cr)}))
@@ -3844,7 +3844,7 @@ algorithm
     DAE.Exp e;
     case (e as DAE.CALL(path = Absyn.IDENT(name = "der"), expLst = {DAE.CREF(componentRef = cr)}), vars)
     equation
-      ({v}, _) = BackendVariable.getVar(cr, vars);
+      (v, _) = BackendVariable.getVarSingle(cr, vars);
       (vars, e) = updateStatesVar(vars, v, e);
       then (e, vars);
     case (e as DAE.CALL(path = Absyn.IDENT(name = "der"), expLst = {DAE.CREF(componentRef = cr)}), vars)
@@ -5268,7 +5268,7 @@ algorithm
       String str;
 
     case (DAE.CALL(path=Absyn.IDENT(name="der"), expLst={DAE.CREF(componentRef=cr, ty=ty)}), (vars, eqnLst, shared, addVar, _)) equation
-      ({v}, _) = BackendVariable.getVar(cr, vars);
+      (v, _) = BackendVariable.getVarSingle(cr, vars);
       cref = BackendVariable.varCref(v);
       v1 = BackendVariable.createAliasDerVar(cref);
       v1 = BackendVariable.mergeNominalAttribute(v, v1, false);

--- a/Compiler/BackEnd/BackendEquation.mo
+++ b/Compiler/BackEnd/BackendEquation.mo
@@ -2375,9 +2375,9 @@ algorithm
 
     case(_,e1 as DAE.CREF(componentRef = cr)) algorithm
       try
-        ({v}, _) := BackendVariable.getVar(cr, inVars);
+        (v, _) := BackendVariable.getVarSingle(cr, inVars);
       else
-        ({v}, _) := BackendVariable.getVar(cr, knvars);
+        (v, _) := BackendVariable.getVarSingle(cr, knvars);
       end try;
 
       lhs := ComponentReference.makeCrefIdent(conCrefName, DAE.T_REAL_DEFAULT, {});

--- a/Compiler/BackEnd/Differentiate.mo
+++ b/Compiler/BackEnd/Differentiate.mo
@@ -1110,7 +1110,7 @@ algorithm
     case ((DAE.CREF(componentRef = cr, ty = tp)), _, BackendDAE.DIFFINPUTDATA(knownVars=SOME(knvars)), _, _)
       equation
         //print("\nExp-Cref\n known vars: " + ExpressionDump.printExpStr(e));
-        (var::{},_) = BackendVariable.getVar(cr, knvars);
+        (var,_) = BackendVariable.getVarSingle(cr, knvars);
         false = BackendVariable.isVarOnTopLevelAndInput(var);
         (zero,_) = Expression.makeZeroExpression(Expression.arrayDimension(tp));
 
@@ -1121,7 +1121,7 @@ algorithm
     // d(discrete)/d(x) = 0
     case ((DAE.CREF(componentRef = cr,ty = tp)), _, BackendDAE.DIFFINPUTDATA(allVars=SOME(timevars)), _, _)
       equation
-        ({BackendDAE.VAR(varKind = kind)},_) = BackendVariable.getVar(cr, timevars);
+        (BackendDAE.VAR(varKind = kind),_) = BackendVariable.getVarSingle(cr, timevars);
         //print("\nExp-Cref\n known vars: " + ComponentReference.printComponentRefStr(cr));
         true = listMember(kind,{BackendDAE.DISCRETE()}) or not Types.isReal(tp);
         (zero,_) = Expression.makeZeroExpression(Expression.arrayDimension(tp));
@@ -1139,7 +1139,7 @@ algorithm
         //se1 = ExpressionDump.printExpStr(e);
         //print("\nExp-Cref\nDUMMY_STATE: " + se1);
 
-        ({var},_) = BackendVariable.getVar(cr, timevars);
+        (var,_) = BackendVariable.getVarSingle(cr, timevars);
         true = BackendVariable.isDummyStateVar(var);
         cr = ComponentReference.crefPrefixDer(cr);
         res = Expression.makeCrefExp(cr, tp);
@@ -1156,7 +1156,7 @@ algorithm
         //print("\nExp-Cref\n all other vars: " + se1);
 
         //({BackendDAE.VAR(varKind = BackendDAE.STATE(index=_))},_) = BackendVariable.getVar(cr, timevars);
-        ({_},_) = BackendVariable.getVar(cr, timevars);
+        (_,_) = BackendVariable.getVarSingle(cr, timevars);
         res = DAE.CALL(Absyn.IDENT("der"),{e},DAE.CALL_ATTR(tp,false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL()));
 
         //se1 = ExpressionDump.printExpStr(res);

--- a/Compiler/BackEnd/DynamicOptimization.mo
+++ b/Compiler/BackEnd/DynamicOptimization.mo
@@ -473,7 +473,7 @@ algorithm
 
     case (DAE.CALL(path=Absyn.IDENT(name = "der"),expLst={DAE.CREF(componentRef=cr)}),(vars,lst,lst1,varLst))
       equation
-        (var::{},_) = BackendVariable.getVar(cr, vars);
+        (var,_) = BackendVariable.getVarSingle(cr, vars);
         true = BackendVariable.isVarOnTopLevelAndInput(var);
         cr1 = ComponentReference.prependStringCref("$TMP$DER$P", cr);
         //cr1 = ComponentReference.crefPrefixDer(cr);
@@ -834,11 +834,11 @@ algorithm
                 vars := BackendVariable.setVarAt(vars, vindx, var_con);
 
                 try
-                  (_,{vindx}) := BackendVariable.getVar(cr, vars);
+                  (_,vindx) := BackendVariable.getVarSingle(cr, vars);
                   vars := BackendVariable.setVarAt(vars, vindx, var_);
                   //print("var" +  BackendDump.varString(var_));
                 else
-                  (_,{vindx}) := BackendVariable.getVar(cr, knownVars);
+                  (_,vindx) := BackendVariable.getVarSingle(cr, knownVars);
                   knownVars := BackendVariable.setVarAt(knownVars, vindx, var_);
                   //print("var" +  BackendDump.varString(var_));
                 end try;

--- a/Compiler/BackEnd/EvaluateParameter.mo
+++ b/Compiler/BackEnd/EvaluateParameter.mo
@@ -752,7 +752,7 @@ algorithm
       equation
         // check for cyclic bindings in start value
         false = BaseHashSet.has(cr, hs);
-        ({v}, _) = BackendVariable.getVar(cr, vars);
+        (v, _) = BackendVariable.getVarSingle(cr, vars);
         e = BackendVariable.varStartValueType(v);
         hs = BaseHashSet.add(cr,hs);
         (e, (_,b,hs)) = Expression.traverseExpBottomUp(e, replaceCrefWithBindStartExp, (vars,b,hs));

--- a/Compiler/BackEnd/IndexReduction.mo
+++ b/Compiler/BackEnd/IndexReduction.mo
@@ -829,20 +829,20 @@ algorithm
       //if der(x) = y, replace all der(x) with y
      case (DAE.CALL(path = Absyn.IDENT(name = "der"),expLst = {DAE.CREF(componentRef = cr)}),vars)
       equation
-        ({BackendDAE.VAR(varKind=BackendDAE.STATE(derName=SOME(dcr)))},_) = BackendVariable.getVar(cr,vars);
+        (BackendDAE.VAR(varKind=BackendDAE.STATE(derName=SOME(dcr))),_) = BackendVariable.getVarSingle(cr,vars);
         e = Expression.crefExp(dcr);
       then
         (e,false,vars);
      case (DAE.CALL(path = Absyn.IDENT(name = "der"),expLst = {DAE.CREF(componentRef = cr),DAE.ICONST(index)},attr=attr),vars)
       equation
         true = intEq(index,2);
-        ({BackendDAE.VAR(varKind=BackendDAE.STATE(derName=SOME(dcr)))},_) = BackendVariable.getVar(cr,vars);
+        (BackendDAE.VAR(varKind=BackendDAE.STATE(derName=SOME(dcr))),_) = BackendVariable.getVarSingle(cr,vars);
         e = Expression.crefExp(dcr);
       then
         (DAE.CALL(Absyn.IDENT("der"),{e},attr),false,vars);
      case (DAE.CALL(path = Absyn.IDENT(name = "der"),expLst = {DAE.CALL(path = Absyn.IDENT(name = "der"),expLst = {DAE.CREF(componentRef = cr)})},attr=attr),vars)
       equation
-        ({BackendDAE.VAR(varKind=BackendDAE.STATE(derName=SOME(dcr)))},_) = BackendVariable.getVar(cr,vars);
+        (BackendDAE.VAR(varKind=BackendDAE.STATE(derName=SOME(dcr))),_) = BackendVariable.getVarSingle(cr,vars);
         e = Expression.crefExp(dcr);
       then
         (DAE.CALL(Absyn.IDENT("der"),{e},attr),false,vars);
@@ -1515,7 +1515,7 @@ protected function getVar
   input BackendDAE.Variables vars;
   output BackendDAE.Var v;
 algorithm
-  ({v},_) := BackendVariable.getVar(cr,vars);
+  (v,_) := BackendVariable.getVarSingle(cr,vars);
 end getVar;
 
 protected type StateSets = list<tuple<Integer,Integer,Integer,Integer,list<BackendDAE.Var>,list<BackendDAE.Equation>,list<BackendDAE.Var>,list<BackendDAE.Equation>>> "Level,nStates,nStateCandidates,nUnassignedEquations,StateCandidates,ConstraintEqns,OtherVars,OtherEqns";
@@ -2255,7 +2255,7 @@ algorithm
       Option<DAE.ComponentRef> derName;
     case (BackendDAE.VAR(varName=cr,varKind=BackendDAE.STATE()),(stateindexs,invmap,indx,nv,hov,derstatesindexs))
       equation
-        (_::_,{s}) = BackendVariable.getVar(cr, hov);
+        (_,s) = BackendVariable.getVarSingle(cr, hov);
         newindx = nv+s;
         arrayUpdate(stateindexs,indx,newindx);
         arrayUpdate(invmap,s,indx);
@@ -3029,7 +3029,7 @@ algorithm
       Boolean b;
     case(BackendDAE.VAR(varKind=BackendDAE.STATE(derName=SOME(cr))),_)
       equation
-        ({v},_) = BackendVariable.getVar(cr, vars);
+        (v,_) = BackendVariable.getVarSingle(cr, vars);
         b = BackendVariable.isDummyStateVar(v);
         prio = if b then 0.0 else 0.55;
       then prio;

--- a/Compiler/BackEnd/OnRelaxation.mo
+++ b/Compiler/BackEnd/OnRelaxation.mo
@@ -2264,7 +2264,7 @@ algorithm
         vlst;
     case(cr::rest, _, _, _, _, _)
       equation
-        (v::{}, i::{}) = BackendVariable.getVar(cr, vars);
+        (v, i) = BackendVariable.getVarSingle(cr, vars);
         p = List.position(i, vindxs);
         ilst = listDelete(vindxs, p);
         vlst = listDelete(inVarLst, p);
@@ -3367,8 +3367,8 @@ algorithm
     case (BackendDAE.EQUATION(exp = DAE.CREF(componentRef=cr1), scalar=DAE.CREF(componentRef=cr2)), _, (id, vec1, vec2))
       equation
         false = intGt(vec2[id], 0);
-        (_, i1::{}) = BackendVariable.getVar(cr1, vars);
-        (_, i2::{}) = BackendVariable.getVar(cr2, vars);
+        (_, i1) = BackendVariable.getVarSingle(cr1, vars);
+        (_, i2) = BackendVariable.getVarSingle(cr2, vars);
         i = aliasMatching1(i1, i2, intGt(vec1[i1], 0), intGt(vec1[i2], 0));
         vec1 = arrayUpdate(vec1, i, id);
         vec2 = arrayUpdate(vec2, id, i);

--- a/Compiler/BackEnd/RemoveSimpleEquations.mo
+++ b/Compiler/BackEnd/RemoveSimpleEquations.mo
@@ -3276,7 +3276,7 @@ algorithm
       equation
         // check for cyclic bindings in start value
         false = BaseHashSet.has(cr, hs);
-        ({BackendDAE.VAR(bindExp = SOME(e))}, _) = BackendVariable.getVar(cr, vars);
+        (BackendDAE.VAR(bindExp = SOME(e)), _) = BackendVariable.getVarSingle(cr, vars);
         hs = BaseHashSet.add(cr, hs);
         (e, (_, _, hs)) = Expression.traverseExpBottomUp(e, replaceCrefWithBindExp, (vars, false, hs));
       then
@@ -3586,7 +3586,7 @@ algorithm
     case (_, _, _)
       equation
         cr::_ = Expression.extractCrefsFromExp(iExp);
-        (BackendDAE.VAR(bindExp=SOME(e))::{}, _) = BackendVariable.getVar(cr, iAVars);
+        (BackendDAE.VAR(bindExp=SOME(e)), _) = BackendVariable.getVarSingle(cr, iAVars);
       then
         fixAliasConstBindings1(cr, e, iAVars);
     else
@@ -3767,11 +3767,11 @@ algorithm
       equation
         cr = BackendVariable.varCref(var);
         false = BaseHashSet.has(cr, hs);
-        ({var}, _) = BackendVariable.getVar(cr, aliasVars);
+        (var, _) = BackendVariable.getVarSingle(cr, aliasVars);
         exp = BackendVariable.varBindExp(var);
         cr::{} = Expression.extractCrefsFromExp(exp);
         b = BaseHashSet.has(cr, hs);
-        ({var}, _) = BackendVariable.getVar(cr, vars);
+        (var, _) = BackendVariable.getVarSingle(cr, vars);
         varlst = List.consOnTrue(not b, var, iAcc);
       then
         replaceOtherStateSetVars(varlst, vars, aliasVars, hs, varlst);
@@ -4466,7 +4466,7 @@ algorithm
   for cr_exp in cr_exp_lst loop
     (cr,e) := cr_exp;
     try
-      ({v},{i}) := BackendVariable.getVar(cr,outVars);
+      (v,i) := BackendVariable.getVarSingle(cr,outVars);
       // add bindExp
       v := BackendVariable.setBindExp(v, SOME(e));
       // Update this to given source information!!!!
@@ -5063,7 +5063,7 @@ algorithm
     (cr1,cr_eq_lst) := tpl;
     BaseHashTable.clear(HTStartExpToInt);
     BaseHashTable.clear(HTNominalExpToInt);
-    ({v},{i}) := BackendVariable.getVar(cr1,outVars);
+    (v,i) := BackendVariable.getVarSingle(cr1,outVars);
     if BackendVariable.varHasStartValue(v) then
       e := BackendVariable.varStartValue(v);
       if Expression.isZero(e) then
@@ -5140,7 +5140,7 @@ algorithm
 
     case ({}) then (outHTStartExpToInt,outHTNominalExpToInt);
     case (cr1,eq)::cr_eq_rest equation
-      ({v},_) = BackendVariable.getVar(cr1,inAliasVars);
+      (v,_) = BackendVariable.getVarSingle(cr1,inAliasVars);
       e = BackendVariable.varBindExp(v);
       if BackendVariable.varHasStartValue(v) then
         res = BackendVariable.varStartValue(v);

--- a/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/Compiler/BackEnd/SymbolicJacobian.mo
@@ -331,12 +331,12 @@ algorithm
       list<DAE.Exp> explst;
     case (e as DAE.CALL(path=Absyn.IDENT(name = "der"),expLst={DAE.CALL(path=Absyn.IDENT(name = "der"),expLst={DAE.CREF(componentRef=cr)})}),(vars,explst))
       equation
-        (var::{},_) = BackendVariable.getVar(cr, vars);
+        (var,_) = BackendVariable.getVarSingle(cr, vars);
         true = BackendVariable.isVarOnTopLevelAndInput(var);
       then (e,false,(vars,e::explst));
     case (e as DAE.CALL(path=Absyn.IDENT(name = "der"),expLst={DAE.CREF(componentRef=cr)}),(vars,explst))
       equation
-        (var::{},_) = BackendVariable.getVar(cr, vars);
+        (var,_) = BackendVariable.getVarSingle(cr, vars);
         true = BackendVariable.isVarOnTopLevelAndInput(var);
       then (e,false,(vars,e::explst));
     else (inExp,true,tpl);
@@ -1973,7 +1973,7 @@ algorithm
        createAllDiffedVars(restVar,cref,inAllVars,inIndex, inMatrixName,iVars);
 
      case(BackendDAE.VAR(varName=currVar,varKind=BackendDAE.STATE())::restVar,cref,_,_, _, _) equation
-      ({_}, _) = BackendVariable.getVar(currVar, inAllVars);
+      (_, _) = BackendVariable.getVarSingle(currVar, inAllVars);
       currVar = ComponentReference.crefPrefixDer(currVar);
       derivedCref = Differentiate.createDifferentiatedCrefName(currVar, cref, inMatrixName);
       r1 = BackendDAE.VAR(derivedCref, BackendDAE.STATE_DER(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
@@ -1981,7 +1981,7 @@ algorithm
       createAllDiffedVars(restVar, cref, inAllVars, inIndex+1, inMatrixName,r1::iVars);
 
     case(BackendDAE.VAR(varName=currVar)::restVar,cref,_,_, _, _) equation
-      ({_}, _) = BackendVariable.getVar(currVar, inAllVars);
+      (_, _) = BackendVariable.getVarSingle(currVar, inAllVars);
       derivedCref = Differentiate.createDifferentiatedCrefName(currVar, cref, inMatrixName);
       r1 = BackendDAE.VAR(derivedCref, BackendDAE.STATE_DER(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
     then
@@ -2792,7 +2792,7 @@ protected function markSetStates
 protected
   Integer index;
 algorithm
-  (_, {index}) := BackendVariable.getVar(inCr, iVars);
+  (_, index) := BackendVariable.getVarSingle(inCr, iVars);
   oMark := arrayUpdate(iMark, index, true);
 end markSetStates;
 

--- a/Compiler/FrontEnd/Types.mo
+++ b/Compiler/FrontEnd/Types.mo
@@ -968,6 +968,31 @@ algorithm
   end matchcontinue;
 end getDimensionSizes;
 
+public function getDimensionProduct "Return the dimension sizes of a Type."
+  input DAE.Type inType;
+  output Integer sz;
+algorithm
+  sz := match (inType)
+    local
+      list<Integer> res;
+      DAE.Dimensions dims;
+      Integer i;
+      Type tp;
+      DAE.TypeSource ts;
+
+    case (DAE.T_ARRAY(dims = dims,ty = tp, source = ts))
+      then product(Expression.dimensionSize(d) for d in dims) * getDimensionProduct(tp);
+
+    case (DAE.T_SUBTYPE_BASIC(complexType=tp))
+      then getDimensionProduct(tp);
+
+    else
+      equation
+        false = arrayType(inType);
+      then 1;
+  end match;
+end getDimensionProduct;
+
 public function getDimensions
 "Returns the dimensions of a Type."
   input DAE.Type inType;

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -4044,7 +4044,7 @@ protected
 algorithm
   ((var, (vars, varLst))) := inTuple;
   SimCodeVar.SIMVAR(name=cref) := var;
-  ({v},_) := BackendVariable.getVar(cref, vars);
+  (v,_) := BackendVariable.getVarSingle(cref, vars);
   outTuple := ((var, (vars, v::varLst)));
 end sortBackVarWithSimVarsOrder;
 
@@ -4076,7 +4076,7 @@ algorithm
        createAllDiffedSimVars(restVar, cref, inAllVars, inIndex, inMatrixName, iVars);
 
      case(BackendDAE.VAR(varName=currVar, varKind=BackendDAE.STATE(), values = dae_var_attr)::restVar, cref, _, _, _, _) equation
-      ({_}, _) = BackendVariable.getVar(currVar, inAllVars);
+      BackendVariable.getVarSingle(currVar, inAllVars);
       currVar = ComponentReference.crefPrefixDer(currVar);
       derivedCref = Differentiate.createDifferentiatedCrefName(currVar, cref, inMatrixName);
       isProtected = getProtected(dae_var_attr);
@@ -4085,7 +4085,7 @@ algorithm
       createAllDiffedSimVars(restVar, cref, inAllVars, inIndex+1, inMatrixName, r1::iVars);
 
     case(BackendDAE.VAR(varName=currVar, values = dae_var_attr)::restVar, cref, _, _, _, _) equation
-      ({_}, _) = BackendVariable.getVar(currVar, inAllVars);
+      BackendVariable.getVarSingle(currVar, inAllVars);
       derivedCref = Differentiate.createDifferentiatedCrefName(currVar, cref, inMatrixName);
       isProtected = getProtected(dae_var_attr);
       r1 = SimCodeVar.SIMVAR(derivedCref, BackendDAE.STATE_DER(), "", "", "", inIndex, NONE(), NONE(), NONE(), NONE(), false, DAE.T_REAL_DEFAULT, false, NONE(), SimCodeVar.NOALIAS(), DAE.emptyElementSource, SimCodeVar.NONECAUS(), NONE(), {}, false, isProtected, hideResult, NONE());
@@ -6127,7 +6127,7 @@ algorithm
 
    case(DAE.CREF(componentRef=cref),_)
      equation
-       ({var},_) = BackendVariable.getVar(cref,varsIn);
+       (var,_) = BackendVariable.getVarSingle(cref,varsIn);
        true =  not artificialVarKind(BackendVariable.varKind(var));// if its not of kind variable(), it is something artificial (DUMMY_DER,...) and the start value is not model based in that case
       // print("VAR: "+BackendDump.varString(var)+" -->");
        if BackendVariable.varHasBindExp(var) /*and Expression.isConst(BackendVariable.varBindExp(var))*/ then
@@ -11796,7 +11796,7 @@ algorithm
     _ := matchcontinue state
       case BackendDAE.VAR(varKind=BackendDAE.STATE(index=index /* TODO: Do we need the number of times it was differentiated? */, derName = SOME(derCref)))
         algorithm
-          ({var},{pos}) := BackendVariable.getVar(derCref, allStates);
+          (var,pos) := BackendVariable.getVarSingle(derCref, allStates);
           if not BackendVariable.varEqual(state, var) then
             arrayUpdate(ders, curIndex, pos);
           else


### PR DESCRIPTION
BackendVariable.getVar returns a list of often size 1, and is expected
to return a list of exactly size 1. This checks that the size is 1
directly in the call to getVarSingle. Also uses isPresent to avoid
constructing the indexes list if it is not desired.