### PR TITLE
- dont interrupt clock-event assignment in cpp runtime

### DIFF
--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -12449,16 +12449,21 @@ template handleSystemEvents(list<ZeroCrossing> zeroCrossings, SimCode simCode ,T
 
     bool restart = true;
     bool state_vars_reinitialized = false;
+    bool clock_event_detected = false;
+
     int iter = 0;
     for(int i =0;i< _dimClock;i++)
 	{
 		if(events[_dimZeroFunc+i])
 		{
 			_clockCondition[i]=true;
+			clock_event_detected = true;
 			 evaluateAll();
-			return false; // no event iteration after clock tick handling
 		}
 	}
+
+	if (clock_event_detected) return false;// no event iteration after clock tick handling
+
     while(restart && !(iter++ > 100))
     {
         bool st_vars_reinit = false;


### PR DESCRIPTION
dont jump out of the loop before finishing all clock events. 