### PR TITLE
Add SourceInfo to typed modifiers

### DIFF
--- a/Compiler/FrontEnd/DAE.mo
+++ b/Compiler/FrontEnd/DAE.mo
@@ -1217,6 +1217,7 @@ uniontype EqMod "To generate the correct set of equations, the translator has to
     Option<Values.Value> modifierAsValue "modifier as Value option" ;
     Properties properties "properties" ;
     Absyn.Exp modifierAsAbsynExp "keep the untyped modifier as an absyn expression for modification comparison";
+    SourceInfo info;
   end TYPED;
 
   record UNTYPED

--- a/Compiler/FrontEnd/InstBinding.mo
+++ b/Compiler/FrontEnd/InstBinding.mo
@@ -553,7 +553,7 @@ algorithm
         aexp1 := Absyn.CREF(acr);
         scode := SCode.EQ_EQUALS(aexp1,aexp2,SCode.noComment,info);
         source := ElementSource.addSymbolicTransformation(inSource,DAE.FLATTEN(scode,NONE()));
-        dae := InstSection.instEqEquation(lhs, DAE.PROP(inType,DAE.C_VAR()), e, prop2, source, SCode.NON_INITIAL(), inImpl);
+        dae := InstSection.instEqEquation(lhs, DAE.PROP(inType,DAE.C_VAR()), e, prop2, source, SCode.NON_INITIAL(), inImpl, extraInfo=info);
       then
         dae;
 

--- a/Compiler/FrontEnd/InstSection.mo
+++ b/Compiler/FrontEnd/InstSection.mo
@@ -1297,6 +1297,7 @@ public function instEqEquation "author: LS, ELN
   input DAE.ElementSource source "the origin of the element";
   input SCode.Initial inInitial5;
   input Boolean inImplicit;
+  input SourceInfo extraInfo=Absyn.dummyInfo "We have 2 sources?";
   output DAE.DAElist outDae;
 algorithm
   outDae := matchcontinue (inExp1,inProperties2,inExp3,inProperties4,source,inInitial5,inImplicit)
@@ -1405,7 +1406,7 @@ algorithm
         s2 = stringAppendList({t1_str,"=",t2_str});
         info = ElementSource.getElementSourceFileInfo(source);
         Types.typeErrorSanityCheck(t1_str, t2_str, info);
-        Error.addSourceMessage(Error.EQUATION_TYPE_MISMATCH_ERROR, {s1,s2}, info);
+        Error.addMultiSourceMessage(Error.EQUATION_TYPE_MISMATCH_ERROR, {s1,s2}, if extraInfo.fileName=="" then {info} else {extraInfo,info});
       then fail();
   end matchcontinue;
 end instEqEquation;

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -4094,7 +4094,7 @@ algorithm
       Absyn.Exp aexp;
       Option<DAE.EqMod> eq;
       InstDims inst_dims;
-      SourceInfo info;
+      SourceInfo info, info2;
 
     // The size of function input arguments should not be set here, since they
     // may vary depending on the inputs. So we ignore any modifications on input
@@ -4135,7 +4135,7 @@ algorithm
       then
         (cache,dim3);
 
-    case (cache,env,cref,_,ad,SOME(DAE.TYPED(e,_,DAE.PROP(t,_),_)),impl,st,doVect, _,pre,info,inst_dims)
+    case (cache,env,cref,_,ad,SOME(DAE.TYPED(e,_,DAE.PROP(t,_),_,info2)),impl,st,doVect, _,pre,info,inst_dims)
       equation
         // adrpo: do not display error when running checkModel
         //        TODO! FIXME! check if this doesn't actually get rid of useful error messages
@@ -4146,7 +4146,7 @@ algorithm
         e_str = ExpressionDump.printExpStr(e);
         t_str = Types.unparseType(t);
         dim_str = printDimStr(dim1);
-        Error.addSourceMessage(Error.ARRAY_DIMENSION_MISMATCH, {e_str,t_str,dim_str}, info);
+        Error.addMultiSourceMessage(Error.ARRAY_DIMENSION_MISMATCH, {e_str,t_str,dim_str}, info2::info::{});
       then
         fail();
 

--- a/Compiler/FrontEnd/InstVar.mo
+++ b/Compiler/FrontEnd/InstVar.mo
@@ -1459,8 +1459,9 @@ algorithm
       Integer dim_size1, dim_size2;
       String exp_str, exp_ty_str, dims_str;
       DAE.Dimensions ty_dims;
+      SourceInfo info;
 
-    case SOME(DAE.TYPED(modifierAsExp = exp, properties = DAE.PROP(type_ = ty)))
+    case SOME(DAE.TYPED(modifierAsExp = exp, properties = DAE.PROP(type_ = ty), info=info))
       equation
         ty_dim = Types.getDimensionNth(ty, 1);
         dim_size1 = Expression.dimensionSize(inDimension);
@@ -1473,8 +1474,8 @@ algorithm
         // rest of the expression's type is correct (will be caught later anyway).
         _ :: ty_dims = Types.getDimensions(ty);
         dims_str = ExpressionDump.dimensionsString(inDimension :: ty_dims);
