### PR TITLE
Attempt to correct storage order of Cpp RefArray, ticket:4093

### DIFF
--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -10964,7 +10964,12 @@ algorithm
     concreteVarIndex := getUnrolledArrayIndex(arraySubscripts,arrayDimensions);
     //print("SimCodeUtil.getVarIndexInfosByMapping: Found variable index for '" + ComponentReference.printComponentRefStr(iVarName) + "'. The value is " + intString(concreteVarIndex) + "\n");
     for arrayIdx in 0:(arraySize-1) loop
-      idx := arrayGet(varIndices, arraySize-arrayIdx);
+      idx := arraySize-arrayIdx;
+      if iColumnMajor then
+        // convert to row major so that column major access will give this idx
+        idx := convertIndexToRowMajor(idx, arrayDimensions0);
+      end if;
+      idx := arrayGet(varIndices, idx);
       if(intLt(idx, 0)) then
         tmpVarIndexListNew := intString((intMul(idx, -1) - 1))::tmpVarIndexListNew;
         //print("SimCodeUtil.tmpVarIndexListNew: Warning, negativ aliases (" + ComponentReference.printComponentRefStr(iVarName) + ") are not supported at the moment!\n");
@@ -10976,11 +10981,12 @@ algorithm
         end if;
       end if;
     end for;
-    if (not isVarIndexListConsecutive(iVarToArrayIndexMapping,iVarName) and iColumnMajor) then
+    if isVarIndexListConsecutive(iVarToArrayIndexMapping,iVarName) and iColumnMajor then
       //if the array is not completely stuffed (e.g. some array variables have been derived and became dummy-derivatives), the array will not be initialized as a consecutive array, therefore we cannot take the colMajor-indexes
-      concreteVarIndex := getUnrolledArrayIndex(arraySubscripts0,arrayDimensions0);
+      // otherwise convert to column major for consecutive array
+      concreteVarIndex := convertIndexToColumnMajor(concreteVarIndex + 1, arrayDimensions0) - 1;
     end if;
-      oConcreteVarIndex := listGet(tmpVarIndexListNew, concreteVarIndex + 1);
+    oConcreteVarIndex := listGet(tmpVarIndexListNew, concreteVarIndex + 1);
   end if;
   if(listEmpty(tmpVarIndexListNew)) then
     Error.addMessage(Error.INTERNAL_ERROR, {"GetVarIndexListByMapping: No Element for " + ComponentReference.printComponentRefStr(varName) + " found!"});
@@ -11008,6 +11014,51 @@ algorithm
     idxOut := idx;
   end if;
 end convertFlattenedIndexToRowMajor;
+
+protected function convertIndexToRowMajor
+ "Converts column-major unrolled idx to row-major, author: rfranke"
+  input Integer idx; // one based, row-major ordered
+  input list<Integer> arrayDimensions;
+  output Integer idxOut; // one based, column-major ordered
+protected
+  Integer idx0, ndim, length, dimj, idxj, fac;
+algorithm
+  ndim := listLength(arrayDimensions);
+  length := List.fold(arrayDimensions, intMul, 1);
+  idx0 := idx - 1; // zero based
+  idxOut := 1; // one based
+  fac := 1;
+  for i in 1:listLength(arrayDimensions) loop
+    dimj := listGet(arrayDimensions, ndim - i + 1);
+    length := intDiv(length, dimj);
+    idxj := intDiv(idx0, length);
+    idx0 := idx0 - idxj*length;
+    idxOut := idxOut + idxj*fac;
+    fac := fac * dimj;
+  end for;
+end convertIndexToRowMajor;
+
+protected function convertIndexToColumnMajor
+ "Converts row-major unrolled idx to column-major, author: rfranke"
+  input Integer idx; // one based, row-major ordered
+  input list<Integer> arrayDimensions;
+  output Integer idxOut; // one based, column-major ordered
+protected
+  Integer idx0, ndim, length, idxi, fac;
+algorithm
+  ndim := listLength(arrayDimensions);
+  length := List.fold(arrayDimensions, intMul, 1);
+  idx0 := idx - 1; // zero based
+  idxOut := 1; // one based
+  fac := 1;
+  for dimi in arrayDimensions loop
+    length := intDiv(length, dimi);
+    idxi := intDiv(idx0, length);
+    idx0 := idx0 - idxi*length;
+    idxOut := idxOut + idxi*fac;
+    fac := fac * dimi;
+  end for;
+end convertIndexToColumnMajor;
 
 public function isVarIndexListConsecutive "author: marcusw
   Check if all variable indices of the given variables, stored in the hash table, are consecutive."

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -10827,7 +10827,6 @@ algorithm
           end if;
           //print("Num of array elements {" + stringDelimitList(List.map(arrayDimensions, intString), ",") + "} : " + intString(listLength(arraySubscripts)) + "  arraySubs "+ExpressionDump.printSubscriptLstStr(arraySubscripts) + "  arrayDimensions[ "+stringDelimitList(List.map(arrayDimensions,intString),",")+"]\n");
           arrayIndex = getUnrolledArrayIndex(arraySubscripts,arrayDimensions);
