### PR TITLE
Add logFormat=xmltcp

### DIFF
--- a/SimulationRuntime/c/simulation/options.c
+++ b/SimulationRuntime/c/simulation/options.c
@@ -30,6 +30,7 @@
 
 #include "options.h"
 #include "util/omc_error.h"
+#include "simulation_runtime.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -50,22 +51,19 @@ int helpFlagSet(int argc, char** argv)
 int setLogFormat(int argc, char** argv)
 {
   const char* value = getOption(FLAG_NAME[FLAG_LOG_FORMAT], argc, argv);
-  if(NULL == value)
+  if (NULL == value) {
     value = getFlagValue(FLAG_NAME[FLAG_LOG_FORMAT], argc, argv);
+  }
 
-  if (NULL != value)
-  {
-    if (0 == strcmp(value, "xml"))
-    {
+  if (NULL != value) {
+    if (0 == strcmp(value, "xml")) {
       setStreamPrintXML(1);
-    }
-    else if (0 == strcmp(value, "text"))
-    {
+    } else if (0 == strcmp(value, "xmltcp")) {
+      setStreamPrintXML(2);
+    } else if (0 == strcmp(value, "text")) {
       setStreamPrintXML(0);
-    }
-    else
-    {
-      warningStreamPrint(LOG_STDOUT, 0, "invalid command line option: -logFormat=%s, expected text or xml", value);
+    } else {
+      warningStreamPrint(LOG_STDOUT, 0, "invalid command line option: -logFormat=%s, expected text, xml, or xmltcp", value);
       return 1;
     }
   }

--- a/SimulationRuntime/c/simulation/options.c
+++ b/SimulationRuntime/c/simulation/options.c
@@ -48,6 +48,7 @@ int helpFlagSet(int argc, char** argv)
   return flagSet("?", argc, argv) || flagSet("help", argc, argv);
 }
 
+#if !defined(OMC_MINIMAL_RUNTIME)
 int setLogFormat(int argc, char** argv)
 {
   const char* value = getOption(FLAG_NAME[FLAG_LOG_FORMAT], argc, argv);
@@ -69,6 +70,7 @@ int setLogFormat(int argc, char** argv)
   }
   return 0;
 }
+#endif
 
 int checkCommandLineArguments(int argc, char **argv)
 {

--- a/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -1006,12 +1006,13 @@ static inline void sendXMLTCPIfClosed()
 {
   if (numOpenTags==0) {
     sim_communication_port.send(xmlTcpStream.str());
-    xmlTcpStream.clear();
+    xmlTcpStream.str("");
   }
 }
 
 static void messageXMLTCP(int type, int stream, int indentNext, char *msg, int subline, const int *indexes)
 {
+  numOpenTags++;
   xmlTcpStream << "<message stream=\"" << LOG_STREAM_NAME[stream] << "\" type=\"" << LOG_TYPE_DESC[type] << "\" text=\"";
   printEscapedXMLTCP(&xmlTcpStream, msg);
   if (indexes) {
@@ -1021,10 +1022,16 @@ static void messageXMLTCP(int type, int stream, int indentNext, char *msg, int s
       xmlTcpStream << "<used index=\"" << indexes[i] << "%d\" />\n";
     }
     if (!indentNext) {
+      numOpenTags--;
       xmlTcpStream << "</message>\n";
     }
   } else {
-    xmlTcpStream << (indentNext ? "\">\n" : "\" />\n");
+    if (indentNext) {
+      xmlTcpStream << "\">\n";
+    } else {
+      numOpenTags--;
+      xmlTcpStream << "\" />\n";
+    }
   }
   sendXMLTCPIfClosed();
 }

--- a/SimulationRuntime/c/simulation/simulation_runtime.h
+++ b/SimulationRuntime/c/simulation/simulation_runtime.h
@@ -74,7 +74,7 @@ extern const char* getNameString(const char** ptr);
 extern double getSimulationStepSize();
 extern void printSimulationStepSize(double in_stepSize, double time);
 
-extern void communicateStatus(const char *phase, double completionPercent);
+extern void communicateStatus(const char *phase, double completionPercent, double currentTime, double currentStepSize);
 extern void communicateMsg(char id, unsigned int size, const char *data);
 
 /* the main function of the simulation runtime!
@@ -85,6 +85,8 @@ extern int _main_SimulationRuntime(int argc, char**argv, DATA *data, threadData_
 #if !defined(OMC_MINIMAL_RUNTIME)
 const char* prettyPrintNanoSec(int64_t ns, int *v);
 #endif
+
+void setStreamPrintXML(int isXML);
 
 #ifdef __cplusplus
 }

--- a/SimulationRuntime/c/simulation/solver/perform_qss_simulation.c
+++ b/SimulationRuntime/c/simulation/solver/perform_qss_simulation.c
@@ -211,7 +211,7 @@ int prefixedName_performQSSSimulation(DATA* data, threadData_t *threadData, SOLV
   while(solverInfo->currentTime < simInfo->stopTime)
   {
     modelica_integer success = 0;
-	uinteger k = 0, j = 0;
+  uinteger k = 0, j = 0;
 
     threadData->currentErrorStage = ERROR_SIMULATION;
     omc_alloc_interface.collect_a_little();
@@ -280,9 +280,8 @@ int prefixedName_performQSSSimulation(DATA* data, threadData_t *threadData, SOLV
     tqp[ind] = tq[ind] + dTnextQ;
     nQh[ind] = nextQ;
 
-    if (0 != strcmp("ia", data->simulationInfo->outputFormat))
-    {
-      communicateStatus("Running", (solverInfo->currentTime-simInfo->startTime)/(simInfo->stopTime-simInfo->startTime));
+    if (0 != strcmp("ia", data->simulationInfo->outputFormat)) {
+      communicateStatus("Running", (solverInfo->currentTime-simInfo->startTime)/(simInfo->stopTime-simInfo->startTime), solverInfo->currentTime, 0.0);
     }
 
     /* get the derivatives depending on state[ind] */

--- a/SimulationRuntime/c/simulation/solver/perform_simulation.c
+++ b/SimulationRuntime/c/simulation/solver/perform_simulation.c
@@ -141,9 +141,8 @@ static int simulationStep(DATA* data, threadData_t *threadData, SOLVER_INFO* sol
 {
   SIMULATION_INFO *simInfo = data->simulationInfo;
 
-  if(0 != strcmp("ia", data->simulationInfo->outputFormat))
-  {
-    communicateStatus("Running", (solverInfo->currentTime - simInfo->startTime)/(simInfo->stopTime - simInfo->startTime));
+  if(0 != strcmp("ia", data->simulationInfo->outputFormat)) {
+    communicateStatus("Running", (solverInfo->currentTime - simInfo->startTime)/(simInfo->stopTime - simInfo->startTime), solverInfo->currentTime, solverInfo->currentStepSize);
   }
   return solver_main_step(data, threadData, solverInfo);
 }

--- a/SimulationRuntime/c/simulation/solver/solver_main.c
+++ b/SimulationRuntime/c/simulation/solver/solver_main.c
@@ -548,7 +548,7 @@ int finishSimulation(DATA* data, threadData_t *threadData, SOLVER_INFO* solverIn
   }
 
   if (0 != strcmp("ia", data->simulationInfo->outputFormat)) {
-    communicateStatus("Finished", 1);
+    communicateStatus("Finished", 1, solverInfo->currentTime, solverInfo->currentStepSize);
   }
 
   /* we have output variables in the command line -output a,b,c */

--- a/SimulationRuntime/c/util/omc_error.c
+++ b/SimulationRuntime/c/util/omc_error.c
@@ -124,7 +124,7 @@ const char *LOG_STREAM_DESC[SIM_LOG_MAX] = {
   "additional information about the zerocrossings"       /* LOG_ZEROCROSSINGS */
 };
 
-static const char *LOG_TYPE_DESC[LOG_TYPE_MAX] = {
+const char *LOG_TYPE_DESC[LOG_TYPE_MAX] = {
   "unknown",
   "info",
   "warning",
@@ -215,18 +215,6 @@ void omc_terminate_function(FILE_INFO info, const char *msg, ...)
   MMC_THROW();
 }
 
-static void printEscapedXML(const char *msg)
-{
-  while (*msg) {
-    if (*msg == '&') fputs("&amp;", stdout);
-    else if (*msg == '<') fputs("&lt;", stdout);
-    else if (*msg == '>') fputs("&gt;", stdout);
-    else if (*msg == '"') fputs("&quot;", stdout);
-    else fputc(*msg, stdout);
-    msg++;
-  }
-}
-
 void messageText(int type, int stream, int indentNext, char *msg, int subline, const int *indexes)
 {
   int i;
@@ -263,71 +251,22 @@ void messageText(int type, int stream, int indentNext, char *msg, int subline, c
   if (indentNext) level[stream]++;
 }
 
-void messageXML(int type, int stream, int indentNext, char *msg, int subline, const int *indexes)
-{
-  printf("<message stream=\"%s\" type=\"%s\" text=\"", LOG_STREAM_NAME[stream], LOG_TYPE_DESC[type]);
-  printEscapedXML(msg);
-  if (indexes) {
-    int i;
-    printf("\">\n");
-    for (i=1; i<=*indexes; i++) {
-      printf("<used index=\"%d\" />\n", indexes[i]);
-    }
-    if (!indentNext) {
-      fputs("</message>\n",stdout);
-    }
-  } else {
-    fputs(indentNext ? "\">\n" : "\" />\n", stdout);
-  }
-  fflush(stdout);
-}
-
 static void messageCloseText(int stream)
 {
   if(ACTIVE_STREAM(stream))
     level[stream]--;
 }
 
-static void messageCloseXML(int stream)
-{
-  if(ACTIVE_STREAM(stream))
-  {
-    fputs("</message>\n", stdout);
-    fflush(stdout);
-  }
-}
-
 static void messageCloseTextWarning(int stream)
 {
-  if(ACTIVE_WARNING_STREAM(stream))
+  if (ACTIVE_WARNING_STREAM(stream)) {
     level[stream]--;
-}
-
-static void messageCloseXMLWarning(int stream)
-{
-  if(ACTIVE_WARNING_STREAM(stream))
-  {
-    fputs("</message>\n", stdout);
-    fflush(stdout);
   }
 }
 
-static void (*messageFunction)(int type, int stream, int indentNext, char *msg, int subline, const int *indexes) = messageText;
+void (*messageFunction)(int type, int stream, int indentNext, char *msg, int subline, const int *indexes) = messageText;
 void (*messageClose)(int stream) = messageCloseText;
 void (*messageCloseWarning)(int stream) = messageCloseTextWarning;
-
-void setStreamPrintXML(int isXML)
-{
-  if (isXML) {
-    messageFunction = messageXML;
-    messageClose = messageCloseXML;
-    messageCloseWarning = messageCloseXMLWarning;
-  } else {
-    messageFunction = messageText;
-    messageClose = messageCloseText;
-    messageCloseWarning = messageCloseTextWarning;
-  }
-}
 
 #define SIZE_LOG_BUFFER 2048
 

--- a/SimulationRuntime/c/util/omc_error.h
+++ b/SimulationRuntime/c/util/omc_error.h
@@ -120,11 +120,6 @@ enum LOG_STREAM
   SIM_LOG_MAX
 };
 
-extern const int firstOMCErrorStream;
-extern const char *LOG_STREAM_NAME[SIM_LOG_MAX];
-extern const char *LOG_STREAM_DESC[SIM_LOG_MAX];
-extern const char *LOG_STREAM_DETAILED_DESC[SIM_LOG_MAX];
-
 enum LOG_TYPE
 {
   LOG_TYPE_UNKNOWN = 0,
@@ -136,14 +131,18 @@ enum LOG_TYPE
   LOG_TYPE_MAX
 };
 
+extern const int firstOMCErrorStream;
+extern const char *LOG_STREAM_NAME[SIM_LOG_MAX];
+extern const char *LOG_STREAM_DESC[SIM_LOG_MAX];
+extern const char *LOG_STREAM_DETAILED_DESC[SIM_LOG_MAX];
+extern const char *LOG_TYPE_DESC[LOG_TYPE_MAX];
+
 extern int useStream[SIM_LOG_MAX];
 extern int level[SIM_LOG_MAX];
 extern int lastType[SIM_LOG_MAX];
 extern int lastStream;
 extern int showAllWarnings;
 extern char logBuffer[2048];
-
-void setStreamPrintXML(int isXML);
 
 #define ACTIVE_STREAM(stream)    (useStream[stream])
 #define ACTIVE_WARNING_STREAM(stream)    (showAllWarnings || useStream[stream])
@@ -164,6 +163,7 @@ void setStreamPrintXML(int isXML);
   #define TRACE_POP
 #endif
 
+extern void (*messageFunction)(int type, int stream, int indentNext, char *msg, int subline, const int *indexes);
 extern void (*messageClose)(int stream);
 extern void (*messageCloseWarning)(int stream);
 

--- a/SimulationRuntime/c/util/simulation_options.c
+++ b/SimulationRuntime/c/util/simulation_options.c
@@ -149,7 +149,7 @@ const char *FLAG_DESC[FLAG_MAX+1] = {
   /* FLAG_JACOBIAN */              "selects the type of the jacobians that is used for the integrator.\n  jacobian=[coloredNumerical (default) |numerical|internalNumerical|coloredSymbolical|symbolical].",
   /* FLAG_L */                     "value specifies a time where the linearization of the model should be performed",
   /* FLAG_L_DATA_RECOVERY */       "emit data recovery matrices with model linearization",
-  /* FLAG_LOG_FORMAT */            "value specifies the log format of the executable. -logFormat=text (default) or -logFormat=xml",
+  /* FLAG_LOG_FORMAT */            "value specifies the log format of the executable. -logFormat=text (default), -logFormat=xml or -logFormat=xmltcp",
   /* FLAG_LS */                    "value specifies the linear solver method (default: lapack, totalpivot (fallback))",
   /* FLAG_LS_IPOPT */              "value specifies the linear solver method for ipopt",
   /* FLAG_LSS */                   "value specifies the linear sparse solver method (default: umfpack)",
@@ -286,7 +286,8 @@ const char *FLAG_DETAILED_DESC[FLAG_MAX+1] = {
   /* FLAG_LOG_FORMAT */
   "  Value specifies the log format of the executable:\n\n"
   "  * text (default)\n"
-  "  * xml",
+  "  * xml\n"
+  "  * xmltcp (required -port flag)",
   /* FLAG_LS */
   "  Value specifies the linear solver method",
   /* FLAG_LS_IPOPT */


### PR DESCRIPTION
logFormat=xmltcp requires a port to be passed and changes the format of
the status sent periodically to be an XML message.

All messages are buffered and sent when the message is finished in order
to always send complete XML fragments to OMEdit.