### PR TITLE
Filter protected and hidden in Cpp runtime, ticket:4089

### DIFF
--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -5876,9 +5876,9 @@ case SIMCODE(modelInfo = MODELINFO(__),makefileParams = MAKEFILE_PARAMS(__))  th
    {
       #if !defined(FMU_BUILD)
         #if defined(__vxworks)
-        _reader  = shared_ptr<IPropertyReader>(new XmlPropertyReader("/SYSTEM/bundles/com.boschrexroth.<%modelname%>/<%fileNamePrefix%>_init.xml"));
+        _reader  = shared_ptr<IPropertyReader>(new XmlPropertyReader(_global_settings, "/SYSTEM/bundles/com.boschrexroth.<%modelname%>/<%fileNamePrefix%>_init.xml"));
         #else
-        _reader  =  shared_ptr<IPropertyReader>(new XmlPropertyReader("<%makefileParams.compileDir%>/<%fileNamePrefix%>_init.xml"));
+        _reader  =  shared_ptr<IPropertyReader>(new XmlPropertyReader(_global_settings, "<%makefileParams.compileDir%>/<%fileNamePrefix%>_init.xml"));
         #endif
         _reader->readInitialValues(*this, getSimVars());
       #endif

--- a/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -608,7 +608,7 @@ void read_input_xml(MODEL_DATA* modelData,
     { \
       out[j].filterOutput = 1; \
     } \
-    else if (!omc_flag[FLAG_EMIT_PROTECTED] && 0 == strcmp(findHashStringString(v, "isProtected"), "true")) \
+    else if (!omc_flag[FLAG_EMIT_PROTECTED] && 0 == strcmp(findHashStringString(v, "isProtected"), "true") && 0 == strcmp(findHashStringString(v, "hideResult"), "true")) \
     { \
       infoStreamPrint(LOG_DEBUG, 0, "filtering protected variable %s", info->name); \
       out[j].filterOutput = 1; \

--- a/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
+++ b/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
@@ -59,16 +59,6 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
           if (descriptonOpt)
             descripton  = *descriptonOpt;
 
-          if (_globalSettings->getEmitResults() != EMIT_ALL)
-          {
-            if (name.substr(0, 3) == "_D_")
-              continue;
-            std::string hideResultInfo = vars.second.get<std::string>("<xmlattr>.hideResult");
-            if (hideResultInfo.compare("true") == 0)
-              // Note: we don't need values of hidden variables because the code calculates them
-              continue;
-          }
-
           refIdx = *refIdxOpt;
           std::string aliasInfo = vars.second.get<std::string>("<xmlattr>.alias");
           std::string variabilityInfo = vars.second.get<std::string>("<xmlattr>.variability");
@@ -76,6 +66,18 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
           //If a start value is given for the alias and the referred variable, skip the alias declaration
           bool isAlias = aliasInfo.compare("alias") == 0;
           bool isNegatedAlias = aliasInfo.compare("negatedAlias") == 0;
+
+          bool emitResult = true;
+          if (_globalSettings->getEmitResults() == EMIT_NONE)
+            emitResult = false;
+          else if (_globalSettings->getEmitResults() != EMIT_ALL)
+          {
+            if (name.substr(0, 3) == "_D_")
+              emitResult = false;
+            std::string hideResultInfo = vars.second.get<std::string>("<xmlattr>.hideResult");
+            if (hideResultInfo.compare("true") == 0)
+              emitResult = false;
+          }
 
           FOREACH(ptree::value_type const& var, vars.second.get_child(""))
           {
@@ -91,10 +93,13 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
               }
               const double& realVar = sim_vars->getRealVar(refIdx);
               const double* realVarPtr = &realVar;
-              if (isParameter)
-                _realVars.addParameter(name,descripton,realVarPtr);
-              else
-                _realVars.addOutputVar(name,descripton,realVarPtr,isNegatedAlias);
+              if (emitResult)
+              {
+                if (isParameter)
+                  _realVars.addParameter(name, descripton, realVarPtr);
+                else
+                  _realVars.addOutputVar(name, descripton, realVarPtr, isNegatedAlias);
+              }
             }
             else if (var.first == "Integer")
             {
@@ -108,10 +113,13 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
               }
               const int& intVar = sim_vars->getIntVar(refIdx);
               const int* intVarPtr = &intVar;
-              if (isParameter)
-                _intVars.addParameter(name,descripton,intVarPtr);
-              else
-                _intVars.addOutputVar(name,descripton,intVarPtr,isNegatedAlias);
+              if (emitResult)
+              {
+                if (isParameter)
+                  _intVars.addParameter(name, descripton, intVarPtr);
+                else
+                  _intVars.addOutputVar(name, descripton, intVarPtr, isNegatedAlias);
+              }
             }
             else if (var.first == "Boolean")
             {
@@ -125,10 +133,13 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
               }
               const bool& boolVar = sim_vars->getBoolVar(refIdx);
               const bool* boolVarPtr = &boolVar;
-              if (isParameter)
-                _boolVars.addParameter(name,descripton,boolVarPtr);
-              else
-                _boolVars.addOutputVar(name,descripton,boolVarPtr,isNegatedAlias);
+              if (emitResult)
+              {
+                if (isParameter)
+                  _boolVars.addParameter(name, descripton, boolVarPtr);
+                else
+                  _boolVars.addOutputVar(name, descripton, boolVarPtr, isNegatedAlias);
+              }
             }
             else if (var.first == "String")
             {
@@ -159,42 +170,24 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
 
 const output_int_vars_t&  XmlPropertyReader::getIntOutVars()
 {
-  static output_int_vars_t int_none;
   if (_isInitialized)
-  {
-    if (_globalSettings->getEmitResults() == EMIT_NONE)
-      return int_none;
-    else
-      return _intVars;
-  }
+    return _intVars;
   else
     throw ModelicaSimulationError(UTILITY, "init xml file has not been read");
 }
 
 const output_real_vars_t& XmlPropertyReader::getRealOutVars()
 {
-  static output_real_vars_t real_none;
   if (_isInitialized)
-  {
-    if (_globalSettings->getEmitResults() == EMIT_NONE)
-      return real_none;
-    else
-      return _realVars;
-  }
+    return _realVars;
   else
     throw ModelicaSimulationError(UTILITY, "init xml file has not been read");
 }
 
 const output_bool_vars_t& XmlPropertyReader::getBoolOutVars()
 {
-  static output_bool_vars_t bool_none;
   if (_isInitialized)
-  {
-    if (_globalSettings->getEmitResults() == EMIT_NONE)
-      return bool_none;
-    else
-      return _boolVars;
-  }
+    return _boolVars;
   else
     throw ModelicaSimulationError(UTILITY, "init xml file has not been read");
 }

--- a/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
+++ b/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
@@ -10,178 +10,172 @@
 #include <iostream>
 
 XmlPropertyReader::XmlPropertyReader(std::string propertyFile)
-	: IPropertyReader()
-	,propertyFile(propertyFile)
-	,_isInitialized(false)
+  : IPropertyReader()
+  ,propertyFile(propertyFile)
+  ,_isInitialized(false)
 {
 }
 
 XmlPropertyReader::~XmlPropertyReader()
 {
-
 }
 
 void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVars> sim_vars)
 {
-	using boost::property_tree::ptree;
-	std::ifstream file;
-	file.open (propertyFile.c_str(), std::ifstream::in);
-	if(file.good())
-	{
-		double *realVars = sim_vars->getRealVarsVector();
-		int *intVars = sim_vars->getIntVarsVector();
-		bool *boolVars = sim_vars->getBoolVarsVector();
-		string *stringVars = sim_vars->getStringVarsVector();
-		int refIdx = -1;
-		boost::optional<int> refIdxOpt;
-		try
-		{
-			ptree tree;
-			read_xml(file, tree);
+  using boost::property_tree::ptree;
+  std::ifstream file;
+  file.open(propertyFile.c_str(), std::ifstream::in);
+  if (file.good())
+  {
+    double *realVars = sim_vars->getRealVarsVector();
+    int *intVars = sim_vars->getIntVarsVector();
+    bool *boolVars = sim_vars->getBoolVarsVector();
+    string *stringVars = sim_vars->getStringVarsVector();
+    int refIdx = -1;
+    boost::optional<int> refIdxOpt;
+    try
+    {
+      ptree tree;
+      read_xml(file, tree);
 
-			ptree modelDescription = tree.get_child("ModelDescription");
+      ptree modelDescription = tree.get_child("ModelDescription");
 
-			FOREACH(ptree::value_type const& vars, modelDescription.get_child("ModelVariables"))
-			{
-				if(vars.first == "ScalarVariable")
-				{
-					refIdxOpt = vars.second.get_optional<int>("<xmlattr>.valueReference");
+      FOREACH(ptree::value_type const& vars, modelDescription.get_child("ModelVariables"))
+      {
+        if (vars.first == "ScalarVariable")
+        {
+          refIdxOpt = vars.second.get_optional<int>("<xmlattr>.valueReference");
 
-					if(!refIdxOpt)
-					{
-						//boost::property_tree::xml_parser::write_xml(std::cout, vars.second);
-						continue;
-					}
-					string name = vars.second.get<string>("<xmlattr>.name");
-					boost::optional<string> descriptonOpt = vars.second.get_optional<string>("<xmlattr>.description");
-					string descripton;
-					if(descriptonOpt)
-						descripton  = *descriptonOpt;
+          if (!refIdxOpt)
+          {
+            //boost::property_tree::xml_parser::write_xml(std::cout, vars.second);
+            continue;
+          }
+          string name = vars.second.get<string>("<xmlattr>.name");
+          boost::optional<string> descriptonOpt = vars.second.get_optional<string>("<xmlattr>.description");
+          string descripton;
+          if (descriptonOpt)
+            descripton  = *descriptonOpt;
 
-					refIdx = *refIdxOpt;
-					std::string aliasInfo = vars.second.get<std::string>("<xmlattr>.alias");
-					std::string variabilityInfo = vars.second.get<std::string>("<xmlattr>.variability");
-					bool isParameter = (variabilityInfo.compare("parameter") == 0);
-					//If a start value is given for the alias and the referred variable, skip the alias declaration
+          refIdx = *refIdxOpt;
+          std::string aliasInfo = vars.second.get<std::string>("<xmlattr>.alias");
+          std::string variabilityInfo = vars.second.get<std::string>("<xmlattr>.variability");
+          bool isParameter = (variabilityInfo.compare("parameter") == 0);
+          //If a start value is given for the alias and the referred variable, skip the alias declaration
+          bool isAlias = aliasInfo.compare("alias") == 0;
+          bool isNegatedAlias = aliasInfo.compare("negatedAlias") == 0;
 
+          FOREACH(ptree::value_type const& var, vars.second.get_child(""))
+          {
 
-					bool isAlias = aliasInfo.compare("alias") == 0;
-                    bool isNegatedAlias = aliasInfo.compare("negatedAlias") == 0;
+            if (var.first == "Real")
+            {
+               //If a start value is given for the alias and the referred variable, skip the alias declaration
+              if (!(isAlias || isNegatedAlias))
+              {
+                boost::optional<double> v = var.second.get_optional<double>("<xmlattr>.start");
+                double value = (v? (*v):0.0);
+                LOGGER_WRITE("XMLPropertyReader: Setting real variable for " + boost::lexical_cast<std::string>(vars.second.get<std::string>("<xmlattr>.name")) + " with reference " + boost::lexical_cast<std::string>(refIdx) + " to " + boost::lexical_cast<std::string>(value) ,LC_INIT,LL_DEBUG);
+                system.setRealStartValue(realVars[refIdx],value);
+              }
+              const double& realVar = sim_vars->getRealVar(refIdx);
+              const double* realVarPtr = &realVar;
+              if (isParameter)
+                _realVars.addParameter(name,descripton,realVarPtr);
+              else
+                _realVars.addOutputVar(name,descripton,realVarPtr,isNegatedAlias);
+            }
+            else if (var.first == "Integer")
+            {
+               //If a start value is given for the alias and the referred variable, skip the alias declaration
+              if (!(isAlias || isNegatedAlias))
+              {
+                boost::optional<int> v = var.second.get_optional<int>("<xmlattr>.start");
+                int value = (v? (*v):0);
+                LOGGER_WRITE("XMLPropertyReader: Setting int variable for " + boost::lexical_cast<std::string>(vars.second.get<std::string>("<xmlattr>.name")) + " with reference " + boost::lexical_cast<std::string>(refIdx) + " to " + boost::lexical_cast<std::string>(value) ,LC_INIT,LL_DEBUG);
+                system.setIntStartValue(intVars[refIdx],value);
+              }
+              const int& intVar = sim_vars->getIntVar(refIdx);
+              const int* intVarPtr = &intVar;
+              if (isParameter)
+                _intVars.addParameter(name,descripton,intVarPtr);
+              else
+                _intVars.addOutputVar(name,descripton,intVarPtr,isNegatedAlias);
+            }
+            else if (var.first == "Boolean")
+            {
+               //If a start value is given for the alias and the referred variable, skip the alias declaration
+              if (!(isAlias || isNegatedAlias))
+              {
+                boost::optional<bool> v = var.second.get_optional<bool>("<xmlattr>.start");
+                bool value = (v? (*v):false);
+                LOGGER_WRITE("XMLPropertyReader: Setting bool variable for " + boost::lexical_cast<std::string>(vars.second.get<std::string>("<xmlattr>.name")) + " with reference " + boost::lexical_cast<std::string>(refIdx) + " to " + boost::lexical_cast<std::string>(value) ,LC_INIT,LL_DEBUG);
+                system.setBoolStartValue(boolVars[refIdx],value);
+              }
+              const bool& boolVar = sim_vars->getBoolVar(refIdx);
+              const bool* boolVarPtr = &boolVar;
+              if (isParameter)
+                _boolVars.addParameter(name,descripton,boolVarPtr);
+              else
+                _boolVars.addOutputVar(name,descripton,boolVarPtr,isNegatedAlias);
+            }
+            else if (var.first == "String")
+            {
+               //If a start value is given for the alias and the referred variable, skip the alias declaration
+              if (!(isAlias || isNegatedAlias))
+              {
+                boost::optional<string> v = var.second.get_optional<string>("<xmlattr>.start");
+                string value = (v? (*v):"");
+                LOGGER_WRITE("XMLPropertyReader: Setting string variable for " + boost::lexical_cast<std::string>(vars.second.get<std::string>("<xmlattr>.name")) + " with reference " + boost::lexical_cast<std::string>(refIdx) + " to " + boost::lexical_cast<std::string>(value) ,LC_INIT,LL_DEBUG);
+                system.setStringStartValue(stringVars[refIdx],value);
+              }
+            }
+          }
+        }
+      }
+    }
+    catch(exception &ex)
+    {
+      std::stringstream sstream;
+      sstream << "Could not read start values. Current variable reference is " << refIdx;
+      throw ModelicaSimulationError(UTILITY,sstream.str());
+    }
+    _isInitialized = true;
+    file.close();
 
-					FOREACH(ptree::value_type const& var, vars.second.get_child(""))
-					{
-
-						if(var.first == "Real")
-						{
-							 //If a start value is given for the alias and the referred variable, skip the alias declaration
-							if(!(isAlias || isNegatedAlias))
-							{
-								boost::optional<double> v = var.second.get_optional<double>("<xmlattr>.start");
-								double value = (v? (*v):0.0);
-								LOGGER_WRITE("XMLPropertyReader: Setting real variable for " + boost::lexical_cast<std::string>(vars.second.get<std::string>("<xmlattr>.name")) + " with reference " + boost::lexical_cast<std::string>(refIdx) + " to " + boost::lexical_cast<std::string>(value) ,LC_INIT,LL_DEBUG);
-								system.setRealStartValue(realVars[refIdx],value);
-							}
-							const double& realVar = sim_vars->getRealVar(refIdx);
-							const double* realVarPtr = &realVar;
-							if(isParameter)
-								_realVars.addParameter(name,descripton,realVarPtr);
-							else
-								_realVars.addOutputVar(name,descripton,realVarPtr,isNegatedAlias);
-						}
-						else if(var.first == "Integer")
-						{
-							 //If a start value is given for the alias and the referred variable, skip the alias declaration
-							if(!(isAlias || isNegatedAlias))
-							{
-								boost::optional<int> v = var.second.get_optional<int>("<xmlattr>.start");
-								int value = (v? (*v):0);
-								LOGGER_WRITE("XMLPropertyReader: Setting int variable for " + boost::lexical_cast<std::string>(vars.second.get<std::string>("<xmlattr>.name")) + " with reference " + boost::lexical_cast<std::string>(refIdx) + " to " + boost::lexical_cast<std::string>(value) ,LC_INIT,LL_DEBUG);
-								system.setIntStartValue(intVars[refIdx],value);
-							}
-							const int& intVar = sim_vars->getIntVar(refIdx);
-							const int* intVarPtr = &intVar;
-							if(isParameter)
-								_intVars.addParameter(name,descripton,intVarPtr);
-							else
-								_intVars.addOutputVar(name,descripton,intVarPtr,isNegatedAlias);
-						}
-						else if(var.first == "Boolean")
-						{
-							 //If a start value is given for the alias and the referred variable, skip the alias declaration
-							if(!(isAlias || isNegatedAlias))
-							{
-								boost::optional<bool> v = var.second.get_optional<bool>("<xmlattr>.start");
-								bool value = (v? (*v):false);
-								LOGGER_WRITE("XMLPropertyReader: Setting bool variable for " + boost::lexical_cast<std::string>(vars.second.get<std::string>("<xmlattr>.name")) + " with reference " + boost::lexical_cast<std::string>(refIdx) + " to " + boost::lexical_cast<std::string>(value) ,LC_INIT,LL_DEBUG);
-								system.setBoolStartValue(boolVars[refIdx],value);
-							}
-							const bool& boolVar = sim_vars->getBoolVar(refIdx);
-							const bool* boolVarPtr = &boolVar;
-							if(isParameter)
-								_boolVars.addParameter(name,descripton,boolVarPtr);
-							else
-								_boolVars.addOutputVar(name,descripton,boolVarPtr,isNegatedAlias);
-						}
-						else if(var.first == "String")
-						{
-							 //If a start value is given for the alias and the referred variable, skip the alias declaration
-							if(!(isAlias || isNegatedAlias))
-							{
-								boost::optional<string> v = var.second.get_optional<string>("<xmlattr>.start");
-								string value = (v? (*v):"");
-								LOGGER_WRITE("XMLPropertyReader: Setting string variable for " + boost::lexical_cast<std::string>(vars.second.get<std::string>("<xmlattr>.name")) + " with reference " + boost::lexical_cast<std::string>(refIdx) + " to " + boost::lexical_cast<std::string>(value) ,LC_INIT,LL_DEBUG);
-								system.setStringStartValue(stringVars[refIdx],value);
-							}
-						}
-					}
-
-
-
-				}
-			}
-		}
-		catch(exception &ex)
-		{
-			std::stringstream sstream;
-			sstream << "Could not read start values. Current variable reference is " << refIdx;
-			throw ModelicaSimulationError(UTILITY,sstream.str());
-		}
-		_isInitialized = true;
-		file.close();
-
-	}
+  }
 }
 
 const output_int_vars_t&  XmlPropertyReader::getIntOutVars()
 {
-	if(_isInitialized)
-		return _intVars;
-	else
-		throw ModelicaSimulationError(UTILITY,"init xml file has not been read");
+  if (_isInitialized)
+    return _intVars;
+  else
+    throw ModelicaSimulationError(UTILITY,"init xml file has not been read");
 }