-          arrayIndex = arrayIndex + 1;
           //print("VarIndices: " + intString(arrayLength(varIndices)) + " arrayIndex: " + intString(arrayIndex) + " varIndex: " + intString(varIdx) + "\n");
           varIndices = arrayUpdate(varIndices, arrayIndex, varIdx);
           tmpVarToArrayIndexMapping = BaseHashTable.add((arrayName, (arrayDimensions,varIndices)), tmpVarToArrayIndexMapping);
@@ -10947,27 +10946,24 @@ protected
   Integer arrayIdx, idx, arraySize, concreteVarIndex;
   array<Integer> varIndices;
   list<String> tmpVarIndexListNew = {};
-  list<DAE.Subscript> arraySubscripts, arraySubscripts0;
-  list<Integer> arrayDimensions, arrayDimensions0;
+  list<DAE.Subscript> arraySubscripts;
+  list<Integer> arrayDimensions;
 algorithm
-  arraySubscripts0 := ComponentReference.crefLastSubs(varName);
+  arraySubscripts := ComponentReference.crefLastSubs(varName);
   varName := ComponentReference.crefStripLastSubs(varName);//removeSubscripts(varName);
   if(BaseHashTable.hasKey(varName, iVarToArrayIndexMapping)) then
-    ((arrayDimensions0,varIndices)) := BaseHashTable.get(varName, iVarToArrayIndexMapping); //varIndices are rowMajorOrder!
-    arrayDimensions := arrayDimensions0;
-    arraySubscripts := arraySubscripts0;
+    ((arrayDimensions,varIndices)) := BaseHashTable.get(varName, iVarToArrayIndexMapping); //varIndices are rowMajorOrder!
     arraySize := arrayLength(varIndices);
-    if(iColumnMajor) then
-      arraySubscripts := listReverse(arraySubscripts0);
-      arrayDimensions := listReverse(arrayDimensions0);
-    end if;
     concreteVarIndex := getUnrolledArrayIndex(arraySubscripts,arrayDimensions);
+    if iColumnMajor then
+      concreteVarIndex := convertIndexToColumnMajor(concreteVarIndex, arrayDimensions);
+    end if;
     //print("SimCodeUtil.getVarIndexInfosByMapping: Found variable index for '" + ComponentReference.printComponentRefStr(iVarName) + "'. The value is " + intString(concreteVarIndex) + "\n");
     for arrayIdx in 0:(arraySize-1) loop
       idx := arraySize-arrayIdx;
       if iColumnMajor then
         // convert to row major so that column major access will give this idx
-        idx := convertIndexToRowMajor(idx, arrayDimensions0);
+        idx := convertIndexToRowMajor(idx, arrayDimensions);
       end if;
       idx := arrayGet(varIndices, idx);
       if(intLt(idx, 0)) then
