### PR TITLE
Escape quoted idents in aliases in _init.xml

### DIFF
--- a/Compiler/SimCode/SerializeInitXML.mo
+++ b/Compiler/SimCode/SerializeInitXML.mo
@@ -557,9 +557,9 @@ function getAliasVar "Returns the alias Attribute of ScalarVariable."
 algorithm
   _ := match aliasvar
   case AliasVariable.ALIAS()
-    algorithm File.write(file, "\"alias\" aliasVariable=\""); CR.writeCref(file, aliasvar.varName); File.write(file, "\""); then ();
+    algorithm File.write(file, "\"alias\" aliasVariable=\""); CR.writeCref(file, aliasvar.varName, XML); File.write(file, "\""); then ();
   case AliasVariable.NEGATEDALIAS()
-    algorithm File.write(file, "\"negatedAlias\" aliasVariable=\""); CR.writeCref(file, aliasvar.varName); File.write(file, "\""); then ();
+    algorithm File.write(file, "\"negatedAlias\" aliasVariable=\""); CR.writeCref(file, aliasvar.varName, XML); File.write(file, "\""); then ();
   else
     algorithm File.write(file, "\"noAlias\""); then ();
   end match;


### PR DESCRIPTION
Escape alias variable names as XML when writing _init.xml. They might have apostrophes (a.k.a. single quotes in Modelica).
This was the only remaining issue for ticket:2571. 