### PR TITLE
Redesigned NFInst to eliminate InstanceTree (WIP).

### DIFF
--- a/Compiler/NFFrontEnd/NFBinding.mo
+++ b/Compiler/NFFrontEnd/NFBinding.mo
@@ -37,8 +37,9 @@ encapsulated package NFBinding
 "
 
 public
-import SCode;
 import DAE;
+import NFInstNode.InstNode;
+import SCode;
 
 protected
 import Dump;
@@ -52,7 +53,7 @@ uniontype Binding
     Absyn.Exp bindingExp;
     SCode.Final finalPrefix;
     SCode.Each eachPrefix;
-    Integer scope;
+    InstNode scope;
     Integer propagatedDims;
     SourceInfo info;
   end RAW_BINDING;
@@ -60,7 +61,7 @@ uniontype Binding
   record UNTYPED_BINDING
     Absyn.Exp bindingExp;
     Boolean isProcessing;
-    Integer scope;
+    InstNode scope;
     Integer propagatedDims;
     SourceInfo info;
   end UNTYPED_BINDING;
@@ -77,7 +78,7 @@ public
     input Option<Absyn.Exp> bindingExp;
     input SCode.Final finalPrefix;
     input SCode.Each eachPrefix;
-    input Integer scope;
+    input InstNode scope;
     input Integer dimensions;
     input SourceInfo info;
     output Binding binding;

--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -51,11 +51,9 @@ uniontype Component
   record COMPONENT_DEF
     Element definition;
     Modifier modifier;
-    Integer scope;
   end COMPONENT_DEF;
 
   record UNTYPED_COMPONENT
-    String name;
     InstNode classInst;
     array<Dimension> dimensions;
     Binding binding;
@@ -64,7 +62,6 @@ uniontype Component
   end UNTYPED_COMPONENT;
 
   record TYPED_COMPONENT
-    String name;
     InstNode classInst;
     Type ty;
     Binding binding;
@@ -76,22 +73,9 @@ uniontype Component
   end EXTENDS_NODE;
 
   record COMPONENT_REF
-    String name;
     Integer node;
     Integer index;
   end COMPONENT_REF;
-
-  function name
-    input Component component;
-    output String name;
-  algorithm
-    name := match component
-      case COMPONENT_DEF(definition = SCode.COMPONENT(name = name)) then name;
-      case UNTYPED_COMPONENT() then component.name;
-      case TYPED_COMPONENT() then component.name;
-      case COMPONENT_REF() then component.name;
-    end match;
-  end name;
 
   function isNamedComponent
     input Component component;
@@ -117,7 +101,7 @@ uniontype Component
     input Modifier modifier;
     input output Component component;
   algorithm
-    _ := match component
+    () := match component
       case COMPONENT_DEF()
         algorithm
           component.modifier := modifier;
@@ -141,8 +125,7 @@ uniontype Component
   algorithm
     component := match component
       case UNTYPED_COMPONENT()
-        then TYPED_COMPONENT(component.name, component.classInst, ty,
-          component.binding, component.attributes);
+        then TYPED_COMPONENT(component.classInst, ty, component.binding, component.attributes);
 
       case TYPED_COMPONENT()
         algorithm
@@ -155,7 +138,7 @@ uniontype Component
   function unliftType
     input output Component component;
   algorithm
-    _ := match component
+    () := match component
       local
         DAE.Type ty;
 
@@ -168,16 +151,6 @@ uniontype Component
       else ();
     end match;
   end unliftType;
-
-  function makeTopComponent
-    input InstNode inst;
-    output Component comp;
-  algorithm
-    comp := TYPED_COMPONENT(InstNode.name(inst), inst, DAE.T_UNKNOWN_DEFAULT,
-      Binding.UNBOUND(), Attributes.ATTRIBUTES(
-        DAE.VarKind.VARIABLE(), DAE.VarDirection.BIDIR(),
-        DAE.VarVisibility.PUBLIC(), DAE.ConnectorType.NON_CONNECTOR()));
-  end makeTopComponent;
 end Component;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/Compiler/NFFrontEnd/NFComponentNode.mo
