### PR TITLE
Pde - ghost cells

### DIFF
--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -2969,7 +2969,7 @@ public function instElementList
   output list<DAE.Var> outVars;
   output ConnectionGraph.ConnectionGraph outGraph = inGraph;
   //output List<tuple<Absyn.ComponentRef,DAE.ComponentRef>> fieldDomLst = {};
-  output InstUtil.DomainFieldsLst domainFieldsList = {};
+  output InstUtil.DomainFieldsLst domainFieldsListOut = {};
 protected
   list<tuple<SCode.Element, DAE.Mod>> el;
   FCore.Cache cache;
@@ -2977,7 +2977,7 @@ protected
   list<DAE.Element> dae;
   list<list<DAE.Var>> varsl = {};
   list<list<DAE.Element>> dael = {};
-  Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>> fieldDomOpt;
+  InstUtil.DomainFieldOpt fieldDomOpt;
   list<Integer> element_order;
   array<tuple<SCode.Element, DAE.Mod>> el_arr;
   array<list<DAE.Var>> var_arr;
@@ -3012,7 +3012,7 @@ algorithm
       arrayUpdate(var_arr, length-idx+1, vars);
       arrayUpdate(dae_arr, length-idx+1, dae);
       if intEq(Flags.getConfigEnum(Flags.GRAMMAR), Flags.PDEMODELICA) then
-        domainFieldsList := InstUtil.optAppendField(domainFieldsList,fieldDomOpt);
+        domainFieldsListOut := InstUtil.optAppendField(domainFieldsListOut,fieldDomOpt);
       end if;
     end for;
 
@@ -3098,7 +3098,7 @@ public function instElement2
   output ClassInf.State outState = inState;
   output list<DAE.Var> outVars = {};
   output ConnectionGraph.ConnectionGraph outGraph = inGraph;
-  output Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>> outFieldDomOpt;
+  output InstUtil.DomainFieldOpt outFieldDomOpt;
 protected
   tuple<SCode.Element, DAE.Mod> elt;
   Boolean is_deleted;
@@ -3211,7 +3211,7 @@ public function instElement "
   output ClassInf.State outState;
   output list<DAE.Var> outVars;
   output ConnectionGraph.ConnectionGraph outGraph;
-  output Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>> outFieldDomOpt = NONE();
+  output InstUtil.DomainFieldOpt outFieldDomOpt = NONE();
 algorithm
   (outCache, outEnv, outIH, outUnitStore, outDae, outSets, outState, outVars, outGraph):=
   matchcontinue (inCache, inEnv, inIH, inUnitStore, inMod, inPrefix, inState,

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -2061,6 +2061,8 @@ algorithm
         (compelts_1, eqs_1, initeqs_1, alg_1, initalg_1) =
           InstUtil.extractConstantPlusDepsTpl(compelts_1, instSingleCref, {}, className, eqs_1, initeqs_1, alg_1, initalg_1);
 
+        compelts_1 = InstUtil.addGhostCells(compelts_1, eqs_1);
+
         //(csets, env2, ih) = InstUtil.addConnectionCrefsFromEqs(csets, eqs_1, pre, env2, ih);
 
         //// fprintln(Flags.INST_TRACE, "Emods to InstUtil.addComponentsToEnv: " + Mod.printModStr(emods));
@@ -2084,7 +2086,7 @@ algorithm
         (smCompCrefs, smInitialCrefs) = InstStateMachineUtil.getSMStatesInContext(eqs_1, pre);
         //ih = List.fold1(smCompCrefs, InnerOuter.updateSMHierarchy, inPrefix3, ih);
         ih = List.fold(smCompCrefs, InnerOuter.updateSMHierarchy, ih);
-        compelts_2 = InstUtil.addGhostCells(compelts_2, eqs_1);
+
         (cache,env5,ih,store,dae1,csets,ci_state2,vars,graph,domainFieldsLst) =
           instElementList(cache, env3, ih, store, mods, pre, ci_state1,
             compelts_2, inst_dims, impl, callscope, graph, csets, true);
@@ -2101,7 +2103,9 @@ algorithm
         if intEq(Flags.getConfigEnum(Flags.GRAMMAR), Flags.PDEMODELICA) then
           eqs_1 = List.fold1(eqs_1, InstUtil.discretizePDE, domainFieldsLst, {});
         end if;
-
+        if className == "ghostTest" then
+          print("GhostTest");
+        end if;
         //Instantiate equations (see function "instEquation")
         (cache,env5,ih,dae2,csets2,ci_state3,graph) =
           instList(cache, env5, ih, pre, csets1, ci_state2, InstSection.instEquation, eqs_1, impl, InstTypes.alwaysUnroll, graph);

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -2084,7 +2084,7 @@ algorithm
         (smCompCrefs, smInitialCrefs) = InstStateMachineUtil.getSMStatesInContext(eqs_1, pre);
         //ih = List.fold1(smCompCrefs, InnerOuter.updateSMHierarchy, inPrefix3, ih);
         ih = List.fold(smCompCrefs, InnerOuter.updateSMHierarchy, ih);
-
+        compelts_2 = InstUtil.addGhostCells(compelts_2, eqs_1);
         (cache,env5,ih,store,dae1,csets,ci_state2,vars,graph,domainFieldsLst) =
           instElementList(cache, env3, ih, store, mods, pre, ci_state1,
             compelts_2, inst_dims, impl, callscope, graph, csets, true);

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -8728,6 +8728,7 @@ algorithm
         List<Absyn.ComponentRef> fieldLst;
         Absyn.Ident name;
         list<Absyn.Subscript> subscripts;
+
       //Normal equation withhout domain specified, no field variables present:
       case SCode.EQUATION(SCode.EQ_EQUALS())
       then {inEQ};
@@ -8736,8 +8737,8 @@ algorithm
                   domain = domainCr as Absyn.CREF_IDENT(), comment = comment, info = info))
         equation
           (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr,info);
