### PR TITLE
Move external object constructors to initialization

### DIFF
--- a/Compiler/BackEnd/Initialization.mo
+++ b/Compiler/BackEnd/Initialization.mo
@@ -806,7 +806,14 @@ algorithm
   allParameterEqns := BackendEquation.emptyEqns();
   otherVariables := BackendVariable.emptyVars();
   (allParameters, allParameterEqns, otherVariables) := BackendVariable.traverseBackendDAEVars(dae.shared.globalKnownVars, selectParameter2, (allParameters, allParameterEqns, otherVariables));
-  (allParameters, allParameterEqns, otherVariables) := BackendVariable.traverseBackendDAEVars(dae.shared.externalObjects, selectParameter2, (allParameters, allParameterEqns, otherVariables));
+
+  // FIXME: This if clause is a workaround. Remove it as soon as cpp runtime is
+  // adapted to handle external objects together with parameters.
+  // see ticket:3446
+  if not stringEq(Config.simCodeTarget(), "Cpp") then
+    (allParameters, allParameterEqns, otherVariables) := BackendVariable.traverseBackendDAEVars(dae.shared.externalObjects, selectParameter2, (allParameters, allParameterEqns, otherVariables));
+  end if;
+
   nParam := BackendVariable.varsSize(allParameters);
 
   if nParam > 0 then

--- a/SimulationRuntime/c/openmodelica_func.h
+++ b/SimulationRuntime/c/openmodelica_func.h
@@ -58,8 +58,6 @@ struct OpenModelicaGeneratedFunctionCallbacks {
 int (*performSimulation)(DATA* data, threadData_t*, void* solverInfo);
 int (*performQSSSimulation)(DATA* data, threadData_t*, void* solverInfo);
 void (*updateContinuousSystem)(DATA *data, threadData_t*);
-/* Function for calling external object constructors */
-void (*callExternalObjectConstructors)(DATA *data, threadData_t*);
 /* Function for calling external object deconstructors */
 void (*callExternalObjectDestructors)(DATA *_data, threadData_t*);
 

--- a/SimulationRuntime/c/simulation/solver/solver_main.c
+++ b/SimulationRuntime/c/simulation/solver/solver_main.c
@@ -474,8 +474,7 @@ int initializeModel(DATA* data, threadData_t *threadData, const char* init_initM
 
   data->localData[0]->timeValue = simInfo->startTime;
 
-  /* instance all external Objects */
-  data->callback->callExternalObjectConstructors(data, threadData);
+
 
   threadData->currentErrorStage = ERROR_SIMULATION;
   /* try */

--- a/SimulationRuntime/fmi/export/fmi1/fmu1_model_interface.c
+++ b/SimulationRuntime/fmi/export/fmi1/fmu1_model_interface.c
@@ -197,9 +197,7 @@ fmiComponent fmiInstantiateModel(fmiString instanceName, fmiString GUID, fmiCall
   strcpy((char*)comp->GUID, (const char*)GUID);
 
   /* read input vars */
-  //input_function(comp->fmuData);
-  /* initial sample and delay before initial the system */
-  comp->fmuData->callback->callExternalObjectConstructors(comp->fmuData, comp->threadData);
+  /* input_function(comp->fmuData);*/
   /* allocate memory for non-linear system solvers */
   initializeNonlinearSystems(comp->fmuData, comp->threadData);
   /* allocate memory for non-linear system solvers */

--- a/SimulationRuntime/fmi/export/fmi2/fmu2_model_interface.c
+++ b/SimulationRuntime/fmi/export/fmi2/fmu2_model_interface.c
@@ -373,9 +373,7 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
   modelInfoInit(&(comp->fmuData->modelData->modelDataXml));
 #endif
   /* read input vars */
-  //input_function(comp->fmuData);
-  /* initial sample and delay before initial the system */
-  comp->fmuData->callback->callExternalObjectConstructors(comp->fmuData, comp->threadData);
+  /* input_function(comp->fmuData); */
 #if !defined(OMC_NUM_NONLINEAR_SYSTEMS) || OMC_NUM_NONLINEAR_SYSTEMS>0
   /* allocate memory for non-linear system solvers */
   initializeNonlinearSystems(comp->fmuData, comp->threadData);
@@ -1282,4 +1280,3 @@ fmi2Status fmi2GetSpecificDerivatives(fmi2Component c, fmi2Real derivatives[], c
   return fmi2Error;
 }
 #endif
-


### PR DESCRIPTION
see [ticket:3446](https://trac.openmodelica.org/OpenModelica/ticket/3446#comment:8)

- [x] This need to be tested with some examples where parameters depend on external objects
- [x] @adrpo wrote: I guess one needs to have a look at the FMI stuff too, so that the order is changed there too.
- [x] Clean up code generation