-        Error.addSourceMessage(Error.ARRAY_DIMENSION_MISMATCH,
-          {exp_str, exp_ty_str, dims_str}, inInfo);
+        Error.addMultiSourceMessage(Error.ARRAY_DIMENSION_MISMATCH,
+          {exp_str, exp_ty_str, dims_str}, info::inInfo::{});
       then
         false;
 

--- a/Compiler/FrontEnd/Mod.mo
+++ b/Compiler/FrontEnd/Mod.mo
@@ -172,7 +172,7 @@ algorithm
         "Bug: will cause elaboration of parameters without value to fail,
          But this can be ok, since a modifier is present, giving it a value from outer modifications.." ;
       then
-        (cache,DAE.MOD(finalPrefix,each_,subs_1,SOME(DAE.TYPED(e_2,e_val,prop,e)),info));
+        (cache,DAE.MOD(finalPrefix,each_,subs_1,SOME(DAE.TYPED(e_2,e_val,prop,e,info)),info));
 
     // Delayed type checking
     case (cache,env,ih,pre,(SCode.MOD(finalPrefix = finalPrefix,eachPrefix = each_,subModLst = subs,binding = SOME(e), info = info)),impl,_,_)
@@ -625,16 +625,16 @@ algorithm
         (cache,e_2) = PrefixUtil.prefixExp(cache, env, ih, e_1, pre);
         if Flags.isSet(Flags.UPDMOD) then
           Debug.trace("Updated mod: ");
-          Debug.traceln(printModStr(DAE.MOD(f,each_,subs_1,SOME(DAE.TYPED(e_2,NONE(),prop,e)),info)));
+          Debug.traceln(printModStr(DAE.MOD(f,each_,subs_1,SOME(DAE.TYPED(e_2,NONE(),prop,e,info)),info)));
         end if;
       then
-        (cache,DAE.MOD(f,each_,subs_1,SOME(DAE.TYPED(e_2,e_val,prop,e)),info));
+        (cache,DAE.MOD(f,each_,subs_1,SOME(DAE.TYPED(e_2,e_val,prop,e,info)),info));
 
     case (cache,env,ih,pre,DAE.MOD(finalPrefix = f,eachPrefix = each_,subModLst = subs,binding = SOME(DAE.TYPED(e_1,e_val,p,e)),info = info),impl,_)
       equation
         (cache,subs_1) = updateSubmods(cache, env, ih, pre, subs, impl, info);
       then
-        (cache,DAE.MOD(f,each_,subs_1,SOME(DAE.TYPED(e_1,e_val,p,e)),info));
+        (cache,DAE.MOD(f,each_,subs_1,SOME(DAE.TYPED(e_1,e_val,p,e,info)),info));
 
     case (cache,env,ih,pre,DAE.MOD(finalPrefix = f,eachPrefix = each_,subModLst = subs,binding = NONE(), info = info),impl,_)
       equation
@@ -1179,10 +1179,11 @@ protected
   Absyn.Exp ae;
   DAE.Type ty;
   DAE.EqMod eq_mod;
+  SourceInfo info;
 algorithm
   try
     SOME(DAE.TYPED(modifierAsValue =
-      SOME(Values.RECORD(orderd = values, comp = names, index = -1)))) := inEqMod;
+      SOME(Values.RECORD(orderd = values, comp = names, index = -1)), info=info)) := inEqMod;
 
     for name in names loop
       v :: values := values;
@@ -1191,7 +1192,7 @@ algorithm
         e := ValuesUtil.valueExp(v);
         ae := Expression.unelabExp(e);
         ty := Types.complicateType(Expression.typeof(e));
-        eq_mod := DAE.TYPED(e, SOME(v), DAE.PROP(ty, DAE.C_CONST()), ae);
+        eq_mod := DAE.TYPED(e, SOME(v), DAE.PROP(ty, DAE.C_CONST()), ae, info);
         outMod := DAE.MOD(inFinal, inEach, {}, SOME(eq_mod), inInfo);
         break;
       end if;
@@ -1495,7 +1496,7 @@ algorithm
     case DAE.TYPED(modifierAsValue = SOME(Values.ARRAY(valueLst = {}))) then NONE();
 
     // A normal typed binding.
-    case DAE.TYPED(exp, oval, DAE.PROP(ty, c), aexp)
+    case DAE.TYPED(exp, oval, DAE.PROP(ty, c), aexp, info)
       algorithm
         // Subscript the expression with the indices.
         for i in inIndices loop
@@ -1525,7 +1526,7 @@ algorithm
           oval := SOME(val);
         end if;
       then
-        SOME(DAE.TYPED(exp, oval, DAE.PROP(ty, c), aexp));
+        SOME(DAE.TYPED(exp, oval, DAE.PROP(ty, c), aexp, info));
 
     else
       algorithm

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -1151,7 +1151,9 @@ algorithm
     // Multiple infos left, print a trace with the first info.
     case (_, _, info :: rest_info)
       equation
-        addSourceMessage(ERROR_FROM_HERE, {}, info);
+        if not listMember(info, rest_info) then
+          addSourceMessage(ERROR_FROM_HERE, {}, info);
+        end if;
         addMultiSourceMessage(inErrorMsg, inMessageTokens, rest_info);
       then
         ();


### PR DESCRIPTION
Use this SourceInfo to try to improve error-messages for some
common errors, to show both the modification and variable source.