### PR TITLE
Use the OM-compiled Sundials for C and C++ runtime

### DIFF
--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -3210,10 +3210,10 @@ case "gcc" then
             endif
 
             LDSYSTEMFLAGS_DYNAMIC=-lOMCppSystem -lOMCppModelicaUtilities -lOMCppDataExchange -lOMCppMath -lOMCppExtensionUtilities -lOMCppOMCFactory $(LDSYSTEMFLAGS_COMMON)
-            LDSYSTEMFLAGS_STATIC=<%staticLibs%> $(LDSYSTEMFLAGS_COMMON)
+            LDSYSTEMFLAGS_STATIC=$(LDSYSTEMFLAGS_COMMON) <%staticLibs%>
 
             LDMAINFLAGS_DYNAMIC= -lOMCppOMCFactory -lOMCppModelicaUtilities -lOMCppExtensionUtilities $(LDMAINFLAGS_COMMON)
-            LDMAINFLAGS_STATIC=<%staticLibs%> $(LDMAINFLAGS_COMMON) $(SUNDIALS_LIBRARIES) $(LAPACK_LIBRARIES)
+            LDMAINFLAGS_STATIC=$(LDMAINFLAGS_COMMON) <%staticLibs%> $(SUNDIALS_LIBRARIES) $(LAPACK_LIBRARIES)
 
             ifeq ($(RUNTIME_STATIC_LINKING),ON)
             $(eval CFLAGS=$(CFLAGS_STATIC))

--- a/Compiler/runtime/config.unix.h.in
+++ b/Compiler/runtime/config.unix.h.in
@@ -44,7 +44,7 @@
 
 /* Skip compiling against some stuff for the JavaScript runtime */
 #if !defined(OMC_EMCC) && !defined(OMC_MINIMAL_RUNTIME)
-@WITH_SUNDIALS@
+#define WITH_SUNDIALS
 #define WITH_IPOPT
 @WITH_UMFPACK@
 @WITH_HWLOC@

--- a/Makefile.common
+++ b/Makefile.common
@@ -424,7 +424,7 @@ clean-sqlite3:
 # build sundials
 sundials: 3rdParty/sundials/CMakeLists.txt umfpack
 	mkdir -p 3rdParty/sundials/build
-	cd 3rdParty/sundials/build && $(CMAKE) .. -G $(CMAKE_TARGET) -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DCMAKE_INSTALL_PREFIX=`pwd` -DKLU_ENABLE:Bool=ON -DKLU_LIBRARY_DIR="$(builddir_lib_omc)" -DKLU_INCLUDE_DIR="$(OMBUILDDIR)/include/omc/c/suitesparse/Include/" -DCMAKE_C_FLAGS="$(CFLAGS) -lm -L $(builddir_lib_omc)" $(SUITESPARSE_LIBS) $(IS_MINGW32) $(IS_MINGW64) -DSUITESPARSECONFIG_LIBRARY=""
+	cd 3rdParty/sundials/build && $(CMAKE) .. -G $(CMAKE_TARGET) -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DCMAKE_INSTALL_PREFIX=`pwd` -DKLU_ENABLE:Bool=ON -DKLU_LIBRARY_DIR="$(builddir_lib_omc)" -DKLU_INCLUDE_DIR="$(OMBUILDDIR)/include/omc/c/suitesparse/Include/" -DCMAKE_C_FLAGS="$(CFLAGS) -lm -L $(builddir_lib_omc)" $(SUITESPARSE_LIBS) $(IS_MINGW32) $(IS_MINGW64) -DSUITESPARSECONFIG_LIBRARY="" -DLAPACK_ENABLE:Bool=ON
 	$(MAKE) -C 3rdParty/sundials/build install
 	# adrpo: do not copy the headers as they are not needed!
 	mkdir -p $(OMBUILDDIR)/include/omc/c/sundials