+
 const output_real_vars_t& XmlPropertyReader::getRealOutVars()
 {
-	if(_isInitialized)
-		return _realVars;
-	else
-		throw ModelicaSimulationError(UTILITY,"init xml file has not been read");
+  if (_isInitialized)
+    return _realVars;
+  else
+    throw ModelicaSimulationError(UTILITY,"init xml file has not been read");
 }
+
 const output_bool_vars_t& XmlPropertyReader::getBoolOutVars()
 {
-	if(_isInitialized)
-		return _boolVars;
-	else
-		throw ModelicaSimulationError(UTILITY,"init xml file has not been read");
+  if (_isInitialized)
+    return _boolVars;
+  else
+    throw ModelicaSimulationError(UTILITY,"init xml file has not been read");
 }
-
-
 
 std::string XmlPropertyReader::getPropertyFile()
 {
-	return propertyFile;
+  return propertyFile;
 }
 
 void XmlPropertyReader::setPropertyFile(std::string file)
 {
-	propertyFile = file;
+  propertyFile = file;
 }

--- a/SimulationRuntime/cpp/Core/SimController/SimController.cpp
+++ b/SimulationRuntime/cpp/Core/SimController/SimController.cpp
@@ -133,7 +133,8 @@ void SimController::StartVxWorks(SimSettings simsettings,string modelKey)
         global_settings->setAlarmTime(simsettings.timeOut);
         global_settings->setLogSettings(simsettings.logSettings);
         global_settings->setOutputPointType(simsettings.outputPointType);
