### PR TITLE
Correct handling of parameters

### DIFF
--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -4978,6 +4978,14 @@ algorithm
         (e,_) = Expression.traverseExpBottomUp(e, replaceVartraverser, vars);
       then (e, vars);
 
+    case (DAE.CREF(componentRef=cr),vars)
+      equation
+        (v::_,_) = BackendVariable.getVar(cr,vars);
+        true = BackendVariable.varFixed(v);
+        e = BackendVariable.varBindExpStartValue(v);
+        (e,_) = Expression.traverseExpBottomUp(e, replaceVartraverser, vars);
+      then (e, vars);
+
     else (inExp,inVars);
 
   end matchcontinue;
@@ -7252,14 +7260,7 @@ protected function allPreOptimizationModules
     (UnitCheck.unitChecking, "unitChecking"),
     (DynamicOptimization.createDynamicOptimization,"createDynamicOptimization"),
     (BackendInline.normalInlineFunction, "normalInlineFunction"),
-    (EvaluateParameter.evaluateEvaluateParameters, "evaluateEvaluateParameters"),
-    (EvaluateParameter.evaluateFinalEvaluateParameters, "evaluateFinalEvaluateParameters"),
-    (EvaluateParameter.evaluateFinalParameters, "evaluateFinalParameters"),
-    (EvaluateParameter.evaluateReplaceFinalEvaluateParameters, "evaluateReplaceFinalEvaluateParameters"),
-    (EvaluateParameter.evaluateReplaceFinalParameters, "evaluateReplaceFinalParameters"),
-   	(EvaluateParameter.evaluateAllParameters, "evaluateAllParameters"),
-    (EvaluateParameter.evaluateReplaceEvaluateParameters, "evaluateReplaceEvaluateParameters"),
-    (EvaluateParameter.evaluateReplaceProtectedFinalEvaluateParameters, "evaluateReplaceProtectedFinalEvaluateParameters"),
+    (EvaluateParameter.evaluateParameters, "evaluateParameters"),
     (RemoveSimpleEquations.removeVerySimpleEquations, "removeVerySimpleEquations"),
     (StateMachineFeatures.stateMachineElab, "stateMachineElab"),
     (BackendDAEOptimize.simplifyIfEquations, "simplifyIfEquations"),
@@ -7402,7 +7403,6 @@ algorithm
 
     enabledModules := deprecatedDebugFlag(Flags.SORT_EQNS_AND_VARS, enabledModules, "sortEqnsVars", "preOptModules+");
     enabledModules := deprecatedDebugFlag(Flags.RESOLVE_LOOPS, enabledModules, "resolveLoops", "preOptModules+");
-    enabledModules := deprecatedDebugFlag(Flags.EVAL_ALL_PARAMS, enabledModules, "evaluateAllParameters", "preOptModules+");
     enabledModules := deprecatedDebugFlag(Flags.ADD_DER_ALIASES, enabledModules, "introduceDerAlias", "preOptModules+");
     if Config.acceptOptimicaGrammar() or Flags.getConfigBool(Flags.GENERATE_DYN_OPTIMIZATION_PROBLEM) then
       enabledModules := "inputDerivativesForDynOpt"::enabledModules;

--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -1302,6 +1302,13 @@ algorithm
   select := isFinalVar(inVar) or hasVarEvaluateAnnotation(inVar);
 end hasVarEvaluateAnnotationOrFinal;
 
+public function hasVarEvaluateAnnotationOrProtected
+  input BackendDAE.Var inVar;
+  output Boolean select;
+algorithm
+  select := isProtectedVar(inVar) or hasVarEvaluateAnnotation(inVar);
+end hasVarEvaluateAnnotationOrProtected;
+
 public function hasVarEvaluateAnnotationOrFinalOrProtected
   input BackendDAE.Var inVar;
   output Boolean select;