-//        then list(newEQFun(i, lhs_exp, rhs_exp, domainCr, comment, info, fieldLst) for i in 2:N-1);
         then creatFieldEqs(lhs_exp, rhs_exp, domainCr, N, fieldLst, comment, info);
+
       //same as previous but with ".interior"
       case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
                   domain = domainCr as Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="interior")),
@@ -8745,36 +8746,8 @@ algorithm
         equation
           domainCr1 = Absyn.CREF_IDENT(name, subscripts);
           (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr1,info);
-//        then list(newEQFun(i, lhs_exp, rhs_exp, domainCr1, comment, info, fieldLst) for i in 2:N-1);
         then creatFieldEqs(lhs_exp, rhs_exp, domainCr, N, fieldLst, comment, info);
 
-        //left boundary extrapolation
-/*        case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
-                      domain = domainCr as Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="left")),
-                      comment = comment, info = info))
-            equation
-//              Absyn.CALL(function_ = Absyn.CREF_IDENT(name="extrapolateField", subscripts={}), functionArgs = Absyn.FUNCTIONARGS(args = {})) = rhs_exp;
-//              Absyn.CREF(fieldCr as Absyn.CREF_IDENT()) = lhs_exp;
-          fieldCr = matchExtrapAndField(lhs_exp, rhs_exp);
-          domainCr1 = Absyn.CREF_IDENT(name, subscripts);
-          (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr1,info);
-        then
-          {extrapolateFieldEq(false, fieldCr, domainCr1, N, comment, info, fieldLst)};
-*/
-/*
-      //right boundary extrapolation
-      case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
-                  domain = domainCr as Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="right")),
-                  comment = comment, info = info))
-        equation
-//          Absyn.CALL(function_ = Absyn.CREF_IDENT(name="extrapolateField", subscripts={}), functionArgs = Absyn.FUNCTIONARGS(args = {})) = rhs_exp;
-//          Absyn.CREF(fieldCr as Absyn.CREF_IDENT()) = lhs_exp;
-
-          fieldCr = matchExtrapAndField(lhs_exp, rhs_exp);
-          domainCr1 = Absyn.CREF_IDENT(name, subscripts);
-          (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr1,info);
-        then
-          {extrapolateFieldEq(true, fieldCr, domainCr1, N, comment, info, fieldLst)};*/
       //left boundary condition or extrapolation
       case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
                   domain = domainCr as Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="left")),
@@ -8786,6 +8759,7 @@ algorithm
           (rhs_exp, _) = Absyn.traverseExp(rhs_exp, extrapFieldTraverseFun, 1);
         then
           {newEQFun(1, lhs_exp, rhs_exp, domainCr1, N, true, fieldLst, comment, info)};
