### PR TITLE
Prefer omc libs over system libs

### DIFF
--- a/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -1957,7 +1957,7 @@ algorithm
         isLinux := stringEq("linux",System.os());
         target := Flags.getConfigString(Flags.TARGET);
         // please, take care about ordering these libraries, the most specific should have the highest priority
-        libs2 := str::platform2::platform1::(Settings.getHomeDir(false)+"/.openmodelica/binaries/"+Absyn.pathFirstIdent(path))::(Settings.getInstallationDirectoryPath() + "/lib/" + System.getTriple() + "/omc")::(Settings.getInstallationDirectoryPath() + "/lib/")::{};
+        libs2 := str::platform2::platform1::(Settings.getHomeDir(false)+"/.openmodelica/binaries/"+Absyn.pathFirstIdent(path))::(Settings.getInstallationDirectoryPath() + "/lib/")::(Settings.getInstallationDirectoryPath() + "/lib/" + System.getTriple() + "/omc")::{};
         libs := List.fold2(libs2, generateExtFunctionLibraryDirectoryFlags2, isLinux, target, libs);
       then (libs, listReverse(libs2), SOME(resourcesStr));
     else (inLibs, {}, NONE());


### PR DESCRIPTION
This should resolve an issue with /usr/lib being preferred over the
OM-provided version of Sundials (ticket:3893).