### PR TITLE
Use start values at first clock tick (ticket:3770)

### DIFF
--- a/Compiler/BackEnd/BackendDAE.mo
+++ b/Compiler/BackEnd/BackendDAE.mo
@@ -246,6 +246,7 @@ uniontype VarKind "variable kind"
   record DUMMY_STATE end DUMMY_STATE;
   record CLOCKED_STATE
     .DAE.ComponentRef previousName "the name of the previous variable";
+    Boolean isStartFixed "is fixed at first clock tick";
   end CLOCKED_STATE;
   record DISCRETE end DISCRETE;
   record PARAM end PARAM;

--- a/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/Compiler/BackEnd/SynchronousFeatures.mo
@@ -290,7 +290,9 @@ algorithm
     for i in 1:arrayLength(isPrevVarArr) loop
       if isPrevVarArr[i] then
         var := BackendVariable.setVarFixed(BackendVariable.getVarAt(inSyst.orderedVars, i), true);
-        var := BackendVariable.setVarKind(var, BackendDAE.CLOCKED_STATE(previousName = ComponentReference.crefPrefixPrevious(var.varName)));
+        var := BackendVariable.setVarKind(var, BackendDAE.CLOCKED_STATE(
+                 previousName = ComponentReference.crefPrefixPrevious(var.varName),
+                 isStartFixed = isSome(subPartition.clock.solver)));
         BackendVariable.setVarAt(inSyst.orderedVars, i, var);
         prevVars := var.varName::prevVars;
       end if;

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -1071,6 +1071,7 @@ package BackendDAE
     record DUMMY_STATE end DUMMY_STATE;
     record CLOCKED_STATE
       DAE.ComponentRef previousName "the name of the previous variable";
+      Boolean isStartFixed "is fixed at first clock tick";
     end CLOCKED_STATE;
     record DISCRETE end DISCRETE;
     record PARAM end PARAM;

--- a/SimulationRuntime/cpp/Core/System/SystemDefaultImplementation.cpp
+++ b/SimulationRuntime/cpp/Core/System/SystemDefaultImplementation.cpp
@@ -55,7 +55,8 @@ SystemDefaultImplementation::SystemDefaultImplementation(IGlobalSettings *global
   , _clockInterval  (NULL)
   , _clockShift     (NULL)
   , _clockTime      (NULL)
-   , _clockCondition(NULL)
+  , _clockCondition (NULL)
+  , _clockStart     (NULL)
   , _outputStream(NULL)
   , _callType        (IContinuous::UNDEF_UPDATE)
   , _initial        (false)
@@ -91,7 +92,8 @@ SystemDefaultImplementation::SystemDefaultImplementation(SystemDefaultImplementa
   , _clockInterval  (NULL)
   , _clockShift     (NULL)
   , _clockTime      (NULL)
-  , _clockCondition(NULL)
+  , _clockCondition (NULL)
+  , _clockStart     (NULL)
   , _outputStream(NULL)
   , _callType        (IContinuous::UNDEF_UPDATE)
   , _initial        (false)
@@ -134,7 +136,8 @@ SystemDefaultImplementation::~SystemDefaultImplementation()
   if(_clockInterval) delete [] _clockInterval;
   if(_clockShift) delete [] _clockShift;
   if(_clockTime) delete [] _clockTime;
-   if(_clockCondition) delete [] _clockCondition;
+  if(_clockCondition) delete [] _clockCondition;
+  if(_clockStart) delete [] _clockStart;
 }
 
 void SystemDefaultImplementation::Assert(bool cond,const string& msg)
@@ -237,17 +240,16 @@ void SystemDefaultImplementation::initialize()
     _clockShift = new double [_dimClock];
     if (_clockTime) delete [] _clockTime;
     _clockTime = new double [_dimClock];
-	  if (_clockCondition) delete [] _clockCondition;
+    if (_clockCondition) delete [] _clockCondition;
     _clockCondition = new bool [_dimClock];
-	memset(_clockCondition,false,(_dimClock)*sizeof(bool));
+    memset(_clockCondition,false,(_dimClock)*sizeof(bool));
+    if (_clockStart) delete [] _clockStart;
+    _clockStart = new bool [_dimClock];
   }
   _start_time = 0.0;
   _terminal = false;
   _terminate = false;
-  _clockStart = true;
-
 };
-
 
 /// Set current integration time
 void SystemDefaultImplementation::setTime(const double& t)

--- a/SimulationRuntime/cpp/Include/Core/System/SystemDefaultImplementation.h
+++ b/SimulationRuntime/cpp/Include/Core/System/SystemDefaultImplementation.h
@@ -181,8 +181,8 @@ protected:
     double *_clockInterval;   ///< time interval between clock ticks
     double *_clockShift;      ///< time before first activation
     double *_clockTime;       ///< time of clock ticks
-	bool* _clockCondition;    ///< clock tick active
-	bool _clockStart;         ///< only active at clock start
+    bool *_clockCondition;    ///< clock tick active
+    bool *_clockStart;        ///< only active at clock start
     std::ostream *_outputStream;        ///< Output stream for results
 
     IContinuous::UPDATETYPE _callType;


### PR DESCRIPTION
This shall only apply to states of solved continuous equations.
We check for the existence of a solver method so far.