+
       //right boundary condition or extrapolation
       case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
                   domain = domainCr as Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="right")),
@@ -9091,7 +9065,7 @@ algorithm
                   );
         then
           Absyn.BINARY(
-            Absyn.BINARY(leftVar, Absyn.SUB(), rightVar),
+            Absyn.BINARY(rightVar, Absyn.SUB(), leftVar),
             Absyn.DIV(),
             Absyn.BINARY(
               Absyn.INTEGER(2),

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -8391,7 +8391,7 @@ end propagateModFinal;
 //------------------------------
 //------  PDE extension:  ------
 //------------------------------
-
+public type DomainFieldOpt = Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>>;
 public type DomainFieldsLst = list<tuple<DAE.ComponentRef,list<Absyn.ComponentRef>>>;
 
 public function elabField
@@ -8407,7 +8407,7 @@ public function elabField
   input SourceInfo inInfo;
   output DAE.Dimensions outDims;
   output DAE.Mod outMod;
-  output Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>> outFieldDomOpt;
+  output DomainFieldOpt outFieldDomOpt;
 
 algorithm
   (outDims, outMod, outFieldDomOpt) := match(attr, inMod)
@@ -8529,7 +8529,7 @@ end addEach;
 
 public function optAppendField
   input DomainFieldsLst inDomFieldsLst;
-  input Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>> fieldDomOpt;
+  input DomainFieldOpt fieldDomOpt;
   output DomainFieldsLst outDomFieldsLst;
 algorithm
   outDomFieldsLst := matchcontinue fieldDomOpt

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -8394,6 +8394,65 @@ end propagateModFinal;
 public type DomainFieldOpt = Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>>;
 public type DomainFieldsLst = list<tuple<DAE.ComponentRef,list<Absyn.ComponentRef>>>;
 
+public function addGhostCells
+//add ghost cells to fields that are differentiated in pder
+  input list<tuple<SCode.Element, DAE.Mod>> inCompelts;
+  input list<SCode.Equation> inEqs;
+  output list<tuple<SCode.Element, DAE.Mod>> outCompelts;
+  protected list<Absyn.Ident> fieldNamesP;
+algorithm
+  fieldNamesP := List.fold(inEqs, fieldsInPderEq, {});
+  //TODO: implement
+
+
+   outCompelts := inCompelts;
+end addGhostCells;
+
+function fieldsInPderEq
+//adds field variable names that are differentiated using pder
+//in given equation to given list if it isn't already there
+  input SCode.Equation eq;
+  input list<Absyn.Ident> inFieldNames;
+  output list<Absyn.Ident> outFieldNames;
+  protected list<Absyn.Ident> fieldNames2;
+algorithm
+  fieldNames2 := match eq
+  local
+    list<Absyn.Ident> fieldNames1;
+    Absyn.Exp lhs_exp, rhs_exp;
+    case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp))
+      /*,domain = domainCr as Absyn.CREF_IDENT(), comment = comment, info = info))*/
+    algorithm
+      (_,fieldNames1) := Absyn.traverseExp(lhs_exp, fieldInPderExp, inFieldNames);
+      (_,fieldNames1) := Absyn.traverseExp(rhs_exp, fieldInPderExp, fieldNames1);
+    then
+      fieldNames1;
+    else
+      inFieldNames;
+  end match;
+  outFieldNames := fieldNames2;
+end fieldsInPderEq;
+
+function fieldInPderExp
+//if given expression is pder call, than adds the differentiated field name
+//to given list of names if it is not already there
+  input Absyn.Exp inExp;
+  input list<Absyn.Ident> inFieldNames;
+  output Absyn.Exp outExp;
+  output list<Absyn.Ident> outFieldNames;
+algorithm
+  outFieldNames := match inExp
+    local
+      Absyn.Ident newFieldName;
+    case Absyn.CALL(function_=Absyn.CREF_IDENT(name="pder"),functionArgs=Absyn.FUNCTIONARGS(args={Absyn.CREF(Absyn.CREF_IDENT(name=newFieldName)),_}))
+    then
+      List.unionElt(newFieldName,inFieldNames);
+    else
+      inFieldNames;
+  end match;
+  outExp := inExp;
+end fieldInPderExp;
+
 public function elabField
 //For field variables: finds the "domain" modifier,
 //finds domain.N - length of discretized field array

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -8400,12 +8400,11 @@ public function addGhostCells
   input list<SCode.Equation> inEqs;
   output list<tuple<SCode.Element, DAE.Mod>> outCompelts;
   protected list<Absyn.Ident> fieldNamesP;
