### PR TITLE
fix for algloop variable attributes assignment in cpp Template/Codege…

### DIFF
--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -6687,7 +6687,7 @@ template createAlgloopVarAttributes(SimVar var, Text &preExp, Text &varDecls, Si
     else
       'HUGE_VAL'
 
-  '{"<%nameStr%>", <%nominalStr%>, <%minStr%>, <%maxStr%>}'
+  'AlgloopVarAttributes("<%nameStr%>", <%nominalStr%>, <%minStr%>, <%maxStr%>)'
 end createAlgloopVarAttributes;
 
 template writeAlgloopvars(list<list<SimEqSystem>> continousEquations,list<SimEqSystem> discreteEquations, list<SimEqSystem> parameterEquations,

--- a/SimulationRuntime/cpp/Include/Core/System/AlgLoopDefaultImplementation.h
+++ b/SimulationRuntime/cpp/Include/Core/System/AlgLoopDefaultImplementation.h
@@ -67,6 +67,14 @@ enum OUTPUT
 /// store attributes of a variable
 struct AlgloopVarAttributes
 {
+  AlgloopVarAttributes() {};
+  AlgloopVarAttributes(const char *name,double nominal,double min,double max)
+  :name(name)
+  ,nominal(nominal)
+  ,min(min)
+  ,max(max)
+  {}
+
   const char *name;
   double nominal;
   double min;


### PR DESCRIPTION
…nCpp.tpl

the v={..} for c++ struct  assignment only woks with c++11.