### PR TITLE
PDEModelica -- different boundary condition handling, bugfixes

### DIFF
--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -2980,7 +2980,7 @@ public function instElementList
   output list<DAE.Var> outVars;
   output ConnectionGraph.ConnectionGraph outGraph = inGraph;
   //output List<tuple<Absyn.ComponentRef,DAE.ComponentRef>> fieldDomLst = {};
-  output InstUtil.DomainFieldsLst domainFieldsList = {};
+  output InstUtil.DomainFieldsLst domainFieldsListOut = {};
 protected
   list<tuple<SCode.Element, DAE.Mod>> el;
   FCore.Cache cache;
@@ -2988,7 +2988,7 @@ protected
   list<DAE.Element> dae;
   list<list<DAE.Var>> varsl = {};
   list<list<DAE.Element>> dael = {};
-  Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>> fieldDomOpt;
+  InstUtil.DomainFieldOpt fieldDomOpt;
   list<Integer> element_order;
   array<tuple<SCode.Element, DAE.Mod>> el_arr;
   array<list<DAE.Var>> var_arr;
@@ -3023,7 +3023,7 @@ algorithm
       arrayUpdate(var_arr, length-idx+1, vars);
       arrayUpdate(dae_arr, length-idx+1, dae);
       if intEq(Flags.getConfigEnum(Flags.GRAMMAR), Flags.PDEMODELICA) then
-        domainFieldsList := InstUtil.optAppendField(domainFieldsList,fieldDomOpt);
+        domainFieldsListOut := InstUtil.optAppendField(domainFieldsListOut,fieldDomOpt);
       end if;
     end for;
 
@@ -3111,7 +3111,7 @@ public function instElement2
   output ClassInf.State outState = inState;
   output list<DAE.Var> outVars = {};
   output ConnectionGraph.ConnectionGraph outGraph = inGraph;
-  output Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>> outFieldDomOpt;
+  output InstUtil.DomainFieldOpt outFieldDomOpt;
 protected
   tuple<SCode.Element, DAE.Mod> elt;
   Boolean is_deleted;
@@ -3224,7 +3224,7 @@ public function instElement "
   output ClassInf.State outState;
   output list<DAE.Var> outVars;
   output ConnectionGraph.ConnectionGraph outGraph;
