### PR TITLE
Detect tuples used as expressions

### DIFF
--- a/Compiler/FrontEnd/InstSection.mo
+++ b/Compiler/FrontEnd/InstSection.mo
@@ -334,8 +334,7 @@ algorithm
         // Check that the equation is valid if the lhs is a tuple.
         checkTupleCallEquationMessage(lhs_aexp, rhs_aexp, info);
 
-        (outCache, lhs_exp, lhs_prop) :=
-          Static.elabExp(inCache, inEnv, lhs_aexp, inImpl, NONE(), true, inPrefix, info);
+        (outCache, lhs_exp, lhs_prop) := Static.elabExpLHS(inCache, inEnv, lhs_aexp, inImpl, NONE(), true, inPrefix, info);
         (outCache, rhs_exp, rhs_prop) :=
           Static.elabExp(inCache, inEnv, rhs_aexp, inImpl, NONE(), true, inPrefix, info);
 
@@ -1112,7 +1111,7 @@ algorithm
       true = boolOr(b3,b4);
       true = Expression.containFunctioncall(elabedE2);
       (e1,prop) = expandTupleEquationWithWild(e1,prop2,prop);
-      (cache,elabedE1_2,prop1,_) = Static.elabExp(cache,env, e1, impl,NONE(),false,pre,info);
+      (cache,elabedE1_2,prop1,_) = Static.elabExpLHS(cache,env, e1, impl,NONE(),false,pre,info);
       (cache, elabedE1_2, prop1) = Ceval.cevalIfConstant(cache, env, elabedE1_2, prop1, impl, info);
       (cache,elabedE2_2,prop2,_) = Static.elabExp(cache,env, e2, impl,NONE(),false,pre,info);
       (cache, elabedE2_2, prop2) = Ceval.cevalIfConstant(cache, env, elabedE2_2, prop2, impl, info);
@@ -5099,7 +5098,7 @@ algorithm
       equation
         Absyn.CALL() = inRhs;
         true = List.all(expl, Absyn.isCref);
-        (cache,e_1,prop1,_) = Static.elabExp(cache,inEnv,e1,inImpl,NONE(),false,inPre,info);
+        (cache,e_1,prop1,_) = Static.elabExpLHS(cache,inEnv,e1,inImpl,NONE(),false,inPre,info);
         lt = Types.getPropType(prop1);
         rt = Types.getPropType(prop2);
         false = Types.subtype(lt, rt);

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -706,6 +706,8 @@ public constant Message NO_JACONIAN_TORNLINEAR_SYSTEM = MESSAGE(289, SYMBOLIC(),
   Util.gettext("A torn linear system has no symbolic jacobian and currently there are no means to solve that numerically. Please compile with the module \"calculateStrongComponentJacobians\" to provide symbolic jacobians for torn linear systems."));
 public constant Message EXT_FN_SINGLE_RETURN_ARRAY = MESSAGE(290, TRANSLATION(), WARNING(),
   Util.gettext("An external declaration with a single output without explicit mapping is defined as having the output as the lhs, but language %s does not support this for array variables. OpenModelica will put the output as an input (as is done when there is more than 1 output), but this is not according to the Modelica Specification. Use an explicit mapping instead of the implicit one to suppress this warning."));
+public constant Message RHS_TUPLE_EXPRESSION = MESSAGE(291, TRANSLATION(), ERROR(),
+  Util.gettext("Tuple expressions may only occur on the left side of an assignment or equation with a single function call on the right side. Got the following expression: %s."));
 
 public constant Message UNBOUND_PARAMETER_WITH_START_VALUE_WARNING = MESSAGE(499, TRANSLATION(), WARNING(),
   Util.gettext("Parameter %s has no value, and is fixed during initialization (fixed=true), using available start value (start=%s) as default value."));


### PR DESCRIPTION
Tuples may only be used on the left side of an assignment in Modelica.
In MetaModelica, we allow tuples anywhere.