### PR TITLE
Fix use of scale factor in unit conversion, ticket:4031

### DIFF
--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -814,14 +814,12 @@ algorithm
         (u1,scaleFactor1,offset1) = UnitAbsynBuilder.str2unitWithScaleFactor(str1,NONE());
         (u2,scaleFactor2,offset2) = UnitAbsynBuilder.str2unitWithScaleFactor(str2,NONE());
         b = valueEq(u1,u2);
-        /* How to calculate the final scale factor and offset?
-        ºF = (ºK - 273.15)* 1.8000 + 32.00 = (ºK - 255.37)* 1.8000
-        ºC = (ºK - 273.15)
-
-        ºF = (ºC - (255.37 - 273.15))*(1.8/1.0)
+        /* How to calculate the final scale factor and offset:
+        F = C*1.8 + 32
+        C = (F - 32)/1.8 = F/1.8 - 32/1.8
         */
         scaleFactor = realDiv(scaleFactor2, scaleFactor1);
-        offset = realSub(offset2,offset1);
+        offset = realSub(offset2, realDiv(offset1, scaleFactor1));
       then
         (cache,Values.TUPLE({Values.BOOL(b),Values.REAL(scaleFactor),Values.REAL(offset)}),st);
 

--- a/Compiler/runtime/unitparser.cpp
+++ b/Compiler/runtime/unitparser.cpp
@@ -1146,6 +1146,7 @@ void UnitParser::initSIUnits() {
 
   addDerived("pressure", "bar", "bar", "Pa", Rational(0), Rational(100000), Rational(0), true);
 
+  addDerived("time", "millisecond", "ms", "s", Rational(-3), Rational(1), Rational(0), true);
   addDerived("time", "minute", "min", "s", Rational(0), Rational(60), Rational(0), true);
   addDerived("time", "hour", "h", "s", Rational(0), Rational(60 * 60), Rational(0), true);
   addDerived("time", "day", "d", "s", Rational(0), Rational(60 * 60 * 24), Rational(0), true);


### PR DESCRIPTION
This bug showed up with the newly introduced degF.

Also re-introduce ms, because OMEdit uses it for scaling of plots
and millisecond is globally unique.