### PR TITLE
Improved function handling in NFInst.

### DIFF
--- a/Compiler/NFFrontEnd/NFBinding.mo
+++ b/Compiler/NFFrontEnd/NFBinding.mo
@@ -32,7 +32,7 @@
 encapsulated uniontype NFBinding
 public
   import DAE;
-  import NFExpression.Expression;
+  import Expression = NFExpression;
   import NFInstNode.InstNode;
   import SCode;
   import Type = NFType;

--- a/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -48,11 +48,12 @@ import Binding = NFBinding;
 import NFClass.Class;
 import NFClass.ClassTree;
 import NFComponent.Component;
-import NFExpression.Expression;
+import Expression = NFExpression;
 import NFInstNode.InstNode;
 import NFInstNode.InstNodeType;
 import NFMod.Modifier;
 import Type = NFType;
+import BuiltinFuncs = NFBuiltinFuncs;
 
 encapsulated package Elements
   import SCode;
@@ -86,23 +87,27 @@ encapsulated package Elements
   constant SCode.Element REAL = SCode.CLASS("Real",
     SCode.defaultPrefixes, SCode.NOT_ENCAPSULATED(), SCode.NOT_PARTIAL(), SCode.R_TYPE(),
     SCode.PARTS({}, {}, {}, {}, {}, {}, {}, NONE()),
-    SCode.noComment,Absyn.dummyInfo);
+    SCode.noComment, Absyn.dummyInfo);
 
   constant SCode.Element INTEGER = SCode.CLASS("Integer",
     SCode.defaultPrefixes, SCode.NOT_ENCAPSULATED(), SCode.NOT_PARTIAL(), SCode.R_TYPE(),
     SCode.PARTS({}, {}, {}, {}, {}, {}, {}, NONE()),
-    SCode.noComment,Absyn.dummyInfo);
+    SCode.noComment, Absyn.dummyInfo);
 
   constant SCode.Element BOOLEAN = SCode.CLASS("Boolean",
     SCode.defaultPrefixes, SCode.NOT_ENCAPSULATED(), SCode.NOT_PARTIAL(), SCode.R_TYPE(),
     SCode.PARTS({}, {}, {}, {}, {}, {}, {}, NONE()),
-    SCode.noComment,Absyn.dummyInfo);
+    SCode.noComment, Absyn.dummyInfo);
 
   constant SCode.Element STRING = SCode.CLASS("String",
     SCode.defaultPrefixes, SCode.NOT_ENCAPSULATED(), SCode.NOT_PARTIAL(), SCode.R_TYPE(),
     SCode.PARTS({}, {}, {}, {}, {}, {}, {}, NONE()),
-    SCode.noComment,Absyn.dummyInfo);
+    SCode.noComment, Absyn.dummyInfo);
 
