### PR TITLE
use memset instead of non-standard bzero

### DIFF
--- a/Compiler/runtime/System_omc.c
+++ b/Compiler/runtime/System_omc.c
@@ -797,7 +797,7 @@ extern void* System_launchParallelTasks(threadData_t *threadData, int numThreads
   int ids[len];
   pthread_t th[numThreads];
   int isInteger = 0;
-  bzero(th, numThreads*sizeof(pthread_t)); /* Make sure we get nothing unexpected here */
+  memset(th, 0, numThreads*sizeof(pthread_t)); /* Make sure we get nothing unexpected here */
 
 #if defined(__MINGW32__)
   /* adrpo: set thread stack size on Windows to 2MB */


### PR DESCRIPTION
bzero is non standard and not supported on msys2/mingw, use memset instead