+  protected list<tuple<SCode.Element, DAE.Mod>> ghostCompelts;
 algorithm
   fieldNamesP := List.fold(inEqs, fieldsInPderEq, {});
-  //TODO: implement
-
-
-   outCompelts := inCompelts;
+  ghostCompelts := List.fold1(inCompelts,addGhostCells2,fieldNamesP,{});
+  outCompelts := listAppend(inCompelts,ghostCompelts);
 end addGhostCells;
 
 function fieldsInPderEq
@@ -8453,6 +8452,82 @@ algorithm
   outExp := inExp;
 end fieldInPderExp;
 
+function addGhostCells2
+  //if name os given variable is in the given array
+  //adds ghost cells for it
+  input tuple<SCode.Element, DAE.Mod> inCompelt;
+  input list<Absyn.Ident> fieldNamesP;
+  input list<tuple<SCode.Element, DAE.Mod>> inGhosts;
+  output list<tuple<SCode.Element, DAE.Mod>> outGhosts;
+algorithm
+  outGhosts := matchcontinue inCompelt
+  local
+    SCode.Ident name;
+    SCode.Prefixes prefixes;
+    SCode.Attributes attributes;
+    Absyn.TypeSpec typeSpec;
+    SCode.Mod modifications;
+    SCode.Comment comment;
+    Option<Absyn.Exp> condition;
+    SCode.SourceInfo info;
+
+    Absyn.ArrayDim arrayDims;
+    SCode.ConnectorType connectorType;
+    SCode.Parallelism parallelism;
+    SCode.Variability variability;
+    Absyn.Direction direction;
+
+    SCode.Final finalPrefix "final prefix";
+    SCode.Each  eachPrefix "each prefix";
+    list<SCode.SubMod> subModLst;
+    Option<Absyn.Exp> binding;
+    SCode.SourceInfo info2;
+
+    DAE.Mod daeMod;
+
+    tuple<SCode.Element, DAE.Mod> ghostL, ghostR;
+
+    case (SCode.COMPONENT(name, prefixes,
+            SCode.ATTR(arrayDims,connectorType,parallelism,
+                       variability, direction, Absyn.FIELD()
+            ), typeSpec,
+            SCode.MOD(finalPrefix, eachPrefix,subModLst,binding,info2)/*modifications*/,
+            comment, condition, info),daeMod)
+      equation
+        listMember(name, fieldNamesP) = true;
+
+        //remove domain from the subModLst:
+        subModLst = List.filterOnFalse(subModLst,isSubModDomainOrStart);
+
+        ghostL = (SCode.COMPONENT(stringAppend(name,".ghostL"), prefixes,
+              SCode.ATTR(arrayDims,connectorType,parallelism,
+             variability, direction, Absyn.NONFIELD()), typeSpec,
+             SCode.MOD(finalPrefix, eachPrefix,subModLst,binding,info2),
+             comment, condition, info),daeMod);
+        ghostR = (SCode.COMPONENT(stringAppend(name,".ghostR"), prefixes,
+             SCode.ATTR(arrayDims,connectorType,parallelism,
+             variability, direction, Absyn.NONFIELD()), typeSpec,
+             SCode.MOD(finalPrefix, eachPrefix,subModLst,binding,info2),
+             comment, condition, info),daeMod);
+      then
+        ghostL::ghostR::inGhosts;
+    else
+      inGhosts;
+  end matchcontinue;
+end addGhostCells2;
+
+function isSubModDomainOrStart
+  input SCode.SubMod subMod;
+  output Boolean isNotDomain;
+algorithm
+  isNotDomain := match subMod
+    case SCode.NAMEMOD(ident="domain") then true;
+    case SCode.NAMEMOD(ident="start") then true;
+    else false;
+  end match;
+end isSubModDomainOrStart;
+
+
 public function elabField
 //For field variables: finds the "domain" modifier,
 //finds domain.N - length of discretized field array
@@ -8487,7 +8562,7 @@ algorithm
       equation
 //        DAE.MOD(finalPrefix = finalPrefix, eachPrefix = eachPrefix, subModLst = subModLst, eqModOption = eqModOption) = inMod;
         //get N from the domain and remove domain from the subModLst:
