### PR TITLE
Add built-in function valueCompare

### DIFF
--- a/Compiler/FrontEnd/MetaModelicaBuiltin.mo
+++ b/Compiler/FrontEnd/MetaModelicaBuiltin.mo
@@ -779,6 +779,14 @@ function valueEq<A>
 external "builtin";
 end valueEq;
 
+function valueCompare<A>
+  "a1 > a2?"
+  input A a1;
+  input A a2;
+  output Integer i "-1, 0, 1";
+external "builtin";
+end valueCompare;
+
 function valueHashMod<A>
   input A value;
   input Integer mod;

--- a/SimulationRuntime/c/meta/meta_modelica.h
+++ b/SimulationRuntime/c/meta/meta_modelica.h
@@ -145,6 +145,7 @@ static inline void *mmc_mk_box_no_assign(mmc_sint_t _slots, mmc_uint_t ctor, int
 }
 
 extern modelica_boolean valueEq(modelica_metatype lhs,modelica_metatype rhs);
+extern modelica_integer valueCompare(modelica_metatype lhs,modelica_metatype rhs);
 
 extern modelica_integer valueHashMod(modelica_metatype p,modelica_integer mod);
 extern void* boxptr_valueHashMod(threadData_t *,void *p, void *mod);


### PR DESCRIPTION
This is needed to create a generic sorting function. valueEq is now
defined as `0==valueCompare(v1,v2)`.