### PR TITLE
Fix the check for final modification.

### DIFF
--- a/Compiler/NFFrontEnd/NFBinding.mo
+++ b/Compiler/NFFrontEnd/NFBinding.mo
@@ -52,8 +52,6 @@ uniontype Binding
 
   record RAW_BINDING
     Absyn.Exp bindingExp;
-    SCode.Final finalPrefix;
-    SCode.Each eachPrefix;
     Component.Scope scope;
     Integer propagatedDims;
     SourceInfo info;
@@ -77,7 +75,6 @@ uniontype Binding
 public
   function fromAbsyn
     input Option<Absyn.Exp> bindingExp;
-    input SCode.Final finalPrefix;
     input SCode.Each eachPrefix;
     input Integer dimensions;
     input SourceInfo info;
@@ -94,7 +91,7 @@ public
           pd := if SCode.eachBool(eachPrefix) then -1 else dimensions;
           scope := Component.Scope.RELATIVE_COMP(0);
         then
-          RAW_BINDING(exp, finalPrefix, eachPrefix, scope, pd, info);
+          RAW_BINDING(exp, scope, pd, info);
 
       else UNBOUND();
     end match;

--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -122,6 +122,19 @@ uniontype Component
     end match;
   end setModifier;
 
+  function mergeModifier
+    input Modifier modifier;
+    input output Component component;
+  algorithm
+    () := match component
+      case COMPONENT_DEF()
+        algorithm
+          component.modifier := Modifier.merge(modifier, component.modifier);
+        then
+          ();
+    end match;
+  end mergeModifier;
+
   function getType
     input Component component;
     output DAE.Type ty;

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -497,7 +497,7 @@ algorithm
             // Modifier is for a component, add it to the component in the array.
             case ClassTree.Entry.COMPONENT()
               algorithm
-                ComponentNode.apply(components[entry.index], Component.setModifier, m);
+                ComponentNode.apply(components[entry.index], Component.mergeModifier, m);
               then
                 ();
 


### PR DESCRIPTION
- Moved the final attribute from NFMod.Modifier to NFBinding.Binding,
  so that an element can be declared final without having a binding.
- Update the check for merging two modifiers where the inner is final.