-        (N, subModLst, SOME(dcr)) = List.fold30(subModLst,domainSearchFun,-1,{},NONE());
+        (N, subModLst, SOME(dcr)) = List.fold30(subModLst,domainSearchFunDAE,-1,{},NONE());
         if (N == -1) then Error.addSourceMessageAndFail(Error.PDEModelica_ERROR,
             {"Domain of the field variable '", name, "' not found."}, inInfo);
         end if;
@@ -8500,7 +8575,7 @@ algorithm
   end match;
 end elabField;
 
-protected function domainSearchFun
+protected function domainSearchFunDAE
 "fold function to find domain modifier in modifiers list"
 //TODO: simplify this function, perhaps not use fold
   input DAE.SubMod subMod;
@@ -8547,7 +8622,7 @@ protected function domainSearchFun
         fail();
     else (subMod::inSubModLst,inN,inCrOpt);
     end matchcontinue;
-end domainSearchFun;
+end domainSearchFunDAE;
 
 protected function findN
 "a map function to find N in domain class modifiers"
@@ -8664,7 +8739,7 @@ algorithm
         equation
           (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr,info);
 //        then list(newEQFun(i, lhs_exp, rhs_exp, domainCr, comment, info, fieldLst) for i in 2:N-1);
-        then creatFieldEqs(lhs_exp, rhs_exp, domainCr, N, comment, info, fieldLst);
+        then creatFieldEqs(lhs_exp, rhs_exp, domainCr, N, fieldLst, comment, info);
       //same as previous but with ".interior"
       case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
                   domain = domainCr as Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="interior")),
@@ -8673,7 +8748,7 @@ algorithm
           domainCr1 = Absyn.CREF_IDENT(name, subscripts);
           (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr1,info);
 //        then list(newEQFun(i, lhs_exp, rhs_exp, domainCr1, comment, info, fieldLst) for i in 2:N-1);
-        then creatFieldEqs(lhs_exp, rhs_exp, domainCr, N, comment, info, fieldLst);
+        then creatFieldEqs(lhs_exp, rhs_exp, domainCr, N, fieldLst, comment, info);
 
         //left boundary extrapolation
 /*        case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
@@ -8712,7 +8787,7 @@ algorithm
           (lhs_exp, _) = Absyn.traverseExp(lhs_exp, extrapFieldTraverseFun, 1);
           (rhs_exp, _) = Absyn.traverseExp(rhs_exp, extrapFieldTraverseFun, 1);
         then
-          {newEQFun(1, lhs_exp, rhs_exp, domainCr1, comment, info, fieldLst)};
+          {newEQFun(1, lhs_exp, rhs_exp, domainCr1, N, true, fieldLst, comment, info)};
       //right boundary condition or extrapolation
       case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
                   domain = domainCr as Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="right")),
@@ -8723,7 +8798,7 @@ algorithm
           (lhs_exp, _) = Absyn.traverseExp(lhs_exp, extrapFieldTraverseFun, N);
           (rhs_exp, _) = Absyn.traverseExp(rhs_exp, extrapFieldTraverseFun, N);
         then
-          {newEQFun(N, lhs_exp, rhs_exp, domainCr1, comment, info, fieldLst)};
+          {newEQFun(N, lhs_exp, rhs_exp, domainCr1, N, true, fieldLst, comment, info)};
     end matchcontinue;
 
   outDiscretizedEQs := listAppend(inDiscretizedEQs, newDiscretizedEQs);
@@ -8771,7 +8846,7 @@ end extrapFieldTraverseFun;
 
 
 
-
+/*
 
 //TODO: remove never called:
 protected function matchExtrapAndField
@@ -8798,7 +8873,7 @@ algorithm
   end match;
 
 end matchExtrapAndField;
-
+*/
 protected function getDomNFields
   input DomainFieldsLst inDomFieldLst;
   input Absyn.ComponentRef inDomainCr;
@@ -8901,9 +8976,9 @@ protected function creatFieldEqs "creates list of equations for fields. If the e
   input Absyn.Exp rhs_exp;
   input Absyn.ComponentRef domainCr;
   input Integer N;
+  input List<Absyn.ComponentRef> fieldLst;
   input SCode.Comment comment;
   input SCode.SourceInfo info;
