### PR TITLE
Only store direction of external variables

### DIFF
--- a/Compiler/FrontEnd/Absyn.mo
+++ b/Compiler/FrontEnd/Absyn.mo
@@ -5370,6 +5370,17 @@ algorithm
   end match;
 end isInput;
 
+public function isOutput
+  input Direction inDirection;
+  output Boolean outIsOutput;
+algorithm
+  outIsOutput := match(inDirection)
+    case OUTPUT() then true;
+    case INPUT_OUTPUT() then true;
+    else false;
+  end match;
+end isOutput;
+
 public function directionEqual
   input Direction inDirection1;
   input Direction inDirection2;

--- a/Compiler/FrontEnd/DAE.mo
+++ b/Compiler/FrontEnd/DAE.mo
@@ -523,7 +523,7 @@ end Distribution;
 public uniontype ExtArg
   record EXTARG
     ComponentRef componentRef;
-    Attributes attributes;
+    Absyn.Direction direction;
     Type type_;
   end EXTARG;
 
@@ -534,7 +534,6 @@ public uniontype ExtArg
 
   record EXTARGSIZE
     ComponentRef componentRef;
-    Attributes attributes;
     Type type_;
     Exp exp;
   end EXTARGSIZE;

--- a/Compiler/FrontEnd/DAEDump.mo
+++ b/Compiler/FrontEnd/DAEDump.mo
@@ -324,7 +324,7 @@ algorithm
       DAE.Attributes attr;
 
     case DAE.NOEXTARG() then "";
-    case DAE.EXTARG(componentRef = cr,attributes = DAE.ATTR())
+    case DAE.EXTARG(componentRef = cr)
       equation
         crstr = ComponentReference.printComponentRefStr(cr);
       then

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -5411,16 +5411,15 @@ algorithm
         // using qualified crefs in external function definitions.
         fcr = ComponentReference.crefFirstCref(cref);
         (cache, fattr, _, _, _, _, _, _, _) = Lookup.lookupVarLocal(cache, inEnv, fcr);
-        attr = DAEUtil.setAttrDirection(attr, DAEUtil.getAttrDirection(fattr));
       then
-        (cache, SOME(DAE.EXTARG(cref, attr, ty)));
+        (cache, SOME(DAE.EXTARG(cref, DAEUtil.getAttrDirection(fattr), ty)));
 
     case (_, _, _, DAE.CREF(componentRef = cref as DAE.CREF_IDENT()),
         DAE.PROP(constFlag = DAE.C_VAR()), _, _)
       equation
         (cache, attr, ty,_, _, _, _, _, _) = Lookup.lookupVarLocal(inCache, inEnv, cref);
       then
-        (cache,SOME(DAE.EXTARG(cref, attr, ty)));
+        (cache,SOME(DAE.EXTARG(cref, DAEUtil.getAttrDirection(attr), ty)));
 
     case (cache,env,_,DAE.CREF(componentRef = cref),DAE.PROP(),_,_)
       equation
@@ -5433,9 +5432,9 @@ algorithm
 
     case (cache,env,_,DAE.SIZE(exp = DAE.CREF(componentRef = cref),sz = SOME(dim)),DAE.PROP(),_,_)
       equation
-        (cache,attr,varty,_,_,_,_,_,_) = Lookup.lookupVarLocal(cache,env, cref);
+        (cache,_,varty,_,_,_,_,_,_) = Lookup.lookupVarLocal(cache,env, cref);
       then
-        (cache,SOME(DAE.EXTARGSIZE(cref,attr,varty,dim)));
+        (cache,SOME(DAE.EXTARGSIZE(cref,varty,dim)));
 
     // adrpo: these can be non-local if they are constants or parameters!
     case (cache,env,_,_,DAE.PROP(type_ = ty,constFlag = DAE.C_CONST()),_,_)

--- a/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -891,7 +891,7 @@ algorithm
   match (extArg)
     local
       DAE.ComponentRef componentRef;
-      DAE.Attributes attributes;
+      Absyn.Direction dir;
       DAE.Type type_;
       Boolean isInput;
       Boolean isOutput;
@@ -899,10 +899,10 @@ algorithm
       DAE.Exp exp_;
       Integer outputIndex;
 
-    case DAE.EXTARG(componentRef, attributes, type_)
+    case DAE.EXTARG(componentRef, dir, type_)
       equation
-        isInput = Types.isInputAttr(attributes);
-        isOutput = Types.isOutputAttr(attributes);
+        isInput = Absyn.isInput(dir);
+        isOutput = Absyn.isOutput(dir);
         outputIndex = if isOutput then -1 else 0; // correct output index is added later by fixOutputIndex
         isArray = Types.isArray(type_);
         type_ = Types.simplifyType(type_);
@@ -913,13 +913,10 @@ algorithm
         type_ = Types.simplifyType(type_);
       then SimCode.SIMEXTARGEXP(exp_, type_);
 
-    case DAE.EXTARGSIZE(componentRef, attributes, type_, exp_)
+    case DAE.EXTARGSIZE(componentRef, type_, exp_)
       equation
-        isInput = Types.isInputAttr(attributes);
-        isOutput = Types.isOutputAttr(attributes);
-        outputIndex = if isOutput then -1 else 0; // correct output index is added later by fixOutputIndex
         type_ = Types.simplifyType(type_);
-      then SimCode.SIMEXTARGSIZE(componentRef, isInput, outputIndex, type_, exp_);
+      then SimCode.SIMEXTARGSIZE(componentRef, true, 0, type_, exp_);
 
     case DAE.NOEXTARG() then SimCode.SIMNOEXTARG();
   end match;


### PR DESCRIPTION
Stream attributes, etc are not necessary for code generation of
external calls.