### PR TITLE
Revert "- getValueReference works with row major order for cpp fmus" 

### DIFF
--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -11771,7 +11771,7 @@ algorithm
     case (SimCodeVar.SIMVAR(aliasvar = SimCodeVar.NEGATEDALIAS(_)), false, _) then
       getDefaultValueReference(inSimVar, inSimCode.modelInfo.varInfo);
     case (_, _, "Cpp") equation
-      valueReference = getVarIndexByMapping(inSimCode.varToArrayIndexMapping, inSimVar.name, false, "-1");
+      valueReference = getVarIndexByMapping(inSimCode.varToArrayIndexMapping, inSimVar.name, true, "-1");
       if stringEqual(valueReference, "-1") then
         Error.addInternalError("invalid return value from getVarIndexByMapping for "+simVarString(inSimVar), sourceInfo());
       end if;


### PR DESCRIPTION
This reverts commit 6c675e6ea5f468277509782de3076522def77f15.
Value references are storage offsets and arrays are stored column major.