-  input List<Absyn.ComponentRef> fieldLst;
   output List<SCode.Equation> outDiscretizedEQs;
   protected Boolean bl, br;
 algorithm
@@ -8914,11 +8989,12 @@ algorithm
     //case ((_,false),(_,false)) //no pder()
     case (false,false) //no pder()
     then
-      list(newEQFun(i, lhs_exp, rhs_exp, domainCr, comment, info, fieldLst) for i in 1:N);
+      list(newEQFun(i, lhs_exp, rhs_exp, domainCr, N, false, fieldLst, comment, info) for i in 1:N);
     else  //contains some pder()
-      list(newEQFun(i, lhs_exp, rhs_exp, domainCr, comment, info, fieldLst) for i in 2:N-1);
+      list(newEQFun(i, lhs_exp, rhs_exp, domainCr, N, false, fieldLst, comment, info) for i in 1:N);
   end match;
 end creatFieldEqs;
+
 
 protected function hasPderTraverseFun
   input Absyn.Exp inExp;
@@ -8940,32 +9016,34 @@ protected function newEQFun
   input Absyn.Exp inLhs_exp;
   input Absyn.Exp inRhs_exp;
   input Absyn.ComponentRef domainCr;
+  input Integer N;
+  input Boolean isBC;  //-1 left ghost cell, 0 no ghost cell, 1 right ghost cell
+  input list<Absyn.ComponentRef> fieldLst;
   input SCode.Comment comment;
   input SCode.SourceInfo info;
-  input list<Absyn.ComponentRef> fieldLst;
   output SCode.Equation outEQ;
   protected Absyn.Exp outLhs_exp, outRhs_exp;
 algorithm
-  (outLhs_exp, _) := Absyn.traverseExpTopDown(inLhs_exp,discretizeTraverseFun,(i,fieldLst,domainCr,info,false));
-  (outRhs_exp, _) := Absyn.traverseExpTopDown(inRhs_exp,discretizeTraverseFun,(i,fieldLst,domainCr,info,false));
+  (outLhs_exp, _) := Absyn.traverseExpTopDown(inLhs_exp,discretizeTraverseFun,(i,fieldLst,domainCr,info,false,N,isBC));
+  (outRhs_exp, _) := Absyn.traverseExpTopDown(inRhs_exp,discretizeTraverseFun,(i,fieldLst,domainCr,info,false,N,isBC));
   outEQ := SCode.EQUATION(SCode.EQ_EQUALS(outLhs_exp, outRhs_exp, comment, info));
 end newEQFun;
 
 protected function discretizeTraverseFun
   input Absyn.Exp inExp;
-  input tuple<Integer, list<Absyn.ComponentRef>, Absyn.ComponentRef, SCode.SourceInfo,Boolean> inTup;
+  input tuple<Integer, list<Absyn.ComponentRef>, Absyn.ComponentRef, SCode.SourceInfo,Boolean,Integer,Boolean> inTup;
   output Absyn.Exp outExp;
-  output tuple<Integer, list<Absyn.ComponentRef>, Absyn.ComponentRef, SCode.SourceInfo,Boolean> outTup;
-  protected Integer i;
+  output tuple<Integer, list<Absyn.ComponentRef>, Absyn.ComponentRef, SCode.SourceInfo,Boolean,Integer,Boolean> outTup;
+  protected Integer i,N;
 //   protected String eqDomainName;
   protected list<Absyn.ComponentRef> fieldLst;
   protected SCode.SourceInfo info;
-  protected Boolean skip, failVar;
+  protected Boolean skip, failVar,isBC;
   protected Absyn.ComponentRef domainCr;
   protected Absyn.Ident domName;
 algorithm
   failVar := false;
-  (i, fieldLst, domainCr, info, skip) := inTup;
+  (i, fieldLst, domainCr, info, skip, N, isBC) := inTup;
   Absyn.CREF_IDENT(name = domName) := domainCr;
   if skip then
     outExp := inExp;
@@ -8977,6 +9055,7 @@ algorithm
       Absyn.Ident name, fieldDomainName;
       list<Absyn.Subscript> subscripts;
       Absyn.ComponentRef fieldCr;
+      Absyn.Exp exp, leftVar, rightVar;
     case  Absyn.CREF(Absyn.CREF_QUAL(name = domName, subscripts = {}, componentRef=Absyn.CREF_IDENT(name="x",subscripts={})))
     //coordinate x
     then
