### PR TITLE
New index reduction method "none"

### DIFF
--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -7215,9 +7215,10 @@ protected
   list<tuple<BackendDAEFunc.StructurallySingularSystemHandlerFunc,String,BackendDAEFunc.stateDeselectionFunc,String>> allIndexReductionMethods;
   String strIndexReductionMethod;
 algorithm
- allIndexReductionMethods := {(IndexReduction.pantelidesIndexReduction,"Pantelides",IndexReduction.noStateDeselection,"uode"),
-                              (IndexReduction.pantelidesIndexReduction,"Pantelides",IndexReduction.dynamicStateSelection,"dynamicStateSelection"),
-                              (IndexReduction.pantelidesIndexReduction,"Pantelides",IndexReduction.dynamicStateSelection,"dummyDerivatives")};
+ allIndexReductionMethods := {(IndexReduction.failIfIndexReduction, "none", IndexReduction.noStateDeselection, "none"),
+                              (IndexReduction.pantelidesIndexReduction, "Pantelides", IndexReduction.noStateDeselection, "uode"),
+                              (IndexReduction.pantelidesIndexReduction, "Pantelides", IndexReduction.dynamicStateSelection, "dynamicStateSelection"),
+                              (IndexReduction.pantelidesIndexReduction, "Pantelides", IndexReduction.dynamicStateSelection, "dummyDerivatives")};
  strIndexReductionMethod := getIndexReductionMethodString();
  strIndexReductionMethod := Util.getOptionOrDefault(ostrIndexReductionMethod,strIndexReductionMethod);
  IndexReductionMethod := selectIndexReductionMethod(strIndexReductionMethod,allIndexReductionMethods);

--- a/Compiler/BackEnd/IndexReduction.mo
+++ b/Compiler/BackEnd/IndexReduction.mo
@@ -158,6 +158,23 @@ algorithm
   end try;
 end pantelidesIndexReduction;
 
+public function failIfIndexReduction "author: lochel
+  This function is used as dummy index reduction function if no index reduction
+  should be performed.
+  This function fails if it is called."
+  input list<list<Integer>> inEqns;
+  output list<Integer> changedEqns = {};
+  input output Integer inActualEqn;
+  input output BackendDAE.EqSystem inSystem;
+  input output BackendDAE.Shared inShared;
+  input output array<Integer> inAssignments1;
+  input output array<Integer> inAssignments2;
+  input output BackendDAE.StructurallySingularSystemHandlerArg inArg;
+algorithm
+  Error.addCompilerError("Structural singular system detected, but no index reduction method has been selected.");
+  fail();
+end failIfIndexReduction;
+
 protected function getChangedEqnsAndLowest
   input Integer index;
   input array<Integer> ass2;

--- a/Compiler/BackEnd/Initialization.mo
+++ b/Compiler/BackEnd/Initialization.mo
@@ -216,7 +216,7 @@ algorithm
     // simplify system
     initOptModules := BackendDAEUtil.getInitOptModules(NONE());
     matchingAlgorithm := BackendDAEUtil.getMatchingAlgorithm(NONE());
-    daeHandler := BackendDAEUtil.getIndexReductionMethod(NONE());
+    daeHandler := BackendDAEUtil.getIndexReductionMethod(SOME("none"));
     initdae := BackendDAEUtil.postOptimizeDAE(initdae, initOptModules, matchingAlgorithm, daeHandler);
 
     if Flags.isSet(Flags.DUMP_INITIAL_SYSTEM) then

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -828,6 +828,7 @@ constant ConfigFlag MATCHING_ALGORITHM = CONFIG_FLAG(14, "matchingAlgorithm",
 constant ConfigFlag INDEX_REDUCTION_METHOD = CONFIG_FLAG(15, "indexReductionMethod",
   NONE(), EXTERNAL(), STRING_FLAG("dynamicStateSelection"),
   SOME(STRING_DESC_OPTION({
+    ("none", Util.gettext("Skip index reduction")),
     ("uode", Util.gettext("Use the underlying ODE without the constraints.")),
     ("dynamicStateSelection", Util.gettext("Simple index reduction method, select (dynamic) dummy states based on analysis of the system.")),
     ("dummyDerivatives", Util.gettext("Simple index reduction method, select (static) dummy states based on heuristic."))


### PR DESCRIPTION
This method can be selected using --indexReductionMethod=none.
It will not handle higher index problems at all and just fail in case to get proper error messages if no higher index problem is expected.