-  output Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>> outFieldDomOpt = NONE();
+  output InstUtil.DomainFieldOpt outFieldDomOpt = NONE();
 algorithm
   (outCache, outEnv, outIH, outUnitStore, outDae, outSets, outState, outVars, outGraph):=
   matchcontinue (inCache, inEnv, inIH, inUnitStore, inMod, inPrefix, inState,

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -2071,8 +2071,9 @@ algorithm
 
         (compelts_1, eqs_1, initeqs_1, alg_1, initalg_1) =
           InstUtil.extractConstantPlusDepsTpl(compelts_1, instSingleCref, {}, className, eqs_1, initeqs_1, alg_1, initalg_1);
-
-        compelts_1 = InstUtil.addGhostCells(compelts_1, eqs_1);
+        if intEq(Flags.getConfigEnum(Flags.GRAMMAR), Flags.PDEMODELICA) then
+          compelts_1 = InstUtil.addGhostCells(compelts_1, eqs_1);
+        end if;
 
         //(csets, env2, ih) = InstUtil.addConnectionCrefsFromEqs(csets, eqs_1, pre, env2, ih);
 
@@ -3115,7 +3116,7 @@ public function instElement2
   output ClassInf.State outState = inState;
   output list<DAE.Var> outVars = {};
   output ConnectionGraph.ConnectionGraph outGraph = inGraph;
-  output InstUtil.DomainFieldOpt outFieldDomOpt;
+  output InstUtil.DomainFieldOpt outFieldDomOpt = NONE();
 protected
   tuple<SCode.Element, DAE.Mod> elt;
   Boolean is_deleted;

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -2095,7 +2095,7 @@ algorithm
         (smCompCrefs, smInitialCrefs) = InstStateMachineUtil.getSMStatesInContext(eqs_1, pre);
         //ih = List.fold1(smCompCrefs, InnerOuter.updateSMHierarchy, inPrefix3, ih);
         ih = List.fold(smCompCrefs, InnerOuter.updateSMHierarchy, ih);
-
+        compelts_2 = InstUtil.addGhostCells(compelts_2, eqs_1);
         (cache,env5,ih,store,dae1,csets,ci_state2,vars,graph,domainFieldsLst) =
           instElementList(cache, env3, ih, store, mods, pre, ci_state1,
             compelts_2, inst_dims, impl, callscope, graph, csets, true);

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -2115,9 +2115,6 @@ algorithm
         if intEq(Flags.getConfigEnum(Flags.GRAMMAR), Flags.PDEMODELICA) then
           eqs_1 = List.fold1(eqs_1, InstUtil.discretizePDE, domainFieldsLst, {});
         end if;
-        if className == "ghostTest" then
-          print("GhostTest");
-        end if;
         //Instantiate equations (see function "instEquation")
         (cache,env5,ih,dae2,csets2,ci_state3,graph) =
           instList(cache, env5, ih, pre, csets1, ci_state2, InstSection.instEquation, eqs_1, impl, InstTypes.alwaysUnroll, graph);

--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -2072,6 +2072,8 @@ algorithm
         (compelts_1, eqs_1, initeqs_1, alg_1, initalg_1) =
           InstUtil.extractConstantPlusDepsTpl(compelts_1, instSingleCref, {}, className, eqs_1, initeqs_1, alg_1, initalg_1);
 
+        compelts_1 = InstUtil.addGhostCells(compelts_1, eqs_1);
+
         //(csets, env2, ih) = InstUtil.addConnectionCrefsFromEqs(csets, eqs_1, pre, env2, ih);
 
         //// fprintln(Flags.INST_TRACE, "Emods to InstUtil.addComponentsToEnv: " + Mod.printModStr(emods));
@@ -2095,7 +2097,7 @@ algorithm
         (smCompCrefs, smInitialCrefs) = InstStateMachineUtil.getSMStatesInContext(eqs_1, pre);
         //ih = List.fold1(smCompCrefs, InnerOuter.updateSMHierarchy, inPrefix3, ih);
         ih = List.fold(smCompCrefs, InnerOuter.updateSMHierarchy, ih);
-        compelts_2 = InstUtil.addGhostCells(compelts_2, eqs_1);
+
         (cache,env5,ih,store,dae1,csets,ci_state2,vars,graph,domainFieldsLst) =
           instElementList(cache, env3, ih, store, mods, pre, ci_state1,
             compelts_2, inst_dims, impl, callscope, graph, csets, true);
@@ -2112,7 +2114,9 @@ algorithm
         if intEq(Flags.getConfigEnum(Flags.GRAMMAR), Flags.PDEMODELICA) then
           eqs_1 = List.fold1(eqs_1, InstUtil.discretizePDE, domainFieldsLst, {});
         end if;
-
+        if className == "ghostTest" then
+          print("GhostTest");
+        end if;
         //Instantiate equations (see function "instEquation")
         (cache,env5,ih,dae2,csets2,ci_state3,graph) =
           instList(cache, env5, ih, pre, csets1, ci_state2, InstSection.instEquation, eqs_1, impl, InstTypes.alwaysUnroll, graph);

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -8317,12 +8317,12 @@ algorithm
         //remove domain from the subModLst:
         subModLst = List.filterOnFalse(subModLst,isSubModDomainOrStart);
 
-        ghostL = (SCode.COMPONENT(stringAppend(name,".ghostL"), prefixes,
+        ghostL = (SCode.COMPONENT(stringAppend(name,"_ghostL"), prefixes,
               SCode.ATTR(arrayDims,connectorType,parallelism,
              variability, direction, Absyn.NONFIELD()), typeSpec,
              SCode.MOD(finalPrefix, eachPrefix,subModLst,binding,info2),
              comment, condition, info),daeMod);
-        ghostR = (SCode.COMPONENT(stringAppend(name,".ghostR"), prefixes,
+        ghostR = (SCode.COMPONENT(stringAppend(name,"_ghostR"), prefixes,
              SCode.ATTR(arrayDims,connectorType,parallelism,
              variability, direction, Absyn.NONFIELD()), typeSpec,
              SCode.MOD(finalPrefix, eachPrefix,subModLst,binding,info2),
@@ -8858,9 +8858,9 @@ algorithm
       equation
         true = List.isMemberOnTrue(fieldCr,fieldLst,Absyn.crefEqual);
         exp = (if isBC and i == 1 then
-                Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostL"), subscripts))  //left BC
+                Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"_ghostL"), subscripts))  //left BC
               elseif isBC and i == N then
-                Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostR"), subscripts))  //right BC
+                Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"_ghostR"), subscripts))  //right BC
               else
                 Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i))::subscripts))  //no BC
               );
