### PR TITLE
Improvements to builtin operators in NFFunc etc

### DIFF
--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -6952,7 +6952,9 @@ algorithm
   end match;
 end elabBuiltinHandlerInternal;
 
-public function isBuiltinFunc "Returns true if the function name given as argument
+public function isBuiltinFunc "Returns three values:
+  the elaborated function isBuiltin, Boolean b, and a path.
+  The Boolean b is true if the function name given as argument
   is a builtin function, which either has a elabBuiltinHandler function
   or can be found in the builtin environment."
   input Absyn.Path inPath "the path of the found function";

--- a/Compiler/FrontEnd/Types.mo
+++ b/Compiler/FrontEnd/Types.mo
@@ -321,7 +321,8 @@ algorithm
 end isSimpleType;
 
 public function isSimpleTypeRealOrIntegerOrBooleanOrEnum
-  "@author petfr: Returns true for the builtin types Integer, Real, Boolean, enumeration"
+  "@author petfr: Returns true for the builtin types Integer, Real, Boolean, enumeration.
+  See also isTypeRealOrIntegerOrBooleanOrEnumOrSubtypes also including arrays of these types"
   input DAE.Type inType;
   output Boolean b;
 algorithm

--- a/Compiler/FrontEnd/Types.mo
+++ b/Compiler/FrontEnd/Types.mo
@@ -313,7 +313,6 @@ algorithm
     case (DAE.T_INTEGER()) then true;
     case (DAE.T_STRING()) then true;
     case (DAE.T_BOOL()) then true;
-    // BTH
     case (DAE.T_CLOCK()) then true;
     case (DAE.T_ENUMERATION()) then true;
     case (DAE.T_SUBTYPE_BASIC(complexType = t)) then isSimpleType(t);
@@ -321,8 +320,25 @@ algorithm
   end match;
 end isSimpleType;
 
+public function isSimpleTypeRealOrIntegerOrBooleanOrEnum
+  "@author petfr: Returns true for the builtin types Integer, Real, Boolean, enumeration"
+  input DAE.Type inType;
+  output Boolean b;
+algorithm
+  b := match (inType)
+    local DAE.Type t;
+    case (DAE.T_REAL()) then true;
+    case (DAE.T_INTEGER()) then true;
+    case (DAE.T_BOOL()) then true;
+    case (DAE.T_ENUMERATION()) then true;
+    case (DAE.T_SUBTYPE_BASIC(complexType = t)) then isSimpleType(t);
+    else false;
+  end match;
+end isSimpleTypeRealOrIntegerOrBooleanOrEnum;
+
+
 public function isSimpleNumericType
-  "Returns true for simple numeric builtin types, Integer and Real"
+  "Returns true for simple numeric builtin types, Integer and Real and subtypes of those"
   input DAE.Type inType;
   output Boolean b;
 algorithm
@@ -335,7 +351,7 @@ algorithm
   end match;
 end isSimpleNumericType;
 
-public function isNumericType "This function checks if the element type is Numeric type or array of Numeric type."
+public function isNumericType "Returns true if Numeric type or array of Numeric type."
   input DAE.Type inType;
   output Boolean outBool;
 algorithm
@@ -707,6 +723,21 @@ algorithm
   end match;
 end isIntegerOrRealOrBooleanOrSubTypeOfEither;
 
+public function isTypeRealOrIntegerOrBooleanOrEnumOrSubtypes "
+@author petfr: Returns true if Real, Integer, Boolean, or Enum, or arrays or subtypes of those."
+  input DAE.Type inType;
+  output Boolean outBool;
+algorithm
+  outBool := match (inType)
+    local Type ty;
+
+    case (DAE.T_ARRAY(ty = ty)) then isTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(ty);
+    case (DAE.T_SUBTYPE_BASIC(complexType = ty)) then isTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(ty);
+    else isSimpleTypeRealOrIntegerOrBooleanOrEnum(inType);
+
+  end match;
+end isTypeRealOrIntegerOrBooleanOrEnumOrSubtypes;
+
 public function isClock
   input DAE.Type tp;
   output Boolean res;
@@ -727,7 +758,7 @@ algorithm
   end match;
 end isScalarClock;
 
-public function isInteger "Returns true if type is Integer"
+public function isInteger "Returns true if type is Integer or array of Integer"
   input DAE.Type tp;
   output Boolean res;
 algorithm
@@ -844,7 +875,7 @@ algorithm
   end match;
 end isString;
 
-public function isEnumeration "Return true if Type is the builtin String type."
+public function isEnumeration "Return true if Type is the builtin enumeration type."
   input DAE.Type inType;
   output Boolean outBoolean;
 algorithm
@@ -2047,7 +2078,8 @@ algorithm
   end match;
 end unliftArrayOrList;
 
-public function arrayElementType "This function turns an array into the element type of the array."
+public function arrayElementType "This function turns an array type
+ into the element type of the array; otherwise just returns the inType"
   input DAE.Type inType;
   output DAE.Type outType;
 algorithm

--- a/Compiler/FrontEnd/Types.mo
+++ b/Compiler/FrontEnd/Types.mo
@@ -296,14 +296,14 @@ algorithm
 end externalObjectConstructorType;
 
 public function simpleType "author: PA
-  Succeeds for all the builtin types, Integer, String, Real, Boolean"
+  Succeeds for all the builtin types, Integer, String, Real, Boolean, Clock, enumeration"
   input DAE.Type inType;
 algorithm
   true := isSimpleType(inType);
 end simpleType;
 
 public function isSimpleType
-  "Returns true for all the builtin types, Integer, String, Real, Boolean"
+  "Returns true for all the builtin types, Integer, String, Real, Boolean, Clock, enumeration"
   input DAE.Type inType;
   output Boolean b;
 algorithm

--- a/Compiler/FrontEnd/Types.mo
+++ b/Compiler/FrontEnd/Types.mo
@@ -320,7 +320,7 @@ algorithm
   end match;
 end isSimpleType;
 
-public function isSimpleTypeRealOrIntegerOrBooleanOrEnum
+public function isSimpleTypeRealOrIntegerOrBooleanOrEnumOrSubtypes
   "@author petfr: Returns true for the builtin types Integer, Real, Boolean, enumeration.
   See also isTypeRealOrIntegerOrBooleanOrEnumOrSubtypes also including arrays of these types"
   input DAE.Type inType;
@@ -335,7 +335,7 @@ algorithm
     case (DAE.T_SUBTYPE_BASIC(complexType = t)) then isSimpleType(t);
     else false;
   end match;
-end isSimpleTypeRealOrIntegerOrBooleanOrEnum;
+end isSimpleTypeRealOrIntegerOrBooleanOrEnumOrSubtypes;
 
 
 public function isSimpleNumericType
@@ -734,7 +734,7 @@ algorithm
 
     case (DAE.T_ARRAY(ty = ty)) then isTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(ty);
     case (DAE.T_SUBTYPE_BASIC(complexType = ty)) then isTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(ty);
