### PR TITLE
Use AvlSetInt instead of lists for inc. matrix

### DIFF
--- a/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -968,7 +968,8 @@ algorithm
       BackendDAE.Variables vars;
       BackendDAE.EquationArray eqns,eqns1;
       DAE.Exp exp,e1,e2,ecr;
-      list<Integer> expvars,controleqns,expvars1;
+      AvlSetInt.Tree expvars;
+      list<Integer> controleqns,expvars1;
       list<list<Integer>> expvarseqns;
 
     case ((elem,pos,m,(mT,vars,eqns,changed)))
@@ -982,9 +983,9 @@ algorithm
         // failure(DAE.CREF(componentRef=_) = exp);
         // failure(DAE.UNARY(operator=DAE.UMINUS(ty=_),exp=DAE.CREF(componentRef=_)) = exp);
         // BackendDump.debugStrExpStrExpStr(("Found ",ecr," = ",exp,"\n"));
-        expvars = BackendDAEUtil.incidenceRowExp(exp,vars,{},NONE(),BackendDAE.NORMAL());
+        expvars = BackendDAEUtil.incidenceRowExp(exp,vars,AvlSetInt.EMPTY(),NONE(),BackendDAE.NORMAL());
         // print("expvars "); BackendDump.debuglst((expvars,intString," ","\n"));
-        (expvars1::expvarseqns) = List.map2(expvars,varEqns,pos,mT);
+        (expvars1::expvarseqns) = List.map2(AvlSetInt.listKeys(expvars),varEqns,pos,mT);
         // print("expvars1 "); BackendDump.debuglst((expvars1,intString," ","\n"));;
         controleqns = getControlEqns(expvars1,expvarseqns);
         // print("controleqns "); BackendDump.debuglst((controleqns,intString," ","\n"));

--- a/Compiler/BackEnd/EvaluateParameter.mo
+++ b/Compiler/BackEnd/EvaluateParameter.mo
@@ -293,6 +293,7 @@ algorithm
       DAE.Exp e;
       DAE.ComponentRef cref;
       Option<DAE.VariableAttributes> attr;
+      AvlSetInt.Tree tree;
       list<Integer> ilst,selectedParameters;
       Integer index;
       BackendDAE.IncidenceMatrix m;
@@ -303,7 +304,8 @@ algorithm
 
     case (v as BackendDAE.VAR(varKind=BackendDAE.PARAM(),bindExp=SOME(e)),(globalKnownVars,index,selectParameter,selectedParameters,m,mt,ht))
       equation
-        (_,(_,ilst)) = Expression.traverseExpTopDown(e, BackendDAEUtil.traversingincidenceRowExpFinder, (globalKnownVars,{}));
+        (_,(_,tree)) = Expression.traverseExpTopDown(e, BackendDAEUtil.traversingincidenceRowExpFinder, (globalKnownVars,AvlSetInt.EMPTY()));
+        ilst = AvlSetInt.listKeys(tree);
         cref = BackendVariable.varCref(v);
         select = selectParameter(v) or AvlSetCR.hasKey(ht, cref);
         selectedParameters = List.consOnTrue(select, index, selectedParameters);
@@ -314,7 +316,8 @@ algorithm
     case (v as BackendDAE.VAR(varKind=BackendDAE.PARAM(),values=attr),(globalKnownVars,index,selectParameter,selectedParameters,m,mt,ht))
       equation
         e = DAEUtil.getStartAttrFail(attr);
-        (_,(_,ilst)) = Expression.traverseExpTopDown(e, BackendDAEUtil.traversingincidenceRowExpFinder, (globalKnownVars,{}));
+        (_,(_,tree)) = Expression.traverseExpTopDown(e, BackendDAEUtil.traversingincidenceRowExpFinder, (globalKnownVars,AvlSetInt.EMPTY()));
+        ilst = AvlSetInt.listKeys(tree);
         cref = BackendVariable.varCref(v);
         select = selectParameter(v) or AvlSetCR.hasKey(ht, cref);
         selectedParameters = List.consOnTrue(select, index, selectedParameters);
@@ -707,13 +710,13 @@ protected function evaluateFixedAttribute1
 protected
   DAE.Exp e1;
   Boolean b;
-  list<Integer> ilst;
+  AvlSetInt.Tree ilst;
   Option<DAE.VariableAttributes> attr1;
 algorithm
    // apply replacements
   (e1,_) := BackendVarTransform.replaceExp(e, repl, NONE());
