### PR TITLE
Use templates to write to file directly

### DIFF
--- a/Compiler/FrontEnd/ExpressionDump.mo
+++ b/Compiler/FrontEnd/ExpressionDump.mo
@@ -41,6 +41,7 @@ encapsulated package ExpressionDump
 // public imports
 public import Absyn;
 public import DAE;
+public import File;
 public import Graphviz;
 
 // protected imports
@@ -441,6 +442,21 @@ public function printExpStr
 algorithm
   s := Tpl.tplString2(ExpressionDumpTpl.dumpExp, e, "\"");
 end printExpStr;
+
+public function writeExp
+"This function prints a complete expression."
+  input File.File file;
+  input DAE.Exp e;
+protected
+  Tpl.Text txt = Tpl.emptyTxt;
+algorithm
+  txt := Tpl.redirectToOpenFile(txt, file);
+  try
+    txt := ExpressionDumpTpl.dumpExp(txt, e, "\"");
+  else
+  end try;
+  Tpl.closeFile(txt);
+end writeExp;
 
 public function printCrefsFromExpStr
   input DAE.Exp e;

--- a/Compiler/Template/CodegenUtil.tpl
+++ b/Compiler/Template/CodegenUtil.tpl
@@ -46,6 +46,7 @@
 package CodegenUtil
 
 import ExpressionDumpTpl.*;
+import DAEDumpTpl.*;
 import interface SimCodeTV;
 
 /* public */ template symbolName(String modelNamePrefix, String symbolName)
@@ -400,14 +401,14 @@ template dumpEqs(list<SimEqSystem> eqs)
       equation index: <%equationIndex(eq)%>
       type: ALGORITHM
 
-      <%e.statements |> stmt => escapeCComments(ppStmtStr(stmt,2))%>
+      <%e.statements |> stmt => escapeCComments(dumpStatement(stmt))%>
       >>
     case e as SES_INVERSE_ALGORITHM(statements=first::_) then
       <<
       equation index: <%equationIndex(eq)%>
       type: INVERSE ALGORITHM
 
-      <%e.statements |> stmt => escapeCComments(ppStmtStr(stmt,2))%>
+      <%e.statements |> stmt => escapeCComments(dumpStatement(stmt))%>
       >>
     case e as SES_LINEAR(lSystem=ls as LINEARSYSTEM(__)) then
       <<

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -3328,16 +3328,6 @@ package ValuesUtil
   end valueExp;
 end ValuesUtil;
 
-package DAEDump
-
-  function ppStmtStr
-    input DAE.Statement stmt;
-    input Integer inInteger;
-    output String outString;
-  end ppStmtStr;
-
-end DAEDump;
-
 package Algorithm
   function getStatementSource
     input DAE.Statement stmt;

--- a/Compiler/Template/TaskSystemDump.tpl
+++ b/Compiler/Template/TaskSystemDump.tpl
@@ -145,7 +145,7 @@ template dumpEqs(list<SimEqSystem> eqs, Integer parent, Boolean withOperations)
         <statement>
           <%uniqcrefs%>
           <stmt>
-          <%e.statements |> stmt => escapeModelicaStringToXmlString(ppStmtStr(stmt,2)) %>
+          <%e.statements |> stmt => escapeModelicaStringToXmlString(dumpStatement(stmt)) %>
           </stmt>
         </statement>
       </equation><%\n%>


### PR DESCRIPTION
Used misc. templates in other templates instead of importing the string
conversion function in the templates. The output changes slightly since
we can no longer trim strings, etc.

Also introduced the possibility to use File and Tpl.Text objects in the
same package (used for JSON serialization, which is mostly directly to
file but also needs to printExpStr).