### PR TITLE
Add flag to control function-binding evaluation

### DIFF
--- a/Compiler/BackEnd/BackendVarTransform.mo
+++ b/Compiler/BackEnd/BackendVarTransform.mo
@@ -2929,7 +2929,7 @@ protected
 algorithm
   (crefs,exps) := getAllReplacements(replIn);
   (exps,_) := List.map_2(exps,ExpressionSimplify.simplify);
-  exps := List.map1(exps, EvaluateFunctions.evaluateConstantFunctionCallExp,functions);
+  exps := List.map2(exps, EvaluateFunctions.evaluateConstantFunctionCallExp, functions, false);
   replOut := addReplacements(replIn,crefs,exps,NONE());
 end simplifyReplacements;
 

--- a/Compiler/BackEnd/EvaluateParameter.mo
+++ b/Compiler/BackEnd/EvaluateParameter.mo
@@ -868,7 +868,7 @@ algorithm
       // apply replacements
       (e, true) = BackendVarTransform.replaceExp(e, iReplEvaluate, NONE());
       (e, _) = ExpressionSimplify.simplify(e);
-      e = EvaluateFunctions.evaluateConstantFunctionCallExp(e, FCore.getFunctionTree(iCache));
+      e = EvaluateFunctions.evaluateConstantFunctionCallExp(e, FCore.getFunctionTree(iCache), Flags.getConfigBool(Flags.EVAL_CONST_ARGS_ONLY));
       v = BackendVariable.setBindExp(var, SOME(e));
       (repl, repleval) = addConstExpReplacement(e, cr, iRepl, iReplEvaluate);
       (attr, (repleval, _)) = BackendDAEUtil.traverseBackendDAEVarAttr(attr, traverseExpVisitorWrapper, (repleval, false));
@@ -889,7 +889,7 @@ algorithm
       // apply replacements
       (e, true) = BackendVarTransform.replaceExp(e, iReplEvaluate, NONE());
       (e, _) = ExpressionSimplify.simplify(e);
-      e = EvaluateFunctions.evaluateConstantFunctionCallExp(e, FCore.getFunctionTree(iCache));
+      e = EvaluateFunctions.evaluateConstantFunctionCallExp(e, FCore.getFunctionTree(iCache), Flags.getConfigBool(Flags.EVAL_CONST_ARGS_ONLY));
       v = BackendVariable.setVarStartValue(var, e);
       (repl, repleval) = addConstExpReplacement(e, cr, iRepl, iReplEvaluate);
       (attr, (repleval, _)) = BackendDAEUtil.traverseBackendDAEVarAttr(attr, traverseExpVisitorWrapper, (repleval, false));
@@ -909,7 +909,7 @@ algorithm
       // apply replacements
       (e, true) = BackendVarTransform.replaceExp(e, iReplEvaluate, NONE());
       (e, _) = ExpressionSimplify.simplify(e);
-      e = EvaluateFunctions.evaluateConstantFunctionCallExp(e, FCore.getFunctionTree(iCache));
+      e = EvaluateFunctions.evaluateConstantFunctionCallExp(e, FCore.getFunctionTree(iCache), Flags.getConfigBool(Flags.EVAL_CONST_ARGS_ONLY));
       v = BackendVariable.setBindExp(var, SOME(e));
       (attr, (repleval, _)) = BackendDAEUtil.traverseBackendDAEVarAttr(attr, traverseExpVisitorWrapper, (iReplEvaluate, false));
       v = BackendVariable.setVarAttributes(v, attr);

--- a/Compiler/BackEnd/RemoveSimpleEquations.mo
+++ b/Compiler/BackEnd/RemoveSimpleEquations.mo
@@ -1841,7 +1841,7 @@ algorithm
         not Expression.isImpure(exp) // lochel: this is at least needed for impure functions
       equation
         //exp2 = Ceval.cevalSimpleWithFunctionTreeReturnExp(exp, functions);
-        exp2 = EvaluateFunctions.evaluateConstantFunctionCallExp(exp,functions);
+        exp2 = EvaluateFunctions.evaluateConstantFunctionCallExp(exp, functions, false);
         if not Expression.isConst(exp2) then
           exp2 = exp;
         end if;

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -6624,7 +6624,7 @@ algorithm
     equation
       if isSome(o1) then
         startValue = Util.getOption(o1);
-        startValue_ = EvaluateFunctions.evaluateConstantFunctionCallExp(startValue,funcTreeIn);
+        startValue_ = EvaluateFunctions.evaluateConstantFunctionCallExp(startValue, funcTreeIn, Flags.getConfigBool(Flags.EVAL_CONST_ARGS_ONLY));
         if not referenceEq(startValue, startValue_) then
           inVar.bindExp = SOME(startValue_);
         end if;
@@ -6654,7 +6654,7 @@ algorithm
       DAE.Exp exp, exp_;
   case(DAE.VAR_ATTR_REAL(start=SOME(exp)),_)
     equation
-      exp_ = EvaluateFunctions.evaluateConstantFunctionCallExp(exp,funcTree);
+      exp_ = EvaluateFunctions.evaluateConstantFunctionCallExp(exp, funcTree, Flags.getConfigBool(Flags.EVAL_CONST_ARGS_ONLY));
       if not referenceEq(exp, exp_) then
         attrIn.start = SOME(exp);
       end if;

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -1320,6 +1320,9 @@ constant ConfigFlag TOTAL_TEARING = CONFIG_FLAG(102, "totalTearing",
 constant ConfigFlag IGNORE_SIMULATION_FLAGS_ANNOTATION = CONFIG_FLAG(103, "ignoreSimulationFlagsAnnotation",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Ignores the simulation flags specified as annotation in the class."));
+constant ConfigFlag EVAL_CONST_ARGS_ONLY = CONFIG_FLAG(104, "evalConstArgsOnly",
+  NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
+  Util.gettext("Only evaluate parameter function-bindings if the arguments could be evaluated to constants."));
 
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
@@ -1428,7 +1431,8 @@ constant list<ConfigFlag> allConfigFlags = {
   CALCULATE_SENSITIVITIES,
   ALARM,
   TOTAL_TEARING,
-  IGNORE_SIMULATION_FLAGS_ANNOTATION
+  IGNORE_SIMULATION_FLAGS_ANNOTATION,
+  EVAL_CONST_ARGS_ONLY
 };
 
 public function new


### PR DESCRIPTION
See [ticket:4000](https://trac.openmodelica.org/OpenModelica/ticket/4000)
Default: Only try to evaluate parameter function-bindings
if their arguments could be evaluated to a constant.