### PR TITLE
When in graphics expression mode, allow failures

### DIFF
--- a/Compiler/FrontEnd/Absyn.mo
+++ b/Compiler/FrontEnd/Absyn.mo
@@ -2668,6 +2668,15 @@ protected
 algorithm
   // First, calculate the length of the string to be generated
   p1 :=  if usefq then path else makeNotFullyQualified(path);
+  _ := match p1
+    case IDENT()
+      algorithm
+        // Do not allocate memory if we're just going to copy the only identifier
+        s := p1.name;
+        return;
+      then ();
+    else ();
+  end match;
   p2 := p1;
   b := true;
   while b loop

--- a/Compiler/FrontEnd/Ceval.mo
+++ b/Compiler/FrontEnd/Ceval.mo
@@ -862,6 +862,12 @@ algorithm
       then
         (inCache, Values.EMPTY(inExp.scope, s, v, inExp.tyStr), inST);
 
+    case (_,env,e,_,_,_,_) guard Config.getGraphicsExpMode()
+      algorithm
+        ty := Expression.typeof(inExp);
+        v := Types.typeToValue(ty);
+      then (inCache, Values.EMPTY("#graphicsExp#", ExpressionDump.printExpStr(inExp), v, Types.unparseType(ty)), inST);
+
     // ceval can fail and that is ok, caught by other rules...
     case (_,env,e,_,_,_,_) // Absyn.MSG())
       equation

--- a/Compiler/FrontEnd/PrefixUtil.mo
+++ b/Compiler/FrontEnd/PrefixUtil.mo
@@ -926,6 +926,8 @@ algorithm
     // no prefix, return the input expression
     case (cache,_,_,e,Prefix.NOPRE()) then (cache,e);
 
+    case (_,_,_,e as DAE.EMPTY(),_) then (inCache,e);
+
     case (_,_,_,e,_)
       equation
         true = Flags.isSet(Flags.FAILTRACE);

--- a/Compiler/FrontEnd/Types.mo
+++ b/Compiler/FrontEnd/Types.mo
@@ -7384,6 +7384,9 @@ algorithm
       then
         v;
 
+    case DAE.T_UNKNOWN() then Values.META_FAIL();
+
+
     // All the other ones we don't handle
     else
       equation

--- a/Compiler/Script/Interactive.mo
+++ b/Compiler/Script/Interactive.mo
@@ -13830,11 +13830,13 @@ algorithm
         try
         (cache, env, graphic_prog) :=
           buildEnvForGraphicProgram(GRAPHIC_ENV_NO_CACHE(inFullProgram, inModelPath), mod);
+          ErrorExt.rollBack("buildEnvForGraphicProgram");
         else
           ErrorExt.delCheckpoint("buildEnvForGraphicProgram");
           fail();
+          // Fallback to only the graphical primitives left in the program
+          (cache, env, graphic_prog) := buildEnvForGraphicProgram(GRAPHIC_ENV_NO_CACHE(inFullProgram, inModelPath), {});
         end try;
-        ErrorExt.rollBack("buildEnvForGraphicProgram");
 
         smod := SCodeUtil.translateMod(SOME(Absyn.CLASSMOD(stripped_mod, Absyn.NOMOD())),
           SCode.NOT_FINAL(), SCode.NOT_EACH(), info);

--- a/Compiler/Util/System.mo
+++ b/Compiler/Util/System.mo
@@ -1242,7 +1242,9 @@ function stringAllocatorStringCopy
   input Integer destOffset=0;
 external "C" om_stringAllocatorStringCopy(dest,source,destOffset) annotation(Include="
 void om_stringAllocatorStringCopy(void *dest, char *source, int destOffset) {
-  strcpy(MMC_STRINGDATA(dest)+destOffset, source);
+  if (*source) {
+    strcpy(MMC_STRINGDATA(dest)+destOffset, source);
+  }
 }
 ", Documentation(info="<html>
 <p>Does a strcpy into the (input) destination. This is dangerous and not valid Modelica.</p>


### PR DESCRIPTION
This handles some models where constant evaluation and prefixing of
expressions sometimes fails, but usually does not influence the
variables we are interested in for the graphics expression.