### PR TITLE
Further append underscores to Modelica names

### DIFF
--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -5396,9 +5396,9 @@ case var as VARIABLE(__) then
   let recordInit = initRecordMembers(var, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
   let &varInits += if recordInit then
   <<
-    //initRecordMembers <%varName%>
-    <%preExp%>
-    <%recordInit%>
+  //initRecordMembers <%varName%>
+  <%preExp%>
+  <%recordInit%>
   >>
   let instDimsInit = (instDims |> exp => daeExp(exp, contextFunction, &varInits , &varDecls,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
 
@@ -5452,7 +5452,7 @@ template recordMemberInit(Var v, Text varName, Text &preExp /*BUFP*/, Text &varD
 ::=
   match v
   case TYPES_VAR(__) then
-    let vn = '<%varName%>.<%name%>'
+    let vn = '<%varName%>.<%name%>_'
     let defaultValue =
       match binding
       case VALBOUND(valBound = val) then

--- a/Compiler/Template/CodegenCppCommon.tpl
+++ b/Compiler/Template/CodegenCppCommon.tpl
@@ -337,8 +337,8 @@ template daeExpCrefRhs(Exp exp, Context context, Text &preExp, Text &varDecls, S
       daeExpRecordCrefRhs(t, cr, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
   case CREF(ty = T_FUNCTION_REFERENCE_FUNC(functionType=t)) then
     functionClosure(underscorePath(crefToPathIgnoreSubs(componentRef)), "", t, t, context, &extraFuncsDecl)
-  case CREF(componentRef = cr, ty = T_FUNCTION_REFERENCE_VAR(__)) then
-    crefStr(cr)
+  case CREF(componentRef = CREF_IDENT(ident=ident), ty = T_FUNCTION_REFERENCE_VAR(__)) then
+    contextFunName(ident, context)
   else
     daeExpCrefRhs2(exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
 end daeExpCrefRhs;


### PR DESCRIPTION
- append undersores to initRecordMembers, see e.g.:
  Modelica.Media.Examples.R134a.R134a1

- don't append underscores to function refs, see e.g.:
  Modelica.Math.Nonlinear.Examples.quadratureLobatto3