### PR TITLE
Inline integration initializes clocked continuous states

### DIFF
--- a/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/Compiler/BackEnd/SynchronousFeatures.mo
@@ -227,6 +227,8 @@ algorithm
               // introduce states to delay derivatives; see MLS 3.3, section 16.8.2 Solver Methods
               exp2 := DAE.CALL(Absyn.IDENT(name = "previous"), {exp2}, DAE.callAttrBuiltinImpureReal);
             end if;
+            exp2 := DAE.IFEXP(DAE.CALL(Absyn.IDENT(name = "firstTick"), {}, DAE.callAttrBuiltinImpureBool),
+                              DAE.RCONST(0), exp2);
             eq := BackendDAE.EQUATION(exp, exp2, var.source, BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC);
             lstEqs := eq :: lstEqs;
           end for;

--- a/Compiler/Template/CodegenCppCommon.tpl
+++ b/Compiler/Template/CodegenCppCommon.tpl
@@ -1712,7 +1712,7 @@ template daeExpCall(Exp call, Context context, Text &preExp /*BUFP*/, Text &varD
     '<%contextSystem(context)%><%cref(crefPrefixPrevious(arg.componentRef), useFlatArrayNotation)%>'
 
   case CALL(path=IDENT(name="firstTick")) then
-    '<%contextSystem(context)%>_clockStart[clockIndex - 1]'
+    '(<%contextSystem(context)%>_clockStart[clockIndex - 1] || <%contextSystem(context)%>_clockSubactive[clockIndex - 1])'
 
   case CALL(path=IDENT(name="interval")) then
     '<%contextSystem(context)%>_clockInterval[clockIndex - 1]'


### PR DESCRIPTION
Initialization during code generation does not work for states
in algebraic loops. This initialization in the backend becomes possible
with the introduction of $DER.x variables for derivatives.