@@ -10984,9 +10980,9 @@ algorithm
     if isVarIndexListConsecutive(iVarToArrayIndexMapping,iVarName) and iColumnMajor then
       //if the array is not completely stuffed (e.g. some array variables have been derived and became dummy-derivatives), the array will not be initialized as a consecutive array, therefore we cannot take the colMajor-indexes
       // otherwise convert to column major for consecutive array
-      concreteVarIndex := convertIndexToColumnMajor(concreteVarIndex + 1, arrayDimensions0) - 1;
+      concreteVarIndex := convertIndexToColumnMajor(concreteVarIndex, arrayDimensions);
     end if;
-    oConcreteVarIndex := listGet(tmpVarIndexListNew, concreteVarIndex + 1);
+    oConcreteVarIndex := listGet(tmpVarIndexListNew, concreteVarIndex);
   end if;
   if(listEmpty(tmpVarIndexListNew)) then
     Error.addMessage(Error.INTERNAL_ERROR, {"GetVarIndexListByMapping: No Element for " + ComponentReference.printComponentRefStr(varName) + " found!"});
@@ -11106,43 +11102,23 @@ algorithm
   oIsConsecutive := consecutive;
 end isVarIndexListConsecutive;
 
-protected function getUnrolledArrayIndex"author: waurich
-wrapper for getUnrolledArrayIndex1 to reverse the list order to be conform to the cpp runtime array adressing"
-  input list<DAE.Subscript> arraySubs;
-  input list<Integer> arrayTypeDimensions;
+protected function getUnrolledArrayIndex
+ "Calculate the one based memory offset for consecutive row major storage,
+  author: rfranke"
+  input list<DAE.Subscript> arraySubscripts;
+  input list<Integer> arrayDimensions;
   output Integer arrayIndex;
-algorithm
-  ((arrayIndex,_,_)) := List.fold(listReverse(arraySubs), getUnrolledArrayIndex1, (0, 1, listReverse(arrayTypeDimensions)));
-end getUnrolledArrayIndex;
-
-protected function getUnrolledArrayIndex1 "author: marcusw
-  Calculate a flat array index, by the given subscripts. E.g. [2,1] for array of size 3x3 will lead to: 2."
-  input DAE.Subscript iCurrentSubscript;
-  input tuple<Integer,Integer,list<Integer>> iCurrentRowIdxRes; //<result, currentOffset, remainingRows>
-  output tuple<Integer,Integer,list<Integer>> oCurrentRowIdxRes;
 protected
-  list<Integer> tail;
-  Integer head, index, currentOffset, result, subscriptIndex;
+  Integer idx, fac;
 algorithm
-  oCurrentRowIdxRes := match(iCurrentSubscript, iCurrentRowIdxRes)
-    case(_, (_,_,{}))
-      equation
-        print("getUnrolledArrayIndex: failed, not enough dimensions given\n");
-      then iCurrentRowIdxRes;
-    case(_, (index, currentOffset, head::tail))
-      equation
-        subscriptIndex = DAEUtil.getSubscriptIndex(iCurrentSubscript) - 1;
-        if(intEq(currentOffset, 0)) then
-          index = subscriptIndex;
-          currentOffset = head;
-        else
-          //print("getUnrolledArrayIndex: index = " + intString(index) + " + " + intString(currentOffset) + " * " + intString(subscriptIndex) + "\n");
-          index = index + intMul(currentOffset, subscriptIndex);
-          currentOffset = intMul(currentOffset, head);
-        end if;
-      then (index, currentOffset, tail);
-  end match;
-end getUnrolledArrayIndex1;
+  arrayIndex := 1; // one based
+  fac := 1;
+  for i in listLength(arraySubscripts):-1:1 loop
+    idx := DAEUtil.getSubscriptIndex(listGet(arraySubscripts, i));
+    arrayIndex := arrayIndex + (idx - 1) * fac;
+    fac := fac * listGet(arrayDimensions, i);
+  end for;
+end getUnrolledArrayIndex;
 
 public function createIdxSCVarMapping "author: marcusw
   Create a mapping from the SCVar-Index (array-Index) to the SCVariable, as it is used in the c-runtime."

