### PR TITLE
Check all dylib files for improper linking

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -86,7 +86,8 @@ omc-bootstrapped: mkbuilddirs
 	$(MAKE) bootstrap-dependencies interactive sim-dependencies
 	$(MAKE) -C Compiler/boot OMBUILDDIR=$(OMBUILDDIR)
 	$(MAKE) -f $(defaultMakefileTarget) -C Compiler install_scripts OMBUILDDIR=$(OMBUILDDIR)
-
+	@# See if any library is linked directly into the build dirs (we should use @rpath everywhere)
+	test ! `uname` = Darwin || ( ! otool -L "$(builddir_lib_omc)"/*.dylib | egrep "$(OMBUILDDIR)|`pwd`" || ( echo All dylibs should be linked using @rpath ; false ) )
 
 omc-no-sim:
 	$(MAKE) bootstrap-dependencies interactive-short


### PR DESCRIPTION
After compiling the OMC target, check all dylib files for links to the
build or source directories. If there is such a link, give an error
message stating that the file should use @rpath.