### PR TITLE
Fix code generation where `&` is used on an rvalue

### DIFF
--- a/Compiler/Util/Util.mo
+++ b/Compiler/Util/Util.mo
@@ -1711,7 +1711,7 @@ public function isCIdentifier
 protected
   Integer i;
 algorithm
-  (i,_) := System.regex(str, "^[][_A-Za-z0-9]*$", 0, true, false);
+  (i,_) := System.regex(str, "^[_A-Za-z][_A-Za-z0-9]*$", 0, true, false);
   b := i == 1;
 end isCIdentifier;
 


### PR DESCRIPTION
Added a daeExpReturnLValue function to Susan which converts an rvalue to
an lvalue when the code requires it. Can also be used when you want to
cache the expression and use its value twice (without evaluating the
expression twice).

This fixes ticket:4212.