### PR TITLE
Improved performance of SimCode zero-crossings

### DIFF
--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -1228,7 +1228,6 @@ algorithm
   oeqSccMapping, oeqBackendSimCodeMapping, obackendMapping, oSccOffset) := List.fold1(inSysts, createEquationsForSystems1, arg, foldArg);
   oequationsForZeroCrossings := Dangerous.listReverseInPlace(oequationsForZeroCrossings);
   ((ouniqueEqIndex, olocalKnownVars)) := BackendVariable.traverseBackendDAEVars(shared.localKnownVars, traverseKnVarsToSimEqSystem, (ouniqueEqIndex, {}));
-
 end createEquationsForSystems;
 
 protected function createEquationsForSystems1
@@ -1268,8 +1267,8 @@ algorithm
         (syst, _, _) = BackendDAEUtil.getIncidenceMatrixfromOption(inSyst, BackendDAE.ABSOLUTE(), SOME(funcs));
 
         stateeqnsmark = arrayCreate(BackendDAEUtil.equationArraySizeDAE(syst), 0);
-        stateeqnsmark = BackendDAEUtil.markStateEquations(syst, stateeqnsmark, ass1);
         zceqnsmarks = arrayCreate(BackendDAEUtil.equationArraySizeDAE(syst), 0);
+        stateeqnsmark = BackendDAEUtil.markStateEquations(syst, stateeqnsmark, ass1);
         zceqnsmarks = BackendDAEUtil.markZeroCrossingEquations(syst, zeroCrossings, zceqnsmarks, ass1);
 
         (odeEquations1, algebraicEquations1, allEquations1, equationsForZeroCrossings1, uniqueEqIndex,
@@ -1279,7 +1278,6 @@ algorithm
                 sccOffset, eqSccMapping, eqBackendSimCodeMapping, backendMapping);
         GC.free(stateeqnsmark);
         GC.free(zceqnsmarks);
-
 
         odeEquations = List.consOnTrue(not listEmpty(odeEquations1), odeEquations1, odeEquations);
         algebraicEquations = List.consOnTrue(not listEmpty(algebraicEquations1), algebraicEquations1, algebraicEquations);
@@ -1948,9 +1946,9 @@ algorithm
 
       // try as is should fallback case is a hack for complex record equations
       try
-	      // make residual equations => 0 = f(x,xd,y)
-	      eqnlst := List.flattenReverse(List.map(eqnlst, BackendEquation.equationToScalarResidualForm));
-	      tmpEqns := {};
+        // make residual equations => 0 = f(x,xd,y)
+        eqnlst := List.flattenReverse(List.map(eqnlst, BackendEquation.equationToScalarResidualForm));
+        tmpEqns := {};
       else
         (eqnlst, tmpEqns, uniqueEqIndex, tempvars) := createDAEResidualComplexEquation(eqnlst, uniqueEqIndex, tempvars);
       end try;

--- a/Compiler/Util/AvlSetInt.mo
+++ b/Compiler/Util/AvlSetInt.mo
@@ -1,0 +1,45 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2014, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package AvlSetInt
+  import BaseAvlSet;
+  extends BaseAvlSet;
+  redeclare type Key = Integer;
+  redeclare function extends keyStr
+  algorithm
+    outString := String(inKey);
+  end keyStr;
+  redeclare function extends keyCompare
+  algorithm
+    outResult := sign(inKey2-inKey1);
+  end keyCompare;
+annotation(__OpenModelica_Interface="backend");
+end AvlSetInt;

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -326,6 +326,7 @@ if true then /* Suppress output */
 
     "../Util/AvlTree.mo",
     "../Util/AvlTreeString.mo",
+    "../Util/AvlSetInt.mo",
 
     "../Util/DiffAlgorithm.mo",
     "../Util/FMI.mo",


### PR DESCRIPTION
Changed the functions to not consume memory when not collecting
anything. When the are many independent equation systems, the
zero-crossings are traversed once per system, making the translation
slow (this is still true; it just uses less memory now).

In order to fix the problems, it needs to be possible to query which
equation system a zero-crossing belongs to in constant time (or vice
versa).