### PR TITLE
simulation(..) return value #3953

### DIFF
--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -227,15 +227,17 @@ protected
   list<Values.Value> vals;
   list<String> fields;
   Boolean isTestType,notest;
+  Values.Value resRecord;
 algorithm
   resultValues := listReverse(inAddResultValues);
   //TODO: maybe we should test if the fields are the ones in simulationResultType_full
   notest := not Config.getRunningTestsuite();
   fields := if notest then List.map(resultValues, Util.tuple21) else {};
   vals := if notest then List.map(resultValues, Util.tuple22) else {};
-  res := Values.RECORD(Absyn.IDENT("SimulationResult"),
+  resRecord := Values.RECORD(Absyn.IDENT("SimulationResult"),
     Values.STRING(resultFile)::Values.STRING(options)::Values.STRING(message)::vals,
     "resultFile"::"simulationOptions"::"messages"::fields,-1);
+  res := Values.STRING(ValuesUtil.valString(resRecord));
 end createSimulationResult;
 
 public function createDrModelicaSimulationResult


### PR DESCRIPTION
Converts the Values.Value in function createSimulationResult into a
string value before returning it. As a result calling `simulation(..)`
in a mos script will return a string (as specified by the signature)
instead of a record.

@adrpo @sjoelund: This commit makes simulation(..) actually return a String (as indicated in the signature of ModelicaBuiltin.mo) instead of a record. However, I'm not sure what is really intended. Should be discussed.
