### PR TITLE
Handle recursion better when inlining calls

### DIFF
--- a/Compiler/Template/CodegenCFunctions.tpl
+++ b/Compiler/Template/CodegenCFunctions.tpl
@@ -4950,7 +4950,7 @@ case BINARY(__) then
               {
                 <%if acceptMetaModelicaGrammar()
                   then '<%generateThrow()%>;<%\n%>'
-                  else 'throwStreamPrint(threadData, "Invalid root: (%g)^(%g)", <%tmp1%>, <%tmp2%>);<%\n%>'%>
+                  else 'throwStreamPrint(threadData, "%s:%d: Invalid root: (%g)^(%g)", __FILE__, __LINE__, <%tmp1%>, <%tmp2%>);<%\n%>'%>
               }
             }
           }
@@ -4962,7 +4962,7 @@ case BINARY(__) then
           {
             <%if acceptMetaModelicaGrammar()
               then '<%generateThrow()%>;<%\n%>'
-              else 'throwStreamPrint(threadData, "Invalid root: (%g)^(%g)", <%tmp1%>, <%tmp2%>);<%\n%>'%>
+              else 'throwStreamPrint(threadData, "%s:%d: Invalid root: (%g)^(%g)", __FILE__, __LINE__, <%tmp1%>, <%tmp2%>);<%\n%>'%>
           }
           >>
         '<%tmp3%>'

--- a/Compiler/Util/AvlSetPath.mo
+++ b/Compiler/Util/AvlSetPath.mo
@@ -1,0 +1,46 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2014, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package AvlSetPath
+  import Absyn;
+  import BaseAvlSet;
+  extends BaseAvlSet;
+  redeclare type Key = Absyn.Path;
+  redeclare function extends keyStr
+  algorithm
+    outString := Absyn.pathString(inKey);
+  end keyStr;
+  redeclare function extends keyCompare
+  algorithm
+    outResult := Absyn.pathCompare(inKey1, inKey2);
+  end keyCompare;
+annotation(__OpenModelica_Interface="frontend");
+end AvlSetPath;

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -172,6 +172,7 @@ if true then /* Suppress output */
   // "Util";
     "../Util/Array.mo",
     "../Util/AvlSetCR.mo",
+    "../Util/AvlSetPath.mo",
     "../Util/AvlSetString.mo",
     "../Util/BaseAvlTree.mo",
     "../Util/BaseAvlSet.mo",


### PR DESCRIPTION
This partially fixes FCSys.Characteristics.Examples.CellPotential (still
fails to compile functions due to them using parameters).