+++ b/Compiler/NFFrontEnd/NFComponentNode.mo
@@ -1,0 +1,196 @@
+
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2014, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package NFComponentNode
+
+import NFComponent.Component;
+import NFMod.Modifier;
+import SCode.Element;
+import NFInstNode.InstNode;
+
+uniontype ComponentNode
+  record COMPONENT_NODE
+    String name;
+    Element definition;
+    array<Component> component;
+    ComponentNode parent;
+  end COMPONENT_NODE;
+
+  record EMPTY_NODE end EMPTY_NODE;
+
+  function new
+    input String name;
+    input Element definition;
+    input ComponentNode parent = EMPTY_NODE();
+    output ComponentNode node;
+  protected
+    array<Component> c;
+  algorithm
+    c := arrayCreate(1, Component.COMPONENT_DEF(definition, Modifier.NOMOD()));
+    node := COMPONENT_NODE(name, definition, c, parent);
+  end new;
+
+  function newExtends
+    input InstNode extendsNode;
+    input Element definition;
+    output ComponentNode node;
+  protected
+    array<Component> c;
+  algorithm
+    c := arrayCreate(1, Component.EXTENDS_NODE(extendsNode));
+    node := COMPONENT_NODE("", definition, c, EMPTY_NODE());
+  end newExtends;
+
+  function newReference
+    input output ComponentNode component;
+    input Integer nodeIndex;
+    input Integer componentIndex;
+  algorithm
+    component := clone(component);
+    component := setComponent(Component.COMPONENT_REF(nodeIndex, componentIndex), component);
+  end newReference;
+
+  function name
+    input ComponentNode node;
+    output String name;
+  algorithm
+    COMPONENT_NODE(name = name) := node;
+  end name;
+
+  function rename
+    input output ComponentNode node;
+    input String name;
+  algorithm
+    () := match node
+      case COMPONENT_NODE()
+        algorithm
+          node.name := name;
+        then
+          ();
+    end match;
+  end rename;
+
+  function parent
+    input ComponentNode node;
+    output ComponentNode parentNode;
+  algorithm
+    COMPONENT_NODE(parent = parentNode) := node;
+  end parent;
+
+  function setParent
+    input ComponentNode parent;
+    input output ComponentNode node;
+  algorithm
+    () := match node
+      case COMPONENT_NODE()
+        algorithm
+          node.parent := parent;
+        then
+          ();
+    end match;
+  end setParent;
+
+  function component
+    input ComponentNode node;
+    output Component component;
+  algorithm
+    component := match node
+      case COMPONENT_NODE() then node.component[1];
+    end match;
+  end component;
+
+  function setComponent
+    input Component component;
+    input output ComponentNode node;
+  algorithm
+    node := match node
+      case COMPONENT_NODE()
+        algorithm
+          arrayUpdate(node.component, 1, component);
+        then
+          node;
+    end match;
+  end setComponent;
+
+  function definition
+    input ComponentNode node;
+    output SCode.Element definition;
+  algorithm
+    COMPONENT_NODE(definition = definition) := node;
+  end definition;
+
+  function setDefinition
+    input SCode.Element definition;
+    input output ComponentNode node;
+  algorithm
+    () := match node
+      case COMPONENT_NODE()
+        algorithm
+          node.definition := definition;
+        then
+          ();
+    end match;
+  end setDefinition;
+
+  function clone
+    input ComponentNode node;
+    output ComponentNode clone;
+  algorithm
+    clone := match node
+      case COMPONENT_NODE()
+        then COMPONENT_NODE(node.name, node.definition, arrayCopy(node.component), node.parent);
+      else node;
+    end match;
+  end clone;
+
+  function apply<ArgT>
+    input output ComponentNode node;
+    input FuncType func;
+    input ArgT arg;
+
+    partial function FuncType
+      input ArgT arg;
+      input output Component node;
+    end FuncType;
+  algorithm
+    () := match node
+      case COMPONENT_NODE()
+        algorithm
+          node.component[1] := func(arg, node.component[1]);
+        then
+          ();
+    end match;
+  end apply;
+end ComponentNode;
+
+annotation(__OpenModelica_Interface="frontend");
+end NFComponentNode;

--- a/Compiler/NFFrontEnd/NFInstanceTree.mo
+++ b/Compiler/NFFrontEnd/NFInstanceTree.mo
@@ -61,8 +61,9 @@ uniontype InstanceTree
     InstNode top;
     InstVector.Vector instances;
   algorithm