--- a/Makefile.in
+++ b/Makefile.in
@@ -46,7 +46,7 @@ OPENBLAS_EXTRA_ARGS=@OPENBLAS_EXTRA_ARGS@
 IPOPT_TARGET=@IPOPT_TARGET@
 UMFPACK_TARGET=@UMFPACK_TARGET@
 UMFPACK_SHARED=@UMFPACK_SHARED@
-SUNDIALS_TARGET=@SUNDIALS_TARGET@
+SUNDIALS_TARGET=sundials
 # We don't want the shared version, but symbols are not exported if we use the static version
 # This compiles the shared and static versions, but we only copy the static version...
 FMILIB_SHARED = @FMILIB_SHARED@

--- a/SimulationRuntime/c/Makefile.common
+++ b/SimulationRuntime/c/Makefile.common
@@ -10,7 +10,7 @@ include Makefile.objs
 
 OMC_MINIMAL_RUNTIME=
 
-CPPFLAGS = -I. -I$(top_builddir)/Compiler/runtime -I$(top_builddir)/3rdParty/gc/include -I$(top_builddir)/3rdParty/FMIL/install/include/ -I$(top_builddir)/3rdParty/lis-1.4.12/include/ -I$(top_builddir)/3rdParty/Ipopt/include/ -I$(top_builddir)/3rdParty/sundials/include/ $(CONFIG_CPPFLAGS) -DGC_REDIRECT_TO_LOCAL -I$(builddir_inc)/c
+CPPFLAGS = -I. -I$(top_builddir)/Compiler/runtime -I$(top_builddir)/3rdParty/gc/include -I$(top_builddir)/3rdParty/FMIL/install/include/ -I$(top_builddir)/3rdParty/lis-1.4.12/include/ -I$(top_builddir)/3rdParty/Ipopt/include/ -I$(builddir_inc)/c/sundials/ $(CONFIG_CPPFLAGS) -DGC_REDIRECT_TO_LOCAL -I$(builddir_inc)/c
 override CFLAGS += $(CPPFLAGS) $(CONFIG_CFLAGS) $(EXTRA_CFLAGS)
 override CXXFLAGS += $(CPPFLAGS) $(CONFIG_CFLAGS) $(EXTRA_CFLAGS)
 

--- a/SimulationRuntime/cpp/CMakeLists.txt
+++ b/SimulationRuntime/cpp/CMakeLists.txt
@@ -35,6 +35,16 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
 
+IF(UNIX)
+IF(APPLE)
+# We set the rpath manually, later...
+ELSE()
+# Needed to find Sundials; actually only the Sundials objects need this,
+# but there are so many of them
+SET(CMAKE_INSTALL_RPATH "$ORIGIN:$ORIGIN/..")
+ENDIF(APPLE)
+ENDIF(LINUX)
+
 if(NOT PLATFORM OR PLATFORM STREQUAL "dynamic")
   set(BUILD_SHARED_LIBS ON)
 elseif(PLATFORM STREQUAL "static")
@@ -75,7 +85,6 @@ OPTION(BOOST_STATIC_LINKING "BOOST_STATIC_LINKING" OFF)
 OPTION(USE_BOOST_REALPATHS "USE_BOOST_REALPATHS" OFF)
 OPTION(RUNTIME_PROFILING "RUNTIME_PROFILING" OFF)
 OPTION(FMU_SUNDIALS "FMU_SUNDIALS" OFF)
-OPTION(SUNDIALS_ROOT "SUNDIALS ROOT" "")
 OPTION(KLU_ROOT "KLU ROOT" "")
 OPTION(TRILINOS_ROOT "TRILINOS ROOT" "")
 OPTION(USE_CPP_03 "USE_CPP_03" OFF)
@@ -415,11 +424,11 @@ FIND_PACKAGE(Boost COMPONENTS log log_setup)
 
 # Deactivate threading stuff in MSVC release mode, because this produces linker errors to boost::exception_ptr
 IF(MSVC AND (CMAKE_BUILD_TYPE_UPPER STREQUAL "RELEASE"))