--- a/SimulationRuntime/cpp/Include/Core/Math/Array.h
+++ b/SimulationRuntime/cpp/Include/Core/Math/Array.h
@@ -452,9 +452,9 @@ public:
    */
   virtual const T& operator()(const vector<size_t>& idx) const
   {
-    assert((size1*size2) > ((idx[0]-1)*size2 + (idx[1]-1)));
+    assert((size1*size2) > ((idx[0]-1) + size1*(idx[1]-1)));
     return *(RefArray<T, size1*size2>::
-             _ref_array[(idx[0]-1)*size2 + (idx[1]-1)]);
+             _ref_array[(idx[0]-1) + size1*(idx[1]-1)]);
   }
 
   /**
@@ -463,9 +463,9 @@ public:
    */
   virtual T& operator()(const vector<size_t>& idx)
   {
-    assert((size1*size2) > ((idx[0]-1)*size2 + (idx[1]-1)));
+    assert((size1*size2) > ((idx[0]-1) + size1*(idx[1]-1)));
     return *(RefArray<T, size1*size2>::
-             _ref_array[(idx[0]-1)*size2 + (idx[1]-1)]);
+             _ref_array[(idx[0]-1) + size1*(idx[1]-1)]);
   }
 
   /**
@@ -475,9 +475,9 @@ public:
    */
   inline virtual T& operator()(size_t i, size_t j)
   {
-    assert((size1*size2) > ((i-1)*size2 + (j-1)));
+    assert((size1*size2) > ((i-1) + size1*(j-1)));
     return *(RefArray<T, size1*size2>::
-             _ref_array[(i-1)*size2 + (j-1)]);
+             _ref_array[(i-1) + size1*(j-1)]);
   }
 
   /**
@@ -580,9 +580,9 @@ public:
    */
   virtual const T& operator()(const vector<size_t>& idx) const
   {
-    assert((size1*size2*size3) > (size3*(size2*(idx[0]-1) + (idx[1]-1)) + idx[2]-1));
+    assert(size1*size2*size3 > idx[0]-1 + size1*(idx[1]-1 + size2*(idx[2]-1)));
     return *(RefArray<T, size1*size2*size3>::
-             _ref_array[size3*(size2*(idx[0]-1) + (idx[1]-1)) + idx[2]-1]);
+             _ref_array[idx[0]-1 + size1*(idx[1]-1 + size2*(idx[2]-1))]);
   }
 
   /**
@@ -591,9 +591,9 @@ public:
    */
   virtual T& operator()(const vector<size_t>& idx)
   {
-    assert((size1*size2*size3) > (size3*(size2*(idx[0]-1) + (idx[1]-1)) + idx[2]-1));
+    assert(size1*size2*size3 > idx[0]-1 + size1*(idx[1]-1 + size2*(idx[2]-1)));
     return *(RefArray<T, size1*size2*size3>::
-             _ref_array[size3*(size2*(idx[0]-1) + (idx[1]-1)) + idx[2]-1]);
+             _ref_array[idx[0]-1 + size1*(idx[1]-1 + size2*(idx[2]-1))]);
   }
 
   /**
@@ -604,9 +604,9 @@ public:
    */
   inline virtual T& operator()(size_t i, size_t j, size_t k)
   {
-    assert((size1*size2*size3) > (size3*(size2*(i-1) + (j-1)) + (k-1)));
+    assert(size1*size2*size3 > i-1 + size1*(j-1 + size2*(k-1)));
     return *(RefArray<T, size1*size2*size3>::
-             _ref_array[size3*(size2*(i-1) + (j-1)) + (k-1)]);
+             _ref_array[i-1 + size1*(j-1 + size2*(k-1))]);
   }
 
   /**


### PR DESCRIPTION
Array.h for sure improves if all array types use the same storage order. SimCodeUtil.mo is adjusted accordingly.