-    top := InstNode.INST_NODE("<top>", NONE(), Instance.emptyInstancedClass(),
-      TOP_SCOPE, NO_SCOPE, InstParent.NO_PARENT());
+    //top := InstNode.INST_NODE("<top>", NONE(), Instance.emptyInstancedClass(),
+    //  TOP_SCOPE, NO_SCOPE, InstParent.NO_PARENT());
+    top := InstNode.EMPTY_NODE();
     instances := InstVector.new();
     instances := InstVector.add(instances, top);
     tree := INST_TREE(top, instances, {});
@@ -96,14 +97,14 @@ uniontype InstanceTree
   function updateNode
     input InstNode node;
     input output InstanceTree tree;
-  protected
-    Integer idx = InstNode.index(node);
-  algorithm
-    tree.instances := InstVector.set(tree.instances, idx, node);
+  //protected
+  //  Integer idx = InstNode.index(node);
+  //algorithm
+  //  tree.instances := InstVector.set(tree.instances, idx, node);
 
-    if idx == InstNode.index(tree.currentScope) then
-      tree.currentScope := node;
-    end if;
+  //  if idx == InstNode.index(tree.currentScope) then
+  //    tree.currentScope := node;
+  //  end if;
   end updateNode;
 
   function setCurrentScopeIndex
@@ -115,7 +116,8 @@ uniontype InstanceTree
 
   function currentScopeIndex
     input InstanceTree tree;
-    output Integer index = InstNode.index(tree.currentScope);
+    //output Integer index = InstNode.index(tree.currentScope);
+    output Integer index = 0;
   end currentScopeIndex;
 
   function setCurrentScope
@@ -135,8 +137,8 @@ uniontype InstanceTree
   function enterParentScope
     input output InstanceTree tree;
   algorithm
-    tree.currentScope :=
-      InstVector.get(tree.instances, InstNode.scopeParent(tree.currentScope));
+    //tree.currentScope :=
+    //  InstVector.get(tree.instances, InstNode.scopeParent(tree.currentScope));
   end enterParentScope;
 
   function pushHierarchy
@@ -184,80 +186,82 @@ uniontype InstanceTree
   function hierarchyPrefix
     input InstanceTree tree;
     output Prefix prefix = Prefix.NO_PREFIX();
-  protected
-    list<Component> hierarchy = tree.hierarchy;
-    Component c;
-  algorithm
-    // Make a prefix out of all but the last (anonymous) instances in the hierarchy.
-    while listLength(hierarchy) > 1 loop
-      c :: hierarchy := hierarchy;
-      prefix := Prefix.add(Component.name(c), {}, DAE.T_UNKNOWN_DEFAULT, prefix);
-    end while;
+  //protected
+  //  list<Component> hierarchy = tree.hierarchy;
+  //  Component c;
+  //algorithm
+  //  // Make a prefix out of all but the last (anonymous) instances in the hierarchy.
+  //  while listLength(hierarchy) > 1 loop
+  //    c :: hierarchy := hierarchy;
+  //    prefix := Prefix.add(Component.name(c), {}, DAE.T_UNKNOWN_DEFAULT, prefix);
+  //  end while;
   end hierarchyPrefix;
 
   function scopePrefix
     input InstanceTree tree;
     output Prefix prefix = Prefix.NO_PREFIX();
-  protected
-    InstNode node = currentScope(tree);
-    Integer parent = NO_SCOPE;
-    list<InstNode> nodes = {};
-  algorithm
-    while parent <> TOP_SCOPE loop
-      nodes := node :: nodes;
-      parent := InstNode.scopeParent(node);
-      node := InstVector.get(tree.instances, parent);
-    end while;
+  //protected
+  //  InstNode node = currentScope(tree);
+  //  Integer parent = NO_SCOPE;
+  //  list<InstNode> nodes = {};
+  //algorithm
+  //  while parent <> TOP_SCOPE loop
+  //    nodes := node :: nodes;
+  //    parent := InstNode.scopeParent(node);
+  //    node := InstVector.get(tree.instances, parent);
+  //  end while;
 
-    for n in nodes loop
-      prefix := Prefix.add(InstNode.name(n), {}, DAE.T_UNKNOWN_DEFAULT, prefix);
-    end for;
+  //  for n in nodes loop
+  //    prefix := Prefix.add(InstNode.name(n), {}, DAE.T_UNKNOWN_DEFAULT, prefix);
+  //  end for;
   end scopePrefix;
 
   function prefix
     input InstNode node;
     output Prefix prefix;
-  protected
-    InstParent ip;
   algorithm