-        global_settings->setOutputFormat(simsettings.outputFomrat);
+        global_settings->setOutputFormat(simsettings.outputFormat);
+        global_settings->setEmitResults(simsettings.emitResults);
         /*shared_ptr<SimManager>*/ _simMgr = shared_ptr<SimManager>(new SimManager(mixedsystem, _config.get()));
 
         ISolverSettings* solver_settings = _config->getSolverSettings();
@@ -185,7 +186,8 @@ void SimController::Start(SimSettings simsettings, string modelKey)
         global_settings->setLogSettings(simsettings.logSettings);
         global_settings->setAlarmTime(simsettings.timeOut);
         global_settings->setOutputPointType(simsettings.outputPointType);
-        global_settings->setOutputFormat(simsettings.outputFomrat);
+        global_settings->setOutputFormat(simsettings.outputFormat);
+        global_settings->setEmitResults(simsettings.emitResults);
         global_settings->setNonLinearSolverContinueOnError(simsettings.nonLinearSolverContinueOnError);
         global_settings->setSolverThreads(simsettings.solverThreads);
         /*shared_ptr<SimManager>*/ _simMgr = shared_ptr<SimManager>(new SimManager(mixedsystem, _config.get()));

--- a/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
+++ b/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
@@ -12,7 +12,7 @@ GlobalSettings::GlobalSettings()
   : _startTime(0.0)
   , _endTime(5.0)
   , _hOutput(0.001)
