### PR TITLE
Support for unary operators in typing and typechecking

### DIFF
--- a/Compiler/FrontEnd/Absyn.mo
+++ b/Compiler/FrontEnd/Absyn.mo
@@ -720,9 +720,9 @@ uniontype Exp "The Exp uniontype is the container of a Modelica expression.
     Exp exp2;
   end BINARY;
 
-  record UNARY  "Unary operations, e.g. -(x)"
+  record UNARY  "Unary operations, e.g. -(x), +(x)"
     Operator op "op" ;
-    Exp exp "exp Logical binary operations: and, or" ;
+    Exp exp "exp - any arithmetic expression" ;
   end UNARY;
 
   record LBINARY
@@ -733,7 +733,7 @@ uniontype Exp "The Exp uniontype is the container of a Modelica expression.
 
   record LUNARY  "Logical unary operations: not"
     Operator op "op" ;
-    Exp exp "exp Relations, e.g. a >= 0" ;
+    Exp exp "exp - any logical or relation expression" ;
   end LUNARY;
 
   record RELATION

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -645,7 +645,6 @@ algorithm
   end try;
 end checkBinaryOperation;
 
-
 public function checkUnaryOperation
   "petfr:
   Type checks arithmetic unary operations. Both for simple scalar types and
@@ -661,13 +660,20 @@ protected
   String e1_str, ty1_str, s1;
 algorithm
   try
-    unaryType := type1;  // ?? correct?, since no type change for unary, see matchType?
+    // Arithmetic type expected for Unary operators, i.e., UMINUS, UMINUS_ARR;  UPLUS removed
+    true := Types.isNumericType(type1);
+
+    unaryType := type1;
     op := Expression.setOpType(operator, unaryType);
-    unaryExp :=  DAE.UNARY(op, exp1);
+    unaryExp := match op
+              case DAE.ADD() then exp1; // If UNARY +, +exp1, remove it since no unary DAE.ADD
+              else DAE.UNARY(op, exp1);
+            end match;
   else
-    e1_str := ExpressionDump.printExpStr(exp1);   // ??Remove possible Error message since Unary?
+    e1_str := ExpressionDump.printExpStr(exp1);
     ty1_str := Types.unparseTypeNoAttr(type1);
-    s1 := "' " + e1_str + DAEDump.dumpOperatorSymbol(operator) + " '";
+    s1 := "' " + e1_str + DAEDump.dumpOperatorSymbol(operator) + " '" +
+       " Arithmetic type expected for this unary operator ";
     Error.addSourceMessage(Error.UNRESOLVABLE_TYPE, {s1, ty1_str}, Absyn.dummyInfo);
     fail();
   end try;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -701,6 +701,14 @@ algorithm
       then
         (typedExp, ty, Types.constAnd(var1, var2));
 
+    case Absyn.Exp.UNARY()  // Unary +, -
+      algorithm
+        (e1, ty1, var1) := typeExp(untypedExp.exp, scope, component, info);
+        op := translateOperator(untypedExp.op);
+        (typedExp, ty) := TypeCheck.checkUnaryOperation(e1, ty1, op);
+      then
+        (typedExp, ty, var1);
+
     case Absyn.Exp.LBINARY()
       algorithm
         (e1, ty1, var1) := typeExp(untypedExp.exp1, scope, component, info);
@@ -710,6 +718,14 @@ algorithm
         (typedExp, ty) := TypeCheck.checkLogicalBinaryOperation(e1, ty1, op, e2, ty2);
       then
         (typedExp, ty, Types.constAnd(var1, var2));
+
+    case Absyn.Exp.LUNARY()  // Unary not
+      algorithm
+        (e1, ty1, var1) := typeExp(untypedExp.exp, scope, component, info);
+        op := translateOperator(untypedExp.op);
+        (typedExp, ty) := TypeCheck.checkLogicalUnaryOperation(e1, ty1, op);
+      then
+        (typedExp, ty, var1);
 
     case Absyn.Exp.RELATION()
       algorithm

--- a/Compiler/boot/Makefile.common
+++ b/Compiler/boot/Makefile.common
@@ -103,10 +103,10 @@ make-bootstrap-tarball: clean
 	xz --best --force bootstrap-sources.tar
 
 templates:
-	$(MAKE) -f $(defaultMakefileTarget) --no-print-directory -C $(TOP_DIR)/Compiler/Template
+	$(MAKE) -f $(defaultMakefileTarget) --no-print-directory -C $(TOP_DIR)/Compiler/Template OMBUILDDIR=$(OMBUILDDIR)
 
 scripting:
-	$(MAKE) -f $(defaultMakefileTarget) --no-print-directory -C $(TOP_DIR)/Compiler/Script
+	$(MAKE) -f $(defaultMakefileTarget) --no-print-directory -C $(TOP_DIR)/Compiler/Script OMBUILDDIR=$(OMBUILDDIR)
 
 clean:
 	rm -rf $(GEN_DIR)


### PR DESCRIPTION
Changes in NFTyping.mo and NFTYpcheck.mo.  Also added removal of unary plus
since it is a noop and is not part of the DAE representation.