### PR TITLE
Refactor the File module

### DIFF
--- a/Compiler/SimCode/SerializeInitXML.mo
+++ b/Compiler/SimCode/SerializeInitXML.mo
@@ -72,7 +72,7 @@ protected
   ModelInfo modelInfo;
   VarInfo vi;
   SimulationSettings s;
-  File.File file = File.File(NONE(), simCode.fileNamePrefix + "_init.xml", true);
+  File.File file = File.File();
 algorithm
   try
   File.open(file, simCode.fileNamePrefix + "_init.xml", File.Mode.Write);

--- a/Compiler/SimCode/SerializeModelInfo.mo
+++ b/Compiler/SimCode/SerializeModelInfo.mo
@@ -66,7 +66,7 @@ function serializeWork "Always succeeds in order to clean-up external objects"
   output Boolean success; // We always need to return in order to clean up external objects
   output String fileName;
 protected
-  File.File file = File.File(NONE(), code.fileNamePrefix + "_info.json", true);
+  File.File file = File.File();
 algorithm
   (success,fileName) := matchcontinue code
     local

--- a/Compiler/Template/Tpl.mo
+++ b/Compiler/Template/Tpl.mo
@@ -1031,7 +1031,7 @@ protected function tokFileText
   input StringToken inStringToken;
   input Boolean doHandleTok=true;
 protected
-  File.File file = File.File(getTextOpaqueFile(inText), File.getFilename(getTextOpaqueFile(inText)), false);
+  File.File file = File.File(getTextOpaqueFile(inText));
   Integer nchars, aind;
   Boolean isstart;
 algorithm
@@ -2462,7 +2462,7 @@ public function redirectToFile
   input output Text text;
   input String fileName;
 protected
-  File.File file = File.File(NONE(), fileName, true);
+  File.File file = File.File();
 algorithm
   if Config.getRunningTestsuite() then
     System.appendFile(Config.getRunningTestsuiteFile(), fileName + "\n");
@@ -2475,7 +2475,7 @@ public function closeFile
 "Magic sourceInfo() function implementation"
   input output Text text;
 protected
-  File.File file = File.File(getTextOpaqueFile(text), File.getFilename(getTextOpaqueFile(text)), false);
+  File.File file = File.File(getTextOpaqueFile(text));
 algorithm
   File.releaseReference(file);
   text := emptyTxt;
@@ -2507,7 +2507,7 @@ protected function stringFile "Like ST_STRING or ST_LINE"
   input Boolean line;
   input Boolean recurseSeparator=true;
 protected
-  File.File file = File.File(getTextOpaqueFile(inText), File.getFilename(getTextOpaqueFile(inText)), false);
+  File.File file = File.File(getTextOpaqueFile(inText));
   Integer nchars;
   IterOptions iopts;
   StringToken septok;
@@ -2543,7 +2543,7 @@ end stringFile;
 protected function newlineFile "Like ST_NEWLINE"
   input Text inText;
 protected
-  File.File file = File.File(getTextOpaqueFile(inText), File.getFilename(getTextOpaqueFile(inText)), false);
+  File.File file = File.File(getTextOpaqueFile(inText));
   Integer nchars;
 algorithm
   _ := match inText
@@ -2560,7 +2560,7 @@ protected function textFileTell
   input Text inText;
   output Integer tell;
 protected
-  File.File file = File.File(getTextOpaqueFile(inText), File.getFilename(getTextOpaqueFile(inText)), false);
+  File.File file = File.File(getTextOpaqueFile(inText));
 algorithm
   tell := File.tell(file);
 end textFileTell;
@@ -2568,7 +2568,6 @@ end textFileTell;
 protected function handleTok "Handle a new token, for example separators"
   input Text txt;
 protected
-  // File.File file = File.File(getTextOpaqueFile(inText), File.getFilename(getTextOpaqueFile(inText)), false);
   StringToken septok;
   array<Option<StringToken>> aseptok;
 algorithm
@@ -2592,47 +2591,6 @@ algorithm
   then ();
   end match;
 end handleTok;