-  , _resultsOutput(true)
+  , _emitResults(EMIT_ALL)
   , _infoOutput(true)
   , _selected_solver("Euler")
   , _selected_lin_solver("Newton")
@@ -22,7 +22,7 @@ GlobalSettings::GlobalSettings()
   , _nonLinSolverContinueOnError(false)
   , _outputPointType(OPT_ALL)
   , _alarm_time(0)
-  ,_outputFormat(MAT)
+  , _outputFormat(MAT)
 {
 }
 
@@ -93,15 +93,15 @@ void GlobalSettings::setLogSettings(LogSettings set)
   _log_settings = set;
 }
 
-///< Write out results ([false,true]; default: true)
-bool GlobalSettings::getResultsOutput()
+///< Write out results (default: EMIT_ALL)
+EmitResults GlobalSettings::getEmitResults()
 {
-  return _resultsOutput;
+  return _emitResults;
 }
 
-void GlobalSettings::setResultsOutput(bool output)
+void GlobalSettings::setEmitResults(EmitResults emitResults)
 {
-  _resultsOutput = output;
+  _emitResults = emitResults;
 }
 
 void GlobalSettings::setResultsFileName(string name)

--- a/SimulationRuntime/cpp/Include/Core/DataExchange/XmlPropertyReader.h
+++ b/SimulationRuntime/cpp/Include/Core/DataExchange/XmlPropertyReader.h
@@ -1,11 +1,6 @@
 #pragma once
 