@@ -8875,12 +8875,12 @@ algorithm
         end if;
         //skip = true
         leftVar = (if i == 1 then
-                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostL"), subscripts))
+                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"_ghostL"), subscripts))
                    else
                      Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i-1))::subscripts))
                   );
         rightVar = (if i == N then
-                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostR"), subscripts))
+                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"_ghostR"), subscripts))
                    else
                      Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i+1))::subscripts))
                   );
@@ -8903,13 +8903,13 @@ algorithm
         end if;
         //skip = true
         leftVar = (if i == 1 then
-                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostL"), subscripts))
+                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"_ghostL"), subscripts))
                    else
                      Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i-1))::subscripts))
                   );
         actualVar = Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i))::subscripts));
         rightVar = (if i == N then
-                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostR"), subscripts))
+                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"_ghostR"), subscripts))
                    else
                      Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i+1))::subscripts))
                   );

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -8208,7 +8208,7 @@ end propagateModFinal;
 //------------------------------
 //------  PDE extension:  ------
 //------------------------------
-
+public type DomainFieldOpt = Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>>;
 public type DomainFieldsLst = list<tuple<DAE.ComponentRef,list<Absyn.ComponentRef>>>;
 
 public function elabField
@@ -8224,7 +8224,7 @@ public function elabField
   input SourceInfo inInfo;
   output DAE.Dimensions outDims;
   output DAE.Mod outMod;
-  output Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>> outFieldDomOpt;
+  output DomainFieldOpt outFieldDomOpt;
 
 algorithm
   (outDims, outMod, outFieldDomOpt) := match(attr, inMod)
@@ -8346,7 +8346,7 @@ end addEach;
 
 public function optAppendField
   input DomainFieldsLst inDomFieldsLst;
-  input Option<tuple<Absyn.ComponentRef,DAE.ComponentRef>> fieldDomOpt;
+  input DomainFieldOpt fieldDomOpt;
   output DomainFieldsLst outDomFieldsLst;
 algorithm
   outDomFieldsLst := match fieldDomOpt

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -8545,6 +8545,7 @@ algorithm
         List<Absyn.ComponentRef> fieldLst;
         Absyn.Ident name;
         list<Absyn.Subscript> subscripts;
+
       //Normal equation withhout domain specified, no field variables present:
       case SCode.EQUATION(SCode.EQ_EQUALS())
       then {inEQ};
@@ -8553,8 +8554,8 @@ algorithm
                   domain = domainCr as Absyn.CREF_IDENT(), comment = comment, info = info))
         equation
           (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr,info);
-//        then list(newEQFun(i, lhs_exp, rhs_exp, domainCr, comment, info, fieldLst) for i in 2:N-1);
         then creatFieldEqs(lhs_exp, rhs_exp, domainCr, N, fieldLst, comment, info);
+
       //same as previous but with ".interior"
       case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
                   domain = domainCr as Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="interior")),
@@ -8562,36 +8563,8 @@ algorithm
         equation
           domainCr1 = Absyn.CREF_IDENT(name, subscripts);
           (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr1,info);
-//        then list(newEQFun(i, lhs_exp, rhs_exp, domainCr1, comment, info, fieldLst) for i in 2:N-1);
         then creatFieldEqs(lhs_exp, rhs_exp, domainCr, N, fieldLst, comment, info);
 
-        //left boundary extrapolation
-/*        case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
-                      domain = domainCr as Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="left")),
-                      comment = comment, info = info))
-            equation
-//              Absyn.CALL(function_ = Absyn.CREF_IDENT(name="extrapolateField", subscripts={}), functionArgs = Absyn.FUNCTIONARGS(args = {})) = rhs_exp;
-//              Absyn.CREF(fieldCr as Absyn.CREF_IDENT()) = lhs_exp;
-          fieldCr = matchExtrapAndField(lhs_exp, rhs_exp);
-          domainCr1 = Absyn.CREF_IDENT(name, subscripts);
-          (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr1,info);
-        then
-          {extrapolateFieldEq(false, fieldCr, domainCr1, N, comment, info, fieldLst)};
-*/
-/*
-      //right boundary extrapolation
-      case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
-                  domain = domainCr as Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="right")),
-                  comment = comment, info = info))
-        equation
-//          Absyn.CALL(function_ = Absyn.CREF_IDENT(name="extrapolateField", subscripts={}), functionArgs = Absyn.FUNCTIONARGS(args = {})) = rhs_exp;
-//          Absyn.CREF(fieldCr as Absyn.CREF_IDENT()) = lhs_exp;
-
-          fieldCr = matchExtrapAndField(lhs_exp, rhs_exp);
-          domainCr1 = Absyn.CREF_IDENT(name, subscripts);
-          (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr1,info);
-        then
-          {extrapolateFieldEq(true, fieldCr, domainCr1, N, comment, info, fieldLst)};*/
       //left boundary condition or extrapolation
       case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
                   domain = Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="left")),