--- a/Compiler/FFrontEnd/FCore.mo
+++ b/Compiler/FFrontEnd/FCore.mo
@@ -471,6 +471,9 @@ algorithm
     case (CACHE(initialGraph,functions,(ht,crs::st),p,program),SCode.PARAM(),_)
       then CACHE(initialGraph,functions,(ht,(cr::crs)::st),p,program);
 
+    case (CACHE(initialGraph,functions,(ht,{}),p,program),SCode.PARAM(),_)
+      then CACHE(initialGraph,functions,(ht,{cr}::{}),p,program);
+
     else cache;
 
   end match;

--- a/Compiler/FrontEnd/InstSection.mo
+++ b/Compiler/FrontEnd/InstSection.mo
@@ -68,6 +68,7 @@ protected import Inst;
 protected import InstDAE;
 protected import InstFunction;
 protected import InstTypes;
+protected import InstUtil;
 protected import NFInstUtil;
 protected import List;
 protected import Lookup;
@@ -395,6 +396,9 @@ algorithm
 
             rest_branches := listRest(rest_branches);
           end for;
+
+          // Add evaluated parameter condition to the structural parameter list to mark it final later
+          outCache := InstUtil.popStructuralParameters(outCache,inPrefix);
 
           // A branch was selected, instantiate it.
           (outCache, outEnv, outIH, outDae, outSets, outState, outGraph) :=

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -7749,6 +7749,7 @@ algorithm
       equation
         ht = prefixAndAddCrefsToHt(cache,ht,pre,crs);
       then FCore.CACHE(ie,f,(ht,crss),p,program);
+    case (FCore.CACHE(ie,f,(ht,{}),p,program),_) then cache;
     case (FCore.NO_CACHE(),_) then cache;
   end match;
 end popStructuralParameters;

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -222,8 +222,8 @@ constant DebugFlag PATTERNM_MOVE_LAST_EXP = DEBUG_FLAG(25, "patternmMoveLastExp"
   Util.gettext("Optimization that moves the last assignment(s) into the result of a match-expression. For example: equation c = fn(b); then c; => then fn(b);"));
 constant DebugFlag EXPERIMENTAL_REDUCTIONS = DEBUG_FLAG(26, "experimentalReductions", false,
   Util.gettext("Turns on custom reduction functions (OpenModelica extension)."));
