### PR TITLE
Fix marking structural parameters final

### DIFF
--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -7759,21 +7759,12 @@ protected function prefixAndAddCrefsToHt
   input HashTable.HashTable iht;
   input Prefix.Prefix pre;
   input list<DAE.ComponentRef> icrs;
-  output HashTable.HashTable oht;
+  output HashTable.HashTable oht=iht;
 algorithm
-  oht := match (cache,iht,pre,icrs)
-    local
-      DAE.ComponentRef cr;
-      HashTable.HashTable ht;
-      list<DAE.ComponentRef> crs;
-
-    case (_,ht,_,{}) then ht;
-    case (_,ht,_,cr::_)
-      equation
-        (_,cr) = PrefixUtil.prefixCref(cache, FGraph.empty(), InnerOuter.emptyInstHierarchy, pre, cr);
-        ht = BaseHashTable.add((cr,1),ht);
-      then ht;
-  end match;
+  for cr in icrs loop
+    (_,cr) := PrefixUtil.prefixCref(cache, FGraph.empty(), InnerOuter.emptyInstHierarchy, pre, cr);
+    oht := BaseHashTable.add((cr,1),oht);
+  end for;
 end prefixAndAddCrefsToHt;
 
 protected function numStructuralParameterScopes


### PR DESCRIPTION
Only one structural parameter was marked final. Now all
structural parameters deciding array dimensions are marked
final.

There are still other issues:
- related parameters are not marked final [(ticket:4052)](https://trac.openmodelica.org/OpenModelica/ticket/4052)
- structural parameters deciding the if-branch are not
  marked final [(ticket:4053)](https://trac.openmodelica.org/OpenModelica/ticket/4053)