-
-/*
-protected function handleSeparatorTextFile
-  input Text txt;
-  input IterOptions iopts;
-protected
-  File.File file = File.File(getTextOpaqueFile(inText), File.getFilename(getTextOpaqueFile(inText)), false);
-  Integer nchars, aind;
-  Boolean isstart;
-algorithm
-  _ := match inText
-    case FILE_TEXT()
-    algorithm
-      nchars := arrayGet(inText.nchars, 1);
-      aind := arrayGet(inText.aind, 1);
-      isstart := arrayGet(inText.isstart, 1);
-      (nchars, isstart, aind) := handleSeparatorFile(file, iopts, nchars, isstart, aind);
-      arrayUpdate(inText.nchars, 1, nchars);
-      arrayUpdate(inText.aind, 1, aind);
-      arrayUpdate(inText.isstart, 1, isstart);
-    then ();
-  end match;
-end handleSeparatorTextFile;
-
-protected function handleSeparatorFile
-  input File.File file;
-  input IterOptions iopts;
-  input output Integer nchars;
-  input output Boolean isstart;
-  input output Integer aind;
-algorithm
-  (nchars,isstart,aind) := match (iopts.separator, iopts.alignNum, iopts.wrapWidth)
-    case (NONE(),_,_) then (nchars,isstart,aind);
-    case (SOME(septok),0,0) then (nchars,isstart,aind);
-    else
-    algorithm
-      Error.addInternalError("haveSeparatorFile failed", sourceInfo());
-    then fail();
-  end match;
-end handleSeparatorFile;
-*/
 
 annotation(__OpenModelica_Interface="susan");
 end Tpl;

--- a/Compiler/Util/File.mo
+++ b/Compiler/Util/File.mo
@@ -33,80 +33,15 @@ encapsulated package File
 
 class File
   extends ExternalObject;
-  function constructor
-    input Option<Integer> fromID = NONE() "If we should restore from another pointer. Note: Option<Integer> is an opaque pointer, not an actual Option.";
-    input String filename = "[none]";
-    input Boolean  makeNew = true;
+  function constructor<T> "File constructor."
+    input Option<Integer> fromID = noReference() "Never pass this an actual Option<Integer>. Only use File.getReference(file) or File.noReference(). Determines if we should restore from another File object or create a new File.";
     output File file;
