### PR TITLE
Improve userDefinedTearing

### DIFF
--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -3050,6 +3050,20 @@ algorithm
   outS := stringAppendList({s2,"(",s3,")"});
 end dumpMarkedVars1;
 
+public function dumpMarkedVarList
+"Dumps the variables given as list of indexes to a string."
+  input list<BackendDAE.Var> varList;
+  input list<Integer> selList;
+  output String outString = "";
+protected
+  BackendDAE.Var var;
+algorithm
+  for sel in selList loop
+    var := listGet(varList, sel);
+    outString := outString + "  " + varString(var) + "\n";
+  end for;
+end dumpMarkedVarList;
+
 public function dumpComponentsGraphStr
 "Dumps the assignment graph used to determine strong
  components to format suitable for Mathematica"

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -847,6 +847,8 @@ public constant Message WRONG_VALUE_OF_ARG = MESSAGE(576, TRANSLATION(), ERROR()
   Util.gettext("Wrong value of argument to %s: %s = %s %s."));
 public constant Message USER_DEFINED_TEARING_ERROR = MESSAGE(577, SYMBOLIC(), ERROR(),
   Util.gettext("Wrong usage of user defined tearing: %s Make sure you use user defined tearing as stated in the flag description."));
+public constant Message USER_TEARING_VARS = MESSAGE(578, SYMBOLIC(), NOTIFICATION(),
+  Util.gettext("Following iteration variables are selected by the user for strong component %s (DAE kind: %s):\n%s"));
 
 public constant Message MATCH_SHADOWING = MESSAGE(5001, TRANSLATION(), ERROR(),
   Util.gettext("Local variable '%s' shadows another variable."));

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -1301,7 +1301,7 @@ constant ConfigFlag INLINE_METHOD = CONFIG_FLAG(96, "inlineMethod",
                "append  : This method inlines by adding additional variables to the whole system. Might lead to much bigger system."));
 constant ConfigFlag SET_TEARING_VARS = CONFIG_FLAG(97, "setTearingVars",
   NONE(), EXTERNAL(), INT_LIST_FLAG({}), NONE(),
-  Util.gettext("Sets the tearing variables by its strong component indexes. Use '+d=tearingdump' to find out the relevant indexes.\nUse following format: '--setTearingVars=(sci,n,t1,...,tn)*', with sci = strong component index, n = number of tearing variables, t1,...tn = tearing variables.\nE.g.: '--setTearingVars=4,2,3,5' would select variables 3 and 5 in strong component 4.\nOnly works in combination with 'setResidualEqns'."));
+  Util.gettext("Sets the tearing variables by its strong component indexes. Use '+d=tearingdump' to find out the relevant indexes.\nUse following format: '--setTearingVars=(sci,n,t1,...,tn)*', with sci = strong component index, n = number of tearing variables, t1,...tn = tearing variables.\nE.g.: '--setTearingVars=4,2,3,5' would select variables 3 and 5 in strong component 4."));
 constant ConfigFlag SET_RESIDUAL_EQNS = CONFIG_FLAG(98, "setResidualEqns",
   NONE(), EXTERNAL(), INT_LIST_FLAG({}), NONE(),
   Util.gettext("Sets the residual equations by its strong component indexes. Use '+d=tearingdump' to find out the relevant indexes for the collective equations.\nUse following format: '--setResidualEqns=(sci,n,r1,...,rn)*', with sci = strong component index, n = number of residual equations, r1,...rn = residual equations.\nE.g.: '--setResidualEqns=4,2,3,5' would select equations 3 and 5 in strong component 4.\nOnly works in combination with 'setTearingVars'."));


### PR DESCRIPTION
Allow to define only tearing variables by --setTearingVars
and residual equations will be found by the compiler
(corresponding to tearingSelect=always).