### PR TITLE
NFInst clean up.

### DIFF
--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -84,7 +84,6 @@ uniontype Component
   end Attributes;
 
   record COMPONENT_DEF
-    Element definition;
     Modifier modifier;
   end COMPONENT_DEF;
 
@@ -93,7 +92,6 @@ uniontype Component
     array<Dimension> dimensions;
     Binding binding;
     Component.Attributes attributes;
-    SourceInfo info;
   end UNTYPED_COMPONENT;
 
   record TYPED_COMPONENT

--- a/Compiler/NFFrontEnd/NFFunc.mo
+++ b/Compiler/NFFrontEnd/NFFunc.mo
@@ -131,7 +131,7 @@ algorithm
   fn_name :=  InstNode.name(classNode);
   cls := InstNode.definition(classNode);
   // create a component that has the name of the function and the scope of the function as its type
-  fakeComponent := InstNode.newComponent(fn_name,
+  fakeComponent := InstNode.newComponent(
      SCode.COMPONENT(
        fn_name,
        SCode.defaultPrefixes,

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -75,30 +75,67 @@ uniontype InstNode
 
   record EMPTY_NODE end EMPTY_NODE;
 
+  function new
+    input SCode.Element definition;
+    input InstNode parent;
+    output InstNode node;
+  algorithm
+    node := match definition
+      case SCode.CLASS()
+        then CLASS_NODE(definition.name, definition,
+          arrayCreate(1, Class.NOT_INSTANTIATED()), parent, NORMAL_CLASS());
+      case SCode.COMPONENT()
+        then COMPONENT_NODE(definition.name, definition,
+          arrayCreate(1, Component.COMPONENT_DEF(Modifier.NOMOD())), parent);
+    end match;
+  end new;
+
   function newClass
-    input String name;
     input SCode.Element definition;
     input InstNode parent;
     input InstNodeType nodeType = NORMAL_CLASS();
     output InstNode node;
   protected
     array<Class> i;
+    String name;
   algorithm
+    SCode.CLASS(name = name) := definition;
     i := arrayCreate(1, Class.NOT_INSTANTIATED());
     node := CLASS_NODE(name, definition, i, parent, nodeType);
   end newClass;
 
   function newComponent
-    input String name;
     input SCode.Element definition;
     input InstNode parent = EMPTY_NODE();
     output InstNode node;
   protected
     array<Component> c;
+    String name;
   algorithm
-    c := arrayCreate(1, Component.COMPONENT_DEF(definition, Modifier.NOMOD()));
+    SCode.COMPONENT(name = name) := definition;
+    c := arrayCreate(1, Component.COMPONENT_DEF(Modifier.NOMOD()));
     node := COMPONENT_NODE(name, definition, c, parent);
   end newComponent;
+
+  function isClass
+    input InstNode node;
+    output Boolean isClass;
+  algorithm
+    isClass := match node
+      case CLASS_NODE() then true;
+      else false;
+    end match;
+  end isClass;
+
+  function isComponent
+    input InstNode node;
+    output Boolean isComponent;
+  algorithm
+    isComponent := match node
+      case COMPONENT_NODE() then true;
+      else false;
+    end match;
+  end isComponent;
 
   function name
     input InstNode node;

--- a/Compiler/NFFrontEnd/NFMod.mo
+++ b/Compiler/NFFrontEnd/NFMod.mo
@@ -130,8 +130,7 @@ uniontype Modifier
   record REDECLARE
     SCode.Final finalPrefix;
     SCode.Each eachPrefix;
-    SCode.Element element;
-    InstNode scope;
+    InstNode element;
   end REDECLARE;
 
   record NOMOD end NOMOD;
@@ -162,7 +161,7 @@ public
           MODIFIER(name, mod.finalPrefix, mod.eachPrefix, binding, submod_table, mod.info);
 
       case SCode.REDECL()
-        then REDECLARE(mod.finalPrefix, mod.eachPrefix, mod.element, scope);
+        then REDECLARE(mod.finalPrefix, mod.eachPrefix, InstNode.new(mod.element, scope));
 
     end match;
   end create;
@@ -184,8 +183,7 @@ public
   algorithm
     name := match modifier
       case MODIFIER() then modifier.name;
-      case REDECLARE(element = SCode.COMPONENT(name = name)) then name;
-      case REDECLARE(element = SCode.CLASS(name = name)) then name;
+      case REDECLARE() then InstNode.name(modifier.element);
     end match;
   end name;
 
@@ -195,7 +193,7 @@ public
   algorithm
     info := match modifier
       case MODIFIER() then modifier.info;
-      case REDECLARE() then SCode.elementInfo(modifier.element);
+      case REDECLARE() then InstNode.info(modifier.element);
       else Absyn.dummyInfo;
     end match;
   end info;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -125,9 +125,10 @@ protected
 algorithm
   () := match c
     // An untyped component, type it.
-    case Component.UNTYPED_COMPONENT(dimensions = dims, info = info)
+    case Component.UNTYPED_COMPONENT(dimensions = dims)
       algorithm
         ty_dims := {};
+        info := InstNode.info(component);
 
         for i in 1:arrayLength(dims) loop
           dims[i] := typeDimension(dims[i], parent, info);


### PR DESCRIPTION
- Remove some parts of Component which are already in InstNode.
- Use an InstNode in NFMod.REDECLARE instead of keeping the element
  and scope separate.