-    else isSimpleTypeRealOrIntegerOrBooleanOrEnum(inType);
+    else isSimpleTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(inType);
 
   end match;
 end isTypeRealOrIntegerOrBooleanOrEnumOrSubtypes;

--- a/Compiler/NFFrontEnd/NFFunc.mo
+++ b/Compiler/NFFrontEnd/NFFunc.mo
@@ -445,7 +445,7 @@ algorithm
 end fillNamedSlot;
 
 protected function isSpecialBuiltinFunctionName
-"@author: adrpo
+"@author: adrpo petfr
  check if the name is special builtin function or
  operator which does not have a definition in ModelicaBuiltin.mo
  TODO FIXME, add all of them"
@@ -480,8 +480,9 @@ algorithm
   end matchcontinue;
 end isSpecialBuiltinFunctionName;
 
+
 protected function isBuiltinFunctionName
-"@author: adrpo
+"@author: adrpo  petfr
  check if the name is a builtin function or operator
  TODO FIXME, add all of them"
   input Absyn.ComponentRef functionName;
@@ -499,8 +500,12 @@ algorithm
 
     case (Absyn.CREF_IDENT(name, {}))
       equation
+
+
+       // See more complete list below from Static.elabbuiltinhandler.
         b = listMember(name,
           {
+            "der",
             "noEvent",
             "smooth",
             "sample",
@@ -533,12 +538,131 @@ algorithm
   end matchcontinue;
 end isBuiltinFunctionName;
 
+
+/*
+from Static.elabBuiltinHandler:
+
+algorithm
+  outHandler := match (inIdent)
+    case "delay" then elabBuiltinDelay;
+    case "smooth" then elabBuiltinSmooth;
+    case "size" then elabBuiltinSize;
+    case "ndims" then elabBuiltinNDims;
+    case "zeros" then elabBuiltinZeros;
+    case "ones" then elabBuiltinOnes;
+    case "fill" then elabBuiltinFill;
+    case "max" then elabBuiltinMax;
+    case "min" then elabBuiltinMin;
+    case "transpose" then elabBuiltinTranspose;
+    case "symmetric" then elabBuiltinSymmetric;
+    case "array" then elabBuiltinArray;
+    case "sum" then elabBuiltinSum;
+    case "product" then elabBuiltinProduct;
+    case "pre" then elabBuiltinPre;
+    case "firstTick" then elabBuiltinFirstTick;
+    case "interval" then elabBuiltinInterval;
+    case "boolean" then elabBuiltinBoolean;
+    case "diagonal" then elabBuiltinDiagonal;
+    case "noEvent" then elabBuiltinNoevent;
+    case "edge" then elabBuiltinEdge;
+    case "der" then elabBuiltinDer;
+    case "change" then elabBuiltinChange;
+    case "cat" then elabBuiltinCat;
+    case "identity" then elabBuiltinIdentity;
+    case "vector" then elabBuiltinVector;
+    case "matrix" then elabBuiltinMatrix;
+    case "scalar" then elabBuiltinScalar;
+    case "String" then elabBuiltinString;
+    case "rooted" then elabBuiltinRooted;
+    case "Integer" then elabBuiltinIntegerEnum;
+    case "EnumToInteger" then elabBuiltinIntegerEnum;
+    case "inStream" then elabBuiltinInStream;
+    case "actualStream" then elabBuiltinActualStream;
+    case "getInstanceName" then elabBuiltinGetInstanceName;
+    case "classDirectory" then elabBuiltinClassDirectory;
+    case "sample" then elabBuiltinSample;
+    case "cardinality" then elabBuiltinCardinality;
+    case "homotopy" then elabBuiltinHomotopy;
+    case "DynamicSelect" then elabBuiltinDynamicSelect;
+    case "Clock"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinClock;
+    case "previous"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinPrevious;
+    case "hold"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinHold;
+    case "subSample"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinSubSample;
+    case "superSample"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinSuperSample;
+    case "shiftSample"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinShiftSample;
+    case "backSample"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinBackSample;
+    case "noClock"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinNoClock;
+    case "transition"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinTransition;
+    case "initialState"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinInitialState;
+    case "activeState"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinActiveState;
+    case "ticksInState"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinTicksInState;
+    case "timeInState"
+      equation
+        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
+      then elabBuiltinTimeInState;
+    case "sourceInfo"
+      equation
+        true = Config.acceptMetaModelicaGrammar();
+      then elabBuiltinSourceInfo;
+    case "SOME"
+      equation
+        true = Config.acceptMetaModelicaGrammar();
+      then elabBuiltinSome;
+    case "NONE"
+      equation
+        true = Config.acceptMetaModelicaGrammar();
+      then elabBuiltinNone;
+    case "isPresent"
+      equation
+        true = Config.acceptMetaModelicaGrammar();
+      then elabBuiltinIsPresent;
+  end match;
+
+  */
+
+
 // adrpo:
 // - see Static.mo for how to check the input arguments or any other checks we need that should be ported
 // - try to use Expression.makePureBuiltinCall everywhere instead of creating the typedExp via DAE.CALL
 // - this function should handle special builtin operators which are not defined in ModelicaBuiltin.mo
 protected function typeSpecialBuiltinFunctionCall
-"@author: adrpo
+"@author: adrpo petfr
  handle all builtin calls that are not defined at all in ModelicaBuiltin.mo
  TODO FIXME, add all"
   input Absyn.ComponentRef functionName;
@@ -598,6 +722,11 @@ end typeSpecialBuiltinFunctionCall;
 
 
 // adrpo:
+// - petfr: ??slow with a lot of linear search for all the builtin function names?, happens for all
+//  function calls in models
+// - petfr: According to Martin, if we do a match only on the string value, it will do a perfect
+// - hash and avoid the linear search
+//
 // - see Static.mo for how to check the input arguments or any other checks we need that should be ported
 // - try to use Expression.makePureBuiltinCall everywhere instead of creating the typedExp via DAE.CALL
 // - all the fuctions that are defined *with no input/output type* in ModelicaBuiltin.mo such as:
@@ -607,7 +736,7 @@ end typeSpecialBuiltinFunctionCall;
 //   need to be handled here!
 // - the functions which have a type in the ModelicaBuiltin.mo should be handled by the last case in this function
 protected function typeBuiltinFunctionCall
-"@author: adrpo
+"@author: adrpo, petfr
  handle all builtin calls that are not in ModelicaBuiltin.mo
  TODO FIXME, add all"
   input Absyn.ComponentRef functionName;
@@ -626,7 +755,7 @@ protected
    String fnName;
    DAE.Const vr, vr1, vr2;
 algorithm
-  (typedExp, ty, variability) := matchcontinue(functionName, functionArgs)
+  (typedExp, ty, variability) := matchcontinue (functionName, functionArgs)
     local
       Absyn.ComponentRef acref;
       Absyn.Exp aexp1, aexp2;
@@ -666,6 +795,7 @@ algorithm
       then
         (DAE.SIZE(dexp1, NONE()), ty, vr);
 
+    // smooth(p, expr) returns expr and states that expr is p times continuously differentiable
     case (Absyn.CREF_IDENT(name = "smooth"), Absyn.FUNCTIONARGS(args = {aexp1, aexp2}))
       algorithm
         call_path := Absyn.crefToPath(functionName);
@@ -678,6 +808,8 @@ algorithm
       then
         (DAE.CALL(call_path, {dexp1,dexp2}, DAE.callAttrBuiltinOther), ty, vr);
 
+    // Connections.rooted(A.R) returns true, if A.R is closer to the root of the spanning tree than B.R;
+    // otherwise false is returned.   rooted(A.R);  is deprecated
     case (Absyn.CREF_IDENT(name = "rooted"), Absyn.FUNCTIONARGS(args = {aexp1}))
       algorithm
         call_path := Absyn.crefToPath(functionName);
@@ -736,6 +868,8 @@ algorithm
       then
         (typedExp, ty, vr);
 
+     // diagonal(v)  Returns a square matrix with the elements of vector v on the diagonal
+     // and all other elements zero ?? how can you be sure to extract an expression aexp1 if the argument is an ident?
     case (Absyn.CREF_IDENT(name = "diagonal"), Absyn.FUNCTIONARGS(args = aexp1::_))
       algorithm
         (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
@@ -747,56 +881,165 @@ algorithm
       then
         (typedExp, ty, vr);
 
+     // product(A) returns scalar product of all the elements of array expression A   petfr OK?
+     // This means that the type is a scalar type, not an array type
+ /**/   case (Absyn.CREF_IDENT(name = "product"), Absyn.FUNCTIONARGS(args = {aexp1}))
+      algorithm
+        (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
+        // Here, we need to extract the element type of array type dexp1
+        ty := Types.arrayElementType(ty1);
+        typedExp :=  Expression.makePureBuiltinCall("product", {dexp1}, ty);
+        vr := vr1;
+      then
+        (typedExp, ty, vr);
+
+       // pre(y) returns left limit y(tpre) of variable y(t) at a time instant t   petfr OK?
+       // pre() operator can be applied if the following three conditions are fulfilled simultaneously:
+       // (a) variable y is either a subtype of a simple type or is a record component,
+       // (b) y is a discrete-time expression
+       // (c) the operator is not applied in a function class  ?? where is this checked?
+/**/ case (Absyn.CREF_IDENT(name = "pre"), Absyn.FUNCTIONARGS(args = {aexp1}))
+      algorithm
+        (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
+        typedExp :=  Expression.makePureBuiltinCall("pre", {dexp1}, ty1);
+      then
+        (typedExp, ty1, vr1);
+
+      // noEvent(expr)  Real elementary relations within expr are taken literally,   petfr OK?
+      // i.e., no state or time event is triggered
+/**/   case (Absyn.CREF_IDENT(name = "noEvent"), Absyn.FUNCTIONARGS(args = {aexp1}))
+      algorithm
+        (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
+        typedExp :=  Expression.makePureBuiltinCall("noEvent", {dexp1}, ty1);
+      then
+        (typedExp, ty1, vr1);
+
+/**/   // sum(A) Returns the scalar sum of all the elements of array expression    petfr OK?
+    case (Absyn.CREF_IDENT(name = "sum"), Absyn.FUNCTIONARGS(args = {aexp1}))
+      algorithm
+       (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
+        ty := Types.arrayElementType(ty1);
+        typedExp :=  Expression.makePureBuiltinCall("sum", {dexp1}, ty);
+      then
+       (typedExp, ty, vr1);
+
+  // inst_assert, inst.assert should not be here
+ /* assert is not a function, should not be here? */
+  // Example:  assert(size(a,1)==size(a,2),"Matrix must be square");
+  //   assert(condition, message); // Uses level=AssertionLevel.error
+  //   assert(condition, message, assertionLevel);
+  //   assert(condition, message, level = assertionLevel);
+  //  First argument is Boolean, second is a string, third is an Integer.  COuld be declared?
+  //  ?? an assert statement has no type, or we just ignore it?  Is there a void type?  AnyType?
+
+
+      // edge(b) is expanded into (b and not pre(b)) for Boolean variable b
+      // The same restrictions as for pre() apply, e.g. not to be used inside functions.
+ /**/  case (Absyn.CREF_IDENT(name = "edge"), Absyn.FUNCTIONARGS(args = {aexp1}))
+      algorithm
+        (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
+        typedExp :=  Expression.makePureBuiltinCall("edge", {dexp1}, ty1);
+        ty := DAE.T_BOOL_DEFAULT;
+      then
+        (typedExp, ty, vr1);
+
+      // change(v) is expanded into  (v<>pre(v)).
+      // The same restrictions as for the pre() operator apply.
+ /**/  case (Absyn.CREF_IDENT(name = "change"), Absyn.FUNCTIONARGS(args = {aexp1}))
+      algorithm
+        (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
+        typedExp :=  Expression.makePureBuiltinCall("change", {dexp1}, ty1);
+        ty := DAE.T_BOOL_DEFAULT;
+      then
+        (typedExp, ty, vr1);
+
+  // array(A,B,C,...) constructs an array from its arguments
+  // All arguments must have the same sizes, i.e., size(A)=size(B)=size(C)=...
+  // All arguments must be type compatible expressions
+  // There must be at least one argument [i.e., array() or {} is not defined
+  // {A, B, C, ...} is a shorthand notation for array(A, B, C, ...)
+  // array(alpha, 2, 3.0) or {alpha, 2, 3.0} is a 3-vector of type Real.
+  // Angle[3] a = {1.0, alpha, 4};   // type of a is Real[3]
+
+  // petfr  ?? CHECK elabBuiltinArray in static.mo
+
+ /**/  //  case (Absyn.CREF_IDENT(name = "array"), Absyn.FUNCTIONARGS(args = afargs))
+ // OLD:  ??OBS: this code is not updated yet
+/*      equation
+        call_path = Absyn.crefToPath(functionName);
+        (pos_args, globals) = NFTyping.typeExps(afargs, inEnv, inPrefix, inInfo, globals);
+      then
+        DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
+*/
+
+
     /* adrpo: adapt these to the new structures, see above
-    case (Absyn.CREF_IDENT(name = "product"), Absyn.FUNCTIONARGS(args = afargs))
+ **   case (Absyn.CREF_IDENT(name = "product"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
         (pos_args, globals) = NFTyping.typeExps(afargs, inEnv, inPrefix, inInfo, globals);
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
-    case (Absyn.CREF_IDENT(name = "pre"), Absyn.FUNCTIONARGS(args = afargs))
+    // pre(y) returns left limit y(tpre) of variable y(t) at a time instant t
+ **    case (Absyn.CREF_IDENT(name = "pre"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
         (pos_args, globals) = NFTyping.typeExps(afargs, inEnv, inPrefix, inInfo, globals);
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
-    case (Absyn.CREF_IDENT(name = "noEvent"), Absyn.FUNCTIONARGS(args = afargs))
+
+ **   case (Absyn.CREF_IDENT(name = "noEvent"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
         (pos_args, globals) = NFTyping.typeExps(afargs, inEnv, inPrefix, inInfo, globals);
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
-    case (Absyn.CREF_IDENT(name = "sum"), Absyn.FUNCTIONARGS(args = afargs))
+    // sum(A) Returns the scalar sum of all the elements of array expression
+ **   case (Absyn.CREF_IDENT(name = "sum"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
         (pos_args, globals) = NFTyping.typeExps(afargs, inEnv, inPrefix, inInfo, globals);
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
-    case (Absyn.CREF_IDENT(name = "assert"), Absyn.FUNCTIONARGS(args = afargs))
+  // Example:  assert(size(a,1)==size(a,2),"Matrix must be square");
+  //   assert(condition, message); // Uses level=AssertionLevel.error
+  //   assert(condition, message, assertionLevel);
+  //   assert(condition, message, level = assertionLevel);
+  //  ?? an assert statement has no type, or we just ignore it?
+ **   case (Absyn.CREF_IDENT(name = "assert"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
         (pos_args, globals) = NFTyping.typeExps(afargs, inEnv, inPrefix, inInfo, globals);
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
-    case (Absyn.CREF_IDENT(name = "change"), Absyn.FUNCTIONARGS(args = afargs))
+ **   case (Absyn.CREF_IDENT(name = "change"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
         (pos_args, globals) = NFTyping.typeExps(afargs, inEnv, inPrefix, inInfo, globals);
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
-    case (Absyn.CREF_IDENT(name = "array"), Absyn.FUNCTIONARGS(args = afargs))
+ **   case (Absyn.CREF_IDENT(name = "array"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
         (pos_args, globals) = NFTyping.typeExps(afargs, inEnv, inPrefix, inInfo, globals);
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
+
+// array "(" expression for iterators ")"
+// is an array constructor with iterators.
+// The expressions inside the iterators of an array constructor shall be vector expressions
+//Example: array(i for i in 1:10)
+// Gives the vector 1:10={1,2,3,...,10}
+//Example: {r for r in 1.0 : 1.5 : 5.5}
+// Gives the vector 1.0:1.5:5.5={1.0, 2.5, 4.0, 5.5}
+//Example: Real hilb[:,:]= {(1/(i+j-1) for i in 1:n, j in 1:n};
     case (Absyn.CREF_IDENT(name = "array"), Absyn.FOR_ITER_FARG(exp=aexp1, iterators=iters))
       equation
         call_path = Absyn.crefToPath(functionName);
@@ -805,6 +1048,7 @@ algorithm
       then
         DAE.CALL(call_path, {dexp1}, DAE.callAttrBuiltinOther);
 
+   // sum( e(i, ..., j) for  i in u, ...,  j in v)
     case (Absyn.CREF_IDENT(name = "sum"), Absyn.FOR_ITER_FARG(exp=aexp1, iterators=iters))
       equation
         call_path = Absyn.crefToPath(functionName);
@@ -813,6 +1057,7 @@ algorithm
       then
         DAE.CALL(call_path, {dexp1}, DAE.callAttrBuiltinOther);
 
+    // min( e(i, ..., j) for  i in u, ...,  j in v)
     case (Absyn.CREF_IDENT(name = "min"), Absyn.FOR_ITER_FARG(exp=aexp1, iterators=iters))
       equation
         call_path = Absyn.crefToPath(functionName);
@@ -821,6 +1066,7 @@ algorithm
       then
         DAE.CALL(call_path, {dexp1}, DAE.callAttrBuiltinOther);
 
+    // max( e(i, ..., j) for  i in u, ...,  j in v)
     case (Absyn.CREF_IDENT(name = "max"), Absyn.FOR_ITER_FARG(exp=aexp1, iterators=iters))
       equation
         call_path = Absyn.crefToPath(functionName);
@@ -829,6 +1075,7 @@ algorithm
       then
         DAE.CALL(call_path, {dexp1}, DAE.callAttrBuiltinOther);
 
+   // The type of product(e(i, ..., j) for i in u, ..., j in v) is the same as the type of e(i,...j)
     case (Absyn.CREF_IDENT(name = "product"), Absyn.FOR_ITER_FARG(exp=aexp1, iterators=iters))
       equation
         call_path = Absyn.crefToPath(functionName);
@@ -837,6 +1084,14 @@ algorithm
       then
         DAE.CALL(call_path, {dexp1}, DAE.callAttrBuiltinOther);
 
+   // function cat(k,A,B,C,...) concatenates arrays A,B,C,... along dimension k
+   // Arrays A, B, C, ... must have the same number of dimensions, i.e., ndims(A) =  ndims(B) =
+   // Arrays A, B, C, ... must be type compatible expressions, integers can become reals
+   // k has to characterize an existing dimension, i.e., 1 <= k <= ndims(A) = ndims(B) = ndims(C);
+   // Size matching: Arrays A, B, C, ... must have identical array sizes with the exception of the size
+   // of dimension k, i.e., size(A,j) = size(B,j), for 1 <= j <= ndims(A) and j <> k
+   // Example: Real[2,3]  r1  = cat(1, {{1.0, 2.0, 3}}, {{4, 5, 6}});
+   // Example: Real[2,6]  r2  = cat(2, r1, 2*r1);
     case (Absyn.CREF_IDENT(name = "cat"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
@@ -844,6 +1099,9 @@ algorithm
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
+  // actualStream(v) returns the actual value of the stream variable v för any flow direction
+  // actualStream(port.h_outflow) = if port.m_flow > 0 then inStream(port.h_outflow) else port.h_outflow;
+  // The operator is vectorizable.
     case (Absyn.CREF_IDENT(name = "actualStream"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
@@ -851,6 +1109,9 @@ algorithm
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
+  // inStream(v)  is only allowed on stream variables v defined in stream connectors,
+  // and is the value of the stream variable v close to the connection point
+  // The operator is vectorizable.
     case (Absyn.CREF_IDENT(name = "inStream"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
@@ -858,6 +1119,16 @@ algorithm
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
+  // String(b, <options>),   String(i, <options>),  String(r, format=s),   String(e, <options>)
+  // String(r, significantDigits=d,  <options>)
+  // Convert a scalar non-String expression to a String representation.
+  // For Real expressions the output shall be according to the Modelica grammar.
+  // String(E.enumvalue) string of enum value, e.g. String(E.Small) gives "Small".
+  // The first argument may be a Boolean b, an Integer i, a Real r or an Enumeration e).
+  // The other arguments must use named arguments. The optional <options> are:
+  //  Integer minimumLength=0: minimum length of the resulting string.
+  //  Boolean leftJustified = true
+  //  Integer significantDigits=6 defines the number of significant digits in the result string
     case (Absyn.CREF_IDENT(name = "String"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
@@ -865,6 +1136,10 @@ algorithm
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
+
+  // Integer(e) Returns the ordinal Integer number of the expression e of enumeration type
+  // that evaluates to the enumeration value E.enumvalue, where Integer(E.e1)=1,
+  // Integer(E.en)= n, for an enumeration type E=enumeration(e1, ..., en)
     case (Absyn.CREF_IDENT(name = "Integer"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
@@ -872,12 +1147,15 @@ algorithm
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
+  // Real(e) ?? is there a Real conversion function?, could not find it in the 3.3 rev1 spec
     case (Absyn.CREF_IDENT(name = "Real"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
         (pos_args, globals) = NFTyping.typeExps(afargs, inEnv, inPrefix, inInfo, globals);
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
+
+
     */
 
     // TODO! FIXME!
@@ -887,6 +1165,10 @@ algorithm
     /*
     // adrpo: no support for $overload functions yet: div, mod, rem, abs, i.e. ModelicaBuiltin.mo:
     // function mod = $overload(OpenModelica.Internal.intMod,OpenModelica.Internal.realMod)
+
+    // rem(x,y)  Returns the integer remainder of x/y, such that div(x,y)*y + rem(x, y) = x.
+    //   Result and arguments shall have type Real or Integer.
+    //   If either of the arguments is Real the result is Real otherwise Integer.
     case (Absyn.CREF_IDENT(name = "rem"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
@@ -894,12 +1176,24 @@ algorithm
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
 
+    // div(x,y)  Returns the algebraic quotient x/y with any fractional part discarded
+    //   Result and arguments shall have type Real or Integer.
+    //   If either of the arguments is Real the result is Real otherwise Integer
+
+    // mod(x,y)  Returns the integer modulus of x/y, i.e. mod(x,y)=x-floor(x/y)*y
+    //   Result and arguments shall have type Real or Integer.
+    //   If either of the arguments is Real the result is Real otherwise Integer
+
+    // abs(v)  Is expanded into  noEvent(if v >= 0 then v else –v)
+    //   Argument v needs to be an Integer or Real expression.
+    //   Result type is Integer or Real depending on the input v
     case (Absyn.CREF_IDENT(name = "abs"), Absyn.FUNCTIONARGS(args = afargs))
       equation
         call_path = Absyn.crefToPath(functionName);
         (pos_args, globals) = NFTyping.typeExps(afargs, inEnv, inPrefix, inInfo, globals);
       then
         DAE.CALL(call_path, pos_args, DAE.callAttrBuiltinOther);
+
     */
 
     // hopefully all the other ones have a complete entry in ModelicaBuiltin.mo

--- a/Compiler/NFFrontEnd/NFFunc.mo
+++ b/Compiler/NFFrontEnd/NFFunc.mo
@@ -613,122 +613,7 @@ algorithm
 end isBuiltinFunctionName;
 
 
-/*
-from Static.elabBuiltinHandler:
 
-algorithm
-  outHandler := match (inIdent)
-    case "delay" then elabBuiltinDelay;
-    case "smooth" then elabBuiltinSmooth;
-    case "size" then elabBuiltinSize;
-    case "ndims" then elabBuiltinNDims;
-    case "zeros" then elabBuiltinZeros;
-    case "ones" then elabBuiltinOnes;
-    case "fill" then elabBuiltinFill;
-    case "max" then elabBuiltinMax;
-    case "min" then elabBuiltinMin;
-    case "transpose" then elabBuiltinTranspose;
-    case "symmetric" then elabBuiltinSymmetric;
-    case "array" then elabBuiltinArray;
-    case "sum" then elabBuiltinSum;
-    case "product" then elabBuiltinProduct;
-    case "pre" then elabBuiltinPre;
-    case "firstTick" then elabBuiltinFirstTick;
-    case "interval" then elabBuiltinInterval;
-    case "boolean" then elabBuiltinBoolean;
-    case "diagonal" then elabBuiltinDiagonal;
-    case "noEvent" then elabBuiltinNoevent;
-    case "edge" then elabBuiltinEdge;
-    case "der" then elabBuiltinDer;
-    case "change" then elabBuiltinChange;
-    case "cat" then elabBuiltinCat;
-    case "identity" then elabBuiltinIdentity;
-    case "vector" then elabBuiltinVector;
-    case "matrix" then elabBuiltinMatrix;
-    case "scalar" then elabBuiltinScalar;
-    case "String" then elabBuiltinString;
-    case "rooted" then elabBuiltinRooted;
-    case "Integer" then elabBuiltinIntegerEnum;
-    case "EnumToInteger" then elabBuiltinIntegerEnum;
-    case "inStream" then elabBuiltinInStream;
-    case "actualStream" then elabBuiltinActualStream;
-    case "getInstanceName" then elabBuiltinGetInstanceName;
-    case "classDirectory" then elabBuiltinClassDirectory;
-    case "sample" then elabBuiltinSample;
-    case "cardinality" then elabBuiltinCardinality;
-    case "homotopy" then elabBuiltinHomotopy;
-    case "DynamicSelect" then elabBuiltinDynamicSelect;
-    case "Clock"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinClock;
-    case "previous"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinPrevious;
-    case "hold"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinHold;
-    case "subSample"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinSubSample;
-    case "superSample"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinSuperSample;
-    case "shiftSample"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinShiftSample;
-    case "backSample"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinBackSample;
-    case "noClock"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinNoClock;
-    case "transition"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinTransition;
-    case "initialState"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinInitialState;
-    case "activeState"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinActiveState;
-    case "ticksInState"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinTicksInState;
-    case "timeInState"
-      equation
-        true = intGe(Flags.getConfigEnum(Flags.LANGUAGE_STANDARD), 33);
-      then elabBuiltinTimeInState;
-    case "sourceInfo"
-      equation
-        true = Config.acceptMetaModelicaGrammar();
-      then elabBuiltinSourceInfo;
-    case "SOME"
-      equation
-        true = Config.acceptMetaModelicaGrammar();
-      then elabBuiltinSome;
-    case "NONE"
-      equation
-        true = Config.acceptMetaModelicaGrammar();
-      then elabBuiltinNone;
-    case "isPresent"
-      equation
-        true = Config.acceptMetaModelicaGrammar();
-      then elabBuiltinIsPresent;
-  end match;
-
-  */
 
 
 // adrpo:
@@ -859,6 +744,7 @@ algorithm
       DAE.Type el_ty, ty1, ty2;
 
     // size(arr, dim)
+    // Returns the size of dimension dim of array expression arr where dim shall be > 0 and <= ndims(arr)
     case (Absyn.CREF_IDENT(name = "size"), Absyn.FUNCTIONARGS(args = {aexp1, aexp2}))
       algorithm
         (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
@@ -866,54 +752,130 @@ algorithm
 
         // TODO FIXME: calculate the correct type and the correct variability, see Static.elabBuiltinSize in Static.mo
         ty := DAE.T_INTEGER_DEFAULT;
-        // the variability does not actually depend on the variability of "arr" but on the variability of the dimensions of "arr"
+        // the size variability does not actually depend on the variability of "arr" but on the variability
+        // of the dimensions of "arr"
         vr := Types.constAnd(vr1, vr2);
       then
         (DAE.SIZE(dexp1, SOME(dexp2)), ty, vr);
 
+
     // size(arr)
+    // Returns a vector of length ndims(arr) containing the dimension sizes of arr.
     case (Absyn.CREF_IDENT(name = "size"), Absyn.FUNCTIONARGS(args = {aexp1}))
       algorithm
         (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
         // TODO FIXME: calculate the correct type and the correct variability, see Static.elabBuiltinSize in Static.mo
         ty := DAE.T_INTEGER_DEFAULT;
-        // the variability does not actually depend on the variability of "arr" but on the variability of the dimensions of "arr"
+        // the variability of size does not actually depend on the variability of "arr" but on the
+        // variability of the dimensions of "arr"
         vr := vr1;
       then
         (DAE.SIZE(dexp1, NONE()), ty, vr);
 
-    // smooth(p, expr) returns expr and states that expr is p times continuously differentiable
+
+    // smooth(p, expr)
+    // smooth(p,expr) - If p>=0 smooth(p, expr) returns expr and states that expr is p times
+    // continuously differentiable, i.e.: expr is continuous in all real variables appearing in
+    // the expression and all partial derivatives with respect to all appearing real variables
+    // exist and are continuous up to order p.
+    // The only allowed types for expr in smooth are: real expressions, arrays of
+    // allowed expressions, and records containing only components of allowed expressions."
     case (Absyn.CREF_IDENT(name = "smooth"), Absyn.FUNCTIONARGS(args = {aexp1, aexp2}))
       algorithm
         call_path := Absyn.crefToPath(functionName);
         (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
         (dexp2, ty2, vr2) := NFTyping.typeExp(aexp1, scope, component, info);
 
+        if not Types.isParameterOrConstant(vr1) or not Types.isInteger(ty1) then
+          errorFailBuiltinWrongArgTypes(functionName, functionArgs,
+            "first argument must be a constant or parameter expression of type Integer", info);
+        end if;
+        if not (Types.isReal(ty2) or Types.isRecordWithOnlyReals(ty2)) then
+          errorFailBuiltinWrongArgTypes(functionName, functionArgs,
+            "second argument must be a Real, array of Reals or record only containing Reals", info);
+        end if;
+
         // TODO FIXME: calculate the correct type and the correct variability, see Static.mo
-        ty := DAE.T_REAL_DEFAULT;
-        vr := vr1;
+        ty := Types.simplifyType(ty2);  //  from static ??OK?, why need simplifyType?
+        vr := vr2;
       then
         (DAE.CALL(call_path, {dexp1,dexp2}, DAE.callAttrBuiltinOther), ty, vr);
 
+  /* ?? Generally TODO Need to add checks for # arguments for all operators later  -- remove this comment
+    e.g. from Static:  if listLength(inPosArgs) <> 2 or not listEmpty(inNamedArgs) then
+       msg_str := ", expected smooth(p, expr)";
+       printBuiltinFnArgError("smooth", msg_str, inPosArgs, inNamedArgs, inPrefix, inInfo);
+     end if;
+  */
+
+
     // Connections.rooted(A.R) returns true, if A.R is closer to the root of the spanning tree than B.R;
-    // otherwise false is returned.  NOTE: rooted(A.R);  is deprecated
+    // otherwise false is returned.  NOTE: rooted(A.R);  is deprecated (but still used?)
+    // R is an overdetermined type or record instance in connector instance A
+
+ // ?? from Static, where? to check "Connections.rooted" instead of just "rooted"
+ //     case Absyn.CREF_QUAL(name = "Connections", componentRef = Absyn.CREF_IDENT(name = "rooted"))
+ //     then elabBuiltinRooted(inCache, inEnv, inPosArgs, inNamedArgs, inImplicit, inPrefix, inInfo);
+//    case Absyn.CREF_FULLYQUALIFIED(cr)
+//      then elabCallBuiltin(inCache, inEnv, cr, inPosArgs, inNamedArgs, inImplicit, inPrefix, inInfo);
+//  checkBuiltinCallArgs(inPosArgs, inNamedArgs, 1, "Connections.isRoot", inInfo);
+// ...
+//  outExp := DAE.CALL(Absyn.QUALIFIED("Connections", Absyn.IDENT("isRoot")),
+
     case (Absyn.CREF_IDENT(name = "rooted"), Absyn.FUNCTIONARGS(args = {aexp1}))
       algorithm
         call_path := Absyn.crefToPath(functionName);
         (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
 
-        // TODO FIXME: calculate the correct type and the correct variability, see Static.mo
+        // TODO FIXME: calculate the correct type and the correct variability, see Static.mo -- fixed
         ty := DAE.T_BOOL_DEFAULT;
-        vr := vr1;
+        vr := DAE.C_VAR();     // ?? this OK variability? yslrm from Static - remove this comment
+        _ := match dexp1
+          case DAE.ARRAY(array = {})  // ??OK ? Added this check for size zero since checked in Static
+            equation
+              Error.addSourceMessage(Error.OVERCONSTRAINED_OPERATOR_SIZE_ZERO_RETURN_FALSE,
+                { Dump.printComponentRefStr(functionName) }, info);
+              fail();
+            then ();
+          else ();
+        end match;
+
       then
         (DAE.CALL(call_path, {dexp1}, DAE.callAttrBuiltinOther), ty, vr);
+
+
+ // ?? from Static:  checking # arguments
+ //  checkBuiltinCallArgs(inPosArgs, inNamedArgs, 1, "Connections.isRoot", inInfo);
+ /*
+protected function checkBuiltinCallArgs
+  input list<Absyn.Exp> inPosArgs;
+  input list<Absyn.NamedArg> inNamedArgs;
+  input Integer inExpectedArgs;
+  input String inFnName;
+  input Absyn.Info inInfo;
+protected
+  String args_str, msg_str;
+  list<String> pos_args, named_args;
+algorithm
+  if listLength(inPosArgs) <> inExpectedArgs or not listEmpty(inNamedArgs) then
+    Error.addSourceMessageAndFail(Error.WRONG_NO_OF_ARGS, {inFnName}, inInfo);
+  end if;
+end checkBuiltinCallArgs;
+*/
+
 
     case (Absyn.CREF_IDENT(name = "transpose"), Absyn.FUNCTIONARGS(args = {aexp1}))
       algorithm
         (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
+        try
+          true := Types.isArray(ty1);
+          DAE.T_ARRAY(DAE.T_ARRAY(el_ty, {d1}, src1), {d2}, src2) := ty1;
+        else
+          errorFailBuiltinWrongArgTypes(functionName, functionArgs,
+            "Two-dimensional array expected", info);
+        end try;
 
         // transpose the type.
-        DAE.T_ARRAY(DAE.T_ARRAY(el_ty, {d1}, src1), {d2}, src2) := ty1;
         ty := DAE.T_ARRAY(DAE.T_ARRAY(el_ty, {d2}, src1), {d1}, src2);
 
         // create the typed transpose expression
@@ -922,19 +884,24 @@ algorithm
       then
         (typedExp, ty, vr);
 
-    // min(arr)  min and max into separate cases, to avoid every function matching into those cases
+    // min(arr)  made min and max into separate cases, to avoid every function matching into those cases
 
     // min(arr) Returns the least element of array expression arr as a scalar
     // Element type: Scalar enumeration, Boolean, Integer or Real
     case (Absyn.CREF_IDENT(name = "min"), Absyn.FUNCTIONARGS(args = {aexp1}))
       algorithm
         (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
-
-        true := Types.isArray(ty1);
-        dexp1 := Expression.matrixToArray(dexp1);
-        el_ty := Types.arrayElementType(ty1);
-        false := Types.isString(el_ty);
-
+        try
+          true := Types.isArray(ty1);
+          el_ty := Types.arrayElementType(ty1);
+          true := Types.isSimpleTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(el_ty);
+        else
+          errorFailBuiltinWrongArgTypes(functionName, functionArgs,
+            "Integer, Real, Boolean or Enumeration array argument expected", info);
+        end try;
+        dexp1 := Expression.matrixToArray(dexp1);  // ??who convert from DAE.Matrix to DAE.Array?
+                                         // ?? Why DAE.Array here and DAE.T_ARRAY in transpose?
+                                         // DAE.T_ARRAY - arrays of unknown size, e.g. Real[:]
         ty := el_ty;
         vr := vr1;
         typedExp := Expression.makePureBuiltinCall("min", {dexp1}, ty);
@@ -945,13 +912,18 @@ algorithm
    // Element type: Scalar enumeration, Boolean, Integer or Real
     case (Absyn.CREF_IDENT(name = "max"), Absyn.FUNCTIONARGS(args = {aexp1}))
       algorithm
-        (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
-
-        true := Types.isArray(ty1);
-        dexp1 := Expression.matrixToArray(dexp1);
-        el_ty := Types.arrayElementType(ty1);
-        false := Types.isString(el_ty);
-
+        (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info); // ??petfr working
+        try
+          true := Types.isArray(ty1);
+          el_ty := Types.arrayElementType(ty1);
+          true := Types.isSimpleTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(el_ty);
+        else
+          errorFailBuiltinWrongArgTypes(functionName, functionArgs,
+            "Integer, Real, Boolean or Enumeration array argument expected", info);
+        end try;
+        dexp1 := Expression.matrixToArray(dexp1);  // ?? why is this call needed, a matrix is an array.
+                                                   // Lowering? Changes from DAE.Matrix to DAE.Array
+                                                   // DAE.ARRAY - Array constructor, e.g. {1,3,4}
         ty := el_ty;
         vr := vr1;
         typedExp := Expression.makePureBuiltinCall("max", {dexp1}, ty);
@@ -960,31 +932,15 @@ algorithm
 
 
     // min(x,y) where x & y are scalars.
-    // Made min and max into separate cases, to avoid many functions diving into this
-    // If vectorized, x and y are arrays
+    // Made min and max into separate cases, to avoid most functions partially matching this
+    // If vectorized, x and y are arrays. Now assumes always scalar according to MLS
     case (Absyn.CREF_IDENT(name = "min"), Absyn.FUNCTIONARGS(args = {aexp1, aexp2}))
       algorithm
         (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
         (dexp2, ty2, vr2) := NFTyping.typeExp(aexp2, scope, component, info);
-
-        ty := Types.scalarSuperType(ty1, ty2);
-        (dexp1, _) := Types.matchType(dexp1, ty1, ty, true);
-        (dexp2, _) := Types.matchType(dexp2, ty2, ty, true);
-        vr := Types.constAnd(vr1, vr2);
-        false := Types.isString(ty);
-        typedExp := Expression.makePureBuiltinCall("min", {dexp1, dexp2}, ty);
-      then
-        (typedExp, ty, vr);
-
-    // max(x,y) where x & y are scalars: Integer, Real, Boolean or Enumeration or subtypes of those
-    // If vectorized, x and y are arrays
-    case (Absyn.CREF_IDENT(name = "max"), Absyn.FUNCTIONARGS(args = {aexp1, aexp2}))
-      algorithm
-        (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
-        (dexp2, ty2, vr2) := NFTyping.typeExp(aexp2, scope, component, info);
         try
-          true := Types.isTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(ty1); // allows vectorization
-          true := Types.isTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(ty2); // allows vectorization
+          true := Types.isSimpleTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(ty1);
+          true := Types.isSimpleTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(ty2);
         else
           errorFailBuiltinWrongArgTypes(functionName, functionArgs,
             "Integer, Real, Boolean or Enumeration arguments expected", info);
@@ -993,7 +949,27 @@ algorithm
         (dexp1, _) := Types.matchType(dexp1, ty1, ty, true);
         (dexp2, _) := Types.matchType(dexp2, ty2, ty, true);
         vr := Types.constAnd(vr1, vr2);
-        // ??possible vectorized output type is still missing
+        typedExp := Expression.makePureBuiltinCall("min", {dexp1, dexp2}, ty);
+      then
+        (typedExp, ty, vr);
+
+    // max(x,y) where x & y are scalars: Integer, Real, Boolean or Enumeration or subtypes of those
+    // If vectorized, x and y are arrays. Now assumes always scalar according to MLS
+    case (Absyn.CREF_IDENT(name = "max"), Absyn.FUNCTIONARGS(args = {aexp1, aexp2}))
+      algorithm
+        (dexp1, ty1, vr1) := NFTyping.typeExp(aexp1, scope, component, info);
+        (dexp2, ty2, vr2) := NFTyping.typeExp(aexp2, scope, component, info);
+        try
+          true := Types.isSimpleTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(ty1);
+          true := Types.isSimpleTypeRealOrIntegerOrBooleanOrEnumOrSubtypes(ty2);
+        else
+          errorFailBuiltinWrongArgTypes(functionName, functionArgs,
+            "Integer, Real, Boolean or Enumeration arguments expected", info);
+        end try;
+        ty := Types.scalarSuperType(ty1, ty2);
+        (dexp1, _) := Types.matchType(dexp1, ty1, ty, true);
+        (dexp2, _) := Types.matchType(dexp2, ty2, ty, true);
+        vr := Types.constAnd(vr1, vr2);
         typedExp := Expression.makePureBuiltinCall("max", {dexp1, dexp2}, ty);
       then
         (typedExp, ty, vr);
@@ -1021,7 +997,7 @@ algorithm
           true := Types.isArray(ty1);
           // Here, we extract the element type of array type
           ty := Types.arrayElementType(ty1);
-          true := isSimpleNumericType(ty);
+          true := Types.isSimpleNumericType(ty);
         else
           errorFailBuiltinWrongArgTypes(functionName, functionArgs,
             "Integer or Real array argument expected", info);

--- a/Compiler/boot/Makefile.common
+++ b/Compiler/boot/Makefile.common
@@ -60,7 +60,7 @@ bootstrap-from-tarball: $(PATCHES)
 	tar xJf bootstrap-sources.tar.xz
 	# Patch _main.c to avoid a new tarball
 	$(PATCH_SOURCES)
-	cd build && for x in ../patches/*.patch; do patch -i "$$x"  "`basename $$x | $(SED) 's/\([.][0-9]*\)\?[.]patch/.c/'`" || exit 1; done
+	# cd build && for x in ../patches/*.patch; do patch -i "$$x"  "`basename $$x | $(SED) 's/\([.][0-9]*\)\?[.]patch/.c/'`" || exit 1; done
 	# We have not compiled OpenModelicaScriptingAPI.mo yet
 	touch build/OpenModelicaScriptingAPI.h
 	$(MAKE) -f $(defaultMakefileTarget) install INCLUDESOURCES=1 OMC=.omc BOOTSTRAP_STAGE_1=1 CPPFLAGS="$(CPPFLAGS) -DOMC_BOOTSTRAPPING_STAGE_1"
@@ -103,10 +103,10 @@ make-bootstrap-tarball: clean
 	xz --best --force bootstrap-sources.tar
 
 templates:
-	$(MAKE) -f $(defaultMakefileTarget) --no-print-directory -C $(TOP_DIR)/Compiler/Template
+	$(MAKE) -f $(defaultMakefileTarget) --no-print-directory -C $(TOP_DIR)/Compiler/Template OMBUILDDIR=$(OMBUILDDIR)
 
 scripting:
-	$(MAKE) -f $(defaultMakefileTarget) --no-print-directory -C $(TOP_DIR)/Compiler/Script
+	$(MAKE) -f $(defaultMakefileTarget) --no-print-directory -C $(TOP_DIR)/Compiler/Script OMBUILDDIR=$(OMBUILDDIR)
 
 clean:
 	rm -rf $(GEN_DIR)

--- a/Compiler/boot/Makefile.omdev.mingw
+++ b/Compiler/boot/Makefile.omdev.mingw
@@ -1,5 +1,10 @@
 OMDEVMSYS=$(shell cygpath $$OMDEV)
 
+ifeq ($(OMBUILDDIR),)
+REALPATH = $(realpath ../../../)
+OMBUILDDIR=$(REALPATH)/build
+endif
+
 ifeq (MINGW32,$(findstring MINGW32,$(shell uname)))
 	EXTRA_LD_FLAGS = -Wl,--stack,16777216,--large-address-aware -L$(OMDEVMSYS)/lib/omniORB-4.2.0-mingw32/lib/x86_win32
 else
@@ -8,7 +13,7 @@ endif
 
 CC=gcc
 CXX=g++
-override CFLAGS += -fno-ipa-pure-const
+override CFLAGS += -g -fno-ipa-pure-const
 TOP_DIR=../../
 OMHOME=$(OMBUILDDIR)
 LDFLAGS=-L./ $(LOMPARSE) $(LCOMPILERRUNTIME) -L"$(OMHOME)/lib/omc" \

--- a/Examples/ConvertBuildingsReferenceToCSV.py
+++ b/Examples/ConvertBuildingsReferenceToCSV.py
@@ -8,6 +8,12 @@ def convertDir(indir,outdir):
   for fil in os.listdir(indir):
     print "Converting file: %s\n" % indir+"/"+fil
     with open(indir+"/"+fil) as f:
+      # skip FMU files!
+      if 'statistics-fmu-dependencies' in f.read():
+        print "... skipping FMU file\n"
+        continue
+      else:
+        f.seek(0)
       v = {}
       for line in f.readlines():
         line = line.strip().split('=')
@@ -22,7 +28,12 @@ def convertDir(indir,outdir):
               raise Exception("Assumed buildings result format has exactly 101 data points")
             v[line[0]] = l
       keys = v.keys()
+      #for key in keys :
+      #  print key + "\n"
+      #try:
       keys.remove('time')
+      #except ValueError:
+      #  pass # no nothing
       keys.sort()
       keys = ['time'] + keys
       values = [v[key] for key in keys]

--- a/Makefile.common
+++ b/Makefile.common
@@ -69,7 +69,7 @@ $(builddir_share)/omc/omc_communication.idl: Compiler/runtime/omc_communication.
 	cp -a "$<" "$@"
 idl: $(builddir_share)/omc/omc_communication.idl
 
-interactive-common: .testvariables mkbuilddirs boehm-gc idl ModelicaExternalC
+interactive-common: .testvariables mkbuilddirs boehm-gc idl ModelicaExternalC $(MINGW_EXTRA_LIBS)
 
 interactive-short: .testvariables interactive-common
 	$(MAKE) -C SimulationRuntime/c -f $(defaultMakefileTarget) bootstrap-dependencies OMBUILDDIR=$(OMBUILDDIR)
@@ -405,7 +405,7 @@ graphstream-clean:
 
 # build lpsolve
 lpsolve: 3rdParty/lpsolve/Makefile
-	$(MAKE) -C 3rdParty/lpsolve/ install CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)"
+	$(MAKE) -C 3rdParty/lpsolve/ install CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" -j1
 	cp -pf 3rdParty/lpsolve/build/lib/liblpsolve55* $(builddir_lib_omc)
 	cp -prf 3rdParty/lpsolve/build/include/* $(builddir_inc)/
 3rdParty/lpsolve/Makefile: 3rdParty/lpsolve/configure.ac

--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -4,7 +4,8 @@ all : .testvariables settings mkbuilddirs omc
 autoconfGeneratedFiles =
 
 ifeq ($(OMBUILDDIR),)
-OMBUILDDIR=$(CURDIR)/build
+REALPATH = $(realpath ..)
+OMBUILDDIR=$(REALPATH)/build
 endif
 
 ifeq ($(BUILDTYPE),)
@@ -23,7 +24,7 @@ docdir = ${prefix}/doc
 CC = gcc
 CXX = g++
 FC = gfortran
-CFLAGS =-g -O2 -falign-functions
+CFLAGS =-g  -falign-functions
 MSGPACK_CFLAGS = -march=i686
 
 CMAKE = $(OMDEVMSYS)/bin/cmake/bin/cmake


### PR DESCRIPTION
MFFunc.mo:
Implemented typing and variability for a number of builtin operators max, min, rem, mod, abs, etc.
Successfully ran tests for max, min, rem, mod, abs, etc.  Tests involving arrays could not be run because other parts
of the new frontend seems to be incomplete
Main changes in  typeBuiltinFunctionCall and in isBuiltinFunctionName.
In typeBuiltinFunctionCall changed to a match on function name (instead of matchcontinue on structure) to be
more efficient and clear, direct jump to the case based on perfect hash value.
Also added error checking and check of number of arguments.

In ModelicaBuiltin.mo commented out the $overload calls (for mod rem div abs); instead implemented those directly.

Types.mo:
Corrected sme comment texts and added two functions, one of them:
isTypeRealOrIntegerOrBooleanOrEnumOrSubtypes

Static.mo
Corrections of some comment texts.