### PR TITLE
Remove special treatment of string return args, ticket:3446

### DIFF
--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -5354,23 +5354,6 @@ case FUNCTION(__)
 case EXTERNAL_FUNCTION(__) then
  let fname = underscorePath(name)
 match var
-/* The storage size of arrays is known at call time, so they can be allocated
- * before set_memory_state. Strings are not known, so we copy them, etc...
- */
-case var as VARIABLE(ty = T_STRING(__)) then
-    if not acceptMetaModelicaGrammar() then
-      // We need to strdup() all strings, then allocate them on the memory pool again, then free the temporary string
-      let strVar = tempDecl("string", &varDecls)
-
-      let &varAssign +=
-        <<
-        //_<%fname%> = <%strVar%>;
-        output = <%strVar%>;
-        >>
-      ""
-    else
-      let &varAssign += /*_<%fname%> */'output = <%contextCref(var.name,contextFunction,simCode , &extraFuncs , &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>;<%\n%>'
-      ""
 case var as VARIABLE(__) then
   let marker = '<%contextCref(var.name,contextFunction,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>'
   let &varInits += '/* varOutput varInits(<%marker%>) */ <%\n%>'


### PR DESCRIPTION
The removed code assigned an uninitialized temporary strVar
to the output of the function. It does not appear needed because
std::string can be assigned like any other variable.