### PR TITLE
NFInst prefixing improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFFunc.mo
+++ b/Compiler/NFFrontEnd/NFFunc.mo
@@ -89,7 +89,7 @@ protected
   String fn_name;
   Absyn.Path fn, fn_1;
   InstNode fakeComponent;
-  InstNode classNode;
+  InstNode classNode, foundScope;
   list<Expression> arguments;
   DAE.CallAttributes ca;
   Type classType, resultType;
@@ -115,7 +115,8 @@ algorithm
 
   try
     // try to lookup the function, if is working then is either a user defined function or present in ModelicaBuiltin.mo
-    (classNode, prefix) := Lookup.lookupFunctionName(functionName, scope, info);
+    (classNode, foundScope) := Lookup.lookupFunctionName(functionName, scope, info);
+    prefix := InstNode.prefix(foundScope);
   else
     // we could not lookup the class, see if is a special builtin such as String(), etc
     if isSpecialBuiltinFunctionName(functionName) then
@@ -642,10 +643,10 @@ algorithm
       Type el_ty, ty1, ty2;
 
     // size(arr, dim)
-    case (Absyn.CREF_IDENT(name = "size"), Absyn.FUNCTIONARGS(args = {aexp1, _}))
+    case (Absyn.CREF_IDENT(name = "size"), Absyn.FUNCTIONARGS(args = {aexp1, aexp2}))
       algorithm
         (dexp1,_, vr1) := Typing.typeExp(aexp1, scope, info);
-        (dexp2,_, vr2) := Typing.typeExp(aexp1, scope, info);
+        (dexp2,_, vr2) := Typing.typeExp(aexp2, scope, info);
 
         // TODO FIXME: calculate the correct type and the correct variability, see Static.elabBuiltinSize in Static.mo
         ty := Type.INTEGER();
@@ -665,11 +666,11 @@ algorithm
       then
         (Expression.SIZE(dexp1, NONE()), ty, vr);
 
-    case (Absyn.CREF_IDENT(name = "smooth"), Absyn.FUNCTIONARGS(args = {aexp1, _}))
+    case (Absyn.CREF_IDENT(name = "smooth"), Absyn.FUNCTIONARGS(args = {aexp1, aexp2}))
       algorithm
         call_path := Absyn.crefToPath(functionName);
         (dexp1,_, vr1) := Typing.typeExp(aexp1, scope, info);
-        (dexp2,_, vr2) := Typing.typeExp(aexp1, scope, info);
+        (dexp2,_, vr2) := Typing.typeExp(aexp2, scope, info);
 
         // TODO FIXME: calculate the correct type and the correct variability, see Static.mo
         ty := Type.REAL();

--- a/Compiler/NFFrontEnd/NFPrefix.mo
+++ b/Compiler/NFFrontEnd/NFPrefix.mo
@@ -69,7 +69,7 @@ uniontype Prefix
     DAE.Type ty;
   algorithm
     if InstNode.isClass(node) then
-      prefix := PREFIX(InstNode.name(node), {}, Type.UNKNOWN(), prefix, PrefixType.CLASS);
+      prefix := PREFIX(InstNode.name(node), {}, Type.COMPLEX(node), prefix, PrefixType.CLASS);
     else
       prefix := PREFIX(InstNode.name(node), {},
         InstNode.getType(node), prefix, PrefixType.COMPONENT);
@@ -81,7 +81,7 @@ uniontype Prefix
     input output Prefix prefix;
   algorithm
     if InstNode.isClass(node) then
-      prefix := PREFIX(InstNode.name(node), {}, Type.UNKNOWN(), prefix, PrefixType.CREF);
+    prefix := PREFIX(InstNode.name(node), {}, Type.COMPLEX(node), prefix, PrefixType.CREF);
     else
       prefix := PREFIX(InstNode.name(node), {},
         Component.getType(InstNode.component(node)), prefix, PrefixType.CREF);


### PR DESCRIPTION
- Changed Lookup.lookupCref to return a list of all found nodes instead
  of a prefix, so the prefix can be properly constructed by the caller.
- Fixed prefixing in Typing.typeCref, which previously typed the prefix
  incorrectly.
- Moved typing of builtin attributes from typeComponent to typeBinding,
  to avoid infinite loops with enumerations.
- Fixed handling of builtin functions size and smooth to use the correct
  arguments.