### PR TITLE
Nf function improvments 2

### DIFF
--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -119,9 +119,11 @@ uniontype Class
     list<Modifier> attributes;
   end INSTANCED_BUILTIN;
 
+  /*
   record OVERLOADED_CLASS
     list<InstNode> overloads;
   end OVERLOADED_CLASS;
+  */
 
   type Element = ClassTree.Entry;
 

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -410,6 +410,7 @@ algorithm
       then
         fail();
 
+    /*
     // OpenModelica $overload extension.
     case SCode.CLASS(classDef = cdef as SCode.OVERLOAD())
       algorithm
@@ -426,6 +427,7 @@ algorithm
         node := InstNode.updateClass(c, node);
       then
         node;
+    */
 
     else
       algorithm
@@ -839,12 +841,14 @@ algorithm
       then
         ();
 
+    /*
     case Class.OVERLOADED_CLASS()
       algorithm
         cls.overloads := list(instClass(o, Modifier.NOMOD(), parent) for o in cls.overloads);
         node := InstNode.updateClass(cls, node);
       then
         ();
+    */
 
     // Any other type of class is already instantiated.
     else ();
@@ -1032,6 +1036,7 @@ algorithm
     case Class.PARTIAL_BUILTIN() then ();
     case Class.INSTANCED_BUILTIN() then ();
 
+    /*
     case Class.OVERLOADED_CLASS()
       algorithm
         for o in cls.overloads loop
@@ -1039,6 +1044,7 @@ algorithm
         end for;
       then
         ();
+     */
 
     else
       algorithm

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -77,7 +77,8 @@ uniontype CachedData
   algorithm
     cache := match cache
       case NO_CACHE() then FUNCTION({fn}, false);
-      case FUNCTION() then FUNCTION(fn :: cache.funcs, false);
+      // Append to end so the error messages are ordered properly.
+      case FUNCTION() then FUNCTION(listAppend(cache.funcs,{fn}), false);
       else
         algorithm
           assert(false, getInstanceName() + ": Invalid cache for function");


### PR DESCRIPTION
- Instantiate overloaded functions one by one and propagate multiple overloads.
    - OVERLOADED_CLASS is not used for overloaded functions anymore. We keep things in the cache.
    - Do not overwrite function names by the overload name.
    - Make sure we can't overload non function classes...
  - Do not match args while insting them.
    - We need the positional and named args separately until we reach typing.
    - If we match and try to replace named args by values then overloading will not work properly.
  - Create slots after typing a function not when insting. We need the type info in the slots.
  - Added a new Call type ARG_TYPED_CALL
    - this is used while typing a call t preserve type and variability info.
  - Track errors and print if no match only.
  - Save type info when filling args from slot defaults.
  - Handle printing of arr_typed_call.
  - Some more changes...

 NFFrontEnd function and typing improvements

  - Overloading is now resolved with priority to exact match if there is any.
  - Overwrite overload resolved name back to the overload name for builtin functions
    - if OpenModelica.Internal.intAbs is matched we just rename the call to abs().
    - Only for builtin functions because they are not collected anyway.
  - If overloading fails print the overload name instead of the actual names in the errors.
  - TypeMatch now notifies how matching is done (exact, cast, generic or UNKNOWN)
  - Function matching now notifies how it is matched (exact, cast, generic or vectorized).

