### PR TITLE
Structural parameters as HashSet instead of Table

### DIFF
--- a/Compiler/FFrontEnd/FCore.mo
+++ b/Compiler/FFrontEnd/FCore.mo
@@ -45,10 +45,10 @@ import BaseAvlTree;
 import DAE;
 import SCode;
 import Prefix;
-import HashTable;
+import HashSet;
 
 protected
-import BaseHashTable;
+import BaseHashSet;
 import DAEUtil;
 import Config;
 
@@ -406,7 +406,7 @@ public constant Id firstId = 0;
 // ************************ Cache structures ***************************
 // ************************ Cache structures ***************************
 
-public type StructuralParameters = tuple<HashTable.HashTable,list<list<DAE.ComponentRef>>>;
+public type StructuralParameters = tuple<HashSet.HashSet,list<list<DAE.ComponentRef>>>;
 public uniontype Cache
   record CACHE
     Option<Graph> initialGraph "and the initial environment";
@@ -443,7 +443,7 @@ protected
   StructuralParameters ht;
 algorithm
   instFuncs := arrayCreate(1, DAE.AvlTreePathFunction.Tree.EMPTY());
-  ht := (HashTable.emptyHashTableSized(BaseHashTable.lowBucketSize),{});
+  ht := (HashSet.emptyHashSetSized(BaseHashSet.lowBucketSize),{});
   cache := CACHE(NONE(),instFuncs,ht,Absyn.IDENT("##UNDEFINED##"),Absyn.dummyProgram);
 end emptyCache;
 
@@ -464,7 +464,7 @@ algorithm
     local
       Option<Graph> initialGraph;
       array<DAE.FunctionTree> functions;
-      HashTable.HashTable ht;
+      HashSet.HashSet ht;
       list<list<DAE.ComponentRef>> st;
       list<DAE.ComponentRef> crs;
       Absyn.Path p;
@@ -480,7 +480,7 @@ end addEvaluatedCref;
 
 public function getEvaluatedParams
   input Cache cache;
-  output HashTable.HashTable ht;
+  output HashSet.HashSet ht;
 algorithm
   CACHE(evaluatedParams=(ht,_)) := cache;
 end getEvaluatedParams;

--- a/Compiler/FrontEnd/Ceval.mo
+++ b/Compiler/FrontEnd/Ceval.mo
@@ -5379,7 +5379,7 @@ protected
   FCore.StructuralParameters structuralParameters;
   array<DAE.FunctionTree> functionTree;
 algorithm
-  structuralParameters := (HashTable.emptyHashTableSized(BaseHashTable.lowBucketSize),{});
+  structuralParameters := (HashSet.emptyHashSetSized(BaseHashSet.lowBucketSize),{});
   functionTree := arrayCreate(1,functions);
   cache := FCore.CACHE(NONE(), functionTree, structuralParameters, Absyn.IDENT(""), Absyn.dummyProgram);
   (_,val,_) := ceval(cache, FGraph.empty(), exp, false, NONE(), Absyn.NO_MSG(),0);

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -7721,7 +7721,7 @@ algorithm
     local
       Option<FCore.Graph> ie;
       array<DAE.FunctionTree> f;
-      HashTable.HashTable ht;
+      HashSet.HashSet ht;
       list<list<DAE.ComponentRef>> crs;
       Absyn.Path p;
       Absyn.Program program;
@@ -7740,7 +7740,7 @@ algorithm
     local
       Option<FCore.Graph> ie;
       array<DAE.FunctionTree> f;
-      HashTable.HashTable ht;
+      HashSet.HashSet ht;
       list<DAE.ComponentRef> crs;
       list<list<DAE.ComponentRef>> crss;
       Absyn.Path p;
@@ -7756,14 +7756,13 @@ end popStructuralParameters;
 protected function prefixAndAddCrefsToHt
   "Cannot be part of Env due to RML issues"
   input FCore.Cache cache;
-  input HashTable.HashTable iht;
+  input output HashSet.HashSet set;
   input Prefix.Prefix pre;
   input list<DAE.ComponentRef> icrs;
-  output HashTable.HashTable oht=iht;
 algorithm
   for cr in icrs loop
     (_,cr) := PrefixUtil.prefixCref(cache, FGraph.empty(), InnerOuter.emptyInstHierarchy, pre, cr);
-    oht := BaseHashTable.add((cr,1),oht);
+    set := BaseHashSet.add(cr,set);
   end for;
 end prefixAndAddCrefsToHt;
 

--- a/Compiler/SimCode/SimCode.mo
+++ b/Compiler/SimCode/SimCode.mo
@@ -54,6 +54,7 @@ encapsulated package SimCode
 import Absyn;
 import BackendDAE;
 import DAE;
+import HashTable;
 import HashTableCrILst;
 import HashTableCrIListArray;
 import HashTableCrefSimVar;

--- a/Compiler/Util/BaseHashTable.mo
+++ b/Compiler/Util/BaseHashTable.mo
@@ -539,9 +539,9 @@ algorithm
       then
         ((n, size, arr));
 
-    case ((_, size, _), _, _)
+    case ((_, size, arr), _, _)
       equation
-        Error.addInternalError("HashTable.valueArraySet(pos="+String(pos)+") size="+String(size)+" failed\n", sourceInfo());
+        Error.addInternalError("HashTable.valueArraySet(pos="+String(pos)+") size="+String(size)+" arrSize="+String(arrayLength(arr))+" failed\n", sourceInfo());
       then
         fail();
 


### PR DESCRIPTION
The FCore.Cache stores the structural parameters as a HashTable, but
does not use the value. This changes the structure to a HashSet
instead.

Note: This also fixes a bug in a model where the HashTable gets
corrupted (probably due to matchcontinue use). The structure should
possibly be changed to an AvlSet instead (or HashTable/HashSet
changed to be fully mutable).