@@ -8603,6 +8576,7 @@ algorithm
           (rhs_exp, _) = Absyn.traverseExp(rhs_exp, extrapFieldTraverseFun, 1);
         then
           {newEQFun(1, lhs_exp, rhs_exp, domainCr1, N, true, fieldLst, comment, info)};
+
       //right boundary condition or extrapolation
       case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
                   domain = Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="right")),
@@ -8908,7 +8882,7 @@ algorithm
                   );
         then
           Absyn.BINARY(
-            Absyn.BINARY(leftVar, Absyn.SUB(), rightVar),
+            Absyn.BINARY(rightVar, Absyn.SUB(), leftVar),
             Absyn.DIV(),
             Absyn.BINARY(
               Absyn.INTEGER(2),

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -8230,23 +8230,21 @@ function fieldsInPderEq
   input SCode.Equation eq;
   input list<Absyn.Ident> inFieldNames;
   output list<Absyn.Ident> outFieldNames;
-  protected list<Absyn.Ident> fieldNames2;
 algorithm
-  fieldNames2 := match eq
+  outFieldNames := match eq
   local
     list<Absyn.Ident> fieldNames1;
     Absyn.Exp lhs_exp, rhs_exp;
     case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp))
       /*,domain = domainCr as Absyn.CREF_IDENT(), comment = comment, info = info))*/
     algorithm
-      (_,fieldNames1) := Absyn.traverseExp(lhs_exp, fieldInPderExp, inFieldNames);
-      (_,fieldNames1) := Absyn.traverseExp(rhs_exp, fieldInPderExp, fieldNames1);
+      (_,fieldNames1) := Absyn.traverseExpTopDown(lhs_exp, fieldInPderExp, inFieldNames);
+      (_,fieldNames1) := Absyn.traverseExpTopDown(rhs_exp, fieldInPderExp, fieldNames1);
     then
-      fieldNames1;
+      listAppend(inFieldNames,fieldNames1);
     else
       inFieldNames;
   end match;
-  outFieldNames := fieldNames2;
 end fieldsInPderEq;
 
 function fieldInPderExp
@@ -8270,7 +8268,7 @@ algorithm
 end fieldInPderExp;
 
 function addGhostCells2
-  //if name os given variable is in the given array
+  //if name of given variable is in the given array
   //adds ghost cells for it
   input tuple<SCode.Element, DAE.Mod> inCompelt;
   input list<Absyn.Ident> fieldNamesP;
@@ -8901,7 +8899,7 @@ algorithm
         leftVar = (if i == 1 then
                      Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostL"), subscripts))
                    else
-                     Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i+1))::subscripts))
+                     Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i-1))::subscripts))
                   );
         rightVar = (if i == N then
                      Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,".ghostR"), subscripts))

--- a/Compiler/FrontEnd/InstUtil.mo
+++ b/Compiler/FrontEnd/InstUtil.mo
@@ -8317,12 +8317,12 @@ algorithm
         //remove domain from the subModLst:
         subModLst = List.filterOnFalse(subModLst,isSubModDomainOrStart);
 