+  constant SCode.Element ENUMERATION = SCode.CLASS("enumeration",
+    SCode.defaultPrefixes, SCode.NOT_ENCAPSULATED(), SCode.NOT_PARTIAL(), SCode.R_TYPE(),
+    SCode.PARTS({}, {}, {}, {}, {}, {}, {}, NONE()),
+    SCode.noComment, Absyn.dummyInfo);
 
   constant SCode.Element STATESELECT = SCode.CLASS("StateSelect",
     SCode.defaultPrefixes, SCode.NOT_ENCAPSULATED(), SCode.NOT_PARTIAL(), SCode.R_TYPE(),
@@ -134,7 +139,7 @@ constant InstNode REAL_TYPE = InstNode.CLASS_NODE("Real",
 constant InstNode INT_TYPE = InstNode.CLASS_NODE("Integer",
   Elements.INTEGER,
   listArray({Class.PARTIAL_BUILTIN(Type.INTEGER(), ClassTree.EMPTY(), listArray({}), Modifier.NOMOD())}),
-  listArray({NFInstNode.CachedData.NO_CACHE()}),
+  listArray({NFInstNode.CachedData.FUNCTION({NFBuiltinFuncs.INTEGER}, true)}),
   InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
 
 constant InstNode BOOLEAN_TYPE = InstNode.CLASS_NODE("Boolean",
@@ -146,6 +151,15 @@ constant InstNode BOOLEAN_TYPE = InstNode.CLASS_NODE("Boolean",
 constant InstNode STRING_TYPE = InstNode.CLASS_NODE("String",
   Elements.STRING,
   listArray({Class.PARTIAL_BUILTIN(Type.STRING(), ClassTree.EMPTY(), listArray({}), Modifier.NOMOD())}),
+  listArray({NFInstNode.CachedData.FUNCTION({
+    NFBuiltinFuncs.STRING_ENUM, NFBuiltinFuncs.STRING_INT,
+    NFBuiltinFuncs.STRING_BOOL, NFBuiltinFuncs.STRING_REAL,
+    NFBuiltinFuncs.STRING_REAL_FORMAT}, true)}),
+  InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
+
+constant InstNode ENUM_TYPE = InstNode.CLASS_NODE("enumeration",
+  Elements.ENUMERATION,
+  listArray({Class.PARTIAL_BUILTIN(Type.ENUMERATION_ANY(), ClassTree.EMPTY(), listArray({}), Modifier.NOMOD())}),
   listArray({NFInstNode.CachedData.NO_CACHE()}),
   InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
 

--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -1,0 +1,142 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2014, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package NFBuiltinFuncs
+
+import NFFunction.Function;
+import NFFunction.Slot;
+import NFFunction.SlotType;
+import NFFunction.FuncType;
+import NFInstNode.InstNode;
+import NFInstNode.InstNodeType;
+import NFComponent.Component;
+import Type = NFType;
+import Expression = NFExpression;
+import Absyn;
+import Absyn.{Path, TypeSpec};
+import SCode;
+import SCode.{Mod, Comment};
+import DAE;
+import Builtin = NFBuiltin;
+import Binding = NFBinding;
+
+// Dummy SCode component, since we usually don't need the definition for anything.
+constant SCode.Element DUMMY_ELEMENT = SCode.COMPONENT("dummy",
+  SCode.defaultPrefixes, SCode.defaultVarAttr,
+  TypeSpec.TPATH(Path.IDENT("$dummy"), NONE()), SCode.Mod.NOMOD(),
+  SCode.Comment.COMMENT(NONE(), NONE()), NONE(), Absyn.dummyInfo);
+
+// Default Integer parameter.
+constant Component INT_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
+  Type.INTEGER(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR);
+
+constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
+  DUMMY_ELEMENT, listArray({INT_COMPONENT}), InstNode.EMPTY_NODE());
+
+// Default Real parameter.
+constant Component REAL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
+  Type.REAL(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR);
+
+constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
+  DUMMY_ELEMENT, listArray({REAL_COMPONENT}), InstNode.EMPTY_NODE());
+
+// Default Boolean parameter.
+constant Component BOOL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
+  Type.BOOLEAN(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR);
+
+constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
+  DUMMY_ELEMENT, listArray({BOOL_COMPONENT}), InstNode.EMPTY_NODE());
+
+// Default String parameter.
+constant Component STRING_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
+  Type.STRING(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR);
+
+constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
+  DUMMY_ELEMENT, listArray({STRING_COMPONENT}), InstNode.EMPTY_NODE());
+
+// Default enumeration(:) parameter.
+constant Component ENUM_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
+  Type.ENUMERATION_ANY(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR);
+
+constant InstNode ENUM_PARAM = InstNode.COMPONENT_NODE("e",
+  DUMMY_ELEMENT, listArray({ENUM_COMPONENT}), InstNode.EMPTY_NODE());
+
+// Integer(e)
+constant Function INTEGER = Function.FUNCTION(Path.IDENT("Integer"),
+  InstNode.EMPTY_NODE(), {ENUM_PARAM}, {}, {}, {
+    Slot.SLOT("e", SlotType.POSITIONAL, NONE(), NONE())
+  }, Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, listArray({true}));
+
+// String(r, significantDigits=d, minimumLength=0, leftJustified=true)
+constant InstNode STRING_NODE = NFInstNode.CLASS_NODE("String", DUMMY_ELEMENT,
+  listArray({}), listArray({}), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
+
+constant Function STRING_REAL = Function.FUNCTION(Path.IDENT("String"),
+  STRING_NODE, {REAL_PARAM, INT_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
+    Slot.SLOT("r", SlotType.POSITIONAL, NONE(), NONE()),
+    Slot.SLOT("significantDigits", SlotType.NAMED, SOME(Expression.INTEGER(6)), NONE()),
+    Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE()),
+    Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE())
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, listArray({true}));
+
+// String(r, format="-0.6g")
+constant Function STRING_REAL_FORMAT = Function.FUNCTION(Path.IDENT("String"),
+  STRING_NODE, {REAL_PARAM, STRING_PARAM}, {STRING_PARAM}, {}, {
+    Slot.SLOT("r", SlotType.POSITIONAL, NONE(), NONE()),
+    Slot.SLOT("format", SlotType.NAMED, SOME(Expression.STRING("-0.6g")), NONE())
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, listArray({true}));
+
+// String(i, minimumLength=0, leftJustified=true)
+constant Function STRING_INT = Function.FUNCTION(Path.IDENT("String"),
+  STRING_NODE, {INT_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
+    Slot.SLOT("i", SlotType.POSITIONAL, NONE(), NONE()),
+    Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE()),
+    Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE())
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, listArray({true}));
+
+// String(b, minimumLength=0, leftJustified=true)
+constant Function STRING_BOOL = Function.FUNCTION(Path.IDENT("String"),
+  STRING_NODE, {BOOL_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
+    Slot.SLOT("b", SlotType.POSITIONAL, NONE(), NONE()),
+    Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE()),
+    Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE())
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, listArray({true}));
+
+// String(e, minimumLength=0, leftJustified=true)
+constant Function STRING_ENUM = Function.FUNCTION(Path.IDENT("String"),
+  STRING_NODE, {ENUM_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
+    Slot.SLOT("e", SlotType.POSITIONAL, NONE(), NONE()),
+    Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE()),
+    Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE())
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, listArray({true}));
+
+annotation(__OpenModelica_Interface="frontend");
+end NFBuiltinFuncs;

--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -32,226 +32,476 @@
 encapsulated package NFCall
 
 import Absyn;
+import DAE;
 import NFInstNode.InstNode;
-import NFExpression.Expression;
+import Expression = NFExpression;
 import Type = NFType;
 
 protected
 import NFInstNode.CachedData;
-import NFExpression.CallAttributes;
 import ComponentRef = NFComponentRef;
 import NFFunction.Function;
 import Inst = NFInst;
+import NFInstNode.InstNodeType;
 import Lookup = NFLookup;
 import Typing = NFTyping;
 import Types;
+import List;
+import NFClass.Class;
 
 public
-function instantiate
-  input Absyn.ComponentRef functionName;
-  input Absyn.FunctionArgs functionArgs;
-  input InstNode scope;
-  input SourceInfo info;
-        output Expression callExp;
+uniontype CallAttributes
+  record CALL_ATTR
+    Type ty "The type of the return value, if several return values this is undefined";
+    Boolean tuple_ "tuple" ;
+    Boolean builtin "builtin Function call" ;
+    Boolean isImpure "if the function has prefix *impure* is true, else false";
+    Boolean isFunctionPointerCall;
+    DAE.InlineType inlineType;
+    DAE.TailCall tailCall "Input variables of the function if the call is tail-recursive";
+  end CALL_ATTR;
+
+  function toDAE
+    input CallAttributes attr;
+    output DAE.CallAttributes fattr;
+  algorithm
+    fattr := DAE.CALL_ATTR(Type.toDAE(attr.ty), attr.tuple_, attr.builtin,
+      attr.isImpure, attr.isFunctionPointerCall, attr.inlineType, attr.tailCall);
+  end toDAE;
+end CallAttributes;
+
+public constant CallAttributes callAttrBuiltinBool = CALL_ATTR(Type.BOOLEAN(),false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+public constant CallAttributes callAttrBuiltinInteger = CALL_ATTR(Type.INTEGER(),false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+public constant CallAttributes callAttrBuiltinReal = CALL_ATTR(Type.REAL(),false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+public constant CallAttributes callAttrBuiltinString = CALL_ATTR(Type.STRING(),false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+public constant CallAttributes callAttrBuiltinOther = CALL_ATTR(Type.UNKNOWN(),false,true,false,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+public constant CallAttributes callAttrBuiltinImpureBool = CALL_ATTR(Type.BOOLEAN(),false,true,true,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+public constant CallAttributes callAttrBuiltinImpureInteger = CALL_ATTR(Type.INTEGER(),false,true,true,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+public constant CallAttributes callAttrBuiltinImpureReal = CALL_ATTR(Type.REAL(),false,true,true,false,DAE.NO_INLINE(),DAE.NO_TAIL());
+
+uniontype Call
+  record UNTYPED_CALL
+    ComponentRef ref;
+    list<Integer> matchingFuncs;
+    list<Expression> arguments;
+  end UNTYPED_CALL;
+
+  record TYPED_CALL
+    Function fn;
+    list<Expression> arguments;
+    CallAttributes attributes;
+  end TYPED_CALL;
+
+  function instantiate
+    input Absyn.ComponentRef functionName;
+    input Absyn.FunctionArgs functionArgs;
+    input InstNode scope;
+    input SourceInfo info;
+          output Expression callExp;
+  protected
+    InstNode fn_node;
+    Function fn;
+    list<Function> fnl;
+    CachedData cache;
+    ComponentRef fn_ref;
+    Absyn.Path fn_path;
+  algorithm
+    // Look up the the function.
+    (fn_node, fn_ref, fn_path) := lookupFunction(functionName, scope, info);
+    cache := InstNode.cachedData(fn_node);
+
+    // Check if a cached instantiation of this function already exists.
+    fnl := match cache
+      case CachedData.FUNCTION() then cache.funcs;
+
+      else // Not yet instantiated, instantiate it and cache it in the node.
+        algorithm
+          // Function components shouldn't be prefixed, so mark the node as root class.
+          fn_node := InstNode.setNodeType(InstNodeType.ROOT_CLASS(), fn_node);
+          fn_node := Inst.instantiate(fn_node);
+          Inst.instExpressions(fn_node);
+          fnl := makeFunctions(fn_path, fn_node);
+          fn_node := InstNode.setCachedData(CachedData.FUNCTION(fnl, false), fn_node);
+        then
+          fnl;
+    end match;
+
+    callExp := makeCall(fn_ref, fnl, functionArgs, scope, info);
+  end instantiate;
+
+  function makeFunctions
+    input Absyn.Path path;
+    input InstNode node;
+    output list<Function> funcs;
+  protected
+    Class cls = InstNode.getClass(node);
+  algorithm
+    funcs := match cls
+      case Class.OVERLOADED_CLASS()
+        algorithm
+          funcs := list(Function.new(path, o) for o in cls.overloads);
+        then
+          funcs;
+
+      else {Function.new(path, node)};
+    end match;
+  end makeFunctions;
+
+  function typeCall
+    input output Expression callExp;
+    input InstNode scope;
+    input SourceInfo info;
+          output Type ty;
+          output DAE.Const variability;
+  protected
+    Call call;
+    InstNode fn_node;
+    list<Function> fnl;
+    Boolean fn_typed;
+    Function fn;
+    list<Expression> args;
+    list<Type> arg_ty;
+    list<DAE.Const> arg_var;
+    CallAttributes ca;
+  algorithm
+    (callExp, ty, variability) := match callExp
+      case Expression.CALL(call = call as UNTYPED_CALL(ref = ComponentRef.CREF(node = fn_node)))
+        algorithm
+          // Fetch the cached function(s).
+          CachedData.FUNCTION(fnl, fn_typed) := InstNode.cachedData(fn_node);
+
+          // Type the function(s) if not already done.
+          if not fn_typed then
+            fnl := list(Function.typeFunction(f) for f in fnl);
+            InstNode.setCachedData(CachedData.FUNCTION(fnl, true), fn_node);
+          end if;
+
+          // The instantiation should make sure this never happens.
+          assert(not listEmpty(fnl), getInstanceName() + " couldn't find a cached function");
+
+          // Type the arguments.
+          (args, arg_ty, arg_var) := Typing.typeExpl(call.arguments, scope, info);
+
+          // TODO: Figure out why this segfaults.
+          //variability := Types.constAnd(v for v in arg_var);
+          variability := List.fold(arg_var, Types.constAnd, DAE.C_CONST());
+
+          // Type check the arguments.
+          (args, fn) := typeCheckCall(fnl, call.matchingFuncs, args, arg_ty, arg_var, info);
+
+          // Construct the call expression.
+          ty := Function.returnType(fn);
+          ca := CallAttributes.CALL_ATTR(
+            ty,
+            Type.isTuple(ty),
+            Function.isBuiltin(fn),
+            Function.isImpure(fn),
+            Function.isFunctionPointer(fn),
+            Function.inlineBuiltin(fn),
+            DAE.NO_TAIL());
+
+          callExp := Expression.CALL(TYPED_CALL(fn, args, ca));
+        then
+          (callExp, ty, variability);
+
+      else
+        algorithm
+          assert(false, getInstanceName() + " got invalid function call expression");
+        then
+          fail();
+    end match;
+  end typeCall;
+
+  function arguments
+    input Call call;
+    output list<Expression> arguments;
+  algorithm
+    arguments := match call
+      case UNTYPED_CALL() then call.arguments;
+      case TYPED_CALL() then call.arguments;
+    end match;
+  end arguments;
+
+  function compare
+    input Call call1;
+    input Call call2;
+    output Integer comp;
+  algorithm
+    comp := match (call1, call2)
+      case (UNTYPED_CALL(), UNTYPED_CALL())
+        then ComponentRef.compare(call1.ref, call2.ref);
+
+      case (TYPED_CALL(), TYPED_CALL())
+        then Absyn.pathCompare(Function.name(call1.fn), Function.name(call2.fn));
+
+      case (UNTYPED_CALL(), TYPED_CALL())
+        then Absyn.pathCompare(ComponentRef.toPath(call1.ref), Function.name(call2.fn));
+
+      case (TYPED_CALL(), UNTYPED_CALL())
+        then Absyn.pathCompare(Function.name(call1.fn), ComponentRef.toPath(call2.ref));
+    end match;
+
+    if comp == 0 then
+      comp := Expression.compareList(arguments(call1), arguments(call2));
+    end if;
+  end compare;
+
+  function toDAE
+    input Call call;
+    output DAE.Exp daeCall;
+  algorithm
+    daeCall := match call
+      case TYPED_CALL()
+        then DAE.CALL(Function.name(call.fn),
+          list(Expression.toDAE(e) for e in call.arguments),
+          CallAttributes.toDAE(call.attributes));
+
+      else
+        algorithm
+          assert(false, getInstanceName() + " got untyped call");
+        then
+          fail();
+    end match;
+  end toDAE;
+
+  function toString
+    input Call call;
+    output String str;
+  protected
+    String name, arg_str;
+  algorithm
+    str := match call
+      case UNTYPED_CALL()
+        algorithm
+          name := ComponentRef.toString(call.ref);
+          arg_str := stringDelimitList(list(Expression.toString(arg) for arg in call.arguments), ", ");
+        then
+          name + "(" + arg_str + ")";
+
+      case TYPED_CALL()
+        algorithm
+          name := Absyn.pathString(Function.name(call.fn));
+          arg_str := stringDelimitList(list(Expression.toString(arg) for arg in call.arguments), ", ");
+        then
+          name + "(" + arg_str + ")";
+    end match;
+  end toString;
+
+  function typedFunction
+    input Call call;
+    output Function fn;
+  algorithm
+    fn := match call
+      case TYPED_CALL() then call.fn;
+      else
+        algorithm
+          assert(false, getInstanceName() + " got untyped function");
+        then
+          fail();
+    end match;
+  end typedFunction;
+
+  //function makeBuiltinCall
+  //  "Create a CALL with the given data for a call to a builtin function."
+  //  input String name;
+  //  input Expression cref "pointer to class and prefix";
+  //  input list<Expression> args;
+  //  input Type result_type;
+  //  input Boolean isImpure;
+  //  output Expression call;
+  //  annotation(__OpenModelica_EarlyInline = true);
+  //algorithm
+  //  call := Expression.CALL(Absyn.IDENT(name), cref, args,
+  //    CallAttributes.CALL_ATTR(result_type, false, true, isImpure, false, DAE.NO_INLINE(), DAE.NO_TAIL()));
+  //end makeBuiltinCall;
+
+  //function makePureBuiltinCall
+  //  "Create a CALL with the given data for a call to a builtin function."
+  //  input String name;
+  //  input Expression cref "pointer to class and prefix";
+  //  input list<Expression> args;
+  //  input Type result_type;
+  //  output Expression call;
+  //  annotation(__OpenModelica_EarlyInline = true);
+  //algorithm
+  //  call := makeBuiltinCall(name, cref, args, result_type, false);
+  //end makePureBuiltinCall;
 protected
-  InstNode fn_node;
-  Function fn;
-  list<Function> fnl;
-  CachedData cache;
-  ComponentRef fn_ref;
-  Absyn.Path fn_path;
-algorithm
-  // Look up the the function.
-  (fn_node, fn_ref, fn_path) := lookupFunction(functionName, scope, info);
-  cache := InstNode.cachedData(fn_node);
+  function lookupFunction
+    input Absyn.ComponentRef functionName;
+    input InstNode scope;
+    input SourceInfo info;
+    output InstNode node;
+    output ComponentRef functionRef;
+    output Absyn.Path functionPath;
+  protected
+    list<InstNode> nodes;
+    InstNode found_scope;
+  algorithm
+    try
+      // Make sure the name is a path.
+      functionPath := Absyn.crefToPath(functionName);
+    else
+      Error.addSourceMessageAndFail(Error.SUBSCRIPTED_FUNCTION_CALL,
+        {Dump.printComponentRefStr(functionName)}, info);
+    end try;
 
-  // Check if a cached instantiation of this function already exists.
-  fnl := match cache
-    case CachedData.FUNCTION() then cache.funcs;
+    // Look up the function and create a cref for it.
+    (node, nodes, found_scope) := Lookup.lookupFunctionName(functionName, scope, info);
 
-    else // Not yet instantiated, instantiate it and cache it in the node.
-      algorithm
-        fn_node := Inst.instantiate(fn_node);
-        Inst.instExpressions(fn_node);
-        fn := Function.new(fn_path, fn_node);
-        fn_node := InstNode.cacheAddFunc(fn, fn_node);
-      then
-        {fn};
-  end match;
+    for s in InstNode.scopeList(found_scope) loop
+      functionPath := Absyn.QUALIFIED(InstNode.name(s), functionPath);
+    end for;
 
-  callExp := makeCall(fn_ref, fnl, functionArgs, scope, info);
-end instantiate;
+    functionRef := ComponentRef.fromNodeList(InstNode.scopeList(found_scope));
+    functionRef := Inst.makeCref(functionName, nodes, scope, info, functionRef);
+  end lookupFunction;
 
-function typeCall
-  input output Expression callExp;
-  input InstNode scope;
-  input SourceInfo info;
-        output Type ty;
-        output DAE.Const variability;
-protected
-  InstNode fn_node;
-  list<Function> fnl;
-  Boolean fn_typed;
-  Function fn;
-  list<Expression> args;
-  list<Type> arg_ty;
-  list<DAE.Const> arg_var;
-  CallAttributes ca;
-algorithm
-  (callExp, ty, variability) := match callExp
-    case Expression.CALL(ref = ComponentRef.CREF(node = fn_node))
-      algorithm
-        // Fetch the cached function(s).
-        CachedData.FUNCTION(fnl, fn_typed) := InstNode.cachedData(fn_node);
+  function makeCall
+    input ComponentRef fnRef;
+    input list<Function> funcs;
+    input Absyn.FunctionArgs callArgs;
+    input InstNode scope;
+    input SourceInfo info;
+    output Expression call;
+  protected
+    list<Expression> args;
+    list<tuple<String, Expression>> named_args;
+    list<Integer> matching_funcs;
+  algorithm
+    (args, named_args) := instArgs(callArgs, scope, info);
+    (args, matching_funcs) := matchArgs(args, named_args, funcs, info);
+    call := Expression.CALL(UNTYPED_CALL(fnRef, matching_funcs, args));
+  end makeCall;
 
-        // Type the function(s) if not already done.
-        if not fn_typed then
-          fnl := list(Function.typeFunction(f) for f in fnl);
-          InstNode.setCachedData(CachedData.FUNCTION(fnl, true), fn_node);
+  function instArgs
+    input Absyn.FunctionArgs args;
+    input InstNode scope;
+    input SourceInfo info;
+    output list<Expression> posArgs;
+    output list<tuple<String, Expression>> namedArgs;
+  algorithm
+    (posArgs, namedArgs) := match args
+      case Absyn.FUNCTIONARGS()
+        algorithm
+          posArgs := list(Inst.instExp(a, scope, info) for a in args.args);
+          namedArgs := list(instNamedArg(a, scope, info) for a in args.argNames);
+        then
+          (posArgs, namedArgs);
+
+      else
+        algorithm
+          assert(false, getInstanceName() + " got unknown function args");
+        then
+          fail();
+    end match;
+  end instArgs;
+
+  function instNamedArg
+    input Absyn.NamedArg absynArg;
+    input InstNode scope;
+    input SourceInfo info;
+    output tuple<String, Expression> arg;
+  protected
+    String name;
+    Absyn.Exp exp;
+  algorithm
+    Absyn.NAMEDARG(argName = name, argValue = exp) := absynArg;
+    arg := (name, Inst.instExp(exp, scope, info));
+  end instNamedArg;
+
+  function matchArgs
+    input list<Expression> posArgs;
+    input list<tuple<String, Expression>> namedArgs;
+    input list<Function> funcs;
+    input SourceInfo info;
+    output list<Expression> args;
+    output list<Integer> matchingFuncs = {};
+  protected
+    Function fn;
+    Boolean matching;
+    list<Expression> argl;
+    Integer i;
+
+    String fn_name, fn_defs, args_str;
+  algorithm
+    if listLength(funcs) == 1 then
+      (args, true) := Function.matchArgs(posArgs, namedArgs, listHead(funcs), SOME(info));
+    else
+      i := 1;
+
+      for fn in funcs loop
+        (argl, matching) := Function.matchArgs(posArgs, namedArgs, fn, NONE());
+
+        if matching then
+          args := argl;
+          matchingFuncs := i :: matchingFuncs;
         end if;
 
-        assert(not listEmpty(fnl), getInstanceName() + " couldn't find a cached function");
+        i := i + 1;
+      end for;
 
-        fn := match fnl
-          case {fn} then fn; // The normal case of only one matching function.
-          else // TODO: Handle overloaded functions.
-            algorithm
-              assert(false, getInstanceName() + ": IMPLEMENT ME");
-            then
-              fail();
-        end match;
+      // No matching function, print an error message.
+      if listEmpty(matchingFuncs) then
+        // TODO: Remove "in component" from error message.
+        Error.addSourceMessage(Error.NO_MATCHING_FUNCTION_FOUND,
+          {Function.callString(listHead(funcs), posArgs, namedArgs), "<REMOVE ME>",
+           ":\n  " + stringDelimitList(list(Function.signatureString(fn, false) for fn in funcs), "\n  ")},
+          info);
 
-
-        // Type the arguments.
-        (args, arg_ty, arg_var) := Typing.typeExpl(callExp.arguments, scope, info);
-        variability := Types.constAnd(v for v in arg_var);
-
-        ty := fn.returnType;
-        ca := CallAttributes.CALL_ATTR(
-          ty,
-          Type.isTuple(fn.returnType),
-          Function.isBuiltin(fn),
-          Function.isImpure(fn),
-          Function.isFunctionPointer(fn),
-          Function.inlineBuiltin(fn),
-          DAE.NO_TAIL());
-
-        // TODO: Type check arguments against the inputs, and check variability.
-
-        callExp := Expression.CALL(callExp.ref, args, SOME(ca));
-      then
-        (callExp, ty, variability);
-
-    else
-      algorithm
-        assert(false, getInstanceName() + " got invalid function call expression");
-      then
         fail();
-  end match;
-end typeCall;
+      end if;
 
-protected
-function lookupFunction
-  input Absyn.ComponentRef functionName;
-  input InstNode scope;
-  input SourceInfo info;
-  output InstNode node;
-  output ComponentRef functionRef;
-  output Absyn.Path functionPath;
-protected
-  list<InstNode> nodes;
-  InstNode found_scope;
-algorithm
-  try
-    // Make sure the name is a path.
-    functionPath := Absyn.crefToPath(functionName);
-  else
-    Error.addSourceMessageAndFail(Error.SUBSCRIPTED_FUNCTION_CALL,
-      {Dump.printComponentRefStr(functionName)}, info);
-  end try;
+      matchingFuncs := listReverse(matchingFuncs);
+    end if;
+  end matchArgs;
 
-  // Look up the function and create a cref for it.
-  (node, nodes, found_scope) := Lookup.lookupFunctionName(functionName, scope, info);
-
-  for s in InstNode.scopeList(found_scope) loop
-    functionPath := Absyn.QUALIFIED(InstNode.name(s), functionPath);
-  end for;
-
-  functionRef := ComponentRef.fromNodeList(InstNode.scopeList(found_scope));
-  functionRef := Inst.makeCref(functionName, nodes, scope, info, functionRef);
-end lookupFunction;
-
-function makeCall
-  input ComponentRef fnRef;
-  input list<Function> funcs;
-  input Absyn.FunctionArgs callArgs;
-  input InstNode scope;
-  input SourceInfo info;
-  output Expression call;
-  output list<Function> matchingFuncs;
-protected
-  list<Expression> args;
-  list<tuple<String, Expression>> named_args;
-algorithm
-  (args, named_args) := instArgs(callArgs, scope, info);
-  (args, matchingFuncs) := matchArgs(args, named_args, funcs, info);
-  call := Expression.CALL(fnRef, args, NONE());
-end makeCall;
-
-function instArgs
-  input Absyn.FunctionArgs args;
-  input InstNode scope;
-  input SourceInfo info;
-  output list<Expression> posArgs;
-  output list<tuple<String, Expression>> namedArgs;
-algorithm
-  (posArgs, namedArgs) := match args
-    case Absyn.FUNCTIONARGS()
-      algorithm
-        posArgs := list(Inst.instExp(a, scope, info) for a in args.args);
-        namedArgs := list(instNamedArg(a, scope, info) for a in args.argNames);
-      then
-        (posArgs, namedArgs);
-
+  function typeCheckCall
+    input list<Function> funcs;
+    input list<Integer> matchingFuncs;
+    input output list<Expression> args;
+    input list<Type> types;
+    input list<DAE.Const> variabilities;
+    input SourceInfo info;
+    output Function fn;
+  protected
+    list<Integer> matching_funcs;
+    Integer i = 1, idx;
+    Boolean correct;
+  algorithm
+    if listLength(funcs) == 1 then
+      fn := listHead(funcs);
+      (args, true) := Function.typeCheckArgs(fn, args, types, variabilities, SOME(info));
     else
-      algorithm
-        assert(false, getInstanceName() + " got unknown function args");
-      then
-        fail();
-  end match;
-end instArgs;
+      idx :: matching_funcs := matchingFuncs;
 
-function instNamedArg
-  input Absyn.NamedArg absynArg;
-  input InstNode scope;
-  input SourceInfo info;
-  output tuple<String, Expression> arg;
-protected
-  String name;
-  Absyn.Exp exp;
-algorithm
-  Absyn.NAMEDARG(argName = name, argValue = exp) := absynArg;
-  arg := (name, Inst.instExp(exp, scope, info));
-end instNamedArg;
+      for func in funcs loop
+        if idx == i then
+          (args, correct) := Function.typeCheckArgs(func, args, types, variabilities, NONE());
 
-function matchArgs
-  input list<Expression> posArgs;
-  input list<tuple<String, Expression>> namedArgs;
-  input list<Function> funcs;
-  input SourceInfo info;
-  output list<Expression> args;
-  output list<Function> matchingFuncs;
-protected
-  Function fn;
-algorithm
-  if listLength(funcs) == 1 then
-    (args, true) := Function.matchArgs(posArgs, namedArgs, listHead(funcs), SOME(info));
-    matchingFuncs := funcs;
-  else
-    // TODO: Implement case for overloaded functions.
-    assert(false, getInstanceName() + ": IMPLEMENT ME");
-  end if;
-end matchArgs;
+          if correct then
+            fn := func;
+            return;
+          elseif listEmpty(matching_funcs) then
+            break;
+          else
+            idx :: matching_funcs := matching_funcs;
+          end if;
+        end if;
+
+        i := i + 1;
+      end for;
+
+      // TODO: Remove "in component" from error message.
+      Error.addSourceMessage(Error.NO_MATCHING_FUNCTION_FOUND,
+        {Function.callString(listHead(funcs), args, {}), "<REMOVE ME>",
+         ":\n  " + stringDelimitList(list(Function.signatureString(fn) for fn in funcs), "\n  ")},
+        info);
+      fail();
+    end if;
+  end typeCheckCall;
+
+end Call;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFCall;

--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -35,10 +35,11 @@ import Binding = NFBinding;
 import ComponentRef = NFComponentRef;
 import Error;
 import NFComponent.Component;
-import NFExpression.Expression;
+import Expression = NFExpression;
 import NFInstNode.InstNode;
 import Operator = NFOperator;
 import Typing = NFTyping;
+import NFCall.Call;
 
 uniontype EvalTarget
   record DIMENSION
@@ -61,6 +62,7 @@ algorithm
       Binding binding;
       Expression exp1, exp2, exp3;
       list<Expression> expl = {};
+      Call call;
 
     case Expression.CREF(cref=ComponentRef.CREF(node=c as InstNode.COMPONENT_NODE()))
       algorithm
@@ -90,13 +92,11 @@ algorithm
         assert(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName());
       then fail();
 
-    case Expression.CALL()
+    case Expression.CALL(call = call as Call.TYPED_CALL())
       algorithm
-        for e in exp.arguments loop
-          exp1 := evalExp(e, target);
-          expl := exp1 :: expl;
-        end for;
-      then Expression.CALL(exp.ref, listReverse(expl), exp.attr);
+        call.arguments := list(evalExp(e, target) for e in call.arguments);
+      then
+        Expression.CALL(call);
 
     case Expression.SIZE()
       algorithm

--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -119,6 +119,10 @@ uniontype Class
     list<Modifier> attributes;
   end INSTANCED_BUILTIN;
 
+  record OVERLOADED_CLASS
+    list<InstNode> overloads;
+  end OVERLOADED_CLASS;
+
   type Element = ClassTree.Entry;
 
   function initExpandedClass

--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -195,6 +195,16 @@ uniontype Component
     end match;
   end setType;
 
+  function isTyped
+    input Component component;
+    output Boolean isTyped;
+  algorithm
+    isTyped := match component
+      case TYPED_COMPONENT() then true;
+      else false;
+    end match;
+  end isTyped;
+
   function unliftType
     input output Component component;
   algorithm

--- a/Compiler/NFFrontEnd/NFDimension.mo
+++ b/Compiler/NFFrontEnd/NFDimension.mo
@@ -38,7 +38,7 @@ public
   import Absyn.Path;
   import Dump;
   import NFClass.Class;
-  import NFExpression.Expression;
+  import Expression = NFExpression;
   import NFInstNode.InstNode;
   import Type = NFType;
   import ComponentRef = NFComponentRef;

--- a/Compiler/NFFrontEnd/NFEquation.mo
+++ b/Compiler/NFFrontEnd/NFEquation.mo
@@ -32,7 +32,7 @@
 encapsulated package NFEquation
 
 import Absyn;
-import NFExpression.Expression;
+import Expression = NFExpression;
 import Type = NFType;
 
 public uniontype Equation

--- a/Compiler/NFFrontEnd/NFRecord.mo
+++ b/Compiler/NFFrontEnd/NFRecord.mo
@@ -43,7 +43,7 @@ import NFClass.Class;
 import NFComponent.Component;
 import Dimension = NFDimension;
 import NFEquation.Equation;
-import NFExpression.Expression;
+import Expression = NFExpression;
 import NFExpression.CallAttributes;
 import NFInstNode.InstNode;
 import NFMod.Modifier;

--- a/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -31,9 +31,10 @@
 
 encapsulated package NFSimplifyExp
 
-import NFExpression.Expression;
+import Expression = NFExpression;
 import Operator = NFOperator;
 import Type = NFType;
+import NFCall.Call;
 
 function simplifyExp
   input output Expression exp;
@@ -49,6 +50,7 @@ function preSimplify
 protected
   Expression exp1, exp2, exp3;
   list<Expression> expl = {};
+  Call call;
 algorithm
   exp := match exp
     case Expression.ARRAY()
@@ -69,13 +71,11 @@ algorithm
         assert(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName());
       then fail();
 
-    case Expression.CALL()
+    case Expression.CALL(call = call as Call.TYPED_CALL())
       algorithm
-        for e in exp.arguments loop
-          exp1 := simplifyExp(e);
-          expl := exp1 :: expl;
-        end for;
-      then Expression.CALL(exp.ref, listReverse(expl), exp.attr);
+        call.arguments := list(simplifyExp(e) for e in call.arguments);
+      then
+        Expression.CALL(call);
 
     case Expression.SIZE()
       algorithm

--- a/Compiler/NFFrontEnd/NFStatement.mo
+++ b/Compiler/NFFrontEnd/NFStatement.mo
@@ -33,7 +33,7 @@ encapsulated package NFStatement
 
 import Absyn;
 import Type = NFType;
-import NFExpression.Expression;
+import Expression = NFExpression;
 
 public uniontype Statement
   record ASSIGNMENT

--- a/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/Compiler/NFFrontEnd/NFSubscript.mo
@@ -37,7 +37,7 @@ protected
   import List;
 
 public
-  import NFExpression.Expression;
+  import Expression = NFExpression;
 
   record UNTYPED
     Expression exp;

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -58,6 +58,9 @@ public
     list<String> literals;
   end ENUMERATION;
 
+  record ENUMERATION_ANY "enumeration(:)"
+  end ENUMERATION_ANY;
+
   record ARRAY
     Type elementType;
     list<Dimension> dimensions;
@@ -174,6 +177,7 @@ public
   algorithm
     isEnum := match ty
       case ENUMERATION() then true;
+      case ENUMERATION_ANY() then true;
       else false;
     end match;
   end isEnumeration;
@@ -232,6 +236,7 @@ public
       case BOOLEAN() then true;
       case CLOCK() then true;
       case ENUMERATION() then true;
+      case ENUMERATION_ANY() then true;
       case FUNCTION() then isScalarBuiltin(ty.resultType);
     end match;
   end isScalarBuiltin;
@@ -339,13 +344,14 @@ public
       case Type.STRING() then "String";
       case Type.BOOLEAN() then "Boolean";
       case Type.ENUMERATION() then "enumeration()";
+      case Type.ENUMERATION_ANY() then "enumeration(:)";
       case Type.CLOCK() then "Clock";
       case Type.ARRAY() then toString(ty.elementType) + "[" + stringDelimitList(List.map(ty.dimensions, Dimension.toString), ", ") + "]";
       case Type.TUPLE() then "tuple(" + stringDelimitList(List.map(ty.types, toString), ", ") + ")";
       case Type.FUNCTION() then "function( output " + toString(ty.resultType) + " )";
       case Type.NORETCALL() then "noretcall()";
       case Type.UNKNOWN() then "unknown()";
-      case Type.COMPLEX() then "complex()";
+      case Type.COMPLEX() then InstNode.name(ty.cls);
       else
         algorithm
           assert(false, getInstanceName() + " got unknown type: " + anyString(ty));
@@ -365,7 +371,6 @@ public
       case Type.BOOLEAN() then DAE.T_BOOL_DEFAULT;
       case Type.ENUMERATION() then DAE.T_ENUMERATION(NONE(), ty.typePath, ty.literals, {}, {});
       case Type.CLOCK() then DAE.T_CLOCK_DEFAULT;
-      case Type.ENUMERATION() then DAE.T_ENUMERATION_DEFAULT;
       case Type.ARRAY()
         then DAE.T_ARRAY(toDAE(ty.elementType),
           list(Dimension.toDAE(d) for d in ty.dimensions));

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -43,7 +43,7 @@ import NFComponent.Component;
 import Dimension = NFDimension;
 import NFEquation.Equation;
 import NFClass.Class;
-import NFExpression.Expression;
+import Expression = NFExpression;
 import NFInstNode.InstNode;
 import NFMod.Modifier;
 import NFStatement.Statement;
@@ -57,7 +57,7 @@ import TypeCheck = NFTypeCheck;
 import Types;
 import ClassInf;
 import InstUtil = NFInstUtil;
-import Call = NFCall;
+import NFCall.Call;
 import NFClass.ClassTree;
 import ComponentRef = NFComponentRef;
 import Ceval = NFCeval;
@@ -480,6 +480,7 @@ algorithm
     case ComponentRef.CREF(node = InstNode.COMPONENT_NODE())
       algorithm
         comp := InstNode.component(cref.node);
+        assert(Component.isTyped(comp), getInstanceName() + " got untyped component ");
         ty := Component.getType(comp);
         variability := ComponentRef.getVariability(cref);
         exp := Expression.CREF(ComponentRef.setType(ty, cref));

--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -2833,30 +2833,23 @@ algorithm
         (cache,env,dae,GlobalScript.SYMBOLTABLE(p,fp,ic_1,iv,cf,lf));
 
     case (_, _, _, GlobalScript.SYMBOLTABLE(p, _, _, _, _, _), _, _)
-      equation
-        false = Flags.isSet(Flags.GRAPH_INST);
-        true = Flags.isSet(Flags.SCODE_INST);
-        scodeP = SCodeUtil.translateAbsyn2SCode(p);
-        // remove extends Modelica.Icons.*
-        //scodeP = SCodeSimplify.simplifyProgram(scodeP);
+      algorithm
+        false := Flags.isSet(Flags.GRAPH_INST);
+        true := Flags.isSet(Flags.SCODE_INST);
+        scodeP := SCodeUtil.translateAbsyn2SCode(p);
 
-       (_,scode_builtin) = FBuiltin.getInitialFunctions();
-       scodeP = listAppend(scode_builtin, scodeP);
+        (_,scode_builtin) := FBuiltin.getInitialFunctions();
+        scodeP := listAppend(scode_builtin, scodeP);
 
-       // nfenv = NFEnv.buildInitialEnv(scodeP, scode_builtin);
-       // (dae, funcs) = NFInst.instClass(className, nfenv);
+        (dae, funcs) := NFInst.instClassInProgram(className, scodeP);
 
-       // cache = FCore.emptyCache();
-       // cache = FCore.setCachedFunctionTree(cache, funcs);
-       // env = FGraph.empty();
+        cache := FCore.setCachedFunctionTree(FCore.emptyCache(), funcs);
+        env := FGraph.empty();
+        st := inInteractiveSymbolTable;
+
        // ic_1 = Interactive.addInstantiatedClass(ic,
        //   GlobalScript.INSTCLASS(className, dae, env));
        // st = GlobalScript.SYMBOLTABLE(p, fp, ic_1, iv, cf, lf);
-        dae = NFInst.instClassInProgram(className, scodeP);
-
-        cache = FCore.emptyCache();
-        env = FGraph.empty();
-        st = inInteractiveSymbolTable;
       then
         (cache, env, dae, st);
 

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -438,6 +438,8 @@ public constant Message WRONG_NUMBER_OF_SUBSCRIPTS = MESSAGE(154, TRANSLATION(),
   Util.gettext("Wrong number of subscripts in %s (%s subscripts for %s dimensions)."));
 public constant Message FUNCTION_ELEMENT_WRONG_KIND = MESSAGE(155, TRANSLATION(), ERROR(),
   Util.gettext("Element is not allowed in function context: %s"));
+public constant Message MISSING_DEFAULT_ARG = MESSAGE(156, TRANSLATION(), WARNING(),
+  Util.gettext("Missing default argument on function parameter %s."));
 public constant Message DUPLICATE_CLASSES_TOP_LEVEL = MESSAGE(157, TRANSLATION(), ERROR(),
   Util.gettext("Duplicate classes on top level is not allowed (got %s)."));
 public constant Message WHEN_EQ_LHS = MESSAGE(158, TRANSLATION(), ERROR(),

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -90,6 +90,7 @@ if true then /* Suppress output */
   // "NFFrontEnd";
     "../NFFrontEnd/NFBinding.mo",
     "../NFFrontEnd/NFBuiltin.mo",
+    "../NFFrontEnd/NFBuiltinFuncs.mo",
     "../NFFrontEnd/NFCall.mo",
     "../NFFrontEnd/NFCeval.mo",
     "../NFFrontEnd/NFComponent.mo",


### PR DESCRIPTION
- Added new uniontype NFCall.Call, and changed NFExpression.CALL to only
  contain an instance of NFCall.Call.
- Moved NFExpression.CallAttributes to NFCall, and changed NFExpression
  to be a uniontype instead of package.
- Added new package NFBuiltinFunc, for defining builtin functions that
  can't be declared in ModelicaBuiltin (currently Integer and String).
- Implemented typing and type checking of function calls.
- Implemented flattening of functions and generation of a
  DAE.FunctionTree during flattening.
- Added lots of error checking for functions and calls.
- Added Type.ENUMERATION_ANY() to represent enumeration(:).
- Implemented support for overloaded functions using $overload.