-constant DebugFlag EVAL_PARAM = DEBUG_FLAG(27, "evalparam", false,
-  Util.gettext("Constant evaluates parameters if set."));
+constant DebugFlag EVAL_PARAM = DEBUG_FLAG(27, "evaluateAllParameters", false,
+  Util.gettext("Evaluates all parameters if set."));
 constant DebugFlag TYPES = DEBUG_FLAG(28, "types", false,
   Util.gettext("Prints extra failtrace from Types."));
 constant DebugFlag SHOW_STATEMENT = DEBUG_FLAG(29, "showStatement", false,
@@ -457,59 +457,57 @@ constant DebugFlag DIS_SIMP_FUN = DEBUG_FLAG(141, "disableSimplifyComplexFunctio
   Util.gettext("disable simplifyComplexFunction\nDeprecated flag: Use --postOptModules-=simplifyComplexFunction/--initOptModules-=simplifyComplexFunction instead."));
 constant DebugFlag DIS_SYMJAC_FMI20 = DEBUG_FLAG(142, "disableSymbolicLinearization", false,
   Util.gettext("For FMI 2.0 only dependecy analysis will be perform."));
-constant DebugFlag EVAL_ALL_PARAMS = DEBUG_FLAG(143, "evalAllParams", false,
-  Util.gettext("Evaluates all parameters in order to increase simulation speed.\nDeprecated flag: Use --preOptModules+=evaluateAllParameters instead."));
-constant DebugFlag EVAL_OUTPUT_ONLY = DEBUG_FLAG(144, "evalOutputOnly", false,
+constant DebugFlag EVAL_OUTPUT_ONLY = DEBUG_FLAG(143, "evalOutputOnly", false,
   Util.gettext("Generates equations to calculate outputs only."));
-constant DebugFlag HARDCODED_START_VALUES = DEBUG_FLAG(145, "hardcodedStartValues", false,
+constant DebugFlag HARDCODED_START_VALUES = DEBUG_FLAG(144, "hardcodedStartValues", false,
   Util.gettext("Embed the start values of variables and parameters into the c++ code and do not read it from xml file."));
-constant DebugFlag DUMP_FUNCTIONS = DEBUG_FLAG(146, "dumpFunctions", false,
+constant DebugFlag DUMP_FUNCTIONS = DEBUG_FLAG(145, "dumpFunctions", false,
   Util.gettext("Add functions to backend dumps."));
-constant DebugFlag DEBUG_DIFFERENTIATION = DEBUG_FLAG(147, "debugDifferentiation", false,
+constant DebugFlag DEBUG_DIFFERENTIATION = DEBUG_FLAG(146, "debugDifferentiation", false,
   Util.gettext("Dumps debug output for the differentiation process."));
-constant DebugFlag DEBUG_DIFFERENTIATION_VERBOSE = DEBUG_FLAG(148, "debugDifferentiationVerbose", false,
+constant DebugFlag DEBUG_DIFFERENTIATION_VERBOSE = DEBUG_FLAG(147, "debugDifferentiationVerbose", false,
   Util.gettext("Dumps verbose debug output for the differentiation process."));
-constant DebugFlag FMU_EXPERIMENTAL = DEBUG_FLAG(149, "fmuExperimental", false,
+constant DebugFlag FMU_EXPERIMENTAL = DEBUG_FLAG(148, "fmuExperimental", false,
   Util.gettext("Include an extra function in the FMU fmi2GetSpecificDerivatives."));
-constant DebugFlag DUMP_DGESV = DEBUG_FLAG(150, "dumpdgesv", false,
+constant DebugFlag DUMP_DGESV = DEBUG_FLAG(149, "dumpdgesv", false,
   Util.gettext("Enables dumping of the information whether DGESV is used to solve linear systems."));
-constant DebugFlag MULTIRATE_PARTITION = DEBUG_FLAG(151, "multirate", false,
+constant DebugFlag MULTIRATE_PARTITION = DEBUG_FLAG(150, "multirate", false,
   Util.gettext("The solver can switch partitions in the system."));
-constant DebugFlag DUMP_EXCLUDED_EXP = DEBUG_FLAG(152, "dumpExcludedSymJacExps", false,
+constant DebugFlag DUMP_EXCLUDED_EXP = DEBUG_FLAG(151, "dumpExcludedSymJacExps", false,
   Util.gettext("This flags dumps all expression that are excluded from differentiation of a symbolic Jacobian."));
-constant DebugFlag DEBUG_ALGLOOP_JACOBIAN = DEBUG_FLAG(153, "debugAlgebraicLoopsJacobian", false,
+constant DebugFlag DEBUG_ALGLOOP_JACOBIAN = DEBUG_FLAG(152, "debugAlgebraicLoopsJacobian", false,
   Util.gettext("Dumps debug output while creating symbolic jacobians for non-linear systems."));
-constant DebugFlag DISABLE_JACSCC = DEBUG_FLAG(154, "disableJacsforSCC", false,
+constant DebugFlag DISABLE_JACSCC = DEBUG_FLAG(153, "disableJacsforSCC", false,
   Util.gettext("Disables calculation of jacobians to detect if a SCC is linear or non-linear. By disabling all SCC will handled like non-linear."));
-constant DebugFlag FORCE_NLS_ANALYTIC_JACOBIAN = DEBUG_FLAG(155, "forceNLSanalyticJacobian", false,
+constant DebugFlag FORCE_NLS_ANALYTIC_JACOBIAN = DEBUG_FLAG(154, "forceNLSanalyticJacobian", false,
   Util.gettext("Forces calculation analytical jacobian also for non-linear strong components with user-defined functions."));
-constant DebugFlag DUMP_LOOPS = DEBUG_FLAG(156, "dumpLoops", false,
+constant DebugFlag DUMP_LOOPS = DEBUG_FLAG(155, "dumpLoops", false,
   Util.gettext("Dumps loop equation."));
-constant DebugFlag SKIP_INPUT_OUTPUT_SYNTACTIC_SUGAR = DEBUG_FLAG(157, "skipInputOutputSyntacticSugar", false,
+constant DebugFlag SKIP_INPUT_OUTPUT_SYNTACTIC_SUGAR = DEBUG_FLAG(156, "skipInputOutputSyntacticSugar", false,
   Util.gettext("Used when bootstrapping to preserve the input output parsing of the code output by the list command."));
-constant DebugFlag OMC_RECORD_ALLOC_WORDS = DEBUG_FLAG(158, "metaModelicaRecordAllocWords", false,
+constant DebugFlag OMC_RECORD_ALLOC_WORDS = DEBUG_FLAG(157, "metaModelicaRecordAllocWords", false,
   Util.gettext("Instrument the source code to record memory allocations (requires run-time and generated files compiled with -DOMC_RECORD_ALLOC_WORDS)."));
-constant DebugFlag TOTAL_TEARING_DUMP = DEBUG_FLAG(159, "totaltearingdump", false,
+constant DebugFlag TOTAL_TEARING_DUMP = DEBUG_FLAG(158, "totaltearingdump", false,
   Util.gettext("Dumps total tearing information."));
-constant DebugFlag TOTAL_TEARING_DUMPVERBOSE = DEBUG_FLAG(160, "totaltearingdumpV", false,
+constant DebugFlag TOTAL_TEARING_DUMPVERBOSE = DEBUG_FLAG(159, "totaltearingdumpV", false,
   Util.gettext("Dumps verbose total tearing information."));
-constant DebugFlag PARALLEL_CODEGEN = DEBUG_FLAG(161, "parallelCodegen", true,
+constant DebugFlag PARALLEL_CODEGEN = DEBUG_FLAG(160, "parallelCodegen", true,
   Util.gettext("Enables code generation in parallel (disable this if compiling a model causes you to run out of RAM)."));
-constant DebugFlag SERIALIZED_SIZE = DEBUG_FLAG(162, "reportSerializedSize", false,
+constant DebugFlag SERIALIZED_SIZE = DEBUG_FLAG(161, "reportSerializedSize", false,
   Util.gettext("Reports serialized sizes of various data structures used in the compiler."));
-constant DebugFlag BACKEND_KEEP_ENV_GRAPH = DEBUG_FLAG(163, "backendKeepEnv", true,
+constant DebugFlag BACKEND_KEEP_ENV_GRAPH = DEBUG_FLAG(162, "backendKeepEnv", true,
   Util.gettext("When enabled, the environment is kept when entering the backend, which enables CevalFunction (function interpretation) to work. This module not essential for the backend to function in most cases, but can improve simulation performance by evaluating functions. The drawback to keeping the environment graph in memory is that it is huge (~80% of the total memory in use when returning the frontend DAE)."));
-constant DebugFlag DUMPBACKENDINLINE = DEBUG_FLAG(164, "dumpBackendInline", false,
+constant DebugFlag DUMPBACKENDINLINE = DEBUG_FLAG(163, "dumpBackendInline", false,
   Util.gettext("Dumps debug output while inline function."));
-constant DebugFlag DUMPBACKENDINLINE_VERBOSE = DEBUG_FLAG(165, "dumpBackendInlineVerbose", false,
+constant DebugFlag DUMPBACKENDINLINE_VERBOSE = DEBUG_FLAG(164, "dumpBackendInlineVerbose", false,
   Util.gettext("Dumps debug output while inline function."));
-constant DebugFlag BLT_MATRIX_DUMP = DEBUG_FLAG(166, "bltmatrixdump", false,
+constant DebugFlag BLT_MATRIX_DUMP = DEBUG_FLAG(165, "bltmatrixdump", false,
   Util.gettext("Dumps the blt matrix in html file. IE seems to be very good in displaying large matrices."));
-constant DebugFlag LIST_REVERSE_WRONG_ORDER = DEBUG_FLAG(167, "listAppendWrongOrder", true,
+constant DebugFlag LIST_REVERSE_WRONG_ORDER = DEBUG_FLAG(166, "listAppendWrongOrder", true,
   Util.gettext("Print notifications about bad usage of listAppend."));
-constant DebugFlag PARTITION_INITIALIZATION = DEBUG_FLAG(168, "partitionInitialization", true,
+constant DebugFlag PARTITION_INITIALIZATION = DEBUG_FLAG(167, "partitionInitialization", true,
   Util.gettext("This flag controls if partitioning is applied to the initialization system."));
-constant DebugFlag EVAL_PARAM_DUMP = DEBUG_FLAG(169, "evalParameterDump", false,
+constant DebugFlag EVAL_PARAM_DUMP = DEBUG_FLAG(168, "evalParameterDump", false,
   Util.gettext("Dumps information for evaluating parameters."));
 
 // This is a list of all debug flags, to keep track of which flags are used. A
@@ -660,7 +658,6 @@ constant list<DebugFlag> allDebugFlags = {
   DUMP_RTEARING,
   DIS_SIMP_FUN,
   DIS_SYMJAC_FMI20,
-  EVAL_ALL_PARAMS,
   EVAL_OUTPUT_ONLY,
   HARDCODED_START_VALUES,
   DUMP_FUNCTIONS,
@@ -743,7 +740,7 @@ public
 constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG(12, "preOptModules",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({
     "normalInlineFunction",
-    "evaluateReplaceProtectedFinalEvaluateParameters",
+    "evaluateParameters",
     "simplifyIfEquations",
     "expandDerOperator",
     "removeEqualFunctionCalls",
@@ -763,14 +760,7 @@ constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG(12, "preOptModules",
     ("dumpDAEXML", Util.gettext("dumps the DAE as xml representation of the current transformation state")),
     ("encapsulateWhenConditions", Util.gettext("This module replaces each when condition with a boolean variable.")),
     ("evalFunc", Util.gettext("evaluates functions partially")),
-    ("evaluateAllParameters", Util.gettext("Evaluates all parameters to increase simulation speed.")),
-    ("evaluateEvaluateParameters", Util.gettext("Structural parameters and parameters declared as final are removed and replaced with their value. They may no longer be changed in the init file.")),
-    ("evaluateFinalEvaluateParameters", Util.gettext("Structural parameters and parameters declared as final are removed and replaced with their value. They may no longer be changed in the init file.")),
-    ("evaluateFinalParameters", Util.gettext("Structural parameters and parameters declared as final are evaluated and replaced with their value in other vars. They may no longer be changed in the init file.")),
-    ("evaluateReplaceEvaluateParameters", Util.gettext("Structural parameters and parameters declared as final are removed and replaced with their value. They may no longer be changed in the init file.")),
-    ("evaluateReplaceFinalEvaluateParameters", Util.gettext("Structural parameters and parameters declared as final are removed and replaced with their value. They may no longer be changed in the init file.")),
-    ("evaluateReplaceFinalParameters", Util.gettext("Structural parameters and parameters declared as final are removed and replaced with their value. They may no longer be changed in the init file.")),
-    ("evaluateReplaceProtectedFinalEvaluateParameters", Util.gettext("Structural parameters and parameters declared as final or protected are removed and replaced with their value. They may no longer be changed in the init file.")),
+    ("evaluateParameters", Util.gettext("Evaluates parameters with annotation(Evaluate=true). Use '--evaluateFinalParameters=true' or '--evaluateProtectedParameters=true' to specify additional parameters to be evaluated. Use '--replaceEvaluatedParameters=true' if the evaluated parameters should be replaced in the DAE. To evaluate all parameters in the Frontend use -d=evaluateAllParameters.")),
     ("expandDerOperator", Util.notrans("Expands der(expr) using Derive.differentiteExpTime.")),
     ("findStateOrder", Util.notrans("Sets derivative information to states.")),
     ("inlineArrayEqn", Util.gettext("This module expands all array equations to scalar equations.")),
@@ -867,13 +857,7 @@ constant ConfigFlag POST_OPT_MODULES = CONFIG_FLAG(16, "postOptModules",
     ("dumpComponentsGraphStr", Util.notrans("Dumps the assignment graph used to determine strong components to format suitable for Mathematica")),
     ("dumpDAE", Util.gettext("dumps the DAE representation of the current transformation state")),
     ("dumpDAEXML", Util.gettext("dumps the DAE as xml representation of the current transformation state")),
-    ("evaluateEvaluateParameters", Util.gettext("Structural parameters and parameters declared as final are removed and replaced with their value. They may no longer be changed in the init file.")),
-    ("evaluateFinalEvaluateParameters", Util.gettext("Structural parameters and parameters declared as final are removed and replaced with their value. They may no longer be changed in the init file.")),
-    ("evaluateFinalParameters", Util.gettext("Structural parameters and parameters declared as final are removed and replaced with their value. They may no longer be changed in the init file.")),
-    ("evaluateReplaceEvaluateParameters", Util.gettext("Structural parameters and parameters declared as final are removed and replaced with their value. They may no longer be changed in the init file.")),
-    ("evaluateReplaceFinalEvaluateParameters", Util.gettext("Structural parameters and parameters declared as final are removed and replaced with their value. They may no longer be changed in the init file.")),
-    ("evaluateReplaceFinalParameters", Util.gettext("Structural parameters and parameters declared as final are removed and replaced with their value. They may no longer be changed in the init file.")),
-    ("evaluateReplaceProtectedFinalEvaluateParameters", Util.notrans("Structural parameters and parameters declared as final and protected parameters are removed and replaced with their value. They may no longer be changed in the init file.")),
+    ("evaluateParameters", Util.gettext("Evaluates parameters with annotation(Evaluate=true). Use '--evaluateFinalParameters=true' or '--evaluateProtectedParameters=true' to specify additional parameters to be evaluated. Use '--replaceEvaluatedParameters=true' if the evaluated parameters should be replaced in the DAE. To evaluate all parameters in the Frontend use -d=evaluateAllParameters.")),
     ("extendDynamicOptimization", Util.gettext("Move loops to constraints.")),
     ("generateSymbolicJacobian", Util.gettext("Generates symbolic Jacobian matrix, where der(x) is differentiated w.r.t. x. This matrix can be used to simulate with dasslColorSymJac.")),
     ("generateSymbolicLinearization", Util.gettext("Generates symbolic linearization matrices A,B,C,D for linear model:\n\t\t:math:`\\dot{x} = Ax + Bu`\n\t:math:`ty = Cx +Du`")),
@@ -1329,6 +1313,15 @@ constant ConfigFlag PREFER_TVARS_WITH_START_VALUE = CONFIG_FLAG(105, "preferTVar
 constant ConfigFlag EQUATIONS_PER_FILE = CONFIG_FLAG(106, "equationsPerFile",
   NONE(), EXTERNAL(), INT_FLAG(2000), NONE(),
   Util.gettext("Generate code for at most this many equations per C-file (partially implemented in the compiler)."));
+constant ConfigFlag EVALUATE_FINAL_PARAMS = CONFIG_FLAG(107, "evaluateFinalParameters",
+  NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
+  Util.gettext("Evaluates all the final parameters in addition to parameters with annotation(Evaluate=true)."));
+constant ConfigFlag EVALUATE_PROTECTED_PARAMS = CONFIG_FLAG(108, "evaluateProtectedParameters",
+  NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
+  Util.gettext("Evaluates all the protected parameters in addition to parameters with annotation(Evaluate=true)."));
+constant ConfigFlag REPLACE_EVALUATED_PARAMS = CONFIG_FLAG(109, "replaceEvaluatedParameters",
+  NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
+  Util.gettext("Replaces all the evaluated parameters in the DAE."));
 
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
@@ -1440,7 +1433,10 @@ constant list<ConfigFlag> allConfigFlags = {
   IGNORE_SIMULATION_FLAGS_ANNOTATION,
   DYNAMIC_TEARING_FOR_INITIALIZATION,
   PREFER_TVARS_WITH_START_VALUE,
-  EQUATIONS_PER_FILE
+  EQUATIONS_PER_FILE,
+  EVALUATE_FINAL_PARAMS,
+  EVALUATE_PROTECTED_PARAMS,
+  REPLACE_EVALUATED_PARAMS
 };
 
 public function new

--- a/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -1006,7 +1006,13 @@ void doOverride(omc_ModelInput *mi, MODEL_DATA *modelData, const char *override,
 
     #define CHECK_OVERRIDE(v) \
       if (findHashStringStringNull(mOverrides, findHashStringString(*findHashLongVar(mi->v,i),"name"))) { \
+        if (0 == strcmp(findHashStringString(*findHashLongVar(mi->v,i), "isValueChangeable"), "true")){ \
         addHashStringString(findHashLongVar(mi->v,i), "start", getOverrideValue(mOverrides, &mOverridesUses, findHashStringString(*findHashLongVar(mi->v,i),"name"))); \
+        } \
+        else{ \
+          addHashStringLong(&mOverridesUses, findHashStringString(*findHashLongVar(mi->v,i),"name"), OMC_OVERRIDE_USED); \
+          warningStreamPrint(LOG_STDOUT, 0, "It is not possible to override the following quantity: %s\nIt seems to be structural, final, protected or evaluated or has a non-constant binding.", findHashStringString(*findHashLongVar(mi->v,i),"name")); \
+        } \
       }
 
     // override all found!


### PR DESCRIPTION
This commit corrects the improper and inconsistent handling
of parameters by implementing what is listed below:

- Only evaluate structural parameters and parameters with
  annotation(Evaluate=true) during compile time by default.
  Final parameters and protected parameters are not evaluated
  any more.
  (see [ticket:3211](https://trac.openmodelica.org/OpenModelica/ticket/3211), [ticket:4027](https://trac.openmodelica.org/OpenModelica/ticket/4027))

- Many different preOpt modules are merged to one preOpt module
  "evaluateParameters" with different flags instead
  -> To calculate additional parameters the following flags are introduced:
     --evaluateFinalParameters=\<true|false\> (default: false)
     --evaluateProtectedParameters=\<true|false\> (default: false)

  -> To activate/deactivate the replacement of the calculated parameters
     in the DAE use:
     --replaceEvaluatedParameters=\<true|false\> (default: true)

- Mark structural parameters deciding the if-branch final
  (see ticket [ticket:4053](https://trac.openmodelica.org/OpenModelica/ticket/4053))

- Structural parameters in instances are detected correctly
  (see [ticket:4059](https://trac.openmodelica.org/OpenModelica/ticket/4059))

- Propagate the final attribute to parameters structural parameters
  depend on
  (see [ticket:4052](https://trac.openmodelica.org/OpenModelica/ticket/4052))

- Mark parameters final if used for calculation of other parameters,
  because otherwise it leads to inconsistency when changing the value
  after compilation.
  Also replace the evaluated expressions because they are already evaluated
  and not changeable anymore.
  (see [ticket:4027](https://trac.openmodelica.org/OpenModelica/ticket/4027), [ticket:3211](https://trac.openmodelica.org/OpenModelica/ticket/3211))

- Make final, structural and protected parameters unchangeable
  -> Write final parameters to _08bnd.c
  -> Make use of the isValueChangeable-flag
  (see [ticket:4060](https://trac.openmodelica.org/OpenModelica/ticket/4060), [ticket:3211](https://trac.openmodelica.org/OpenModelica/ticket/3211), [ticket:4027](https://trac.openmodelica.org/OpenModelica/ticket/4027))