### PR TITLE
Deactivated state machine  when-equations hack

### DIFF
--- a/Compiler/FrontEnd/StateMachineFlatten.mo
+++ b/Compiler/FrontEnd/StateMachineFlatten.mo
@@ -119,8 +119,8 @@ algorithm
   (flatSmLst, otherLst) := List.extractOnTrue(dAElist, isFlatSm);
   elementLst2 := List.fold2(flatSmLst, flatSmToDataFlow, NONE(), NONE(), {});
 
-  // FIXME HACK1 Wrap equations in when clauses hack (as long as clocked features are not fully supported in C runtime)
-  if (not listEmpty(flatSmLst) and not stringEqual(Config.simCodeTarget(), "Cpp")) then
+  // HACK1 Wrap semantic state machine equations in when clauses for continuous-time state machines
+  if Flags.getConfigBool(Flags.CT_STATE_MACHINES) then
     elementLst2 := wrapHack(cache, elementLst2);
   end if;
 
@@ -131,11 +131,11 @@ algorithm
   // traverse dae expressions for making substitutions activeState(x) -> x.active
   (outDAElist, _, (_,nOfSubstitutions)) := DAEUtil.traverseDAE(outDAElist, FCore.getFunctionTree(cache), Expression.traverseSubexpressionsHelper, (traversingSubsActiveState, 0));
 
-  if (not listEmpty(flatSmLst) and not stringEqual(Config.simCodeTarget(), "Cpp")) then
-    // FIXME HACK2 traverse dae expressions for making substitutions previous(x) -> pre(x) (as long as clocked features are not fully supported in C runtime)
+  if Flags.getConfigBool(Flags.CT_STATE_MACHINES) then
+    // HACK2 traverse dae expressions for making substitutions previous(x) -> pre(x)
     (outDAElist, _, (_,nOfSubstitutions)) := DAEUtil.traverseDAE(outDAElist, FCore.getFunctionTree(cache), Expression.traverseSubexpressionsHelper, (traversingSubsPreForPrevious, 0));
-    // FIXME HACK3 traverse dae expressions for making substitutions sample(x, _) -> x (as long as clocked features are not fully supported in C runtime)
-    (outDAElist, _, (_,nOfSubstitutions)) := DAEUtil.traverseDAE(outDAElist, FCore.getFunctionTree(cache), Expression.traverseSubexpressionsHelper, (traversingSubsXForSampleX, 0));
+    // FIXME not needed any more? HACK3 traverse dae expressions for making substitutions sample(x, _) -> x
+    // (outDAElist, _, (_,nOfSubstitutions)) := DAEUtil.traverseDAE(outDAElist, FCore.getFunctionTree(cache), Expression.traverseSubexpressionsHelper, (traversingSubsXForSampleX, 0));
   end if;
   //print("StateMachineFlatten.stateMachineToDataFlow: outDAElist:\n" + DAEDump.dumpStr(outDAElist,FCore.getFunctionTree(cache)));
 end stateMachineToDataFlow;


### PR DESCRIPTION
Removed the hack that has been used for state machines to compensate for insufficient support of clocked elements in the C-runtime (the C-runtime support was improved considerably some time ago).