-    ip := InstNode.instParent(node);
+    prefix := Prefix.NO_PREFIX();
+  //protected
+  //  InstParent ip;
+  //algorithm
+  //  ip := InstNode.instParent(node);
 
-    prefix := match ip
-      case InstParent.CLASS()
-        then prefix2(node);
-      //case InstParent.COMPONENT() then hierarchyPrefix(node);
-      case InstParent.NO_PARENT() then Prefix.NO_PREFIX();
-      else Prefix.NO_PREFIX();
-    end match;
+  //  prefix := match ip
+  //    case InstParent.CLASS()
+  //      then prefix2(node);
+  //    //case InstParent.COMPONENT() then hierarchyPrefix(node);
+  //    case InstParent.NO_PARENT() then Prefix.NO_PREFIX();
+  //    else Prefix.NO_PREFIX();
+  //  end match;
   end prefix;
 
-  function prefix2
-    input InstNode node;
-    output Prefix prefix;
-  protected
-    InstParent ip = InstNode.instParent(node);
-    InstNode n;
-    list<InstNode> nodes = {};
-  algorithm
-    while not InstParent.isEmpty(ip) loop
-      ip := match ip
-        case InstParent.CLASS()
-          algorithm
-            nodes := ip.node :: nodes;
-          then
-            InstNode.instParent(ip.node);
+  //function prefix2
+  //  input InstNode node;
+  //  output Prefix prefix;
+  //protected
+  //  InstParent ip = InstNode.instParent(node);
+  //  InstNode n;
+  //  list<InstNode> nodes = {};
+  //algorithm
+  //  while not InstParent.isEmpty(ip) loop
+  //    ip := match ip
+  //      case InstParent.CLASS()
+  //        algorithm
+  //          nodes := ip.node :: nodes;
+  //        then
+  //          InstNode.instParent(ip.node);
 
-        else InstParent.NO_PARENT();
-      end match;
-    end while;
+  //      else InstParent.NO_PARENT();
+  //    end match;
+  //  end while;
 
-    prefix := Prefix.addClass(InstNode.name(node), Prefix.NO_PREFIX());
+  //  prefix := Prefix.addClass(InstNode.name(node), Prefix.NO_PREFIX());
 
-    while listLength(nodes) > 1 loop
-      n :: nodes := nodes;
-      prefix := Prefix.addClass(InstNode.name(n), prefix);
-    end while;
-  end prefix2;
+  //  while listLength(nodes) > 1 loop
+  //    n :: nodes := nodes;
+  //    prefix := Prefix.addClass(InstNode.name(n), prefix);
+  //  end while;
+  //end prefix2;
 end InstanceTree;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/Compiler/NFFrontEnd/NFMod.mo
+++ b/Compiler/NFFrontEnd/NFMod.mo
@@ -43,6 +43,7 @@ public
 import Absyn;
 import BaseAvlTree;
 import NFBinding.Binding;
+import NFInstNode.InstNode;
 import SCode;
 
 protected
@@ -127,7 +128,7 @@ uniontype Modifier
     SCode.Final finalPrefix;
     SCode.Each eachPrefix;
     SCode.Element element;
-    Integer scope;
+    InstNode scope;
   end REDECLARE;
 
   record NOMOD end NOMOD;
@@ -137,7 +138,7 @@ public
     input SCode.Mod mod;
     input String name;
     input ModifierScope modScope;
-    input Integer scope;
+    input InstNode scope;
     output Modifier newMod;
   algorithm
     newMod := match mod
@@ -377,7 +378,7 @@ protected
   function createSubMod
     input SCode.SubMod subMod;
     input ModifierScope modScope;
-    input Integer scope;
+    input InstNode scope;
     output Modifier mod = create(subMod.mod, subMod.ident, modScope, scope);
   end createSubMod;
 

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -91,6 +91,7 @@ if true then /* Suppress output */
     "../NFFrontEnd/NFBinding.mo",
     "../NFFrontEnd/NFBuiltin.mo",
     "../NFFrontEnd/NFComponent.mo",
+    "../NFFrontEnd/NFComponentNode.mo",
     //"../NFFrontEnd/NFConnect2.mo",
     //"../NFFrontEnd/NFConnectCheck.mo",
     //"../NFFrontEnd/NFConnectEquations.mo",


### PR DESCRIPTION
- Changed NFInstNode to contain a mutable instance, instead of using
  indices to an array of all classes.
- Added NFComponentNode which is similar to NFInstNode but for
  components, to allow for a bidirectional instance tree.