### PR TITLE
Don't evaluate alg. loops once before start of simulation

### DIFF
--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -6143,8 +6143,8 @@ case SIMCODE(modelInfo = MODELINFO(__)) then
      void <%modelname%>Algloop<%nls.index%>::initialize()
      {
        <%initAlgloopEquation(eq,simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, context, stateDerVectorName, useFlatArrayNotation)%>
-       // Update the equations once before start of simulation
-       evaluate();
+       // Don't update the equations once before start of simulation
+       // evaluate();
      }
      >>
  case SES_LINEAR(lSystem = ls as LINEARSYSTEM(__)) then


### PR DESCRIPTION
@niklwors - It causes trouble to evaluate alg. loops once before start of simulation if there are variables that are only present in the simulation DAE but not in the initialization DAE.

I will test this PR with MSL3.2.1 before I trigger Hudson.