-
-
-
 class IContinuous;
-
-
 
 class BOOST_EXTENSION_XML_READER_DECL XmlPropertyReader : public IPropertyReader
 {
@@ -17,16 +12,16 @@ class BOOST_EXTENSION_XML_READER_DECL XmlPropertyReader : public IPropertyReader
 
     std::string getPropertyFile();
     void setPropertyFile(std::string file);
-	const output_int_vars_t& getIntOutVars();
-	const output_real_vars_t& getRealOutVars();
-	const output_bool_vars_t& getBoolOutVars();
+    const output_int_vars_t& getIntOutVars();
+    const output_real_vars_t& getRealOutVars();
+    const output_bool_vars_t& getBoolOutVars();
   private:
 
     string propertyFile;
 
-	output_int_vars_t _intVars;
-	output_bool_vars_t _boolVars;
-	output_real_vars_t _realVars;
+    output_int_vars_t _intVars;
+    output_bool_vars_t _boolVars;
+    output_real_vars_t _realVars;
 
     bool _isInitialized;
 };

--- a/SimulationRuntime/cpp/Include/Core/DataExchange/XmlPropertyReader.h
+++ b/SimulationRuntime/cpp/Include/Core/DataExchange/XmlPropertyReader.h
@@ -1,11 +1,12 @@
 #pragma once
 
 class IContinuous;