-	SET(Boost_THREAD_LIBRARY_RELEASE "NOT_FOUND")
-	SET(Boost_THREAD_LIBRARY_DEBUG "NOT_FOUND")
-	MESSAGE(STATUS "Boost threading disabled because othwerwise the MSVC build produces linker errors in release mode.")
+  SET(Boost_THREAD_LIBRARY_RELEASE "NOT_FOUND")
+  SET(Boost_THREAD_LIBRARY_DEBUG "NOT_FOUND")
+  MESSAGE(STATUS "Boost threading disabled because othwerwise the MSVC build produces linker errors in release mode.")
 ELSE(MSVC AND (CMAKE_BUILD_TYPE_UPPER STREQUAL "RELEASE"))
-	FIND_PACKAGE(Boost COMPONENTS thread atomic)
+  FIND_PACKAGE(Boost COMPONENTS thread atomic)
 ENDIF(MSVC AND (CMAKE_BUILD_TYPE_UPPER STREQUAL "RELEASE"))
 
 IF(NOT(COMPILER_SUPPORTS_CXX11))
@@ -497,16 +506,18 @@ IF(USE_SUNDIALS)
   ELSE(MSVC)
     SET(Sundials_Path "${CMAKE_SOURCE_DIR}/../../3rdParty/sundials/build")
   ENDIF(MSVC)
-  SET(SUNDIALS_INLCUDE_HOME  ${Sundials_Path}/include)
-  SET(SUNDIALS_LIBRARY_RELEASE_HOME  ${Sundials_Path}/lib)
+  SET(SUNDIALS_INLCUDE_HOME  ${CMAKE_INSTALL_PREFIX}/include/omc/c/sundials)
+  SET(SUNDIALS_LIBRARY_RELEASE_HOME   ${CMAKE_INSTALL_PREFIX}/${LIBINSTALLEXT}/..)
   MESSAGE(STATUS "Sundials include:")
   MESSAGE(STATUS "${SUNDIALS_INLCUDE_HOME}")
   MESSAGE(STATUS "Sundials library:")
   MESSAGE(STATUS "${SUNDIALS_LIBRARY_RELEASE_HOME}")
 
-  FIND_PATH(SUNDIALS_INCLUDE_DIR cvode/cvode.h PATHS ${SUNDIALS_INLCUDE_HOME} $ENV{SUNDIALS_ROOT}/include)
+
+
+  FIND_PATH(SUNDIALS_INCLUDE_DIR cvode/cvode.h PATHS ${SUNDIALS_INLCUDE_HOME})
   IF (NOT SUNDIALS_INCLUDE_DIR)
-    MESSAGE(FATAL_ERROR "Could not find Sundials, specify environment variable SUNDIALS_ROOT")
+    MESSAGE(FATAL_ERROR "Could not find Sundials; compile omc first")
   ELSE(NOT SUNDIALS_INCLUDE_DIR)
     INCLUDE_DIRECTORIES(${SUNDIALS_INCLUDE_DIR})
     # Extract the version number from sundials_config.h
@@ -587,11 +598,11 @@ IF(USE_KLU)
   ENDIF(MSVC)
 
   IF(MSVC)
-	SET(KLU_INLCUDE_HOME ${Klu_Path}/include/omc/c/suitesparse/Include) #${Klu_Path}/KLU/Include)
-	SET(KLU_LIBRARY_RELEASE_HOME ${Klu_Path}/lib/omc) #${Klu_Path}/build)
+  SET(KLU_INLCUDE_HOME ${Klu_Path}/include/omc/c/suitesparse/Include) #${Klu_Path}/KLU/Include)
+  SET(KLU_LIBRARY_RELEASE_HOME ${Klu_Path}/lib/omc) #${Klu_Path}/build)
   ELSE(MSVC)
-	SET(KLU_INLCUDE_HOME ${Klu_Path}/Include) #${Klu_Path}/KLU/Include)
-	SET(KLU_LIBRARY_RELEASE_HOME ${Klu_Path}/build) #${Klu_Path}/build)
+  SET(KLU_INLCUDE_HOME ${Klu_Path}/Include) #${Klu_Path}/KLU/Include)
+  SET(KLU_LIBRARY_RELEASE_HOME ${Klu_Path}/build) #${Klu_Path}/build)
   ENDIF(MSVC)
 
   MESSAGE(STATUS "Klu include:")
