### PR TITLE
Fix KinsolLapack.cpp with sundials 2.7.0

### DIFF
--- a/SimulationRuntime/cpp/Include/Solver/Kinsol/KinsolLapack.h
+++ b/SimulationRuntime/cpp/Include/Solver/Kinsol/KinsolLapack.h
@@ -12,7 +12,7 @@ static int KINLapackCompletePivotingSolve(KINMem kin_mem, N_Vector x, N_Vector b
 #else
 static int KINLapackCompletePivotingSolve(KINMem kin_mem, N_Vector x, N_Vector b, realtype *res_norm);
 #endif
-static void KINLapackCompletePivotingFree(KINMem kin_mem);
+static int KINLapackCompletePivotingFree(KINMem kin_mem);
 static int calcJacobian(KINMem kin_mem);
 
 struct linSysData

--- a/SimulationRuntime/cpp/Solver/Kinsol/KinsolLapack.cpp
+++ b/SimulationRuntime/cpp/Solver/Kinsol/KinsolLapack.cpp
@@ -85,7 +85,7 @@ static int KINLapackCompletePivotingSetup(KINMem kin_mem)
  *  \return Return_Description
  *  \details Details
  */
-static void KINLapackCompletePivotingFree(KINMem kin_mem)
+int KINLapackCompletePivotingFree(KINMem kin_mem)
 {
 	linSysData* data = (linSysData*)kin_mem->kin_lmem;
 
@@ -94,6 +94,7 @@ static void KINLapackCompletePivotingFree(KINMem kin_mem)
 	delete [] data->ihelpArray;
 	delete [] data->jhelpArray;
 	delete data;
+	return 0;
 }
 /**\brief Brief callback function to solve linear system
  *  \param [in] kin_mem Parameter_Description


### PR DESCRIPTION
This fixes this compilation error in KinsolLapack.cpp:
```
/openmodelica-git/src/openmodelica-git/OMCompiler/SimulationRuntime/cpp/Solver/Kinsol/KinsolLapack.cpp: In function ‘int KINLapackCompletePivoting(void*, int)’:
/openmodelica-git/src/openmodelica-git/OMCompiler/SimulationRuntime/cpp/Solver/Kinsol/KinsolLapack.cpp:44:24: error: invalid conversion from ‘void (*)(KINMem) {aka void (*)(KINMemRec*)}’ to ‘int (*)(KINMemRec*)’ [-fpermissive]
kin_mem->kin_lfree = KINLapackCompletePivotingFree;
```