### PR TITLE
Fix extends modifier issue in NFInst.

### DIFF
--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -452,20 +452,13 @@ algorithm
           is_builtin := Class.isBuiltin(InstNode.getClass(ext_node));
 
           if not is_builtin then
-            // TODO: Reinstantiating the class might not be needed any more.
-            // TODO: Inherited components need unique scopes, so the class needs
-            //       to at least be cloned.
-            ext_node := InstNode.updateClass(Class.NOT_INSTANTIATED(), ext_node);
-            ext_node := InstNode.setNodeType(InstNodeType.BASE_CLASS(currentScope), ext_node);
-            ext_node := InstNode.rename(ext_node, "$extends." + InstNode.name(ext_node));
+            ext_node := InstNode.newExtends(ext_node, currentScope);
             ext_node := expand(ext_node);
           end if;
 
-          //ext_node := InstNode.setDefinition(e, ext_node);
 
           // Initialize the modifiers from the extends clause.
           mod_scope := ModifierScope.EXTENDS_SCOPE(e.baseClassPath);
-          // adrpo: TODO! FIXME! the modifier scope of the extends clause should be the currentScope not ext_node??!!
           mod := Modifier.create(e.modifications, "", mod_scope, currentScope);
 
           // Apply the modifier from the extends clause to the expanded class.

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -122,6 +122,30 @@ uniontype InstNode
     node := COMPONENT_NODE(name, definition, c, parent);
   end newComponent;
 
+  function newExtends
+    input InstNode node;
+    input InstNode scope;
+    output InstNode extendsNode;
+  algorithm
+    extendsNode := match node
+      local
+        array<Class> cls;
+
+      case CLASS_NODE()
+        algorithm
+          cls := arrayCreate(1, Class.NOT_INSTANTIATED());
+        then
+          CLASS_NODE("$extends." + node.name, node.definition, cls,
+            node.parentScope, InstNodeType.BASE_CLASS(scope));
+
+      else
+        algorithm
+          assert(false, getInstanceName() + " got non-class");
+        then
+          fail();
+    end match;
+  end newExtends;
+
   function fromComponent
     input String name;
     input Component component;


### PR DESCRIPTION
- Fixed extends modifier issue by cloning base classes, so that
  modifiers aren't applied to the class tree.