-  (_,(_,ilst)) := Expression.traverseExpTopDown(e1, BackendDAEUtil.traversingincidenceRowExpFinder, (globalKnownVars,{}));
-  (globalKnownVars,cache,mark,repl) := evaluateSelectedParameters1(ilst,globalKnownVars,m,inIEqns,cache,graph,mark,markarr,repl);
+  (_,(_,ilst)) := Expression.traverseExpTopDown(e1, BackendDAEUtil.traversingincidenceRowExpFinder, (globalKnownVars,AvlSetInt.EMPTY()));
+  (globalKnownVars,cache,mark,repl) := evaluateSelectedParameters1(AvlSetInt.listKeys(ilst),globalKnownVars,m,inIEqns,cache,graph,mark,markarr,repl);
   (e1,_) := BackendVarTransform.replaceExp(e1, repl, NONE());
   (e1,_) := ExpressionSimplify.simplify(e1);
    b := Expression.isConst(e1);

--- a/Compiler/BackEnd/IndexReduction.mo
+++ b/Compiler/BackEnd/IndexReduction.mo
@@ -2344,6 +2344,7 @@ algorithm
     match (iEqns, vars, index, sindex, m, mT, om, mapEqnIncRow, mapIncRowEqn, stateindexs, functionTree)
     local
       list<BackendDAE.Equation> rest;
+      AvlSetInt.Tree rowTree;
       list<Integer> row,rowindxs,negrow;
       BackendDAE.Equation e;
       Integer i1,rowSize,size;
@@ -2354,7 +2355,8 @@ algorithm
     case (e::rest, _, _, _, _, _, _, _, _, _, _)
       equation
         // compute the row
-        (row,size) = BackendDAEUtil.incidenceRow(e, vars, BackendDAE.SOLVABLE(), SOME(functionTree), {});
+        (rowTree,size) = BackendDAEUtil.incidenceRow(e, vars, BackendDAE.SOLVABLE(), SOME(functionTree), AvlSetInt.EMPTY());
+        row = AvlSetInt.listKeys(rowTree);
         rowSize = sindex + size;
         i1 = index+1;
         rowindxs = List.intRange2(sindex+1, rowSize);

--- a/Compiler/Util/BaseAvlSet.mo
+++ b/Compiler/Util/BaseAvlSet.mo
@@ -243,6 +243,59 @@ algorithm
   end match;
 end setTreeLeftRight;
 
+function intersection
+  "Takes two sets and returns the intersection as well as the remainder
+  of both sets after removing the duplicates in both sets."
+  input Tree tree1, tree2;
+  output Tree intersect=Tree.EMPTY(), rest1=Tree.EMPTY(), rest2=Tree.EMPTY();
+protected
+  function intersectionWork
+    input Tree tree1, tree2;
+    input Boolean buildTree;
+    input output Tree intersection=Tree.EMPTY(), rest=Tree.EMPTY();
+  protected
+    Boolean b;
+  algorithm
+    (intersection,rest) := match tree1
+      case EMPTY() then (intersection, rest);
+      case LEAF()
+        algorithm
+          b := hasKey(tree2, tree1.key);
+        then (if b then add(intersection, tree1.key) else intersection, if b or not buildTree then rest else add(rest, tree1.key));
+      case NODE()
+        algorithm
+          (intersection,rest) := intersectionWork(tree1.left, tree2, buildTree, intersection, rest);
+          (intersection,rest) := intersectionWork(tree1.right, tree2, buildTree, intersection, rest);
+          b := hasKey(tree2, tree1.key);
+        then (if b then add(intersection, tree1.key) else intersection, if b or not buildTree then rest else add(rest, tree1.key));
+    end match;
+  end intersectionWork;
+algorithm
+  if isEmpty(tree1) then
+    rest2 := tree2;
+    return;
+  end if;
+  if isEmpty(tree2) then
+    rest1 := tree1;
+    return;
+  end if;
+
+  (intersect, rest1) := intersectionWork(tree1, tree2, isPresent(rest1));
+
+  if isPresent(rest2) then
+    if isEmpty(intersect) then
+      rest2 := tree2;
+    else
+      // TODO: Make a faster version of this?
+      for key in listKeys(tree2) loop
+        if not hasKey(intersect, key) then
+          rest2 := add(rest2, key);
+        end if;
+      end for;
+    end if;
+  end if;
+end intersection;
+
 protected
 
 function referenceEqOrEmpty

--- a/Compiler/Util/BaseAvlTree.mo
+++ b/Compiler/Util/BaseAvlTree.mo
@@ -334,6 +334,11 @@ algorithm
   end match;
 end forEach;
 
+redeclare function intersection
+algorithm
+  fail();
+end intersection;
+
 function map
   "Traverses the tree in depth-first pre-order and applies the given function to
    each node, constructing a new tree with the resulting nodes."


### PR DESCRIPTION
The incidence matrix takes a long time to calculate for certain systems,
especially when you have one equation that ties into all of the other
equations.