@@ -8985,8 +9064,15 @@ algorithm
     //field
       equation
         true = List.isMemberOnTrue(fieldCr,fieldLst,Absyn.crefEqual);
+        exp = (if isBC and i == 1 then
+                Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostL"), subscripts))  //left BC
+              elseif isBC and i == N then
+                Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostR"), subscripts))  //right BC
+              else
+                Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i))::subscripts))  //no BC
+              );
       then
-        Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i))::subscripts));
+        exp;
     case Absyn.CALL(Absyn.CREF_IDENT("pder",{}),Absyn.FUNCTIONARGS({Absyn.CREF(fieldCr as Absyn.CREF_IDENT(name, subscripts)),Absyn.CREF(Absyn.CREF_IDENT(name="x"))},_))
     //pder
       equation
@@ -8994,14 +9080,20 @@ algorithm
           failVar = true;
           Error.addSourceMessageAndFail(Error.COMPILER_ERROR,{"Field variable '" +  name + "' has different domain than the equation or is not a field." }, info);
         end if;
-          skip = true;
+        skip = true;
+        leftVar = (if i == 1 then
+                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostL"), subscripts))
+                   else
+                     Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i+1))::subscripts))
+                  );
+        rightVar = (if i == N then
+                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostR"), subscripts))
+                   else
+                     Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i+1))::subscripts))
+                  );
         then
           Absyn.BINARY(
-            Absyn.BINARY(
-              Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i+1))::subscripts)),
-              Absyn.SUB(),
-              Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i-1))::subscripts))
-            ),
+            Absyn.BINARY(leftVar, Absyn.SUB(), rightVar),
             Absyn.DIV(),
             Absyn.BINARY(
               Absyn.INTEGER(2),
@@ -9026,7 +9118,7 @@ algorithm
   if failVar then
     fail();
   end if;
-  outTup := (i, fieldLst, domainCr, info, skip);
+  outTup := (i, fieldLst, domainCr, info, skip, N, isBC);
 end discretizeTraverseFun;
 
 protected function findDomF<T>

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -8413,23 +8413,21 @@ function fieldsInPderEq
   input SCode.Equation eq;
   input list<Absyn.Ident> inFieldNames;
   output list<Absyn.Ident> outFieldNames;
-  protected list<Absyn.Ident> fieldNames2;
 algorithm
-  fieldNames2 := match eq
+  outFieldNames := match eq
   local
     list<Absyn.Ident> fieldNames1;
     Absyn.Exp lhs_exp, rhs_exp;
     case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp))
       /*,domain = domainCr as Absyn.CREF_IDENT(), comment = comment, info = info))*/
     algorithm
-      (_,fieldNames1) := Absyn.traverseExp(lhs_exp, fieldInPderExp, inFieldNames);
-      (_,fieldNames1) := Absyn.traverseExp(rhs_exp, fieldInPderExp, fieldNames1);
+      (_,fieldNames1) := Absyn.traverseExpTopDown(lhs_exp, fieldInPderExp, inFieldNames);
+      (_,fieldNames1) := Absyn.traverseExpTopDown(rhs_exp, fieldInPderExp, fieldNames1);
     then
-      fieldNames1;
+      listAppend(inFieldNames,fieldNames1);
     else
       inFieldNames;
   end match;
-  outFieldNames := fieldNames2;
 end fieldsInPderEq;
 
 function fieldInPderExp
@@ -8453,7 +8451,7 @@ algorithm
 end fieldInPderExp;
 
 function addGhostCells2
-  //if name os given variable is in the given array
+  //if name of given variable is in the given array
   //adds ghost cells for it
   input tuple<SCode.Element, DAE.Mod> inCompelt;
   input list<Absyn.Ident> fieldNamesP;
@@ -9084,7 +9082,7 @@ algorithm
         leftVar = (if i == 1 then
                      Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostL"), subscripts))
                    else
-                     Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i+1))::subscripts))
+                     Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i-1))::subscripts))
                   );
         rightVar = (if i == N then
                      Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostR"), subscripts))


### PR DESCRIPTION
For each field variable (converted into array in front end) that is differentiated using pder() operator are added two variables of the same type named fieldName.ghostL and fieldName.ghostR. In ghost cells are BC assigned and are used in evaluation of partial derivative on the first or last element of the array.