### PR TITLE
add further daeMode option

### DIFF
--- a/Compiler/SimCode/SimCode.mo
+++ b/Compiler/SimCode/SimCode.mo
@@ -264,6 +264,11 @@ uniontype VarInfo "Number of variables of various types in a Modelica model."
   end VARINFO;
 end VarInfo;
 
+uniontype DaeModeConfig
+  record ALL_EQUATIONS end ALL_EQUATIONS;
+  record DYNAMIC_EQUATIONS end DYNAMIC_EQUATIONS;
+end DaeModeConfig;
+
 uniontype DaeModeData
   "contains data that belongs to the dae mode"
   record DAEMODEDATA
@@ -271,6 +276,7 @@ uniontype DaeModeData
     Option<JacobianMatrix> sparsityPattern "contains the sparsity pattern for the daeMode";
     list<SimCodeVar.SimVar> residualVars;  // variable used to calculate residuals of a DAE form, they are real
     list<SimCodeVar.SimVar> algebraicDAEVars;  // variable used to calculate residuals of a DAE form, they are real
+    DaeModeConfig modeCreated; // indicates the mode in which
   end DAEMODEDATA;
 end DaeModeData;
 

--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -1091,7 +1091,7 @@ template simulationFile(SimCode simCode, String guid, Boolean isModelExchangeFMU
       data.modelData = &modelData;
       data.simulationInfo = &simInfo;
       measure_time_flag = <% if profileHtml() then "5" else if profileSome() then "1" else if profileAll() then "2" else "0" /* Would be good if this was not a global variable...*/ %>;
-      compiledInDAEMode = <% if Flags.getConfigBool(Flags.DAE_MODE) then '1' else '0' %>;
+      compiledInDAEMode = <%intSub(Flags.getConfigEnum(Flags.DAE_MODE), 1)%>;
       <%mainInit%>
       <%mainTop(mainBody,"https://trac.openmodelica.org/OpenModelica/newticket")%>
 

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -613,6 +613,11 @@ package SimCode
       end VARINFO;
   end VarInfo;
 
+  uniontype DaeModeConfig
+    record ALL_EQUATIONS end ALL_EQUATIONS;
+    record DYNAMIC_EQUATIONS end DYNAMIC_EQUATIONS;
+  end DaeModeConfig;
+
   uniontype DaeModeData
     "contains data that belongs to the dae mode"
     record DAEMODEDATA
@@ -3321,6 +3326,11 @@ package Flags
     input ConfigFlag inFlag;
     output String outValue;
   end getConfigString;
+
+  function getConfigEnum
+    input ConfigFlag inFlag;
+    output Integer outValue;
+  end getConfigEnum;
 
   function getConfigStringList
     input ConfigFlag inFlag;

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -1281,9 +1281,15 @@ constant ConfigFlag NO_TEARING_FOR_COMPONENT = CONFIG_FLAG(93, "noTearingForComp
 constant ConfigFlag CT_STATE_MACHINES = CONFIG_FLAG(94, "ctStateMachines",
   NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Experimental: Enable continuous-time state machine prototype"));
+
 constant ConfigFlag DAE_MODE = CONFIG_FLAG(95, "daeMode",
-  NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
-  Util.gettext("Generates additional code for DAE mode, where dynamic equations are not causelized."));
+  NONE(), EXTERNAL(), ENUM_FLAG(1, {("none", 1), ("all",2), ("dynamic",3)}),
+  SOME(STRING_OPTION({"none", "all", "dynamic"})),
+  Util.gettext("Generates additional code for DAE mode, where the equations are not causelized, when one of the following option is selected:\n"+
+               "all    : In this mode all equations are passed to the integrator.\n"+
+               "dynamic : In this mode only the equation for the dynamic part of the system are passed to the integrator.")
+);
+
 constant ConfigFlag INLINE_METHOD = CONFIG_FLAG(96, "inlineMethod",
   NONE(), EXTERNAL(), ENUM_FLAG(1, {("replace",1), ("append",2)}),
   SOME(STRING_OPTION({"replace", "append"})),

--- a/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -1051,7 +1051,11 @@ int rootsFunctionIDA(double time, N_Vector yy, N_Vector yp, double *gout, void* 
   externalInputUpdate(data);
   data->callback->input_function(data, threadData);
   /* eval needed equations*/
-  data->callback->function_ZeroCrossingsEquations(data, threadData);
+  if (idaData->daeMode && compiledInDAEMode == 1){}
+  else
+  {
+    data->callback->function_ZeroCrossingsEquations(data, threadData);
+  }
 
   data->callback->function_ZeroCrossings(data, threadData, gout);
 


### PR DESCRIPTION
This adds an additional option for the daeMode=[all,dynamic]. 
So far the dynamic option was default, with the option "all", all equations (also the output algebraic equations) are used by the integrator, this reduces the costs of the zero crossings evaluation, but increases the problem size further. 