-  external "C" file=om_file_new(fromID, makeNew, filename) annotation(Include="
-#ifndef __OMC_FILE_NEW
-#define __OMC_FILE_NEW
-#include <stdio.h>
-#include <gc.h>
-
-#ifndef __OMC_FILE_STRUCT
-#define __OMC_FILE_STRUCT
-typedef struct {
-  FILE* file /* the file */;
-  mmc_sint_t cnt /* reference count */;
-  char* name /* the file name */;
-} __OMC_FILE;
-#endif
-
-static inline void* om_file_new(void *fromID, modelica_boolean makeNew, const char *filename)
-{
-  if (makeNew) {
-    __OMC_FILE *res = (__OMC_FILE*) GC_malloc(sizeof(__OMC_FILE));
-    res->file = NULL;
-    res->cnt = 0;
-    res->name = filename;
-#if __OMC_FILE_DEBUG
-    fprintf(stderr,\"File.constructor: new: %s, %p\\n\", res->name, res); fflush(NULL);
-#endif
-    return res;
-  } else {
-    ((__OMC_FILE*)fromID)->cnt++; /* Increase reference count */
-#if __OMC_FILE_DEBUG
-    fprintf(stderr,\"File.constructor: fromID: %s, %d %p\\n\", ((__OMC_FILE*)fromID)->name, ((__OMC_FILE*)fromID)->cnt, fromID); fflush(NULL);
-#endif
-    return fromID;
-  }
-}
-#endif
-");
+  external "C" file=om_file_new(fromID) annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
   end constructor;
 
   function destructor
     input File file;
-  external "C" om_file_free(file) annotation(Include="
-#ifndef __OMC_FILE_FREE
-#define __OMC_FILE_FREE
-#include <stdio.h>
-
-#ifndef __OMC_FILE_STRUCT
-#define __OMC_FILE_STRUCT
-typedef struct {
-  FILE* file /* the file */;
-  mmc_sint_t cnt /* reference count */;
-  char* name /* the file name */;
-} __OMC_FILE;
-#endif
-
-static inline void om_file_free(__OMC_FILE *file)
-{
-  if (file->cnt /* reference count */) {
-    file->cnt--;
-    return;
-  }
-#if __OMC_FILE_DEBUG
-  fprintf(stderr,\"File.destructor: close:%s,%p,%p\\n\",file->name, file->file, file); fflush(NULL);
-#endif
-  fclose(file->file);
-  file->file = 0;
-  GC_free(file);
-}
-#endif
-");
+  external "C" om_file_free(file) annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
   end destructor;
 end File;
 
@@ -116,139 +51,27 @@ function open
   input File file;
   input String filename;
   input Mode mode = Mode.Read;
-external "C" om_file_open(file,filename,mode) annotation(Include="
-#ifndef __OMC_FILE_OPEN
-#define __OMC_FILE_OPEN
-#include <stdio.h>
-#include <errno.h>
-#include \"ModelicaUtilities.h\"
-
-#ifndef __OMC_FILE_STRUCT
-#define __OMC_FILE_STRUCT
-typedef struct {
-  FILE* file /* the file */;
-  mmc_sint_t cnt /* reference count */;
-  char* name /* the file name */;
-} __OMC_FILE;
-#endif
-
-static inline void om_file_open(__OMC_FILE *file, const char *filename, int mode)
-{
-  if (file->file) {
-#if __OMC_FILE_DEBUG
-    fprintf(stderr,\"File.open: close :%s,%p,%p\\n\",file->name, file->file, file); fflush(NULL);
-#endif
-    fclose(file->file);
-  }
-  file->file = fopen(filename, mode == 1 ? \"rb\" : \"wb\");
-  file->name = filename;
-#if __OMC_FILE_DEBUG
-  fprintf(stderr,\"File.open: f:%s,%p,%p\\n\",file->name,file->file,file); fflush(NULL);
-#endif
-  if (0 == file->file) {
-    ModelicaFormatError(\"File.open: Failed to open file %s with mode %d: %s\\n\", filename, mode, strerror(errno));
-  }
-}
-#endif
-");
+external "C" om_file_open(file,filename,mode) annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
 end open;
 
 function write
   input File file;
   input String data;
-external "C" om_file_write(file,data) annotation(Include="
-#ifndef __OMC_FILE_WRITE
-#define __OMC_FILE_WRITE
-#include <stdio.h>
-#include <errno.h>
-#include \"ModelicaUtilities.h\"
-
-#ifndef __OMC_FILE_STRUCT
-#define __OMC_FILE_STRUCT
-typedef struct {
-  FILE* file /* the file */;
-  mmc_sint_t cnt /* reference count */;
-  char* name /* the file name */;
-} __OMC_FILE;
-#endif
-
-static inline void om_file_write(__OMC_FILE *file,const char *data)
-{
-  if (!file->file) {
-    ModelicaFormatError(\"File.write: Failed to write to file: %s (not open)\", file->name);
-  }
-  if (EOF == fputs(data, file->file)) {
-    ModelicaFormatError(\"File.write: Failed to write to file: %s error: %s\\n\", file->name, strerror(errno));
-  }
-}
-#endif
-");
+external "C" om_file_write(file,data) annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
 end write;
 
 function writeInt
   input File file;
   input Integer data;
   input String format="%d";
-external "C" om_file_write_int(file,data,format) annotation(Include="
-#ifndef __OMC_FILE_WRITE_INT
-#define __OMC_FILE_WRITE_INT
-#include <stdio.h>
-#include <errno.h>
-#include \"ModelicaUtilities.h\"
-
-#ifndef __OMC_FILE_STRUCT
-#define __OMC_FILE_STRUCT
-typedef struct {
-  FILE* file /* the file */;
-  mmc_sint_t cnt /* reference count */;
-  char* name /* the file name */;
-} __OMC_FILE;
-#endif
-
-static inline void om_file_write_int(__OMC_FILE *file, int data, const char *format)
-{
-  if (!file->file) {
-    ModelicaFormatError(\"File.writeInt: Failed to write to file: %s (not open)\", file->name);
-  }
-  if (EOF == fprintf(file->file, format, data)) {
-    ModelicaFormatError(\"File.writeInt: Failed to write to file: %s error: %s\\n\", file->name, strerror(errno));
-  }
-}
-#endif
-");
+external "C" om_file_write_int(file,data,format) annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
 end writeInt;
 
 function writeReal
   input File file;
   input Real data;
   input String format="%.15g";
-external "C" om_file_write_real(file,data,format) annotation(Include="
-#ifndef __OMC_FILE_WRITE_REAL
-#define __OMC_FILE_WRITE_REAL
-#include <stdio.h>
-#include <errno.h>
-#include \"ModelicaUtilities.h\"
-
-#ifndef __OMC_FILE_STRUCT
-#define __OMC_FILE_STRUCT
-typedef struct {
-  FILE* file /* the file */;
-  mmc_sint_t cnt /* reference count */;
-  char* name /* the file name */;
-} __OMC_FILE;
-#endif
-
-static inline void om_file_write_real(__OMC_FILE *file, double data, const char *format)
-{
-  if (!file->file) {
-    ModelicaFormatError(\"File.writeReal: Failed to write to file: %s (not open)\", file->name);
-  }
-  if (EOF == fprintf(file->file, format, data)) {
-    ModelicaFormatError(\"File.writeReal: Failed to write to file: %s error: %s\\n\", file->name, strerror(errno));
-  }
-}
-#endif
-");
+external "C" om_file_write_real(file,data,format) annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
 end writeReal;
 
 type Escape = enumeration(None "No escape string",
@@ -260,93 +83,7 @@ function writeEscape
   input File file;
   input String data;
   input Escape escape;
-external "C" om_file_write_escape(file,data,escape) annotation(Include="
-#ifndef __OMC_FILE_WRITE_ESCAPE
-#define __OMC_FILE_WRITE_ESCAPE
-#include <stdio.h>
-#include <errno.h>
-#include \"ModelicaUtilities.h\"
-
-#ifndef __OMC_FILE_STRUCT
-#define __OMC_FILE_STRUCT
-typedef struct {
-  FILE* file /* the file */;
-  mmc_sint_t cnt /* reference count */;
-  char* name /* the file name */;
-} __OMC_FILE;
-#endif
-
-enum escape_t {
-  None=1,
-  C,
-  JSON,
-  XML
-};
-#define ERROR_WRITE() ModelicaFormatError(\"File.writeEscape: Failed to write to file: %s error: %s\\n\", file->file, strerror(errno))
-
-static inline void om_file_write_escape(__OMC_FILE *file, const char *data, enum escape_t escape)
-{
-  if (!file->file) {
-    ModelicaFormatError(\"File.writeEscape: Failed to write to file: %s (not open)\", file->name);
-  }
-  switch (escape) {
-  case None:
-    if (EOF == fputs(data, file->file)) {
-      ModelicaFormatError(\"File.writeEscape: Failed to write to file: %s error: %s\\n\", file->name, strerror(errno));
-    }
-    break;
-  case C:
-    while (*data) {
-      if (*data == '\\n') {
-        if (fputs(\"\\\\n\", file->file) < 0) ERROR_WRITE();
-      } else if (*data == '\"') {
-        if (fputs(\"\\\\\\\"\", file->file) < 0) ERROR_WRITE();
-      } else {
-        if (putc(*data, file->file) < 0) ERROR_WRITE();
-      }
-      data++;
-    }
-    break;
-  case JSON:
-    while (*data) {
-      switch (*data) {
-      case '\\\"': if (fputs(\"\\\\\\\"\", file->file) < 0) ERROR_WRITE();break;
-      case '\\\\': if (fputs(\"\\\\\\\\\", file->file) < 0) ERROR_WRITE();break;
-      case '\\n': if (fputs(\"\\\\n\", file->file) < 0) ERROR_WRITE();break;
-      case '\\b': if (fputs(\"\\\\b\", file->file) < 0) ERROR_WRITE();break;
-      case '\\f': if (fputs(\"\\\\f\", file->file) < 0) ERROR_WRITE();break;
-      case '\\r': if (fputs(\"\\\\r\", file->file) < 0) ERROR_WRITE();break;
-      case '\\t': if (fputs(\"\\\\t\", file->file) < 0) ERROR_WRITE();break;
-      default:
-        if (*data < ' ') { /* Escape other control characters */
-          if (fprintf(file->file, \"\\\\u%04x\",*data) < 0) ERROR_WRITE();
-        } else {
-          if (putc(*data, file->file) < 0) ERROR_WRITE();
-        }
-      }
-      data++;
-    }
-    break;
-  case XML:
-    while (*data) {
-      switch (*data) {
-      case '<': if (fputs(\"&lt;\", file->file) < 0) ERROR_WRITE();break;
-      case '>': if (fputs(\"&gt;\", file->file) < 0) ERROR_WRITE();break;
-      case '\"': if (fputs(\"&#34;\", file->file) < 0) ERROR_WRITE();break;
-      case '&': if (fputs(\"&amp;\", file->file) < 0) ERROR_WRITE();break;
-      case '\\'': if (fputs(\"&#39;\", file->file) < 0) ERROR_WRITE();break;
-      default:
-        if (putc(*data, file->file) < 0) ERROR_WRITE();
-      }
-      data++;
-    }
-    break;
-  default:
-    ModelicaFormatError(\"File.writeEscape: No such escape enumeration: %d\\n\", escape);
-  }
-}
-#endif
-");
+external "C" om_file_write_escape(file,data,escape) annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
 end writeEscape;
 
 type Whence = enumeration(Set "SEEK_SET 0=start of file",Current "SEEK_CUR 0=current byte",End "SEEK_END 0=end of file");
@@ -356,145 +93,35 @@ function seek
   input Integer offset;
   input Whence whence = Whence.Set;
   output Boolean success;
-external "C" success = om_file_seek(file,offset,whence) annotation(Include="
-#ifndef __OMC_FILE_SEEK
-#define __OMC_FILE_SEEK
-#include <stdio.h>
-#include \"ModelicaUtilities.h\"
-enum whence_t {
-  OMC_SEEK_SET=1,
-  OMC_SEEK_CURRENT,
-  OMC_SEEK_END
-};
-
-#ifndef __OMC_FILE_STRUCT
-#define __OMC_FILE_STRUCT
-typedef struct {
-  FILE* file /* the file */;
-  mmc_sint_t cnt /* reference count */;
-  char* name /* the file name */;
-} __OMC_FILE;
-#endif
-
-static inline int om_file_seek(__OMC_FILE *file, int offset, enum whence_t whence)
-{
-  if (!file->file) {
-    return 0;
-  }
-  return 0 == fseek(file->file, offset, whence == OMC_SEEK_SET ? SEEK_SET : whence == OMC_SEEK_CURRENT ? OMC_SEEK_CURRENT : SEEK_END);
-}
-#endif
-");
+external "C" success = om_file_seek(file,offset,whence) annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
 end seek;
 
 function tell
   input File file;
   output Integer pos;
-external "C" pos = om_file_tell(file) annotation(Include="
-#ifndef __OMC_FILE_TELL
-#define __OMC_FILE_TELL
-#include <stdio.h>
-
-#ifndef __OMC_FILE_STRUCT
-#define __OMC_FILE_STRUCT
-typedef struct {
-  FILE* file /* the file */;
-  mmc_sint_t cnt /* reference count */;
-  char* name /* the file name */;
-} __OMC_FILE;
-#endif
-
-static inline int om_file_tell(__OMC_FILE *file)
-{
-  if (!file->file) {
-    return -1;
-  }
-  return ftell(file->file);
-}
-#endif
-");
+external "C" pos = om_file_tell(file) annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
 end tell;
 
 function getFilename
   input Option<Integer> file;
   output String fileName;
-external "C" fileName = om_file_get_filename(file) annotation(Include="
-#ifndef __OMC_FILE_FILENAME
-#define __OMC_FILE_FILENAME
-#include <stdio.h>
-
-#ifndef __OMC_FILE_STRUCT
-#define __OMC_FILE_STRUCT
-typedef struct {
-  FILE* file /* the file */;
-  mmc_sint_t cnt /* reference count */;
-  char* name /* the file name */;
-} __OMC_FILE;
-#endif
-
-static inline void* om_file_get_filename(__OMC_FILE *file)
-{
-#if __OMC_FILE_DEBUG
-  fprintf(stderr,\"File.getFilename: %s, %p %p\\n\", file->name, file->file, file); fflush(NULL);
-#endif
-  return mmc_mk_scon(file->name);
-}
-#endif
-");
+external "C" fileName = om_file_get_filename(file) annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
 end getFilename;
 
-function getReference
+function noReference "Returns NULL (an opaque pointer; not actually Option<Integer>)"
+  output Option<Integer> reference;
+external "C" reference = om_file_no_reference() annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
+end noReference;
+
+function getReference "Returns an opaque pointer (not actually Option<Integer>)"
   input File file;
   output Option<Integer> reference;
-external "C" reference = om_file_get_reference(file) annotation(Include="
-#ifndef __OMC_FILE_REFERENCE
-#define __OMC_FILE_REFERENCE
-#include <stdio.h>
-
-#ifndef __OMC_FILE_STRUCT
-#define __OMC_FILE_STRUCT
-typedef struct {
-  FILE* file /* the file */;
-  mmc_sint_t cnt /* reference count */;
-  char* name /* the file name */;
-} __OMC_FILE;
-#endif
-
-static inline void* om_file_get_reference(__OMC_FILE *file)
-{
-#if __OMC_FILE_DEBUG
-  fprintf(stderr,\"File.getReference: %s, %p %p\\n\", file->name, file->file, file); fflush(NULL);
-#endif
-  file->cnt++;
-  return file;
-}
-#endif
-");
+external "C" reference = om_file_get_reference(file) annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
 end getReference;
 
 function releaseReference
   input File file;
-external "C" om_file_release_reference(file) annotation(Include="
-#ifndef __OMC_FILE_RELEASE_REFERENCE
-#define __OMC_FILE_RELEASE_REFERENCE
-#include <stdio.h>
-
-#ifndef __OMC_FILE_STRUCT
-#define __OMC_FILE_STRUCT
-typedef struct {
-  FILE* file /* the file */;
-  mmc_sint_t cnt /* reference count */;
-  char* name /* the file name */;
-} __OMC_FILE;
-#endif
-
-static inline void* om_file_release_reference(__OMC_FILE *file)
-{
-  file->cnt--;
-  return file;
-}
-#endif
-");
+external "C" om_file_release_reference(file) annotation(IncludeDirectory="modelica://File/", Include="#include \"omc_file.h\"");
 end releaseReference;
 
 function writeSpace

--- a/Compiler/Util/omc_file.h
+++ b/Compiler/Util/omc_file.h
@@ -1,0 +1,251 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2014, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef __OMC_FILE_H
+#define __OMC_FILE_H
+
+#include <stdio.h>
+#include <gc.h>
+#include <errno.h>
+#include "ModelicaUtilities.h"
+
+typedef struct {
+  FILE* file /* the file */;
+  mmc_sint_t cnt /* reference count */;
+  const char* name /* the file name */;
+} __OMC_FILE;
+
+enum escape_t {
+  None=1,
+  C,
+  JSON,
+  XML
+};
+
+enum whence_t {
+  OMC_SEEK_SET=1,
+  OMC_SEEK_CURRENT,
+  OMC_SEEK_END
+};
+
+
+static inline void* om_file_new(void *fromID)
+{
+  if (0==fromID) {
+    __OMC_FILE *res = (__OMC_FILE*) GC_malloc(sizeof(__OMC_FILE));
+    res->file = NULL;
+    res->cnt = 0;
+    res->name = "[no open file]";
+#if defined(__OMC_FILE_DEBUG)
+    fprintf(stderr,"File.constructor: new %s\n", res->name); fflush(NULL);
+#endif
+    return res;
+  } else {
+    ((__OMC_FILE*)fromID)->cnt++; /* Increase reference count */
+#if defined(__OMC_FILE_DEBUG)
+    fprintf(stderr,"File.constructor: fromID: %s, %ld %p\n", ((__OMC_FILE*)fromID)->name, (long) ((__OMC_FILE*)fromID)->cnt, fromID); fflush(NULL);
+#endif
+    return fromID;
+  }
+}
+
+static inline void om_file_free(__OMC_FILE *file)
+{
+  if (file->cnt /* reference count */) {
+    file->cnt--;
+    return;
+  }
+#if defined(__OMC_FILE_DEBUG)
+  fprintf(stderr,"File.destructor: close:%s,%p,%p\n",file->name, file->file, file); fflush(NULL);
+#endif
+  fclose(file->file);
+  file->file = 0;
+  file->name = "[closed]";
+  GC_free(file);
+}
+
+static inline void om_file_open(__OMC_FILE *file, const char *filename, int mode)
+{
+  if (file->file) {
+#if defined(__OMC_FILE_DEBUG)
+    fprintf(stderr,"File.open: close :%s,%p,%p\n",file->name, file->file, file); fflush(NULL);
+#endif
+    fclose(file->file);
+  }
+  file->file = fopen(filename, mode == 1 ? "rb" : "wb");
+  file->name = filename;
+#if defined(__OMC_FILE_DEBUG)
+  fprintf(stderr,"File.open: f:%s,%p,%p\n",file->name,file->file,file); fflush(NULL);
+#endif
+  if (0 == file->file) {
+    ModelicaFormatError("File.open: Failed to open file %s with mode %d: %s\n", filename, mode, strerror(errno));
+  }
+}
+
+static inline void om_file_write(__OMC_FILE *file,const char *data)
+{
+  if (!file->file) {
+    ModelicaFormatError("File.write: Failed to write to file: %s (not open)", file->name);
+  }
+  if (EOF == fputs(data, file->file)) {
+    ModelicaFormatError("File.write: Failed to write to file: %s error: %s\n", file->name, strerror(errno));
+  }
+}
+
+static inline void om_file_write_int(__OMC_FILE *file, int data, const char *format)
+{
+  if (!file->file) {
+    ModelicaFormatError("File.writeInt: Failed to write to file: %s (not open)", file->name);
+  }
+  if (EOF == fprintf(file->file, format, data)) {
+    ModelicaFormatError("File.writeInt: Failed to write to file: %s error: %s\n", file->name, strerror(errno));
+  }
+}
+
+static inline void om_file_write_real(__OMC_FILE *file, double data, const char *format)
+{
+  if (!file->file) {
+    ModelicaFormatError("File.writeReal: Failed to write to file: %s (not open)", file->name);
+  }
+  if (EOF == fprintf(file->file, format, data)) {
+    ModelicaFormatError("File.writeReal: Failed to write to file: %s error: %s\n", file->name, strerror(errno));
+  }
+}
+
+#define OMC_ERROR_WRITE() ModelicaFormatError("File.writeEscape: Failed to write to file %s: %s error: %s\n", file->name, file->file, strerror(errno))
+
+static inline void om_file_write_escape(__OMC_FILE *file, const char *data, enum escape_t escape)
+{
+  if (!file->file) {
+    ModelicaFormatError("File.writeEscape: Failed to write to file: %s (not open)", file->name);
+  }
+  switch (escape) {
+  case None:
+    if (EOF == fputs(data, file->file)) {
+      ModelicaFormatError("File.writeEscape: Failed to write to file: %s error: %s\n", file->name, strerror(errno));
+    }
+    break;
+  case C:
+    while (*data) {
+      if (*data == '\n') {
+        if (fputs("\\n", file->file) < 0) OMC_ERROR_WRITE();
+      } else if (*data == '"') {
+        if (fputs("\\\"", file->file) < 0) OMC_ERROR_WRITE();
+      } else {
+        if (putc(*data, file->file) < 0) OMC_ERROR_WRITE();
+      }
+      data++;
+    }
+    break;
+  case JSON:
+    while (*data) {
+      switch (*data) {
+      case '"': if (fputs("\\\"", file->file) < 0) OMC_ERROR_WRITE();break;
+      case '\\': if (fputs("\\\\", file->file) < 0) OMC_ERROR_WRITE();break;
+      case '\n': if (fputs("\\n", file->file) < 0) OMC_ERROR_WRITE();break;
+      case '\b': if (fputs("\\b", file->file) < 0) OMC_ERROR_WRITE();break;
+      case '\f': if (fputs("\\f", file->file) < 0) OMC_ERROR_WRITE();break;
+      case '\r': if (fputs("\\r", file->file) < 0) OMC_ERROR_WRITE();break;
+      case '\t': if (fputs("\\t", file->file) < 0) OMC_ERROR_WRITE();break;
+      default:
+        if (*data < ' ') { /* Escape other control characters */
+          if (fprintf(file->file, "\\u%04x",*data) < 0) OMC_ERROR_WRITE();
+        } else {
+          if (putc(*data, file->file) < 0) OMC_ERROR_WRITE();
+        }
+      }
+      data++;
+    }
+    break;
+  case XML:
+    while (*data) {
+      switch (*data) {
+      case '<': if (fputs("&lt;", file->file) < 0) OMC_ERROR_WRITE();break;
+      case '>': if (fputs("&gt;", file->file) < 0) OMC_ERROR_WRITE();break;
+      case '"': if (fputs("&#34;", file->file) < 0) OMC_ERROR_WRITE();break;
+      case '&': if (fputs("&amp;", file->file) < 0) OMC_ERROR_WRITE();break;
+      case '\'': if (fputs("&#39;", file->file) < 0) OMC_ERROR_WRITE();break;
+      default:
+        if (putc(*data, file->file) < 0) OMC_ERROR_WRITE();
+      }
+      data++;
+    }
+    break;
+  default:
+    ModelicaFormatError("File.writeEscape: No such escape enumeration: %d\n", escape);
+  }
+}
+
+static inline int om_file_seek(__OMC_FILE *file, int offset, enum whence_t whence)
+{
+  if (!file->file) {
+    return 0;
+  }
+  return 0 == fseek(file->file, offset, whence == OMC_SEEK_SET ? SEEK_SET : whence == OMC_SEEK_CURRENT ? SEEK_CUR : SEEK_END);
+}
+
+static inline int om_file_tell(__OMC_FILE *file)
+{
+  if (!file->file) {
+    return -1;
+  }
+  return ftell(file->file);
+}
+
+static inline void* om_file_get_filename(__OMC_FILE *file)
+{
+#if defined(__OMC_FILE_DEBUG)
+  fprintf(stderr,"File.getFilename: %s, %p %p\n", file->name, file->file, file); fflush(NULL);
+#endif
+  return mmc_mk_scon(file->name);
+}
+
+static inline void* om_file_no_reference()
+{
+  return 0;
+}
+
+static inline void* om_file_get_reference(__OMC_FILE *file)
+{
+#if defined(__OMC_FILE_DEBUG)
+  fprintf(stderr,"File.getReference: %s, %p %p\n", file->name, file->file, file); fflush(NULL);
+#endif
+  file->cnt++;
+  return file;
+}
+
+static inline void* om_file_release_reference(__OMC_FILE *file)
+{
+  file->cnt--;
+  return file;
+}
+
+#endif /* __OMC_FILE_H */

--- a/Compiler/boot/Makefile.in
+++ b/Compiler/boot/Makefile.in
@@ -18,7 +18,7 @@ ifeq (@WITH_FMIL@,yes)
 FMILIB = -L$(TOP_DIR)/3rdParty/FMIL/install/lib -lfmilib
 endif
 GSLIB = -L$(TOP_DIR)/3rdParty/graphstream/gs-netstream/c++/ -lnetstream
-CPPFLAGS=-I"$(OMHOME)/include/omc/c" @CPPFLAGS@ -DADD_METARECORD_DEFINITIONS=
+CPPFLAGS=-I"$(OMHOME)/include/omc/c" -I../Util/ @CPPFLAGS@ -DADD_METARECORD_DEFINITIONS=
 CORBALIBS=@CORBALIBS@
 ULIMIT_CMD=true
 SHREXT=@DLLEXT@

--- a/Compiler/boot/Makefile.omdev.mingw
+++ b/Compiler/boot/Makefile.omdev.mingw
@@ -23,7 +23,7 @@ $(EXTRA_LD_FLAGS)
 
 FMILIB = -L$(TOP_DIR)/3rdParty/FMIL/install/lib -lfmilib
 GSLIB = -L$(TOP_DIR)/3rdParty/graphstream/gs-netstream/c++/ -lnetstream
-CPPFLAGS=-I"$(OMHOME)/include/omc/c" -Iinclude/ -DADD_METARECORD_DEFINITIONS=
+CPPFLAGS=-I"$(OMHOME)/include/omc/c" -I../Util/ -DADD_METARECORD_DEFINITIONS=
 CORBALIBS=
 ULIMIT_CMD=true
 SHREXT=.dll


### PR DESCRIPTION
The C-code was much larger than the Modelica code (and contained much
duplicated boilerplate code); it has been moved to its own file.

The File constructor was changed back to only taking one input (an
opaque pointer); it is no longer is passed NONE() but instead is passed
NULL (`File.noReference()`).