-        ghostL = (SCode.COMPONENT(stringAppend(name,"_ghostL"), prefixes,
+        ghostL = (SCode.COMPONENT(stringAppend(name,"$ghostL"), prefixes,
               SCode.ATTR(arrayDims,connectorType,parallelism,
              variability, direction, Absyn.NONFIELD()), typeSpec,
              SCode.MOD(finalPrefix, eachPrefix,subModLst,binding,info2),
              comment, condition, info),daeMod);
-        ghostR = (SCode.COMPONENT(stringAppend(name,"_ghostR"), prefixes,
+        ghostR = (SCode.COMPONENT(stringAppend(name,"$ghostR"), prefixes,
              SCode.ATTR(arrayDims,connectorType,parallelism,
              variability, direction, Absyn.NONFIELD()), typeSpec,
              SCode.MOD(finalPrefix, eachPrefix,subModLst,binding,info2),
@@ -8535,9 +8535,6 @@ public function discretizePDE
   output List<SCode.Equation> outDiscretizedEQs;
   protected List<SCode.Equation> newDiscretizedEQs;
 algorithm
-    newDiscretizedEQs := {inEQ};
-    //TODO: fix:
-
     newDiscretizedEQs := match inEQ
       local
         Absyn.Exp lhs_exp, rhs_exp;
@@ -8549,9 +8546,6 @@ algorithm
         Absyn.Ident name;
         list<Absyn.Subscript> subscripts;
 
-      //Normal equation withhout domain specified, no field variables present:
-      case SCode.EQUATION(SCode.EQ_EQUALS())
-      then {inEQ};
       //PDE with domain specified, allow for field variables:
       case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
                   domain = domainCr as Absyn.CREF_IDENT(), comment = comment, info = info))
@@ -8591,6 +8585,14 @@ algorithm
           (rhs_exp, _) = Absyn.traverseExp(rhs_exp, extrapFieldTraverseFun, N);
         then
           {newEQFun(N, lhs_exp, rhs_exp, domainCr1, N, true, fieldLst, comment, info)};
+      //Unhandled pde
+      case SCode.EQUATION(SCode.EQ_PDE())
+        equation
+          print("Unhandled type of EQ_PDE in discretizePDE\n");
+          fail();
+      then {};
+      //Other than EQ_PDE:
+      else {inEQ};
     end match;
 
   outDiscretizedEQs := listAppend(inDiscretizedEQs, newDiscretizedEQs);
@@ -8858,9 +8860,9 @@ algorithm
       equation
         true = List.isMemberOnTrue(fieldCr,fieldLst,Absyn.crefEqual);
         exp = (if isBC and i == 1 then
-                Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"_ghostL"), subscripts))  //left BC
+                Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"$ghostL"), subscripts))  //left BC
               elseif isBC and i == N then
-                Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"_ghostR"), subscripts))  //right BC
+                Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"$ghostR"), subscripts))  //right BC
               else
                 Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i))::subscripts))  //no BC
               );
@@ -8875,12 +8877,12 @@ algorithm
         end if;
         //skip = true
         leftVar = (if i == 1 then
-                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"_ghostL"), subscripts))
+                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"$ghostL"), subscripts))
                    else
                      Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i-1))::subscripts))
                   );
         rightVar = (if i == N then
-                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"_ghostR"), subscripts))
+                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"$ghostR"), subscripts))
                    else
                      Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i+1))::subscripts))
                   );
@@ -8903,13 +8905,13 @@ algorithm
         end if;
         //skip = true
         leftVar = (if i == 1 then
-                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"_ghostL"), subscripts))
+                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"$ghostL"), subscripts))
                    else
                      Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i-1))::subscripts))
                   );
         actualVar = Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i))::subscripts));
         rightVar = (if i == N then
-                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"_ghostR"), subscripts))
+                     Absyn.CREF(Absyn.CREF_IDENT(stringAppend(name,"$ghostR"), subscripts))
                    else
                      Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i+1))::subscripts))
                   );

--- a/Compiler/FrontEnd/PDEModelicaBuiltin.mo
+++ b/Compiler/FrontEnd/PDEModelicaBuiltin.mo
@@ -34,10 +34,11 @@
 record DomainLineSegment1D "Record representing 1-dimensional domain where a partial differential equation hold."
   record Region
   end Region;
+  parameter Real x0(unit="m")=0 "x value at left boundary";
   parameter Real L(unit="m")=1 "length of the domain";
   constant Integer N(unit="")=10 "number of grid nodes";
   parameter Real dx = L / (N-1) "grid space step";
-  parameter Real[N] x(each unit="m") = array(i*dx for i in 0:N-1) "space coordinate";
+  parameter Real[N] x(each unit="m") = array(x0 + i*dx for i in 0:N-1) "space coordinate";
   Region left, right, interior "regions representing boundaries and the interior";
 end DomainLineSegment1D;
 


### PR DESCRIPTION
BC are handled differently - using so-called ghost cells. New variables for this ghost cells are created automatically for every field that is differentiated with respect to space coordinate.
Some bugfixes, namely #3835.