### PR TITLE
fix in fmu 1.0 export and cpp runtime for ambiguous symbols for share…

### DIFF
--- a/SimulationRuntime/cpp/Include/FMU/FMULibInterface.h
+++ b/SimulationRuntime/cpp/Include/FMU/FMULibInterface.h
@@ -35,7 +35,7 @@
 //#include "FMU/log.hpp"
 #include <iostream>
 
-using namespace std;
+
 
 //#define LOG_FMI()   EmptyLog()
 //#define DO_LOG_FMI  false


### PR DESCRIPTION
…d_ptr