### PR TITLE
unify the way we handle version in Windows / Linux

### DIFF
--- a/Compiler/runtime/omc_config.h
+++ b/Compiler/runtime/omc_config.h
@@ -155,9 +155,9 @@
 #endif /* #if !defined(MSYS2_AUTOCONF) && (defined(__MINGW32__) || defined(_MSC_VER)) */
 
 #ifdef CONFIG_REVISION
-#define CONFIG_VERSION CONFIG_REVISION
+#define CONFIG_VERSION "OpenModelica " CONFIG_REVISION
 #else
-#define CONFIG_VERSION "unknown"
+#define CONFIG_VERSION "OpenModelica unknown"
 #endif
 
 

--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -141,12 +141,12 @@ ifeq ($(CONFIG_REVISION),)
 else # revision is not empty, update it if it changed
 	@if test -f revision.h; \
 	then \
-		echo "#define CONFIG_REVISION \"OpenModelica $(CONFIG_REVISION) $(PLATFORM_ARCH)\"" > revision.h.tmp; diff revision.h revision.h.tmp > /dev/null; \
+		echo "#define CONFIG_REVISION \"$(CONFIG_REVISION) $(PLATFORM_ARCH)\"" > revision.h.tmp; diff revision.h revision.h.tmp > /dev/null; \
 		if [ $$? -eq 0 ]; then echo No change in revision; rm revision.h.tmp; \
 		else echo Revision has changed. updating revision.h; \mv revision.h.tmp revision.h; touch Compiler/runtime/omc_config.h; \
 		fi; \
 	else \
-		echo "#define CONFIG_REVISION \"OpenModelica $(CONFIG_REVISION) $(PLATFORM_ARCH)\"" > revision.h; echo Retrieved revision number. revision.h was created; \
+		echo "#define CONFIG_REVISION \"$(CONFIG_REVISION) $(PLATFORM_ARCH)\"" > revision.h; echo Retrieved revision number. revision.h was created; \
 	fi;
 endif
 


### PR DESCRIPTION
- add OpenModelica prefix to the CONFIG_REVISION in omc_config.h
- removed OpenModelica prefix from Windows generated revision.h