### PR TITLE
Check if binding type does match the component type

### DIFF
--- a/Compiler/NFFrontEnd/NFBinding.mo
+++ b/Compiler/NFFrontEnd/NFBinding.mo
@@ -121,6 +121,13 @@ public
     end match;
   end typedExp;
 
+  function getTypedExp
+    input Binding binding;
+    output Expression exp;
+  algorithm
+    TYPED_BINDING(bindingExp = exp) := binding;
+  end getTypedExp;
+
   function setTypedExp
     input Expression exp;
     input output Binding binding;
@@ -174,6 +181,16 @@ public
       else false;
     end match;
   end isEach;
+
+  function isTyped
+    input Binding binding;
+    output Boolean isTyped;
+  algorithm
+    isTyped := match binding
+      case TYPED_BINDING() then true;
+      else false;
+    end match;
+  end isTyped;
 
   function toString
     input Binding binding;


### PR DESCRIPTION
This introduces a check for the component binding type. It should match the component type (or be implicitly convertible).

@perost Is this the intended way of implementing it?
@mahge It seems that there is a problem with overloaded functions. Can you please have look at FuncOverloadMulti.mo? It generates now the following error message:
```
[NFTyping.mo:307:13-307:164:writable]Modelica Assert: NFTyping.typeComponentBinding got type mismatch between component x and its binding bool_string(true)!
Error processing file: FuncOverloadMulti.mo
```