@@ -891,8 +902,8 @@ GET_TARGET_PROPERTY(libPeer ${PeerName} LOCATION)
 GET_FILENAME_COMPONENT(libPeerName ${libPeer} NAME)
 
 IF(OPENMP_FOUND)
-	GET_TARGET_PROPERTY(libCppDASSL ${CppDASSLName} LOCATION)
-	GET_FILENAME_COMPONENT(libCppDASSLName ${libCppDASSL} NAME)
+  GET_TARGET_PROPERTY(libCppDASSL ${CppDASSLName} LOCATION)
+  GET_FILENAME_COMPONENT(libCppDASSLName ${libCppDASSL} NAME)
 ENDIF(OPENMP_FOUND)
 
 GET_TARGET_PROPERTY(libRTRK ${RTRKName} LOCATION)

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,6 @@ AC_SUBST(RT_LDFLAGS_GENERATED_CODE_SIM)
 AC_SUBST(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU)
 AC_SUBST(RT_LDFLAGS_SHARED)
 AC_SUBST(OMCRUNTIME_SHARED_LDFLAGS)
-AC_SUBST(WITH_SUNDIALS)
 AC_SUBST(SUNDIALS_LDFLAGS)
 AC_SUBST(SUNDIALS_TARGET)
 AC_SUBST(IPOPT_LDFLAGS)
@@ -519,29 +518,9 @@ fi
 
 OMC_AC_LAPACK(RequireFound)
 
-AC_CHECK_HEADERS(idas/idas.h idas/idas.h idas/idas_dense.h kinsol/kinsol.h kinsol/kinsol_dense.h nvector/nvector_serial.h sundials/sundials_types.h sundials/sundials_math.h,[],[NO_SUNDIALS="yes"])
 SUNDIALS_LDFLAGS="-lsundials_idas -lsundials_kinsol -lsundials_nvecserial $LD_LAPACK"
-LIBS="$SUNDIALS_LDFLAGS -lm"
-AC_MSG_CHECKING([Sundials linking])
-AC_LINK_IFELSE([AC_LANG_CALL([], [KINInit])],
-  [AC_MSG_RESULT([ok])],
-  [LIBS="-lsundials_kinsol -lsundials_nvecserial -llapack -lblas -lm";
-  AC_LINK_IFELSE([AC_LANG_CALL([], [KINInit])],
-  [AC_MSG_RESULT([ok])],[AC_MSG_RESULT([failed to link KINInit]); NO_SUNDIALS="yes"])])
-
-if ! test "$NO_SUNDIALS" = "yes"; then
-  FINAL_MESSAGES="$FINAL_MESSAGES\nSimulations may use sundials suite: Yes"
-  WITH_SUNDIALS="#define WITH_SUNDIALS"
-  SUNDIALS_TARGET="sundials"
-else
-  FINAL_MESSAGES="$FINAL_MESSAGES\nSimulations may use sundials suite: No"
-  WITH_SUNDIALS="/* Without Sundials */"
-# We need -llapack regardless if we use Sundials or not
-  SUNDIALS_LDFLAGS="$LD_LAPACK"
-  SUNDIALS_TARGET=""
-fi
-
-LIBS=""
+FINAL_MESSAGES="$FINAL_MESSAGES\nSimulations may use sundials suite: Yes"
+SUNDIALS_TARGET="sundials"
 
 AC_CHECK_HEADERS(locale.h libintl.h,[
 AC_MSG_CHECKING([gettext linking])


### PR DESCRIPTION
This means Sundials is always available (before it was only compiled,
and compilation only succeeded if Sundials was installed locally and of
the same version as the OM Sundials; the C runtime linked against the
OM sundials while the C++ runtime used the OM headers and the OS lib).