### PR TITLE
small memory optimizations

### DIFF
--- a/Compiler/Util/List.mo
+++ b/Compiler/Util/List.mo
@@ -99,6 +99,7 @@ protected
 import MetaModelica.Dangerous.{listReverseInPlace, arrayGetNoBoundsChecking, arrayUpdateNoBoundsChecking, arrayCreateNoInit};
 import MetaModelica.Dangerous;
 import DoubleEndedList;
+import GC;
 
 public function create<T>
   "Creates a list from an element."
@@ -1044,6 +1045,7 @@ algorithm
 
     arrayUpdate(arr, i, false);
   end for;
+  GC.free(arr);
 end uniqueIntN;
 
 public function uniqueIntNArr

--- a/SimulationRuntime/c/meta/meta_modelica_builtin.h
+++ b/SimulationRuntime/c/meta/meta_modelica_builtin.h
@@ -158,7 +158,7 @@ static inline modelica_metatype arrayCreateNoInit(modelica_integer nelts, modeli
   if (nelts < 0) {
     MMC_THROW();
   } else {
-    return (struct mmc_struct*)mmc_mk_box_no_assign(nelts, MMC_ARRAY_TAG, MMC_IS_IMMEDIATE(dummy));
+    return (struct mmc_struct*)mmc_mk_box_no_assign(nelts, MMC_ARRAY_TAG, 0);
   }
 }
 #define arrayGetNoBoundsChecking(arr,ix) (MMC_STRUCTDATA((arr))[(ix)-1])


### PR DESCRIPTION
- free the array in List.mo
- return the input in SystemImpl__iconv if to == from
- signal that we don't want malloc_atomic in arrayCreateNoInit