+class IGlobalSettings;
 
 class BOOST_EXTENSION_XML_READER_DECL XmlPropertyReader : public IPropertyReader
 {
   public:
-    XmlPropertyReader(std::string propertyFile);
+    XmlPropertyReader(IGlobalSettings *globalSettings, std::string propertyFile);
     ~XmlPropertyReader();
 
     void readInitialValues(IContinuous& system, shared_ptr<ISimVars> sim_vars);
@@ -15,9 +16,10 @@ class BOOST_EXTENSION_XML_READER_DECL XmlPropertyReader : public IPropertyReader
     const output_int_vars_t& getIntOutVars();
     const output_real_vars_t& getRealOutVars();
     const output_bool_vars_t& getBoolOutVars();
-  private:
 
-    string propertyFile;
+  private:
+    IGlobalSettings *_globalSettings;
+    string _propertyFile;
 
     output_int_vars_t _intVars;
     output_bool_vars_t _boolVars;

--- a/SimulationRuntime/cpp/Include/Core/SimController/ISimController.h
+++ b/SimulationRuntime/cpp/Include/Core/SimController/ISimController.h
@@ -21,7 +21,8 @@ struct SimSettings
   LogSettings logSettings;
   bool nonLinearSolverContinueOnError;
   int solverThreads;
-  OutputFormat outputFomrat;
+  OutputFormat outputFormat;
+  EmitResults emitResults;
 };
 
 /**

--- a/SimulationRuntime/cpp/Include/Core/SimulationSettings/GlobalSettings.h
+++ b/SimulationRuntime/cpp/Include/Core/SimulationSettings/GlobalSettings.h
@@ -21,9 +21,9 @@ public:
   ///< Output step size (default: 20 ms)
   virtual double gethOutput();
   virtual void sethOutput(double);
-  ///< Write out results ([false,true]; default: true)
-  virtual bool getResultsOutput();
-  virtual void setResultsOutput(bool);
+  ///< Write out results (default: EMIT_ALL)
+  virtual EmitResults getEmitResults();
+  virtual void setEmitResults(EmitResults);
   ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false, true]; default: true)
   virtual bool getInfoOutput();
   virtual void setInfoOutput(bool);
@@ -62,12 +62,13 @@ public:
 
 private:
   double
-      _startTime, ///< Start time of integration (default: 0.0)
-      _endTime, ///< End time of integraiton (default: 1.0)
-      _hOutput; //< Output step size (default: 20 ms)
+      _startTime,   ///< Start time of integration (default: 0.0)
+      _endTime,     ///< End time of integraiton (default: 1.0)
+      _hOutput;     ///< Output step size (default: 20 ms)
+  EmitResults
+      _emitResults; ///< Write out results (default: EMIT_ALL)
   bool
-      _resultsOutput,   ///< Write out results ([false,true]; default: true)
-      _infoOutput,      ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false,true]; default: true)
+      _infoOutput,  ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false,true]; default: true)
       _endless_sim,
       _nonLinSolverContinueOnError;
   string

--- a/SimulationRuntime/cpp/Include/Core/SimulationSettings/IGlobalSettings.h
+++ b/SimulationRuntime/cpp/Include/Core/SimulationSettings/IGlobalSettings.h
@@ -28,7 +28,8 @@ using std::string;
 enum LogCategory {LC_INIT = 0, LC_NLS = 1, LC_LS = 2, LC_SOLV = 3, LC_OUT = 4, LC_EVT = 5, LC_OTHER = 6, LC_MOD = 7};
 enum LogLevel {LL_ERROR = 0, LL_WARNING = 1, LL_INFO = 2, LL_DEBUG = 3};
 enum OutputPointType {OPT_ALL, OPT_STEP, OPT_NONE};
-enum OutputFormat{CSV, MAT,BUFFER,EMPTY};
+enum OutputFormat {CSV, MAT, BUFFER, EMPTY};
+enum EmitResults {EMIT_ALL, EMIT_PUBLIC, EMIT_NONE};
 struct LogSettings
 {
 	std::vector<LogLevel> modes;
@@ -58,9 +59,9 @@ public:
   ///< Output step size (default: 20 ms)
   virtual double gethOutput() = 0;
   virtual void sethOutput(double) = 0;
-  ///< Write out results ([false,true]; default: true)
-  virtual bool getResultsOutput() = 0;
-  virtual void setResultsOutput(bool) = 0;
+  ///< Write out results (default: EMIT_ALL)
+  virtual EmitResults getEmitResults() = 0;
+  virtual void setEmitResults(EmitResults) = 0;
   virtual OutputPointType getOutputPointType() = 0;
   virtual void setOutputPointType(OutputPointType) = 0;
   virtual LogSettings getLogSettings() = 0;

--- a/SimulationRuntime/cpp/Include/FMU/FMUGlobalSettings.h
+++ b/SimulationRuntime/cpp/Include/FMU/FMUGlobalSettings.h
@@ -24,9 +24,9 @@ public:
     ///< Output step size (default: 20 ms)
     virtual double gethOutput() { return 20; }
     virtual void sethOutput(double) {}
-    ///< Write out results ([false,true]; default: true)
-    virtual bool getResultsOutput() { return false; }
-    virtual void setResultsOutput(bool) {}
+    ///< Write out results (EMIT_NONE)
+    virtual EmitResults getEmitResults() { return EMIT_NONE; }
+    virtual void setEmitResults(EmitResults) {}
     virtual bool useEndlessSim() {return true; }
     virtual void useEndlessSim(bool) {}
     ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false,true]; default: true)

--- a/SimulationRuntime/cpp/Include/FMU2/FMU2GlobalSettings.h
+++ b/SimulationRuntime/cpp/Include/FMU2/FMU2GlobalSettings.h
@@ -56,9 +56,9 @@ class FMU2GlobalSettings : public IGlobalSettings
   ///< Output step size (default: 20 ms)
   virtual double          gethOutput() { return 20; }
   virtual void            sethOutput(double) {}
-  ///< Write out results ([false,true]; default: true)
-  virtual bool            getResultsOutput() { return false; }
-  virtual void            setResultsOutput(bool) {}
+  ///< Write out results (EMIT_NONE)
+  virtual EmitResults     getEmitResults() { return EMIT_NONE; }
+  virtual void            setEmitResults(EmitResults) {}
   virtual bool            useEndlessSim() {return true; }
   virtual void            useEndlessSim(bool) {}
   ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false,true]; default: true)

--- a/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
+++ b/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
@@ -378,6 +378,7 @@ vector<const char *> OMCFactory::handleComplexCRuntimeArguments(int argc, const 
 void OMCFactory::fillArgumentsToIgnore()
 {
   _argumentsToIgnore = unordered_set<string>();
+  _argumentsToIgnore.insert("-abortSlowSimulation"); // used by nightly tests
 }
 
 void OMCFactory::fillArgumentsToReplace()
@@ -385,6 +386,7 @@ void OMCFactory::fillArgumentsToReplace()
   _argumentsToReplace = map<string, string>();
   _argumentsToReplace.insert(pair<string,string>("-r", "-F"));
   _argumentsToReplace.insert(pair<string,string>("-w", "-V all=warning"));
+  _argumentsToReplace.insert(pair<string,string>("-alarm", "--alarm"));
   _argumentsToReplace.insert(pair<string,string>("-emit_protected", "--emit-results all"));
 }
 


### PR DESCRIPTION
The former global setting ResultsOutput {true, false} is replaced
with enum EmitResults {EMIT_ALL, EMIT_PUBLIC, EMIT_NONE}.
The default value is EMIT_ALL (cf. former true).

OMCFactory uses the default value EMIT_PUBLIC and introduces the
new option --emit-results with the values all, public or none.
The OMEdit option `-emit-protected` is tranlated to `--emit-results all`.

The actual filtering simply skips values in XmlPropertyReader. This works
out as protected values are not needed from init.xml because they are
calculated in the generated code.
