### PR TITLE
Fix output type of simulate

### DIFF
--- a/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -2525,7 +2525,19 @@ function simulate "simulates a modelica model by generating c code, build it and
   input String variableFilter = ".*" "Filter for variables that should store in result file. <default> = \".*\"";
   input String cflags = "<default>" "cflags. <default> = \"\"";
   input String simflags = "<default>" "simflags. <default> = \"\"";
-  output String simulationResults;
+  output SimulationResult simulationResults;
+  record SimulationResult
+    String resultFile;
+    String simulationOptions;
+    String messages;
+    Real timeFrontend;
+    Real timeBackend;
+    Real timeSimCode;
+    Real timeTemplates;
+    Real timeCompile;
+    Real timeSimulation;
+    Real timeTotal;
+  end SimulationResult;
 external "builtin";
 annotation(preferredView="text");
 end simulate;


### PR DESCRIPTION
@sjoelund @bernhard-thiele I'm not sure if this works, because most of the attributes of the record `SimulationResult` are removed when running in "test suite mode".

This is related to #953.