### PR TITLE
Improve module wrapFunctionCalls

### DIFF
--- a/Compiler/BackEnd/BackendDAE.mo
+++ b/Compiler/BackEnd/BackendDAE.mo
@@ -227,10 +227,11 @@ uniontype Var "variables"
     .DAE.VarDirection varDirection "input, output or bidirectional";
     .DAE.VarParallelism varParallelism "parallelism of the variable. parglobal, parlocal or non-parallel";
     Type varType "built-in type or enumeration";
-    Option< .DAE.Exp> bindExp "Binding expression e.g. for parameters";
+    Option<.DAE.Exp> bindExp "Binding expression e.g. for parameters";
+    Option<.DAE.Exp> tplExp "Variable is part of a tuple. Needed for the globalKnownVars and localKnownVars";
     .DAE.InstDims arryDim "array dimensions of non-expanded var";
     .DAE.ElementSource source "origin of variable";
-    Option< .DAE.VariableAttributes> values "values on built-in attributes";
+    Option<.DAE.VariableAttributes> values "values on built-in attributes";
     Option<TearingSelect> tearingSelectOption "value for TearingSelect";
     .DAE.Exp hideResult "expression from the hideResult annotation";
     Option<SCode.Comment> comment "this contains the comment and annotation from Absyn";

--- a/Compiler/BackEnd/BackendDAECreate.mo
+++ b/Compiler/BackEnd/BackendDAECreate.mo
@@ -797,7 +797,7 @@ algorithm
         ts = BackendDAEUtil.setTearingSelectAttribute(comment);
         hideResult = BackendDAEUtil.setHideResultAttribute(comment, b, name);
       then
-        (BackendDAE.VAR(name, kind_1, dir, prl, tp, NONE(), dims, source, dae_var_attr, ts, hideResult, comment, ct, DAEUtil.toDAEInnerOuter(io), false));
+        (BackendDAE.VAR(name, kind_1, dir, prl, tp, NONE(), NONE(), dims, source, dae_var_attr, ts, hideResult, comment, ct, DAEUtil.toDAEInnerOuter(io), false));
   end match;
 end lowerDynamicVar;
 
@@ -862,7 +862,7 @@ algorithm
         ts = NONE();
         hideResult = BackendDAEUtil.setHideResultAttribute(comment, b, name);
       then
-        (BackendDAE.VAR(name, kind_1, dir, prl, tp, bind, dims, source, dae_var_attr, ts, hideResult, comment, ct, DAEUtil.toDAEInnerOuter(io), false), iInlineHT, eqLst);
+        (BackendDAE.VAR(name, kind_1, dir, prl, tp, bind, NONE(), dims, source, dae_var_attr, ts, hideResult, comment, ct, DAEUtil.toDAEInnerOuter(io), false), iInlineHT, eqLst);
 
     else
       equation
@@ -1181,7 +1181,7 @@ algorithm
         ts = NONE();
         hideResult = DAE.BCONST(false);
       then
-        BackendDAE.VAR(name, kind_1, dir, prl, tp, bind, dims, source, dae_var_attr, ts, hideResult, comment, ct, DAEUtil.toDAEInnerOuter(io), false);
+        BackendDAE.VAR(name, kind_1, dir, prl, tp, bind, NONE(), dims, source, dae_var_attr, ts, hideResult, comment, ct, DAEUtil.toDAEInnerOuter(io), false);
   end match;
 end lowerExtObjVar;
 
@@ -1845,7 +1845,7 @@ algorithm
   outVars := BackendDAE.VAR (
                   varName = cr, varKind = BackendDAE.VARIABLE(),
                   varDirection = DAE.BIDIR(), varParallelism = DAE.NON_PARALLEL(),
-                  varType = DAE.T_CLOCK_DEFAULT, bindExp = NONE(),
+                  varType = DAE.T_CLOCK_DEFAULT, bindExp = NONE(), tplExp = NONE(),
                   arryDim = {}, source = DAE.emptyElementSource,
                   values = NONE(), tearingSelectOption = SOME(BackendDAE.DEFAULT()), hideResult = DAE.BCONST(false),
                   comment = NONE(), connectorType = DAE.NON_CONNECTOR(),

--- a/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -5543,7 +5543,7 @@ protected
 algorithm
   (BackendDAE.DAE(eqs, shared), _) := BackendDAEUtil.mapEqSystemAndFold(inDAE, addTimeAsState1, 0);
   orderedVars := BackendVariable.emptyVars();
-  var := BackendDAE.VAR(DAE.crefTimeState, BackendDAE.STATE(1, NONE()), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
+  var := BackendDAE.VAR(DAE.crefTimeState, BackendDAE.STATE(1, NONE()), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
   var := BackendVariable.setVarFixed(var, true);
   var := BackendVariable.setVarStartValue(var, DAE.CREF(DAE.crefTime, DAE.T_REAL_DEFAULT));
   orderedVars := BackendVariable.addVar(var, orderedVars);

--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -381,7 +381,7 @@ protected
 algorithm
   name := Expression.reductionIterName(iter);
   cr := ComponentReference.makeCrefIdent(name,DAE.T_INTEGER_DEFAULT,{});
-  backendVar := BackendDAE.VAR(cr, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_INTEGER_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+  backendVar := BackendDAE.VAR(cr, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_INTEGER_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
 end makeIterVariable;
 
 protected function checkEquationSize"author: Frenkel TUD 2010-12
@@ -6364,26 +6364,27 @@ algorithm
       Boolean unreplaceable;
       String name;
       Option<BackendDAE.Var> v;
+      Option<DAE.Exp> tplExp;
 
     case NONE()
     then (NONE(), inTypeA);
 
-    case SOME(BackendDAE.VAR(cref, varKind, varDirection, varParallelism, varType, SOME(e1), instdims, source, attr, ts, hideResult, comment, ct, io, unreplaceable)) equation
+    case SOME(BackendDAE.VAR(cref, varKind, varDirection, varParallelism, varType, SOME(e1), tplExp, instdims, source, attr, ts, hideResult, comment, ct, io, unreplaceable)) equation
       (e1_, ext_arg_1) = func(e1, inTypeA);
       (attr_, ext_arg_2) = traverseBackendDAEVarAttr(attr, func, ext_arg_1);
       if referenceEq(e1,e1_) and referenceEq(attr,attr_) then
         v = inVar;
       else
-        v = SOME(BackendDAE.VAR(cref, varKind, varDirection, varParallelism, varType, SOME(e1_), instdims, source, attr_, ts, hideResult, comment, ct, io, unreplaceable));
+        v = SOME(BackendDAE.VAR(cref, varKind, varDirection, varParallelism, varType, SOME(e1_), tplExp, instdims, source, attr_, ts, hideResult, comment, ct, io, unreplaceable));
       end if;
     then (v, ext_arg_2);
 
-    case SOME(BackendDAE.VAR(cref, varKind, varDirection, varParallelism, varType, NONE(), instdims, source, attr, ts, hideResult, comment, ct, io, unreplaceable)) equation
+    case SOME(BackendDAE.VAR(cref, varKind, varDirection, varParallelism, varType, NONE(), tplExp, instdims, source, attr, ts, hideResult, comment, ct, io, unreplaceable)) equation
       (attr_, ext_arg_2) = traverseBackendDAEVarAttr(attr, func, inTypeA);
       if referenceEq(attr,attr_) then
         v = inVar;
       else
-        v = SOME(BackendDAE.VAR(cref, varKind, varDirection, varParallelism, varType, NONE(), instdims, source, attr_, ts, hideResult, comment, ct, io, unreplaceable));
+        v = SOME(BackendDAE.VAR(cref, varKind, varDirection, varParallelism, varType, NONE(), tplExp, instdims, source, attr_, ts, hideResult, comment, ct, io, unreplaceable));
       end if;
     then (v, ext_arg_2);
 
@@ -6793,8 +6794,6 @@ public function getSolvedSystem "Run the equation system pipeline."
   output Boolean outUseHomotopy "true if homotopy(...) is used during initialization";
   output Option<BackendDAE.BackendDAE> outInitDAE_lambda0;
   output list<BackendDAE.Equation> outRemovedInitialEquationLst;
-  output list<BackendDAE.Var> outPrimaryParameters "already sorted";
-  output list<BackendDAE.Var> outAllPrimaryParameters "already sorted";
 protected
   BackendDAE.BackendDAE dae, simDAE;
   list<tuple<BackendDAEFunc.optimizationModule, String>> preOptModules;
@@ -6851,7 +6850,7 @@ algorithm
   end if;
 
   // generate system for initialization
-  (outInitDAE, outUseHomotopy, outInitDAE_lambda0, outRemovedInitialEquationLst, outPrimaryParameters, outAllPrimaryParameters, globalKnownVars) := Initialization.solveInitialSystem(dae);
+  (outInitDAE, outUseHomotopy, outInitDAE_lambda0, outRemovedInitialEquationLst, globalKnownVars) := Initialization.solveInitialSystem(dae);
 
   // use function tree from initDAE further for simDAE
   simDAE := BackendDAEUtil.setFunctionTree(dae, BackendDAEUtil.getFunctions(outInitDAE.shared));
@@ -6867,6 +6866,9 @@ algorithm
 
   // post-optimization phase
   outSimDAE := postOptimizeDAE(simDAE, postOptModules, matchingAlgorithm, daeHandler);
+
+  // sort the globalKnownVars
+  outSimDAE := sortGlobalKnownVarsInDAE(outSimDAE);
 
   if Flags.isSet(Flags.DUMP_INDX_DAE) then
     BackendDump.dumpBackendDAE(outSimDAE, "dumpindxdae");
@@ -7241,6 +7243,58 @@ algorithm
   //bcall(Flags.isSet(Flags.DUMP_BACKENDDAE_INFO) or Flags.isSet(Flags.DUMP_STATESELECTION_INFO) or Flags.isSet(Flags.DUMP_DISCRETEVARS_INFO), BackendDump.dumpCompShort, outDAE);
   //fcall2(Flags.DUMP_EQNINORDER, BackendDump.dumpEqnsSolved, outDAE, "system for jacobians");
 end getSolvedSystemforJacobians;
+
+protected function sortGlobalKnownVarsInDAE "
+author: ptaeuber
+This function adds the external objects to globalKnownVars and sorts the globalKnownVars"
+  input output BackendDAE.BackendDAE backendDAE;
+protected
+  BackendDAE.Variables globalKnownVars, globalKnownVars_sorted;
+  BackendDAE.EquationArray parameterEqns;
+  BackendDAE.EqSystem paramSystem;
+  BackendDAE.IncidenceMatrix m;
+  BackendDAE.Var var;
+  array<Integer> ass1, ass2;
+  list<list<Integer>> comps;
+  list<Integer> flatComps;
+algorithm
+  globalKnownVars := backendDAE.shared.globalKnownVars;
+  globalKnownVars := BackendVariable.addVariables(backendDAE.shared.externalObjects, globalKnownVars);
+  parameterEqns := BackendEquation.emptyEqns();
+  parameterEqns := BackendVariable.traverseBackendDAEVars(globalKnownVars, createParameterEquations, parameterEqns);
+
+  paramSystem := BackendDAEUtil.createEqSystem(globalKnownVars, parameterEqns);
+  (m, _) := BackendDAEUtil.incidenceMatrix(paramSystem, BackendDAE.NORMAL(), NONE());
+  (ass1, ass2) := Matching.PerfectMatching(m);
+  comps := Sorting.Tarjan(m, ass1);
+  flatComps := list(Initialization.flattenParamComp(comp, globalKnownVars) for comp in comps);
+
+  globalKnownVars_sorted := BackendVariable.emptyVars();
+  for i in flatComps loop
+      var := BackendVariable.getVarAt(globalKnownVars, i);
+      globalKnownVars_sorted := BackendVariable.addVar(var, globalKnownVars_sorted);
+  end for;
+
+  backendDAE := setDAEGlobalKnownVars(backendDAE, globalKnownVars_sorted);
+end sortGlobalKnownVarsInDAE;
+
+protected function createParameterEquations
+  input output BackendDAE.Var var;
+  input output BackendDAE.EquationArray parameterEqns;
+protected
+  DAE.Exp lhs, rhs;
+  BackendDAE.Equation eqn;
+algorithm
+  lhs := BackendVariable.varExp(var);
+  try
+    rhs := BackendVariable.varBindExpStartValue(var);
+  else
+    rhs := DAE.RCONST(0.0);
+  end try;
+  eqn := BackendDAE.EQUATION(lhs, rhs, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_BINDING);
+  parameterEqns := BackendEquation.addEquation(eqn, parameterEqns);
+end createParameterEquations;
+
 
 /*************************************************
  * index reduction method Selection

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -2360,7 +2360,8 @@ algorithm
   unreplaceableStr := if inVar.unreplaceable then " unreplaceable" else "";
   dimensions := ExpressionDump.dimensionsString(inVar.arryDim);
   dimensions := if dimensions <> "" then " [" + dimensions + "]" else "";
-  outStr := DAEDump.dumpDirectionStr(inVar.varDirection) + ComponentReference.printComponentRefStr(inVar.varName) + ":"
+  outStr := DAEDump.dumpDirectionStr(inVar.varDirection) + ComponentReference.printComponentRefStr(inVar.varName)
+            + (if isSome(inVar.tplExp) then " in " + ExpressionDump.printExpStr(Util.getOption(inVar.tplExp)) else "") + ":"
             + kindString(inVar.varKind) + "(" + connectorTypeString(inVar.connectorType) + attributesString(inVar.values)
             + ") " + optExpressionString(inVar.bindExp, "") + DAEDump.dumpCommentAnnotationStr(inVar.comment)
             + stringDelimitList(paths_lst, ", ") + " type: " + DAEDump.daeTypeStr(inVar.varType) + dimensions + unreplaceableStr;

--- a/Compiler/BackEnd/BackendEquation.mo
+++ b/Compiler/BackEnd/BackendEquation.mo
@@ -2301,7 +2301,7 @@ algorithm
 
     case (_, DAE.RELATION(e1, DAE.LESS(_), e2, _, _)) equation
       lhs = ComponentReference.makeCrefIdent(conCrefName, DAE.T_REAL_DEFAULT, {});
-      dummyVar = BackendDAE.VAR(lhs, conKind, DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      dummyVar = BackendDAE.VAR(lhs, conKind, DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
       rhs = Expression.expSub(e1,e2);
       (rhs, _) = ExpressionSimplify.simplify1(rhs);
       expNull = DAE.RCONST(0.0);
@@ -2311,7 +2311,7 @@ algorithm
 
     case (_, DAE.RELATION(e1, DAE.LESSEQ(_), e2, _, _)) equation
       lhs = ComponentReference.makeCrefIdent(conCrefName, DAE.T_REAL_DEFAULT, {});
-      dummyVar = BackendDAE.VAR(lhs, conKind, DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      dummyVar = BackendDAE.VAR(lhs, conKind, DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
       rhs = Expression.expSub(e1,e2);
       (rhs, _) = ExpressionSimplify.simplify1(rhs);
       expNull = DAE.RCONST(0.0);
@@ -2321,7 +2321,7 @@ algorithm
 
     case (_, DAE.RELATION(e1, DAE.GREATER(_), e2, _, _)) equation
       lhs = ComponentReference.makeCrefIdent(conCrefName, DAE.T_REAL_DEFAULT, {});
-      dummyVar = BackendDAE.VAR(lhs, conKind, DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      dummyVar = BackendDAE.VAR(lhs, conKind, DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
       rhs =  Expression.expSub(e2,e1);
       (rhs, _) = ExpressionSimplify.simplify1(rhs);
       expNull = DAE.RCONST(0.0);
@@ -2331,7 +2331,7 @@ algorithm
 
     case (_, DAE.RELATION(e1, DAE.GREATEREQ(_), e2, _, _)) equation
       lhs = ComponentReference.makeCrefIdent(conCrefName, DAE.T_REAL_DEFAULT, {});
-      dummyVar = BackendDAE.VAR(lhs, conKind, DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      dummyVar = BackendDAE.VAR(lhs, conKind, DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
       rhs =  Expression.expSub(e2,e1);
       (rhs, _) = ExpressionSimplify.simplify(rhs);
       expNull = DAE.RCONST(0.0);
@@ -2341,7 +2341,7 @@ algorithm
 
     case (_, DAE.RELATION(e1, DAE.EQUAL(_), e2, _, _)) equation
       lhs = ComponentReference.makeCrefIdent(conCrefName, DAE.T_REAL_DEFAULT, {});
-      dummyVar = BackendDAE.VAR(lhs, conKind, DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      dummyVar = BackendDAE.VAR(lhs, conKind, DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
       rhs =  Expression.expSub(e2,e1);
       (rhs, _) = ExpressionSimplify.simplify(rhs);
       expNull = DAE.RCONST(0.0);
@@ -2356,7 +2356,7 @@ algorithm
       end try;
 
       lhs := ComponentReference.makeCrefIdent(conCrefName, DAE.T_REAL_DEFAULT, {});
-      dummyVar := BackendDAE.VAR(lhs, conKind, DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      dummyVar := BackendDAE.VAR(lhs, conKind, DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
       dummyVar := BackendVariable.mergeAliasVars(dummyVar, v, false, knvars);
       eqn := BackendDAE.SOLVED_EQUATION(lhs, e1, Source, BackendDAE.EQ_ATTR_DEFAULT_UNKNOWN);
 

--- a/Compiler/BackEnd/BackendInline.mo
+++ b/Compiler/BackEnd/BackendInline.mo
@@ -519,14 +519,15 @@ algorithm
       DAE.ConnectorType ct;
       DAE.ElementSource source;
       Option<DAE.Exp> bind;
+      Option<DAE.Exp> tplExp;
       Boolean b1,b2;
       DAE.VarInnerOuter io;
       Boolean unreplaceable;
 
-    case BackendDAE.VAR(varName,varKind,varDirection,varParallelism,varType,bind,arrayDim,source,values,ts,hideResult,comment,ct,io,unreplaceable) equation
+    case BackendDAE.VAR(varName,varKind,varDirection,varParallelism,varType,bind,tplExp,arrayDim,source,values,ts,hideResult,comment,ct,io,unreplaceable) equation
       (bind,source,b1) = Inline.inlineExpOpt(bind,inElementList,source);
       (values1,source,b2) = Inline.inlineStartAttribute(values,source,inElementList);
-    then (BackendDAE.VAR(varName,varKind,varDirection,varParallelism,varType,bind,arrayDim,source,values1,ts,hideResult,comment,ct,io,unreplaceable), b1 or b2);
+    then (BackendDAE.VAR(varName,varKind,varDirection,varParallelism,varType,bind,tplExp,arrayDim,source,values1,ts,hideResult,comment,ct,io,unreplaceable), b1 or b2);
 
     else (inVar, false);
   end match;

--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -318,7 +318,7 @@ algorithm
 end varBindExp;
 
 public function varHasConstantBindExp
-"Returns the true if the bindExp is constant otherwise false."
+"Returns true if the bindExp is constant otherwise false."
   input BackendDAE.Var v;
   output Boolean  out;
 algorithm
@@ -332,6 +332,22 @@ algorithm
     else false;
   end match;
 end varHasConstantBindExp;
+
+public function varHasNonConstantBindExpOrStartValue
+"Returns true if the bindExp is not constant otherwise false."
+  input BackendDAE.Var v;
+  output Boolean  out;
+algorithm
+  out := match(v)
+    local
+      DAE.Exp e;
+
+    case (BackendDAE.VAR(bindExp=SOME(e)))
+    then not Expression.isConst(e);
+
+    else not varHasConstantStartExp(v);
+  end match;
+end varHasNonConstantBindExpOrStartValue;
 
 public function varHasConstantStartExp
 "Returns the true if the binding/start value is constant otherwise false."
@@ -1118,6 +1134,18 @@ algorithm
   end match;
 end isStringParam;
 
+public function isVar
+"Return true if variable is a variable."
+  input BackendDAE.Var inVar;
+  output Boolean outBoolean;
+algorithm
+  outBoolean:= match (inVar)
+    case BackendDAE.VAR(varKind = BackendDAE.VARIABLE()) then true;
+    case BackendDAE.VAR(varKind = BackendDAE.DISCRETE()) then true;
+    else false;
+  end match;
+end isVar;
+
 public function isExtObj
 "Return true if variable is an external object."
   input BackendDAE.Var inVar;
@@ -1430,7 +1458,7 @@ protected
   DAE.ComponentRef cr;
 algorithm
   cr := ComponentReference.prependStringCref(BackendDAE.derivativeNamePrefix, inCref);
-  outVar := BackendDAE.VAR(cr, BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),DAE.T_REAL_DEFAULT,NONE(),{},
+  outVar := BackendDAE.VAR(cr, BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),DAE.T_REAL_DEFAULT,NONE(),NONE(),{},
                           DAE.emptyElementSource,
                           NONE(),
                           NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
@@ -1474,12 +1502,12 @@ algorithm
       DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(path)) = inType;
       source = DAE.SOURCE(Absyn.dummyInfo, {}, Prefix.NOCOMPPRE(), {}, {path}, {}, {});
       varKind = if Types.isDiscreteType(inType) then BackendDAE.DISCRETE() else BackendDAE.VARIABLE();
-      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), {}, source, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
+      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), NONE(), {}, source, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
     then outVar;
 
     else equation
       varKind = if Types.isDiscreteType(inType) then BackendDAE.DISCRETE() else BackendDAE.VARIABLE();
-      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
+      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
     then outVar;
   end match;
 end createCSEVar;
@@ -1493,7 +1521,7 @@ public function generateVar
   input Option<DAE.VariableAttributes> attr;
   output BackendDAE.Var var;
 algorithm
-  var := BackendDAE.VAR(cr,varKind,DAE.BIDIR(),DAE.NON_PARALLEL(),varType,NONE(),subs,DAE.emptyElementSource,attr,NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(),DAE.NOT_INNER_OUTER(),false);
+  var := BackendDAE.VAR(cr,varKind,DAE.BIDIR(),DAE.NON_PARALLEL(),varType,NONE(),NONE(),subs,DAE.emptyElementSource,attr,NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(),DAE.NOT_INNER_OUTER(),false);
 end generateVar;
 
 public function generateArrayVar
@@ -1530,7 +1558,7 @@ algorithm
         vars;
     case (_,_,_,_)
       equation
-        var = BackendDAE.VAR(name,varKind,DAE.BIDIR(),DAE.NON_PARALLEL(),varType,NONE(),{},DAE.emptyElementSource,attr,NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(),DAE.NOT_INNER_OUTER(), false);
+        var = BackendDAE.VAR(name,varKind,DAE.BIDIR(),DAE.NON_PARALLEL(),varType,NONE(),NONE(),{},DAE.emptyElementSource,attr,NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(),DAE.NOT_INNER_OUTER(), false);
       then
         {var};
   end match;
@@ -1554,12 +1582,12 @@ algorithm
       DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(path)) = inType;
       source = DAE.SOURCE(Absyn.dummyInfo, {}, Prefix.NOCOMPPRE(), {}, {path}, {}, {});
       varKind = if Types.isDiscreteType(inType) then BackendDAE.DISCRETE() else BackendDAE.VARIABLE();
-      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), inArryDim, source, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
+      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), NONE(), inArryDim, source, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
     then outVar;
 
     else equation
       varKind = if Types.isDiscreteType(inType) then BackendDAE.DISCRETE() else BackendDAE.VARIABLE();
-      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), inArryDim, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
+      outVar = BackendDAE.VAR(inCref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), inType, NONE(), NONE(), inArryDim, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
     then outVar;
   end match;
 end createCSEArrayVar;
@@ -2332,6 +2360,30 @@ algorithm
   end match;
 end deleteVar;
 
+public function deleteVarIfExistsAndReturn
+"author: PA
+  Deletes a variable from Variables and returns it."
+  input DAE.ComponentRef inComponentRef;
+  input BackendDAE.Variables inVariables;
+  output list<BackendDAE.Var> outVarLst;
+  output BackendDAE.Variables outVariables;
+algorithm
+  (outVarLst,outVariables) := matchcontinue(inComponentRef,inVariables)
+    local
+      BackendDAE.Variables vars;
+      DAE.ComponentRef cr;
+      list<Integer> ilst;
+
+    case (cr,_) equation
+      (outVarLst,ilst) = getVar(cr,inVariables);
+      (vars,_) = removeVars(ilst,inVariables,{});
+      vars = listVar1(varList(vars));
+    then (outVarLst, vars);
+
+    else ({}, inVariables);
+  end matchcontinue;
+end deleteVarIfExistsAndReturn;
+
 public function removeCrefs "author: wbraun
   Removes a list of DAE.ComponentRef from BackendDAE.Variables"
   input list<DAE.ComponentRef> varlst;
@@ -2486,7 +2538,7 @@ protected
   DAE.Type tp = ComponentReference.crefLastType(cr);
   DAE.Dimensions dims = Expression.arrayDimension(tp);
 algorithm
- v := BackendDAE.VAR(cr, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), dims, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+ v := BackendDAE.VAR(cr, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), dims, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
 end makeVar;
 
 public function addVarDAE

--- a/Compiler/BackEnd/CommonSubExpression.mo
+++ b/Compiler/BackEnd/CommonSubExpression.mo
@@ -32,8 +32,8 @@
 encapsulated package CommonSubExpression
 " file:        CommonSubExpression.mo
   package:     CommonSubExpression
-  description: This package contains functions for the optimization module
-               CommonSubExpression."
+  description: This package contains functions for the optimization modules
+               wrapFunctionCalls, commonSubExpressionReplacement and cseBinary."
 
 
 public
@@ -56,6 +56,7 @@ import ExpressionDump;
 import ExpressionSolve;
 import ExpressionSimplify;
 import Global;
+import HashSet;
 import HashTableExpToExp;
 import HashTableExpToIndex;
 import HpcOmTaskGraph;
@@ -73,6 +74,8 @@ end CSE_Equation;
 
 constant CSE_Equation dummy_equation = CSE_EQUATION(DAE.RCONST(0.0), DAE.RCONST(0.0), {});
 constant Boolean debug = false;
+constant String BORDER = "###############################################################";
+constant String UNDERLINE = "========================================";
 
 protected function printCSEEquation
   input CSE_Equation cseEquation;
@@ -94,105 +97,199 @@ algorithm
   str := str + "}";
 end printCSEEquation;
 
-public function wrapFunctionCalls "authors: Jan Hagemann and Lennart Ochel (FH Bielefeld, Germany)
-  main function: is called by postOpt and SymbolicJacobian"
+public function wrapFunctionCalls "
+  This function traverses the equation systems and looks for function calls to store in $cse variables.
+  This avoids unnecessary function evaluations.
+  Main function: is called by postOpt and SymbolicJacobian
+  authors: Jan Hagemann, Lennart Ochel and Patrick Täuber (FH Bielefeld, Germany)"
   input BackendDAE.BackendDAE inDAE;
   output BackendDAE.BackendDAE outDAE;
 protected
   Integer size;
   HashTableExpToIndex.HashTable HT "call -> index";
+  HashTableExpToIndex.HashTable HT_initial "call -> index (filled with globalKnownVars)";
   ExpandableArray<CSE_Equation> exarray "id -> (cse, call, dependencies)";
+  ExpandableArray<CSE_Equation> exarray_initial "id -> (cse, call, dependencies - filled with globalKnownVars)";
 
   Integer cseIndex = System.tmpTickIndex(Global.backendDAE_cseIndex);
-  Integer index;
+  Integer index = 0, index_initial = 0;
 
+  BackendDAE.Shared shared;
   DAE.FunctionTree functionTree;
   BackendDAE.EquationArray orderedEqs, orderedEqs_new;
-  BackendDAE.Variables orderedVars;
+  BackendDAE.Variables orderedVars, globalKnownVars;
   list<BackendDAE.EqSystem> eqSystems = {};
   list<BackendDAE.Var> varList;
+  String daeTypeStr = BackendDump.printBackendDAEType2String(inDAE.shared.backendDAEType);
+  Boolean isSimulationDAE = stringEq(daeTypeStr, "simulation");
+
+  HashSet.HashSet globalKnownVarHT;
 
   DAE.Exp cse, call;
   list<Integer> dependencies;
 algorithm
   size := BackendDAEUtil.maxSizeOfEqSystems(inDAE.eqs) + 42;   //create data structures independent from the size of the EqSystem
   exarray := ExpandableArray.new(size, dummy_equation);
+  exarray_initial := ExpandableArray.new(size, dummy_equation);
 
   size := Util.nextPrime(realInt(2.4*size));
   HT := HashTableExpToIndex.emptyHashTableSized(size);
+  HT_initial := HashTableExpToIndex.emptyHashTableSized(size);
 
-  BackendDAE.SHARED(functionTree=functionTree) := inDAE.shared;
+  shared := inDAE.shared;
+  BackendDAE.SHARED(globalKnownVars=globalKnownVars,functionTree=functionTree) := shared;
 
+  // Create Hashtable and store globally known variables in it
+  globalKnownVarHT := HashSet.emptyHashSetSized(Util.nextPrime(realInt(2.4*(globalKnownVars.numberOfVars + 42))));
+  if isSimulationDAE then
+    globalKnownVarHT := BackendVariable.traverseBackendDAEVars(globalKnownVars, VarToGlobalKnownVarHT, globalKnownVarHT);
+  end if;
+
+  if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
+    print("Start optimization module wrapFunctionCalls for " + daeTypeStr + " DAE\n" + BORDER + BORDER + "\n\n\n");
+    print("Pre-Phase: Set up data structure\n" + BORDER + "\n");
+    BackendDump.dumpVariables(globalKnownVars, "globalKnownVars before WFC");
+    print("globalKnownVarHT before analysis\n" + UNDERLINE + "\n");
+    BaseHashSet.dumpHashSet(globalKnownVarHT);
+    print("\nPhase 0: Analyse the globalKnownVars\n" + BORDER + "\n");
+  end if;
+
+  if isSimulationDAE then
+    // Traverse globalKnownVars and perform the WFC analysis phase on it
+    (HT_initial, exarray_initial, cseIndex, index_initial, functionTree, globalKnownVarHT) := BackendVariable.traverseBackendDAEVars(globalKnownVars, findCallsInGlobalKnownVars, (HT_initial, exarray_initial, cseIndex, index_initial, functionTree, globalKnownVarHT));
+  end if;
+
+  if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
+    print("Hastable after analysis of globalKnownVars (HT_initial)\n" + UNDERLINE + "\n");
+    BaseHashTable.dumpHashTable(HT_initial);
+    ExpandableArray.dump(exarray_initial, "\nExpandable Array after analysis of globalKnownVars (exarray_initial)", printCSEEquation);
+    print("\nglobalKnownVarHT after analysis\n" + UNDERLINE + "\n");
+    BaseHashSet.dumpHashSet(globalKnownVarHT);
+  end if;
+
+  // Start the WFC algorithm for all equation systems
   for syst in inDAE.eqs loop
-    HT := BaseHashTable.clear(HT);
-    exarray := ExpandableArray.clear(exarray);
+    if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
+      print("\n\nHandle system (belongs to " + daeTypeStr + " DAE):\n" + BORDER + "\n");
+      BackendDump.dumpVariables(syst.orderedVars, "Variables");
+      BackendDump.dumpEquationArray(syst.orderedEqs, "Equations");
+      print("\n\nPhase 1: Analysis\n" + BORDER + "\n");
+    end if;
+    HT := BaseHashTable.copy(HT_initial);
+    exarray := ExpandableArray.copy(exarray_initial, dummy_equation);
+    index := index_initial;
+
     orderedEqs := syst.orderedEqs;
     orderedVars := syst.orderedVars;
 
-    // analysis
-    index := 0;
-    (HT, exarray, cseIndex, index, _) := BackendEquation.traverseEquationArray(orderedEqs, wrapFunctionCalls_analysis, (HT, exarray, cseIndex, index, functionTree));
+    // Phase 1: Analysis
+    (HT, exarray, cseIndex, index, _, globalKnownVarHT) := BackendEquation.traverseEquationArray(orderedEqs, wrapFunctionCalls_analysis, (HT, exarray, cseIndex, index, functionTree, globalKnownVarHT));
+
+    if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
+      print("Hastable after analysis\n" + UNDERLINE + "\n");
+      BaseHashTable.dumpHashTable(HT);
+      ExpandableArray.dump(exarray, "\nExpandable Array after analysis", printCSEEquation);
+      print("\nglobalKnownVarHT after analysis\n" + UNDERLINE + "\n");
+      BaseHashSet.dumpHashSet(globalKnownVarHT);
+    end if;
 
     if index > 0 then
-      // determine dependencies
+      // Phase 2: Dependencies
       exarray := determineDependencies(exarray, HT);
 
-      if debug then
-        print("#############################################\n");
-        print("after analysis###############################\n");
+      if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
+        print("\n\nPhase 2: Dependencies\n" + BORDER + "\n\n");
+        print("Hashtable after dependencies\n" + UNDERLINE + "\n");
         BaseHashTable.dumpHashTable(HT);
-        ExpandableArray.dump(exarray, "Expandable Array", printCSEEquation);
+        ExpandableArray.dump(exarray, "\nExpandable Array after dependencies", printCSEEquation);
+        print("\n\nPhase3: Substitution\n" + BORDER + "\n");
       end if;
 
-      // substitution
+      // Phase 3: Substitution
       orderedEqs_new := BackendEquation.emptyEqnsSized(orderedEqs.numberOfElement + ExpandableArray.getNumberOfElements(exarray));
       (HT, exarray, orderedEqs_new) := BackendEquation.traverseEquationArray(orderedEqs, wrapFunctionCalls_substitution, (HT, exarray, orderedEqs_new));
 
-      //for id in 1:exarray.numberOfElements loop
-      //  CSE_EQUATION(cse=cse, call=call, dependencies=dependencies) := ExpandableArray.get(id, exarray);
-      //  (HT, exarray) := substituteDependencies(dependencies, HT, exarray, call, cse);
-      //  ExpandableArray.update(id, CSE_EQUATION(cse, call, {}), exarray);
-      //end for;
-
-      if debug then
-        print("#############################################\n");
-        print("after substitution###########################\n");
+      if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
+        print("Hashtable after substitution\n" + UNDERLINE + "\n");
         BaseHashTable.dumpHashTable(HT);
-        ExpandableArray.dump(exarray, "Expandable Array", printCSEEquation);
+        ExpandableArray.dump(exarray, "\nExpandable Array after substitution", printCSEEquation);
+        print("\n\nPhase 4: Create CSE-Equations\n" + BORDER + "\n\n");
       end if;
 
-      // create cse equations
-      (orderedEqs_new, varList) := createCseEquations(exarray, orderedEqs_new);
-      syst.orderedEqs := orderedEqs_new;
-      syst.orderedVars := BackendVariable.addVars(varList, orderedVars);
+      // Phase 4: Create CSE equations
+      (orderedEqs_new, orderedVars, globalKnownVars) := createCseEquations(exarray, orderedEqs_new, orderedVars, globalKnownVarHT, globalKnownVars);
 
-      // reset Matching
+      syst.orderedEqs := orderedEqs_new;
+      syst.orderedVars := orderedVars;
+
+      // Reset Matching
       syst.m := NONE();
       syst.mT := NONE();
       syst.matching := BackendDAE.NO_MATCHING();
 
       if Flags.isSet(Flags.DUMP_CSE) or Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
-        BackendDump.dumpVariables(syst.orderedVars, "########### Updated Variable List (" + BackendDump.printBackendDAEType2String(inDAE.shared.backendDAEType) + ") ###########");
-        BackendDump.dumpEquationArray(syst.orderedEqs, "########### Updated Equation List (" + BackendDump.printBackendDAEType2String(inDAE.shared.backendDAEType) + ") ###########");
-        ExpandableArray.dump(exarray, "cse replacements", printCSEEquation);
+        print("\n\n\n" + BORDER + "\nFinal Results\n" + BORDER + "\n");
+        BackendDump.dumpVariables(syst.orderedVars, "########### Updated Variable List (" + BackendDump.printBackendDAEType2String(shared.backendDAEType) + ")");
+        BackendDump.dumpEquationArray(syst.orderedEqs, "########### Updated Equation List (" + BackendDump.printBackendDAEType2String(shared.backendDAEType) + ")");
+        BackendDump.dumpVariables(globalKnownVars, "########### Updated globalKnownVars (" + BackendDump.printBackendDAEType2String(shared.backendDAEType) + ")");
+        ExpandableArray.dump(exarray, "\n########### CSE Replacements", printCSEEquation);
       end if;
 
-      if debug then
-        print("#############################################\n");
-        print("final result#################################\n");
-        BackendDump.dumpEqSystem(syst, "new syst");
+      if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
+        print("\n\n" + BORDER);
+        BackendDump.dumpEqSystem(syst, "Final EqSystem");
+      end if;
+    else
+      if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
+        print("\n" + BORDER + "\nNo function calls found. Exiting the algorithm...\n\n\n");
       end if;
     end if;
 
     eqSystems := syst::eqSystems;
   end for;
 
+  shared.globalKnownVars := globalKnownVars;
+
   System.tmpTickSetIndex(cseIndex, Global.backendDAE_cseIndex);
   eqSystems := MetaModelica.Dangerous.listReverseInPlace(eqSystems);
-  outDAE := BackendDAE.DAE(eqSystems, inDAE.shared);
+  outDAE := BackendDAE.DAE(eqSystems, shared);
 end wrapFunctionCalls;
 
+protected function VarToGlobalKnownVarHT
+" Adds all globalKnownVars with bindExp to globalKnownVarHT except inputs and nonfixed parameters"
+  input BackendDAE.Var inVar;
+  input HashSet.HashSet inGlobalKnownVarHT;
+  output BackendDAE.Var outVar = inVar;
+  output HashSet.HashSet outGlobalKnownVarHT = inGlobalKnownVarHT;
+algorithm
+  // To-Do: Move inputs to localKnownVars
+  if not BackendVariable.isInput(inVar) and not (BackendVariable.isParam(inVar) and not BackendVariable.varFixed(inVar)) and isSome(inVar.bindExp) then
+    outGlobalKnownVarHT := BaseHashSet.add(BackendVariable.varCref(inVar), inGlobalKnownVarHT);
+  end if;
+end VarToGlobalKnownVarHT;
+
+protected function findCallsInGlobalKnownVars
+"This function traverses the globalKnownVars and looks for function calls. The calls are stored in the HT/expArray"
+  input BackendDAE.Var inVar;
+  input tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree, HashSet.HashSet> inTuple;
+  output BackendDAE.Var outVar = inVar;
+  output tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree, HashSet.HashSet> outTuple = inTuple;
+protected
+  DAE.Exp exp;
+  BackendDAE.Equation eq;
+algorithm
+  // To-Do: Move inputs to localKnownVars
+  if not BackendVariable.isInput(inVar) and not (BackendVariable.isParam(inVar) and not BackendVariable.varFixed(inVar)) and isSome(inVar.bindExp) then
+    SOME(exp):= inVar.bindExp;
+    if isCall(exp) then
+      eq := BackendEquation.generateEquation(DAE.CREF(inVar.varName, inVar.varType), exp);
+      (_, outTuple) := wrapFunctionCalls_analysis(eq, inTuple);
+    end if;
+  end if;
+end findCallsInGlobalKnownVars;
+
 protected function wrapFunctionCalls_substitution
+"Third phase of the WFC algorithm: The found function calls in the equation system which are stored in the HT are replaced by its cse-variables."
   input BackendDAE.Equation inEq;
   input tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, BackendDAE.EquationArray> inTuple;
   output BackendDAE.Equation outEq = inEq;
@@ -207,7 +304,7 @@ algorithm
 
   _ := match(inEq)
     case BackendDAE.COMPLEX_EQUATION() equation
-      if debug then
+      if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
         BackendDump.dumpEquationList({inEq}, "wrapFunctionCalls_substitution (COMPLEX_EQUATION)");
       end if;
 
@@ -215,18 +312,18 @@ algorithm
 
       if not isEquationRedundant(eq) then
         orderedEqs_new = BackendEquation.addEquation(eq, orderedEqs_new);
-        if debug then
+        if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
           BackendDump.dumpEquationList({eq}, "isEquationRedundant? no");
         end if;
       else
-        if debug then
+        if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
           BackendDump.dumpEquationList({eq}, "isEquationRedundant? yes");
         end if;
       end if;
     then ();
 
     case BackendDAE.EQUATION() equation
-      if debug then
+      if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
         BackendDump.dumpEquationList({inEq}, "wrapFunctionCalls_substitution (EQUATION)");
       end if;
 
@@ -377,24 +474,110 @@ algorithm
 end substituteExp2;
 
 protected function createCseEquations
+" Fourth phase of the WFC algorithm:
+  Creates CSE equations from the expandable array and stores them in the correct data structure:
+  1) cse var (i.e. function call) with $cse-prefix is dependending on variables
+       -> store eqn in orderedEqs and var in orderedVars
+  2) cse var (i.e. function call) without $cse-prefix is dependending on variables
+       -> store eqn in orderedEqs
+  3) cse var (i.e. function call) with $cse-prefix is only dependending on globally known variables
+       -> store var in globalKnownVars (bindExp=call)
+  4) cse var (i.e. function call) without $cse-prefix is only dependending on globally known variables
+       -> store var in globalKnownVars (bindExp=call) and delete var from orderedVars
+  author: ptaeuber"
   input ExpandableArray<CSE_Equation> exarray "id -> (cse, call, dependencies)";
-  input output BackendDAE.EquationArray orderedEqs;
-  output list<BackendDAE.Var> varList = {};
+  input output BackendDAE.EquationArray orderedEqs "equations of the system";
+  input output BackendDAE.Variables orderedVars;
+  input HashSet.HashSet inGlobalKnownVarHT;
+  input output BackendDAE.Variables globalKnownVars;
 protected
   DAE.Exp cse, call;
+  list<DAE.Exp> callArg;
   BackendDAE.Equation eq;
+  list<DAE.ComponentRef> crefList;
+  DAE.ComponentRef cr;
+  BackendDAE.Var var;
+  list<BackendDAE.Var> varList, delVars;
+  Boolean eqRedundant, addEquation;
+  list<Integer> var_indexes;
 algorithm
+  if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
+    print("globalKnownVars:\n" + UNDERLINE + "\n");
+    BaseHashSet.dumpHashSet(inGlobalKnownVarHT);
+    print("\nTraverse expandable array\n"  + UNDERLINE + "\n");
+  end if;
   for i in 1:ExpandableArray.getNumberOfElements(exarray) loop
+    addEquation := true;
     CSE_EQUATION(cse=cse, call=call) := ExpandableArray.get(i, exarray);
+    if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
+      print("\n--> cse-equation: " + ExpressionDump.printExpStr(cse) + " = " + ExpressionDump.printExpStr(call) + "\n");
+    end if;
+
     eq := BackendEquation.generateEquation(cse, call);
-    if not isEquationRedundant(eq) then
-      orderedEqs := BackendEquation.addEquation(eq, orderedEqs);
-      varList := createVarsForExp(cse, varList);
+    (eqRedundant, globalKnownVars, orderedVars) := isEquationRedundant_flatten(eq, inGlobalKnownVarHT, globalKnownVars, orderedVars);
+
+    if debug then print("\ndebug 1 - eq redundant?\n"); end if;
+    if not eqRedundant then
+      if debug then print("\ndebug 2 - no, not redundant. let's loop\n"); end if;
+      varList := createVarsForExp(cse);
+      // If cse is a constant number add the equation
+      if listEmpty(varList) then
+        orderedEqs := BackendEquation.addEquation(eq, orderedEqs);
+      else
+        for var in varList loop
+          if debug then print("\ndebug 3 - handle var: " + BackendDump.varString(var) + " Is it a globalKnownVar?\n"); end if;
+          cr := BackendVariable.varCref(var);
+          // Variable is not in globalKnownVars HT
+          if not allArgsInGlobalKnownVars({call}, inGlobalKnownVarHT) then
+            if debug then print("\ndebug 4 - The variable is not a globalKnownVar. Should an equation be added?\n"); end if;
+            if addEquation then
+              if debug then print("\ndebug 5 - yes, definitely!\n"); end if;
+              orderedEqs := BackendEquation.addEquation(eq, orderedEqs);
+              addEquation := false;
+            end if;
+            if debug then print("\ndebug 6 - Is this cref a CSE cref?: " + ExpressionDump.printExpStr(Expression.crefExp(cr)) + "\n"); end if;
+            if isCSECref(cr) then
+              if debug then print("\ndebug 7 - yes it is a CSE cref. Add to orderedVars!\n"); end if;
+              orderedVars := BackendVariable.addVar(var, orderedVars);
+            end if;
+            if debug then print("\ndebug 8\n"); end if;
+
+          // Variable is in globalKnownVars HT: Add it to globalKnownVars and not to ordered vars and do not create a cse-equation
+          else
+            if debug then print("\ndebug 9 - The variable is a globalKnownVar.\n"); end if;
+
+            if not isCSECref(cr) then
+              if debug then print("\ndebug 10 - The globalKnownVar is no CSE cref, so copy attributes and delete it from orderedVars if it is in that list.\n"); end if;
+              (delVars, orderedVars) := BackendVariable.deleteVarIfExistsAndReturn(cr, orderedVars);
+              if listEmpty(delVars) then
+                (delVars, _) := BackendVariable.getVar(cr, globalKnownVars);
+              end if;
+              var := listGet(delVars, 1);
+            end if;
+
+            // Save the rhs (call) as bind expression
+            var := BackendVariable.setBindExp(var, SOME(call));
+
+            // If it is a tuple or a record (or record within tuple)
+            if intGt(listLength(varList), 1) then
+              if debug then print("\ndebug 11 - It is a tuple! Add it to tplExp\n"); end if;
+              var.tplExp := SOME(cse);
+            end if;
+
+            if debug then print("\ndebug 12 - Add the variable to globalKnownVars\n"); end if;
+            // Add var to globalKnownVars
+            globalKnownVars := BackendVariable.addVar(var, globalKnownVars);
+
+          end if;
+        end for;
+      end if;
     end if;
   end for;
+  if debug then print("\ndebug 13\n"); end if;
 end createCseEquations;
 
-function determineDependencies
+protected function determineDependencies
+"Second phase of the WFC algorithm: Finds the dependencies between nested function calls and stores them in the expandable array."
   input output ExpandableArray<CSE_Equation> exarray "id -> (cse, call, dependencies)";
   input HashTableExpToIndex.HashTable HT "call -> index";
 protected
@@ -436,86 +619,204 @@ algorithm
   end if;
 end determineDependencies2;
 
+protected function addConstantCseVarsToGlobalKnownVarHT
+"Traverses the callArgs and adds the cse variable to the globalKnownVarHT if all args are globally known.
+ For tuples the crefs are stored separately.
+ author: ptaeuber"
+  input DAE.Exp cse_crExp;
+  input list<DAE.Exp> callArgs;
+  input output HashSet.HashSet globalKnownVarHT;
+protected
+  list<DAE.ComponentRef> crefList;
+algorithm
+  if allArgsInGlobalKnownVars(callArgs, globalKnownVarHT) then
+    globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT2(cse_crExp, globalKnownVarHT);
+  end if;
+end addConstantCseVarsToGlobalKnownVarHT;
+
+protected function allArgsInGlobalKnownVars
+"Returns true if all call arguments are globally known"
+  input list<DAE.Exp> callArgs;
+  input HashSet.HashSet globalKnownVarHT;
+  output Boolean allCrefsAreGlobal = true;
+protected
+  list<DAE.ComponentRef> crefList;
+algorithm
+  (_,crefList) := Expression.traverseExpList(callArgs, Expression.traversingComponentRefFinder, {});
+  for cr in crefList loop
+    if allCrefsAreGlobal then
+      allCrefsAreGlobal := BaseHashSet.has(cr, globalKnownVarHT);
+    else
+      return;
+    end if;
+  end for;
+end allArgsInGlobalKnownVars;
+
+protected function addConstantCseVarsToGlobalKnownVarHT2
+  input DAE.Exp cse_crExp;
+  input output HashSet.HashSet globalKnownVarHT;
+algorithm
+  _ :=  match(cse_crExp)
+    local
+      list<DAE.Exp> expLst;
+      DAE.ComponentRef cr;
+      list<DAE.ComponentRef> crefs;
+
+    case(DAE.TUPLE(PR = expLst))
+      algorithm
+        for exp in expLst loop
+          if Expression.isNotWild(exp) then
+            globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT2(exp, globalKnownVarHT);
+          end if;
+        end for;
+     then ();
+
+    case DAE.CREF(componentRef=cr, ty = DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(_)))
+      algorithm
+        globalKnownVarHT := BaseHashSet.add(cr, globalKnownVarHT);
+        crefs := ComponentReference.expandCref(cr, true /*the way it is now we won't get records here. but if we do somehow expand them*/);
+
+        for cr_ in crefs loop
+          globalKnownVarHT := BaseHashSet.add(cr_, globalKnownVarHT);
+        end for;
+     then ();
+
+    case DAE.CREF(componentRef=cr) guard(Expression.isArrayType(Expression.typeof(cse_crExp)))
+      algorithm
+        globalKnownVarHT := BaseHashSet.add(cr, globalKnownVarHT);
+        crefs := ComponentReference.expandCref(cr, true);
+
+        for cr_ in crefs loop
+          globalKnownVarHT := BaseHashSet.add(cr_, globalKnownVarHT);
+        end for;
+     then ();
+
+    case(DAE.CREF(componentRef=cr))
+      algorithm
+        globalKnownVarHT := BaseHashSet.add(cr, globalKnownVarHT);
+     then ();
+  end match;
+end addConstantCseVarsToGlobalKnownVarHT2;
+
 protected function wrapFunctionCalls_analysis
+"First phase of the WFC algorithm: The equation system is traversed and all occuring function calls are stored in the HT and the expandable array."
   input BackendDAE.Equation inEq;
-  input tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree> inTuple;
+  input tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree, HashSet.HashSet> inTuple;
   output BackendDAE.Equation outEq = inEq;
-  output tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree> outTuple;
+  output tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree, HashSet.HashSet> outTuple;
 protected
   DAE.FunctionTree functionTree;
   HashTableExpToIndex.HashTable HT;
   ExpandableArray<CSE_Equation> exarray;
+  HashSet.HashSet globalKnownVarHT;
+
   Integer cseIndex, exIndex, index, ix;
   DAE.Exp lhs, rhs;
   DAE.Exp cref, call;
   DAE.Exp exp;
+  list<DAE.Exp> expLst;
   DAE.Type ty;
   list<DAE.Type> types;
   CSE_Equation cseEquation;
+  Boolean allCrefsAreGlobal = true;
+  list<DAE.ComponentRef> crefList;
+  list<BackendDAE.Var> varList;
 algorithm
-  (HT, exarray, cseIndex, index, functionTree) := inTuple;
+  (HT, exarray, cseIndex, index, functionTree, globalKnownVarHT) := inTuple;
 
   _ := match(inEq)
     case BackendDAE.COMPLEX_EQUATION(left=lhs, right=rhs) algorithm
-      if debug then
+      if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
         BackendDump.dumpEquationList({inEq}, "wrapFunctionCalls_analysis (COMPLEX_EQUATION)");
       end if;
 
       // TUPLE = CALL
+      // ************
       if isCallAndTuple(lhs, rhs) then
         (cref, call) := getTheRightPattern(lhs, rhs);
+
+        // Tuple is already in HT
         if BaseHashTable.hasKey(call, HT) then
           exIndex := BaseHashTable.get(call, HT);
           cseEquation := ExpandableArray.get(exIndex, exarray);
-          //print("cref1: " + ExpressionDump.printExpStr(cseEquation.cse) + "\n");
-          //print("cref2: " + ExpressionDump.printExpStr(cref) + "\n");
           cseEquation.cse := mergeCSETuples(cseEquation.cse, cref);
           exarray := ExpandableArray.update(exIndex, cseEquation, exarray);
+
+          // Add cse vars which are only depending on globalKnownVars to globalKnownVarHT
+          DAE.CALL(expLst = expLst) := call;
+          globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(cseEquation.cse, expLst, globalKnownVarHT);
+
+        // Tuple is not already in HT
         elseif not isSkipCase(call, functionTree) then
           index := index + 1;
           HT := BaseHashTable.add((call, index), HT);
           exarray := ExpandableArray.set(index, CSE_EQUATION(cref, call, {}), exarray);
+
+          // Add cse vars which are only depending on globalKnownVars to globalKnownVarHT
+          DAE.CALL(expLst = expLst) := call;
+          globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(cref, expLst, globalKnownVarHT);
         end if;
 
+      // RECORD = CALL
+      // *************
       elseif isCallAndRecord(lhs, rhs) then
         (cref, call) := getTheRightPattern(lhs, rhs);
         if BaseHashTable.hasKey(call, HT) then
           exIndex := BaseHashTable.get(call, HT);
           cseEquation := ExpandableArray.get(exIndex, exarray);
-          //print("cref old: " + ExpressionDump.printExpStr(cseEquation.cse) + "\n");
-          //print("cref new: " + ExpressionDump.printExpStr(cref) + "\n");
           cseEquation.cse := cref;
           exarray := ExpandableArray.update(exIndex, cseEquation, exarray);
+
+          // Add cse vars which are only depending on globalKnownVars to globalKnownVarHT
+          DAE.CALL(expLst = expLst) := call;
+          globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(cseEquation.cse, expLst, globalKnownVarHT);
         elseif not isSkipCase(call, functionTree) then
           index := index + 1;
           HT := BaseHashTable.add((call, index), HT);
           exarray := ExpandableArray.set(index, CSE_EQUATION(cref, call, {}), exarray);
+
+          // Add cse vars which are only depending on globalKnownVars to globalKnownVarHT
+          DAE.CALL(expLst = expLst) := call;
+          globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(cref, expLst, globalKnownVarHT);
         end if;
       end if;
 
-      (_, (HT, exarray, cseIndex, index, functionTree)) := BackendEquation.traverseExpsOfEquation(inEq, wrapFunctionCalls_analysis2, (HT, exarray, cseIndex, index, functionTree));
+      (_, (HT, exarray, cseIndex, index, functionTree, globalKnownVarHT)) := BackendEquation.traverseExpsOfEquation(inEq, wrapFunctionCalls_analysis2, (HT, exarray, cseIndex, index, functionTree, globalKnownVarHT));
     then ();
 
     case BackendDAE.EQUATION(exp=lhs, scalar=rhs) algorithm
-      if debug then
+      if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then
         BackendDump.dumpEquationList({inEq}, "wrapFunctionCalls_analysis (EQUATION)");
       end if;
 
       // CREF = CALL or CONST = CALL
+      // ***************************
       if isCallAndCref(lhs, rhs) or isConstAndCall(lhs, rhs) then
         (cref, call) := getTheRightPattern(lhs, rhs);
+
+
         if BaseHashTable.hasKey(call, HT) then
           exIndex := BaseHashTable.get(call, HT);
           cseEquation := ExpandableArray.get(exIndex, exarray);
           cseEquation.cse := cref;
           exarray := ExpandableArray.update(exIndex, cseEquation, exarray);
+
+          // Add cse vars which are only depending on globalKnownVars to globalKnownVarHT
+          DAE.CALL(expLst = expLst) := call;
+          globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(cref, expLst, globalKnownVarHT);
+
         elseif not isSkipCase(call, functionTree) then
           index := index + 1;
           HT := BaseHashTable.add((call, index), HT);
           exarray := ExpandableArray.set(index, CSE_EQUATION(cref, call, {}), exarray);
+
+          // Add cse vars which are only depending on globalKnownVars to globalKnownVarHT
+          DAE.CALL(expLst = expLst) := call;
+          globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(cref, expLst, globalKnownVarHT);
         end if;
 
       // CREF = TSUB
+      // ***********
       elseif isTsubAndCref(lhs, rhs) then
         (cref, DAE.TSUB(call as DAE.CALL(attr=DAE.CALL_ATTR(ty=DAE.T_TUPLE(types=types))),ix,_)) := getTheRightPattern(lhs, rhs);
         if BaseHashTable.hasKey(call, HT) then
@@ -524,15 +825,24 @@ algorithm
           cref := createCrefForTsub(listLength(types), ix, cref);
           cseEquation.cse := mergeCSETuples(cseEquation.cse, cref);
           exarray := ExpandableArray.update(exIndex, cseEquation, exarray);
+
+          // Add cse vars which are only depending on globalKnownVars to globalKnownVarHT
+          DAE.CALL(expLst = expLst) := call;
+          globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(cseEquation.cse, expLst, globalKnownVarHT);
+
         elseif not isSkipCase(call, functionTree) then
           index := index + 1;
           HT := BaseHashTable.add((call, index), HT);
           cref := createCrefForTsub(listLength(types), ix, cref);
           exarray := ExpandableArray.set(index, CSE_EQUATION(cref, call, {}), exarray);
+
+          // Add cse vars which are only depending on globalKnownVars to globalKnownVarHT
+          DAE.CALL(expLst = expLst) := call;
+          globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(cref, expLst, globalKnownVarHT);
         end if;
       end if;
 
-      (_, (HT, exarray, cseIndex, index, functionTree)) := BackendEquation.traverseExpsOfEquation(inEq, wrapFunctionCalls_analysis2, (HT, exarray, cseIndex, index, functionTree));
+      (_, (HT, exarray, cseIndex, index, functionTree, globalKnownVarHT)) := BackendEquation.traverseExpsOfEquation(inEq, wrapFunctionCalls_analysis2, (HT, exarray, cseIndex, index, functionTree, globalKnownVarHT));
     then ();
 
     // all other cases are not handled (e.g. algorithms)
@@ -540,7 +850,7 @@ algorithm
   end match;
 
 
-  outTuple := (HT, exarray, cseIndex, index, functionTree);
+  outTuple := (HT, exarray, cseIndex, index, functionTree, globalKnownVarHT);
 end wrapFunctionCalls_analysis;
 
 protected function createCrefForTsub "(4, 2, x)  -> TUPLE(_,x,_,_)"
@@ -563,9 +873,9 @@ end createCrefForTsub;
 
 protected function wrapFunctionCalls_analysis2
   input DAE.Exp inExp;
-  input tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree> inTuple;
+  input tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree, HashSet.HashSet> inTuple;
   output DAE.Exp outExp = inExp;
-  output tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree> outTuple;
+  output tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree, HashSet.HashSet> outTuple;
 algorithm
   (_, outTuple) := Expression.traverseExpTopDown(inExp, wrapFunctionCalls_analysis3, inTuple);
 end wrapFunctionCalls_analysis2;
@@ -573,26 +883,31 @@ end wrapFunctionCalls_analysis2;
 
 protected function wrapFunctionCalls_analysis3
   input DAE.Exp inExp;
-  input tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree> inTuple;
+  input tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree, HashSet.HashSet> inTuple;
   output DAE.Exp outExp = inExp;
   output Boolean cont;
-  output tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree> outTuple;
+  output tuple<HashTableExpToIndex.HashTable, ExpandableArray<CSE_Equation>, Integer, Integer, DAE.FunctionTree, HashSet.HashSet> outTuple;
 protected
   DAE.FunctionTree functionTree;
   HashTableExpToIndex.HashTable HT;
   ExpandableArray<CSE_Equation> exarray;
   Integer cseIndex, index;
+  HashSet.HashSet globalKnownVarHT;
+  list<DAE.ComponentRef> crefList;
+  DAE.Exp tsub;
 algorithm
-  (HT, exarray, cseIndex, index, functionTree) := inTuple;
+  (HT, exarray, cseIndex, index, functionTree, globalKnownVarHT) := inTuple;
 
   cont := match(inExp)
     local
-      DAE.Exp cse_var, call, e;
+      DAE.Exp cse_var, cse_var2, call, e;
       DAE.Type ty;
       list<DAE.Type> types;
       Integer length, ix, id;
-      list<DAE.Exp> expList={};
+      list<DAE.Exp> expList={}, expLst;
       CSE_Equation cseEquation;
+      Boolean allCrefsAreGlobal = true;
+      DAE.ComponentRef cr;
 
     case DAE.IFEXP()
     then false;
@@ -602,13 +917,17 @@ algorithm
     guard isSkipCase(inExp, functionTree)
     then false;
 
-    case DAE.TSUB(exp=call as DAE.CALL(attr=DAE.CALL_ATTR(ty=DAE.T_TUPLE(types=types))), ix=ix, ty=ty) algorithm
+    case tsub as DAE.TSUB(exp=call as DAE.CALL(attr=DAE.CALL_ATTR(ty=DAE.T_TUPLE(types=types)), expLst=expLst), ix=ix, ty=ty) algorithm
       if not BaseHashTable.hasKey(call, HT) then
         index := index + 1;
         HT := BaseHashTable.add((call, index), HT);
         (cse_var, cseIndex) := createReturnExp(ty, cseIndex, inComplex=false);
-        cse_var := createCrefForTsub(listLength(types), ix, cse_var);
-        exarray := ExpandableArray.set(index, CSE_EQUATION(cse_var, call, {}), exarray);
+        cse_var2 := createCrefForTsub(listLength(types), ix, cse_var);
+        exarray := ExpandableArray.set(index, CSE_EQUATION(cse_var2, call, {}), exarray);
+
+        // Add cse vars which are only depending on globalKnownVars to globalKnownVarHT
+        globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(cse_var, expLst, globalKnownVarHT);
+
       else
         id := BaseHashTable.get(call, HT);
         cseEquation := ExpandableArray.get(id, exarray);
@@ -620,6 +939,9 @@ algorithm
             expList := List.set(expList, ix, cse_var);
             cseEquation.cse := DAE.TUPLE(expList);
             exarray := ExpandableArray.update(id, cseEquation, exarray);
+
+            // Add cse vars which are only depending on globalKnownVars to globalKnownVarHT
+            globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(cse_var, expLst, globalKnownVarHT);
           end if;
         else
           print("This should never appear\n");
@@ -627,19 +949,22 @@ algorithm
       end if;
     then true;
 
-    case DAE.CALL(attr=DAE.CALL_ATTR(ty=ty)) algorithm
+    case DAE.CALL(attr=DAE.CALL_ATTR(ty=ty), expLst=expLst) algorithm
       if not BaseHashTable.hasKey(inExp, HT) then
         index := index + 1;
         HT := BaseHashTable.add((inExp, index), HT);
         (cse_var, cseIndex) := createReturnExp(ty, cseIndex, inComplex=false);
         exarray := ExpandableArray.set(index, CSE_EQUATION(cse_var, inExp, {}), exarray);
+
+        // Add cse vars which are only depending on globalKnownVars to globalKnownVarHT
+        globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(cse_var, expLst, globalKnownVarHT);
       end if;
     then true;
 
     else true;
   end match;
 
-  outTuple := (HT, exarray, cseIndex, index, functionTree);
+  outTuple := (HT, exarray, cseIndex, index, functionTree, globalKnownVarHT);
 end wrapFunctionCalls_analysis3;
 
 protected function getTheRightPattern
@@ -712,6 +1037,89 @@ algorithm
 
   result := isEquationRedundant2(ll, rr);
 end isEquationRedundant2;
+
+protected function isEquationRedundant_flatten
+  "Same as isEquationRedundant but flattens equations of form 'tuple = tuple'
+  (e.g. (a,_,b) = (_,c,d) => b=d), if left tuple elements are in globalKnownVarHT and adds them to globalKnownVars"
+  input BackendDAE.Equation inEq;
+  input HashSet.HashSet globalKnownVarHT;
+  output Boolean outB "true if 'x=x', else false";
+  input output BackendDAE.Variables globalKnownVars;
+  input output BackendDAE.Variables orderedVars;
+algorithm
+  (outB, globalKnownVars, orderedVars) := match(inEq)
+    local
+      DAE.Exp exp1, exp2;
+      list<DAE.Exp> lhs, rhs;
+
+    case BackendDAE.EQUATION(exp=exp1, scalar=exp2)
+     then (Expression.expEqual(exp1, exp2), globalKnownVars, orderedVars);
+
+    case BackendDAE.EQUATION(exp=DAE.TUPLE(lhs), scalar=DAE.TUPLE(rhs)) guard (listLength(lhs) == listLength(rhs)) equation
+      print("This should never appear\n");
+     then isEquationRedundant_flatten2(lhs, rhs, globalKnownVarHT, globalKnownVars, orderedVars);
+
+    case BackendDAE.COMPLEX_EQUATION(left=DAE.TUPLE(lhs), right=DAE.TUPLE(rhs)) guard (listLength(lhs) == listLength(rhs))
+     then isEquationRedundant_flatten2(lhs, rhs, globalKnownVarHT, globalKnownVars, orderedVars);
+
+    else (false, globalKnownVars, orderedVars);
+  end match;
+end isEquationRedundant_flatten;
+
+protected function isEquationRedundant_flatten2
+  input list<DAE.Exp> lhs;
+  input list<DAE.Exp> rhs;
+  input HashSet.HashSet globalKnownVarHT;
+  output Boolean result = true;
+  input output BackendDAE.Variables globalKnownVars;
+  input output BackendDAE.Variables orderedVars;
+protected
+  DAE.Exp l, r;
+  list<DAE.Exp> ll, rr;
+  BackendDAE.Var var;
+algorithm
+  if listEmpty(lhs) then
+    return;
+  end if;
+
+  l::ll := lhs;
+  r::rr := rhs;
+
+  if not isWildCref(l) and not isWildCref(r) then
+    //print(ExpressionDump.printExpStr(l) + " ?= " + ExpressionDump.printExpStr(r) + "\n");
+    if not Expression.expEqual(l, r) then
+      // Left variable in globalKnownVarHT?
+      if BaseHashSet.has(Expression.expCref(l), globalKnownVarHT) then
+        // create variable with bind exp
+        {var} := createVarsForExp(l, {});
+        var := BackendVariable.setBindExp(var, SOME(r));
+
+        // Add var to globalKnownVars
+        globalKnownVars := BackendVariable.addVar(var, globalKnownVars);
+
+        // Delete var from ordered vars if no cse-cref
+        if not isCSECref(var.varName) then
+          (_, orderedVars) := BackendVariable.deleteVarIfExistsAndReturn(var.varName, orderedVars);
+        end if;
+      else
+        result := false;
+        return;
+      end if;
+    end if;
+  end if;
+
+  (result, globalKnownVars, orderedVars) := isEquationRedundant_flatten2(ll, rr, globalKnownVarHT, globalKnownVars, orderedVars);
+end isEquationRedundant_flatten2;
+
+protected function isCall
+  input DAE.Exp inExp;
+  output Boolean outBoolean;
+algorithm
+  outBoolean := match(inExp)
+    case DAE.CALL() then true;
+    else false;
+  end match;
+end isCall;
 
 protected function isCallAndCref
   input DAE.Exp inExp;
@@ -1058,7 +1466,8 @@ algorithm
   end match;
 end createReturnExp;
 
-protected function createVarsForExp     //cse in varList
+protected function createVarsForExp_onlyCSECrefs
+"Same as createVarsForExp but only creates a variable if the crefs in inExp are $cse-crefs"
   input DAE.Exp inExp;
   input list<BackendDAE.Var> inAccumVarLst;
   output list<BackendDAE.Var> outVarLst;
@@ -1115,6 +1524,82 @@ algorithm
     then var::inAccumVarLst;
 
     case DAE.TUPLE(expLst) equation
+      outVarLst = List.fold(expLst, createVarsForExp_onlyCSECrefs, inAccumVarLst);
+    then outVarLst;
+
+    case DAE.ARRAY(array=expLst) equation
+      //print("This should never appear\n");
+      outVarLst = List.fold(expLst, createVarsForExp_onlyCSECrefs, inAccumVarLst);
+    then outVarLst;
+
+    case DAE.RECORD(exps=expLst) equation
+      print("This should never appear\n");
+      outVarLst = List.fold(expLst, createVarsForExp_onlyCSECrefs, inAccumVarLst);
+    then outVarLst;
+
+    // add no variable in all other cases
+    else inAccumVarLst;
+  end match;
+end createVarsForExp_onlyCSECrefs;
+
+protected function createVarsForExp
+"Creates a variable list for crefs in inExp, e.g. inExp = (a, b, _, d) -> outVarLst = {a,b,d}"
+  input DAE.Exp inExp;
+  input list<BackendDAE.Var> inAccumVarLst = {};
+  output list<BackendDAE.Var> outVarLst;
+algorithm
+  (outVarLst) := match (inExp)
+    local
+      DAE.ComponentRef cr, cr_;
+      list<DAE.ComponentRef> crefs;
+      list<DAE.Exp> expLst;
+      BackendDAE.Var var;
+      DAE.Type ty;
+      DAE.InstDims arrayDim;
+/*
+    case DAE.CREF(componentRef=cr) guard(not Expression.isArrayType(Expression.typeof(inExp))
+                                         and not Expression.isRecordType(Expression.typeof(inExp))) equation
+      // use the correct type when creating var. The cref might have subs.
+      var = BackendVariable.createCSEVar(cr, Expression.typeof(inExp));
+    then var::inAccumVarLst;
+*/
+    case DAE.CREF(componentRef=DAE.WILD()) then inAccumVarLst;
+
+    case DAE.CREF(componentRef=cr, ty = DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(_))) algorithm
+      // use the correct type when creating var. The cref might have subs.
+      crefs := ComponentReference.expandCref(cr, true /*the way it is now we won't get records here. but if we do somehow expand them*/);
+
+      /* Create SimVars from the list of expanded crefs.*/
+      /* Mark the first element as an arrayCref i.e. we have 'SOME(arraycref)' since this is how the C template
+         detects first elements of arrays to generate VARNAME_indexed(..) macros for accessing the array
+         with variable indexes.*/
+      outVarLst := inAccumVarLst;
+      for cr_ in crefs loop
+        arrayDim := ComponentReference.crefDims(cr_);
+        outVarLst := BackendVariable.createCSEArrayVar(cr_, ComponentReference.crefTypeFull(cr_), arrayDim)::outVarLst;
+      end for;
+    then outVarLst;
+
+    case DAE.CREF(componentRef=cr) guard(Expression.isArrayType(Expression.typeof(inExp))) algorithm
+      // use the correct type when creating var. The cref might have subs.
+      crefs := ComponentReference.expandCref(cr, true);
+
+      outVarLst := inAccumVarLst;
+      ty := DAEUtil.expTypeElementType(Expression.typeof(inExp));
+      for cr_ in crefs loop
+        arrayDim := ComponentReference.crefDims(cr_);
+        //expLst := DAE.CREF(cr_, ComponentReference.crefType(cr_))::expLst;
+        outVarLst := BackendVariable.createCSEArrayVar(cr_, ty, arrayDim)::outVarLst;
+      end for;
+      //expLst = list(DAE.CREF(cr_, ComponentReference.crefType(cr_)) for cr_ in crefs);
+    then outVarLst;
+
+    case DAE.CREF(componentRef=cr) equation
+      // use the correct type when creating var. The cref might have subs.
+      var = BackendVariable.createCSEVar(cr, Expression.typeof(inExp));
+    then var::inAccumVarLst;
+
+    case DAE.TUPLE(expLst) equation
       outVarLst = List.fold(expLst, createVarsForExp, inAccumVarLst);
     then outVarLst;
 
@@ -1134,20 +1619,23 @@ algorithm
 end createVarsForExp;
 
 protected function isCSECref
+"Returns true if the cref is prefixed with '$cse'"
   input DAE.ComponentRef cr;
   output Boolean b;
 protected
   String s;
 algorithm
-  try
-    DAE.CREF_IDENT(ident=s) := cr;
-    b := substring(s, 1, 4) == "$cse";
-  else
-    b := false;
-  end try;
+  b := matchcontinue(cr)
+    case(DAE.CREF_IDENT(ident=s))
+     then (substring(s, 1, 4) == "$cse");
+    case(DAE.CREF_QUAL(ident=s))
+     then (substring(s, 1, 4) == "$cse");
+    else false;
+  end matchcontinue;
 end isCSECref;
 
 protected function isCSEExp
+"Returns true if the exp is prefixed with '$cse'"
   input DAE.Exp inExp;
   output Boolean b;
 protected
@@ -1293,7 +1781,7 @@ algorithm
 
       if not BaseHashTable.hasKey(value, HT3) then
         HT3 = BaseHashTable.add((value, 1), HT3);
-        varLst = createVarsForExp(value, varLst);
+        varLst = createVarsForExp_onlyCSECrefs(value, varLst);
         eq = BackendEquation.generateEquation(value, inExp, source /* TODO: Add CSE? */, BackendDAE.EQ_ATTR_DEFAULT_BINDING);
         eqLst = eq::eqLst;
       end if;

--- a/Compiler/BackEnd/Differentiate.mo
+++ b/Compiler/BackEnd/Differentiate.mo
@@ -830,7 +830,7 @@ end differentiateExp;
       case DAE.STMT_FOR(type_=type_, iterIsArray=iterIsArray, iter=ident, index=index, range=exp, statementLst=statementLst, source=source)::restStatements
         equation
           cref = ComponentReference.makeCrefIdent(ident, DAE.T_INTEGER_DEFAULT, {});
-          controlVar = BackendDAE.VAR(cref, BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+          controlVar = BackendDAE.VAR(cref, BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
           inputData = addAllVars({controlVar}, inInputData);
           (derivedStatements1, functions) = differentiateStatements(statementLst, inDiffwrtCref, inputData, inDiffType, {}, inFunctionTree, maxIter, expStack);
 

--- a/Compiler/BackEnd/DynamicOptimization.mo
+++ b/Compiler/BackEnd/DynamicOptimization.mo
@@ -239,7 +239,7 @@ protected function makeVar "author: Vitalij Ruge"
 
 algorithm
   cr := ComponentReference.makeCrefIdent(name, DAE.T_REAL_DEFAULT, {});
-  v :=  BackendDAE.VAR(cr, BackendDAE.VARIABLE(), DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), SOME(BackendDAE.AVOID()), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+  v :=  BackendDAE.VAR(cr, BackendDAE.VARIABLE(), DAE.OUTPUT(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), SOME(BackendDAE.AVOID()), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
 end makeVar;
 
 protected function addOptimizationVarsEqns1

--- a/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/Compiler/BackEnd/FindZeroCrossings.mo
@@ -327,7 +327,7 @@ algorithm
         ht := BaseHashTable.add((inCondition, inIndex), inHT);
         crStr := "$whenCondition" + intString(inIndex);
 
-        var := BackendDAE.VAR(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_BOOL_DEFAULT, NONE(), {}, inSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
+        var := BackendDAE.VAR(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_BOOL_DEFAULT, NONE(), NONE(), {}, inSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
         var := BackendVariable.setVarFixed(var, true);
         eqn := BackendDAE.EQUATION(DAE.CREF(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), DAE.T_BOOL_DEFAULT), inCondition, inSource, BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC);
 
@@ -496,7 +496,7 @@ algorithm
     case (DAE.ARRAY(array={condition})) equation
       crStr = "$whenCondition" + intString(inIndex);
 
-      var = BackendDAE.VAR(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_BOOL_DEFAULT, NONE(), {}, inSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
+      var = BackendDAE.VAR(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_BOOL_DEFAULT, NONE(), NONE(), {}, inSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
       var = BackendVariable.setVarFixed(var, true);
       stmt = DAE.STMT_ASSIGN(DAE.T_BOOL_DEFAULT, DAE.CREF(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), DAE.T_BOOL_DEFAULT), condition, inSource);
 
@@ -512,7 +512,7 @@ algorithm
     case _ equation
       crStr = "$whenCondition" + intString(inIndex);
 
-      var = BackendDAE.VAR(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_BOOL_DEFAULT, NONE(), {}, inSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
+      var = BackendDAE.VAR(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_BOOL_DEFAULT, NONE(), NONE(), {}, inSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
       var = BackendVariable.setVarFixed(var, true);
       stmt = DAE.STMT_ASSIGN(DAE.T_BOOL_DEFAULT, DAE.CREF(DAE.CREF_IDENT(crStr, DAE.T_BOOL_DEFAULT, {}), DAE.T_BOOL_DEFAULT), inCondition, inSource);
 

--- a/Compiler/BackEnd/HpcOmEqSystems.mo
+++ b/Compiler/BackEnd/HpcOmEqSystems.mo
@@ -1157,7 +1157,7 @@ algorithm
         aName = "$a"+intString(tornSysIdx)+"_"+intString(resIdx)+"_"+intString(iIdx);
         ty = DAE.T_REAL_DEFAULT;
         aCRef = ComponentReference.makeCrefIdent(aName,ty,{});
-        a_ii = BackendDAE.VAR(aCRef,BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),ty,NONE(),{},DAE.emptyElementSource,NONE(),NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+        a_ii = BackendDAE.VAR(aCRef,BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),ty,NONE(),NONE(),{},DAE.emptyElementSource,NONE(),NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
         a_ii = BackendVariable.setVarStartValue(a_ii,DAE.RCONST(0.0));
 
         // build the equations to solve for the coefficients
@@ -1186,7 +1186,7 @@ algorithm
         aName = "$a"+intString(tornSysIdx)+"_"+intString(resIdx)+"_"+intString(iIdx);
         ty = DAE.T_REAL_DEFAULT;
         aCRef = ComponentReference.makeCrefIdent(aName,ty,{});
-        a_ii = BackendDAE.VAR(aCRef,BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),ty,NONE(),{},DAE.emptyElementSource,NONE(),NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+        a_ii = BackendDAE.VAR(aCRef,BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),ty,NONE(),NONE(),{},DAE.emptyElementSource,NONE(),NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
         a_ii = BackendVariable.setVarStartValue(a_ii,DAE.RCONST(0.0));
 
         // build the equations to solve for the coefficients
@@ -1471,7 +1471,7 @@ algorithm
   varExp := Expression.crefExp(cRef);
   replacementOut := BackendVarTransform.addReplacement(replacementIn,oVarCRef,varExp,NONE());
   ty := ComponentReference.crefLastType(cRef);
-  replVar := BackendDAE.VAR(cRef,BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),ty,NONE(),{},DAE.emptyElementSource,NONE(),NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+  replVar := BackendDAE.VAR(cRef,BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),ty,NONE(),NONE(),{},DAE.emptyElementSource,NONE(),NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
   replVar := BackendVariable.setVarStartValue(replVar,DAE.RCONST(0.0));
   replVarLstOut := replVar::replVarLstIn;
   tplOut := (replVarLstOut,replacementOut);
@@ -1777,7 +1777,7 @@ protected
   DAE.ComponentRef cr;
 algorithm
   cr := ComponentReference.makeCrefIdent(ident,ty,{});
-  var := BackendDAE.VAR(cr,BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),ty,NONE(),{},DAE.emptyElementSource,NONE(),NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(),DAE.NOT_INNER_OUTER(), false);
+  var := BackendDAE.VAR(cr,BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),ty,NONE(),NONE(),{},DAE.emptyElementSource,NONE(),NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(),DAE.NOT_INNER_OUTER(), false);
 end makeVarOfIdent;
 
 protected function getNewChioRow
@@ -1831,7 +1831,7 @@ algorithm
   (detExp,_) := ExpressionSimplify.simplify(detExp);
   detVarName := "$det_a"+intString(iter)+"__"+intString(row-1)+"_"+intString(col-1);
   detCR := ComponentReference.makeCrefIdent(detVarName,ty,{});
-  detAVar := BackendDAE.VAR(detCR,BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),ty,NONE(),{},DAE.emptyElementSource,NONE(),NONE(),DAE.BCONST(false), NONE(),DAE.NON_CONNECTOR(),DAE.NOT_INNER_OUTER(), false);
+  detAVar := BackendDAE.VAR(detCR,BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),ty,NONE(),NONE(),{},DAE.emptyElementSource,NONE(),NONE(),DAE.BCONST(false), NONE(),DAE.NON_CONNECTOR(),DAE.NOT_INNER_OUTER(), false);
   detVarExp := Expression.crefExp(detCR);
   detAeq :=  BackendDAE.EQUATION(exp=detVarExp,scalar=detExp,source=DAE.emptyElementSource,attr=BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC);
   matrixB := Array.consToElement(row-1,detVarExp,matrixB);
@@ -1846,7 +1846,7 @@ algorithm
   (detExp,_) := ExpressionSimplify.simplify(detExp);
   detVarName := "$det_b"+intString(iter)+"__"+intString(row-1)+"_"+intString(col-1);
   detCR := ComponentReference.makeCrefIdent(detVarName,ty,{});
-  detAiVar := BackendDAE.VAR(detCR,BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),ty,NONE(),{},DAE.emptyElementSource,NONE(),NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(),DAE.NOT_INNER_OUTER(), false);
+  detAiVar := BackendDAE.VAR(detCR,BackendDAE.VARIABLE(),DAE.BIDIR(),DAE.NON_PARALLEL(),ty,NONE(),NONE(),{},DAE.emptyElementSource,NONE(),NONE(),DAE.BCONST(false),NONE(),DAE.NON_CONNECTOR(),DAE.NOT_INNER_OUTER(), false);
   detVarExp := Expression.crefExp(detCR);
   detAieq :=  BackendDAE.EQUATION(exp=detVarExp,scalar=detExp,source=DAE.emptyElementSource,attr=BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC);
   arrayUpdate(vecAi,row-1,detVarExp);

--- a/Compiler/BackEnd/IndexReduction.mo
+++ b/Compiler/BackEnd/IndexReduction.mo
@@ -3296,7 +3296,7 @@ algorithm
         dattr = BackendVariable.getVariableAttributefromType(tp);
         odattr = DAEUtil.setFixedAttr(SOME(dattr), SOME(DAE.BCONST(false)));
         //kind = if_(intGt(n,1),BackendDAE.DUMMY_DER(),BackendDAE.STATE(1,NONE()));
-        var = BackendDAE.VAR(cr,BackendDAE.STATE(1,NONE()),dir,prl,tp,NONE(),dim,source,odattr,ts,hideResult,comment,ct,io,false);
+        var = BackendDAE.VAR(cr,BackendDAE.STATE(1,NONE()),dir,prl,tp,NONE(),NONE(),dim,source,odattr,ts,hideResult,comment,ct,io,false);
       then (var,ht);
    // state
     case (BackendDAE.VAR(varKind=BackendDAE.STATE(index=diffcount,derName=derName)),_,_)
@@ -3442,7 +3442,7 @@ algorithm
         dattr = BackendVariable.getVariableAttributefromType(tp);
         odattr = DAEUtil.setFixedAttr(SOME(dattr), SOME(DAE.BCONST(false)));
         kind = if intGt(diffCount,0) then BackendDAE.STATE(diffCount,NONE()) else BackendDAE.DUMMY_DER();
-        var = BackendDAE.VAR(name,kind,dir,prl,tp,NONE(),dim,source,odattr,ts,hideResult,comment,ct,io,false);
+        var = BackendDAE.VAR(name,kind,dir,prl,tp,NONE(),NONE(),dim,source,odattr,ts,hideResult,comment,ct,io,false);
         (vlst,ht,n) = makeHigherStatesRepl1(diffCount-1,diffedCount+1,iOrigName,name,inVar,vars,var::iVarLst,ht,iN+1);
       then (vlst,ht,n);
     // finished
@@ -3496,6 +3496,7 @@ algorithm
       DAE.VarParallelism prl;
       DAE.Type tp;
       Option<DAE.Exp> bind;
+      Option<DAE.Exp> tplExp;
       DAE.InstDims dim;
       DAE.ElementSource source;
       Option<DAE.VariableAttributes> attr;
@@ -3526,22 +3527,22 @@ algorithm
         var = BackendVariable.setVarKind(var, BackendDAE.STATE(1,NONE()));
       then (var,(vars,so,varlst,ht));
     // state, replaceable with known derivative
-    case (var as BackendDAE.VAR(name,BackendDAE.STATE(derName=SOME(_)),dir,prl,tp,bind,dim,source,attr,ts,hideResult,comment,ct,io),(vars,so,varlst,ht))
+    case (var as BackendDAE.VAR(name,BackendDAE.STATE(derName=SOME(_)),dir,prl,tp,bind,tplExp,dim,source,attr,ts,hideResult,comment,ct,io),(vars,so,varlst,ht))
       equation
         // add replacement for each derivative
         (varlst,ht) = makeAllDummyVarandDummyDerivativeRepl1(1,1,name,name,var,vars,so,varlst,ht);
         cr = ComponentReference.crefPrefixDer(name);
         source = ElementSource.addSymbolicTransformation(source,DAE.NEW_DUMMY_DER(cr,{}));
-      then (BackendDAE.VAR(name,BackendDAE.DUMMY_STATE(),dir,prl,tp,bind,dim,source,attr,ts,hideResult,comment,ct,io,false),(vars,so,varlst,ht));
+      then (BackendDAE.VAR(name,BackendDAE.DUMMY_STATE(),dir,prl,tp,bind,tplExp,dim,source,attr,ts,hideResult,comment,ct,io,false),(vars,so,varlst,ht));
     // state replacable without unknown derivative
-    case (var as BackendDAE.VAR(name,BackendDAE.STATE(index=diffcount,derName=NONE()),dir,prl,tp,bind,dim,source,attr,ts,hideResult,comment,ct,io),(vars,so,varlst,ht))
+    case (var as BackendDAE.VAR(name,BackendDAE.STATE(index=diffcount,derName=NONE()),dir,prl,tp,bind,tplExp,dim,source,attr,ts,hideResult,comment,ct,io),(vars,so,varlst,ht))
       equation
         // add replacement for each derivative
         (varlst,ht) = makeAllDummyVarandDummyDerivativeRepl1(diffcount,1,name,name,var,vars,so,varlst,ht);
         // dummy_der name vor Source information
         cr = ComponentReference.crefPrefixDer(name);
         source = ElementSource.addSymbolicTransformation(source,DAE.NEW_DUMMY_DER(cr,{}));
-      then (BackendDAE.VAR(name,BackendDAE.DUMMY_STATE(),dir,prl,tp,bind,dim,source,attr,ts,hideResult,comment,ct,io,false),(vars,so,varlst,ht));
+      then (BackendDAE.VAR(name,BackendDAE.DUMMY_STATE(),dir,prl,tp,bind,tplExp,dim,source,attr,ts,hideResult,comment,ct,io,false),(vars,so,varlst,ht));
     else (inVar,inTpl);
   end matchcontinue;
 end makeAllDummyVarandDummyDerivativeRepl;
@@ -3607,7 +3608,7 @@ algorithm
         /* Dummy variables are algebraic variables without start value, min/max, .., hence fixed = false */
         dattr = BackendVariable.getVariableAttributefromType(tp);
         odattr = DAEUtil.setFixedAttr(SOME(dattr), SOME(DAE.BCONST(false)));
-        var = BackendDAE.VAR(name,BackendDAE.DUMMY_DER(),dir,prl,tp,NONE(),dim,source,odattr,ts,hideResult,comment,ct,io, false);
+        var = BackendDAE.VAR(name,BackendDAE.DUMMY_DER(),dir,prl,tp,NONE(),NONE(),dim,source,odattr,ts,hideResult,comment,ct,io, false);
         (vlst,ht) = makeAllDummyVarandDummyDerivativeRepl1(diffCount-1,diffedCount+1,iOrigName,name,inVar,vars,so,var::iVarLst,ht);
       then (vlst,ht);
     else
@@ -3689,9 +3690,9 @@ algorithm
         /* Dummy variables are algebraic variables, hence fixed = false */
         dattr = BackendVariable.getVariableAttributefromType(tp);
         odattr = DAEUtil.setFixedAttr(SOME(dattr), SOME(DAE.BCONST(false)));
-        dummy_derstate = BackendDAE.VAR(dummyderName,BackendDAE.DUMMY_DER(),dir,prl,tp,NONE(),dim,source,odattr,ts,hideResult,comment,ct,io, false);
+        dummy_derstate = BackendDAE.VAR(dummyderName,BackendDAE.DUMMY_DER(),dir,prl,tp,NONE(),NONE(),dim,source,odattr,ts,hideResult,comment,ct,io, false);
         kind = if intEq(dn,0) then BackendDAE.DUMMY_STATE() else BackendDAE.DUMMY_DER();
-        dummy_state = BackendDAE.VAR(name,kind,dir,prl,tp,NONE(),dim,source,odattr,ts,hideResult,comment,ct,io, false);
+        dummy_state = BackendDAE.VAR(name,kind,dir,prl,tp,NONE(),NONE(),dim,source,odattr,ts,hideResult,comment,ct,io, false);
         dummy_state = if intEq(dn,0) then inVar else dummy_state;
         dummy_state = BackendVariable.setVarKind(dummy_state, kind);
         vars = BackendVariable.addVar(dummy_derstate, vars);
@@ -3973,6 +3974,7 @@ algorithm
       DAE.VarParallelism prl;
       BackendDAE.Type tp;
       Option<DAE.Exp> bind;
+      Option<DAE.Exp> tplExp;
       list<DAE.Dimension> dim;
       DAE.ElementSource source;
       Option<DAE.VariableAttributes> attr;
@@ -3995,6 +3997,7 @@ algorithm
               varParallelism = prl,
               varType = tp,
               bindExp = bind,
+              tplExp = tplExp,
               arryDim = dim,
               source = source,
               values = attr,
@@ -4006,7 +4009,7 @@ algorithm
     equation
       b = intGt(counter,diffcounter);
       diffcounter = if b then counter else diffcounter;
-      var = BackendDAE.VAR(cr, BackendDAE.STATE(diffcounter,dcr), dir, prl, tp, bind, dim, source, attr, ts, hideResult, comment, ct,io, false);
+      var = BackendDAE.VAR(cr, BackendDAE.STATE(diffcounter,dcr), dir, prl, tp, bind, tplExp, dim, source, attr, ts, hideResult, comment, ct,io, false);
       vars = if b then BackendVariable.addVar(var, inVars) else inVars;
       changedVars = List.consOnTrue(b,i,iChangedVars);
       (vars,ilst) = increaseDifferentiation(vlst,ilst,counter,vars,changedVars);

--- a/Compiler/BackEnd/OnRelaxation.mo
+++ b/Compiler/BackEnd/OnRelaxation.mo
@@ -1822,7 +1822,7 @@ algorithm
       cr = ComponentReference.makeCrefIdent(stringAppendList({"$tmp", sa, "_", sb}), DAE.T_REAL_DEFAULT, {});
       cexp = Expression.crefExp(cr);
       eqns = BackendEquation.addEquation(BackendDAE.EQUATION(cexp, e, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_UNKNOWN), inEqns);
-      v = BackendDAE.VAR(cr, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      v = BackendDAE.VAR(cr, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
       vars = BackendVariable.addVar(v, inVars);
     then
       (vars, eqns, cexp, (a, b+1));

--- a/Compiler/BackEnd/OpenTURNS.mo
+++ b/Compiler/BackEnd/OpenTURNS.mo
@@ -90,8 +90,6 @@ public function generateOpenTURNSInterface "generates the dll and the python scr
   Option<BackendDAE.BackendDAE> initDAE_lambda0;
   Boolean useHomotopy "true if homotopy(...) is used during initialization";
   list<BackendDAE.Equation> removedInitialEquationLst;
-  list<BackendDAE.Var> primaryParameters "already sorted";
-  list<BackendDAE.Var> allPrimaryParameters "already sorted";
 algorithm
   cname_str := Absyn.pathString(inPath);
   cname_last_str := Absyn.pathLastIdent(inPath);
@@ -112,13 +110,13 @@ algorithm
  // Strip correlation vector from dae to be able to compile (bug in OpenModelica with vectors of records )
   strippedDae := stripCorrelationFromDae(inDaelow);
 
-  (strippedDae, initDAE, _, useHomotopy, initDAE_lambda0, removedInitialEquationLst, primaryParameters, allPrimaryParameters) := BackendDAEUtil.getSolvedSystem(strippedDae,"");
+  (strippedDae, initDAE, _, useHomotopy, initDAE_lambda0, removedInitialEquationLst) := BackendDAEUtil.getSolvedSystem(strippedDae,"");
 
   //print("strippedDae :");
   //BackendDump.dump(strippedDae);
   _ := System.realtimeTock(ClockIndexes.RT_CLOCK_BACKEND); // Is this necessary?
 
-  (libs, fileDir, _, _) := SimCodeMain.generateModelCode(strippedDae, initDAE, NONE(), useHomotopy, initDAE_lambda0, removedInitialEquationLst, primaryParameters, allPrimaryParameters,inProgram, inPath, cname_str, SOME(simSettings), Absyn.FUNCTIONARGS({}, {}));
+  (libs, fileDir, _, _) := SimCodeMain.generateModelCode(strippedDae, initDAE, NONE(), useHomotopy, initDAE_lambda0, removedInitialEquationLst,inProgram, inPath, cname_str, SOME(simSettings), Absyn.FUNCTIONARGS({}, {}));
 
   //print("..compiling, fileNamePrefix = "+fileNamePrefix+"\n");
   CevalScript.compileModel(fileNamePrefix , libs);

--- a/Compiler/BackEnd/StateMachineFeatures.mo
+++ b/Compiler/BackEnd/StateMachineFeatures.mo
@@ -1437,7 +1437,7 @@ Create a BackendDAE.Var with some defaults"
   input BackendDAE.Type varType;
   output BackendDAE.Var var;
 algorithm
-  var := BackendDAE.VAR(cref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), varType, NONE(), {},
+  var := BackendDAE.VAR(cref, varKind, DAE.BIDIR(), DAE.NON_PARALLEL(), varType, NONE(), NONE(), {},
     DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(),false);
 end createVarWithDefaults;
 
@@ -1562,6 +1562,7 @@ protected
   DAE.VarParallelism varParallelism "parallelism of the variable. parglobal, parlocal or non-parallel";
   BackendDAE.Type varType "built-in type or enumeration";
   Option<DAE.Exp> bindExp "Binding expression e.g. for parameters";
+  Option<DAE.Exp> tupleExp "Variable is part of a tuple";
   DAE.InstDims arryDim "array dimensions of non-expanded var";
   DAE.ElementSource source "origin of variable";
   Option<DAE.VariableAttributes> values "values on built-in attributes";
@@ -1574,7 +1575,7 @@ protected
 algorithm
   try
     (SOME(var), mt) := inVarModeTable;
-    BackendDAE.VAR(varName, varKind, DAE.OUTPUT(), varParallelism, varType, bindExp,
+    BackendDAE.VAR(varName, varKind, DAE.OUTPUT(), varParallelism, varType, bindExp, tupleExp,
       arryDim, source, values, tearingSelectOption, hideResult, comment, connectorType, DAE.OUTER()) := var;
 
     DAE.SOURCE(instance=instance as Prefix.PRE()) := source;
@@ -2619,6 +2620,7 @@ protected
   DAE.VarParallelism varParallelism "parallelism of the variable. parglobal, parlocal or non-parallel";
   BackendDAE.Type varType "built-in type or enumeration";
   Option<DAE.Exp> bindExp "Binding expression e.g. for parameters";
+  Option<DAE.Exp> tupleExp "Variable is part of a tuple";
   DAE.InstDims arryDim "array dimensions of non-expanded var";
   DAE.ElementSource source "origin of variable";
   Option<DAE.VariableAttributes> values "values on built-in attributes";
@@ -2628,8 +2630,8 @@ protected
   DAE.ConnectorType connectorType "flow, stream, unspecified or not connector.";
   DAE.VarInnerOuter io;
 algorithm
-  BackendDAE.VAR(varName, varKind, varDirection, varParallelism, varType,
-   bindExp, arryDim, source, values, tearingSelectOption, hideResult, comment, connectorType, io) := inVar;
+  BackendDAE.VAR(varName, varKind, varDirection, varParallelism, varType, bindExp, tupleExp,
+   arryDim, source, values, tearingSelectOption, hideResult, comment, connectorType, io) := inVar;
    sVarName := ComponentReference.crefStr(varName);
    sVarKind := BackendDump.kindString(varKind);
    sVarDirection := DAEDump.dumpDirectionStr(varDirection);

--- a/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/Compiler/BackEnd/SymbolicJacobian.mo
@@ -2097,7 +2097,7 @@ protected
   DAE.ComponentRef derivedCref;
 algorithm
   derivedCref := Differentiate.createSeedCrefName(indiffVar, inMatrixName);
-  outSeedVar := BackendDAE.VAR(derivedCref, BackendDAE.STATE_DER(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(),DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+  outSeedVar := BackendDAE.VAR(derivedCref, BackendDAE.STATE_DER(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(),DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
 end createSeedVars;
 
 protected function createAllDiffedVars "author: wbraun"
@@ -2127,27 +2127,27 @@ algorithm
       (_, _) = BackendVariable.getVarSingle(currVar, inAllVars);
       currVar = ComponentReference.crefPrefixDer(currVar);
       derivedCref = Differentiate.createDifferentiatedCrefName(currVar, cref, inMatrixName);
-      r1 = BackendDAE.VAR(derivedCref, BackendDAE.STATE_DER(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
+      r1 = BackendDAE.VAR(derivedCref, BackendDAE.STATE_DER(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
     then
       createAllDiffedVars(restVar, cref, inAllVars, inIndex+1, inMatrixName,r1::iVars);
 
     case(BackendDAE.VAR(varName=currVar)::restVar,cref,_,_, _, _) equation
       (_, _) = BackendVariable.getVarSingle(currVar, inAllVars);
       derivedCref = Differentiate.createDifferentiatedCrefName(currVar, cref, inMatrixName);
-      r1 = BackendDAE.VAR(derivedCref, BackendDAE.STATE_DER(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
+      r1 = BackendDAE.VAR(derivedCref, BackendDAE.STATE_DER(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), true);
     then
       createAllDiffedVars(restVar, cref, inAllVars, inIndex+1, inMatrixName,r1::iVars);
 
      case(BackendDAE.VAR(varName=currVar,varKind=BackendDAE.STATE())::restVar,cref,_,_, _, _) equation
       currVar = ComponentReference.crefPrefixDer(currVar);
       derivedCref = Differentiate.createDifferentiatedCrefName(currVar, cref, inMatrixName);
-      r1 = BackendDAE.VAR(derivedCref, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      r1 = BackendDAE.VAR(derivedCref, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
     then
       createAllDiffedVars(restVar, cref, inAllVars, inIndex, inMatrixName,r1::iVars);
 
     case(BackendDAE.VAR(varName=currVar)::restVar,cref,_,_, _, _) equation
       derivedCref = Differentiate.createDifferentiatedCrefName(currVar, cref, inMatrixName);
-      r1 = BackendDAE.VAR(derivedCref, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+      r1 = BackendDAE.VAR(derivedCref, BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
     then
       createAllDiffedVars(restVar, cref, inAllVars, inIndex, inMatrixName,r1::iVars);
 

--- a/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/Compiler/BackEnd/SynchronousFeatures.mo
@@ -237,7 +237,7 @@ algorithm
           // add all $DER.x as additional variables
           for derVar in derVars loop
             var := listGet(BackendVariable.getVar(derVar, syst.orderedVars), 1);
-            var := BackendDAE.VAR(ComponentReference.crefPrefixDer(derVar), BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), var.varType, NONE(), var.arryDim, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
+            var := BackendDAE.VAR(ComponentReference.crefPrefixDer(derVar), BackendDAE.VARIABLE(), DAE.BIDIR(), DAE.NON_PARALLEL(), var.varType, NONE(), NONE(), var.arryDim, DAE.emptyElementSource, NONE(), NONE(), DAE.BCONST(false), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
             syst.orderedVars := BackendVariable.addVar(var, syst.orderedVars);
           end for;
           // add defining equations for $DER.x, depending on solverMethod
@@ -1805,7 +1805,7 @@ algorithm
   outVar := BackendDAE.VAR (
                   varName = inComp, varKind = BackendDAE.VARIABLE(),
                   varDirection = DAE.BIDIR(), varParallelism = DAE.NON_PARALLEL(),
-                  varType = inType, bindExp = NONE(),
+                  varType = inType, bindExp = NONE(), tplExp = NONE(),
                   arryDim = {}, source = DAE.emptyElementSource,
                   values = NONE(), tearingSelectOption = SOME(BackendDAE.DEFAULT()),
                   hideResult = DAE.BCONST(false),

--- a/Compiler/BackEnd/Uncertainties.mo
+++ b/Compiler/BackEnd/Uncertainties.mo
@@ -2152,7 +2152,8 @@ protected
   DAE.VarDirection dir;
   DAE.VarParallelism prl;
   DAE.Type tp;
-  Option<DAE.Exp> bind ;
+  Option<DAE.Exp> bind;
+  Option<DAE.Exp> tplExp;
   DAE.InstDims ad;
   DAE.ElementSource source;
   Option<DAE.VariableAttributes> attr;
@@ -2162,8 +2163,8 @@ protected
   DAE.ConnectorType ct;
   DAE.VarInnerOuter io;
 algorithm
-  BackendDAE.VAR(name,kind,dir,prl,tp,bind,ad,source,attr,ts,hideResult,cmt,ct,io,_) := inVar;
-  outVar := BackendDAE.VAR(cr,kind,dir,prl,tp,bind,ad,source,attr,ts,hideResult,cmt,ct,io,false);
+  BackendDAE.VAR(name,kind,dir,prl,tp,bind,tplExp,ad,source,attr,ts,hideResult,cmt,ct,io,_) := inVar;
+  outVar := BackendDAE.VAR(cr,kind,dir,prl,tp,bind,tplExp,ad,source,attr,ts,hideResult,cmt,ct,io,false);
 end setVarCref;
 
 public function setVarBindingOpt "author: PA
@@ -2177,7 +2178,8 @@ protected
   DAE.VarDirection dir;
   DAE.VarParallelism prl;
   BackendDAE.Type tp;
-  Option<DAE.Exp> bind ;
+  Option<DAE.Exp> bind;
+  Option<DAE.Exp> tplExp;
   DAE.InstDims ad;
   DAE.ElementSource source;
   Option<DAE.VariableAttributes> attr;
@@ -2187,8 +2189,8 @@ protected
   DAE.ConnectorType ct;
   DAE.VarInnerOuter innerOuter;
 algorithm
-  BackendDAE.VAR(name,kind,dir,prl,tp,bind,ad,source,attr,ts,hideResult,cmt,ct,innerOuter,_) := inVar;
-  outVar := BackendDAE.VAR(name,kind,dir,prl,tp,bindExp,ad,source,attr,ts,hideResult,cmt,ct,innerOuter,false);
+  BackendDAE.VAR(name,kind,dir,prl,tp,bind,tplExp,ad,source,attr,ts,hideResult,cmt,ct,innerOuter,_) := inVar;
+  outVar := BackendDAE.VAR(name,kind,dir,prl,tp,bindExp,tplExp,ad,source,attr,ts,hideResult,cmt,ct,innerOuter,false);
 end setVarBindingOpt;
 
 public function moveVariables "

--- a/Compiler/Main/Main.mo
+++ b/Compiler/Main/Main.mo
@@ -596,14 +596,12 @@ protected
   Boolean useHomotopy "true if homotopy(...) is used during initialization";
   Option<BackendDAE.BackendDAE> initDAE_lambda0;
   list<BackendDAE.Equation> removedInitialEquationLst;
-  list<BackendDAE.Var> primaryParameters "already sorted";
-  list<BackendDAE.Var> allPrimaryParameters "already sorted";
 algorithm
   if Config.simulationCg() then
     info := BackendDAE.EXTRA_INFO(DAEUtil.daeDescription(dae), Absyn.pathString(inClassName));
     dlow := BackendDAECreate.lower(dae, inCache, inEnv, info);
-    (dlow, initDAE, inlineData, useHomotopy, initDAE_lambda0, removedInitialEquationLst, primaryParameters, allPrimaryParameters) := BackendDAEUtil.getSolvedSystem(dlow, "");
-    simcodegen(dlow, initDAE, inlineData, useHomotopy, initDAE_lambda0, removedInitialEquationLst, primaryParameters, allPrimaryParameters, inClassName, ap);
+    (dlow, initDAE, inlineData, useHomotopy, initDAE_lambda0, removedInitialEquationLst) := BackendDAEUtil.getSolvedSystem(dlow, "");
+    simcodegen(dlow, initDAE, inlineData, useHomotopy, initDAE_lambda0, removedInitialEquationLst, inClassName, ap);
   end if;
 end optimizeDae;
 
@@ -615,8 +613,6 @@ protected function simcodegen "
   input Boolean inUseHomotopy "true if homotopy(...) is used during initialization";
   input Option<BackendDAE.BackendDAE> inInitDAE_lambda0;
   input list<BackendDAE.Equation> inRemovedInitialEquationLst;
-  input list<BackendDAE.Var> inPrimaryParameters "already sorted";
-  input list<BackendDAE.Var> inAllPrimaryParameters "already sorted";
   input Absyn.Path inClassName;
   input Absyn.Program inProgram;
 protected
@@ -636,7 +632,7 @@ algorithm
       SimCodeMain.createSimulationSettings(0.0, 1.0, 500, 1e-6, "dassl", "", "mat", ".*", "");
 
     System.realtimeTock(ClockIndexes.RT_CLOCK_BACKEND); // Is this necessary?
-    SimCodeMain.generateModelCode(inBackendDAE, inInitDAE, inInlineData, inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inPrimaryParameters, inAllPrimaryParameters, inProgram, inClassName, cname, SOME(sim_settings), Absyn.FUNCTIONARGS({}, {}));
+    SimCodeMain.generateModelCode(inBackendDAE, inInitDAE, inInlineData, inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inProgram, inClassName, cname, SOME(sim_settings), Absyn.FUNCTIONARGS({}, {}));
 
     execStat("Codegen Done");
   end if;

--- a/Compiler/SimCode/HpcOmSimCodeMain.mo
+++ b/Compiler/SimCode/HpcOmSimCodeMain.mo
@@ -70,8 +70,6 @@ public function createSimCode "
   input Boolean inUseHomotopy "true if homotopy(...) is used during initialization";
   input Option<BackendDAE.BackendDAE> inInitDAE_lambda0;
   input list<BackendDAE.Equation> inRemovedInitialEquationLst;
-  input list<BackendDAE.Var> inPrimaryParameters "already sorted";
-  input list<BackendDAE.Var> inAllPrimaryParameters "already sorted";
   input Absyn.Path inClassName;
   input String filenamePrefix;
   input String inString11;
@@ -134,7 +132,7 @@ algorithm
       //Setup
       //-----
       (simCode,(lastEqMappingIdx,equationSccMapping)) =
-          SimCodeUtil.createSimCode( inBackendDAE, inInitDAE, NONE(), inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inPrimaryParameters, inAllPrimaryParameters, inClassName, filenamePrefix, inString11, functions,
+          SimCodeUtil.createSimCode( inBackendDAE, inInitDAE, NONE(), inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inClassName, filenamePrefix, inString11, functions,
                                      externalFunctionIncludes, includeDirs, libs,libPaths,program, simSettingsOpt, recordDecls, literals, args );
 
       //get simCode-backendDAE mappings
@@ -189,7 +187,7 @@ algorithm
       //-----
       System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT_HPCOM_MODULES);
       (simCode,(lastEqMappingIdx,equationSccMapping)) =
-          SimCodeUtil.createSimCode( inBackendDAE, inInitDAE, NONE(), inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inPrimaryParameters, inAllPrimaryParameters, inClassName, filenamePrefix, inString11, functions,
+          SimCodeUtil.createSimCode( inBackendDAE, inInitDAE, NONE(), inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inClassName, filenamePrefix, inString11, functions,
                                      externalFunctionIncludes, includeDirs, libs,libPaths,program, simSettingsOpt, recordDecls, literals, args );
 
       //get simCode-backendDAE mappings

--- a/Compiler/SimCode/SimCodeMain.mo
+++ b/Compiler/SimCode/SimCodeMain.mo
@@ -125,8 +125,6 @@ protected function generateModelCodeFMU "
   input Boolean inUseHomotopy "true if homotopy(...) is used during initialization";
   input Option<BackendDAE.BackendDAE> inInitDAE_lambda0;
   input list<BackendDAE.Equation> inRemovedInitialEquationLst;
-  input list<BackendDAE.Var> inPrimaryParameters "already sorted";
-  input list<BackendDAE.Var> inAllPrimaryParameters "already sorted";
   input Absyn.Program p;
   input Absyn.Path className;
   input String FMUVersion;
@@ -153,7 +151,7 @@ algorithm
   fileDir := CevalScriptBackend.getFileDir(a_cref, p);
   (libs,libPaths,includes, includeDirs, recordDecls, functions, literals) :=
     SimCodeUtil.createFunctions(p, inBackendDAE);
-  simCode := createSimCode(inBackendDAE, inInitDAE, NONE(), inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inPrimaryParameters, inAllPrimaryParameters,
+  simCode := createSimCode(inBackendDAE, inInitDAE, NONE(), inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst,
     className, filenamePrefix, fileDir, functions, includes, includeDirs, libs, libPaths, p, SOME(simSettings), recordDecls, literals, Absyn.FUNCTIONARGS({},{}), isFMU=true, FMUVersion=FMUVersion);
   timeSimCode := System.realtimeTock(ClockIndexes.RT_CLOCK_SIMCODE);
   ExecStat.execStat("SimCode");
@@ -172,8 +170,6 @@ protected function generateModelCodeXML "
   input Boolean inUseHomotopy "true if homotopy(...) is used during initialization";
   input Option<BackendDAE.BackendDAE> inInitDAE_lambda0;
   input list<BackendDAE.Equation> inRemovedInitialEquationLst;
-  input list<BackendDAE.Var> inPrimaryParameters "already sorted";
-  input list<BackendDAE.Var> inAllPrimaryParameters "already sorted";
   input Absyn.Program p;
   input Absyn.Path className;
   input String filenamePrefix;
@@ -199,7 +195,7 @@ algorithm
   fileDir := CevalScriptBackend.getFileDir(a_cref, p);
   (libs, libPaths, includes, includeDirs, recordDecls, functions, literals) :=
     SimCodeUtil.createFunctions(p, inBackendDAE);
-  (simCode,_) := SimCodeUtil.createSimCode(inBackendDAE, inInitDAE, NONE(), inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inPrimaryParameters, inAllPrimaryParameters,
+  (simCode,_) := SimCodeUtil.createSimCode(inBackendDAE, inInitDAE, NONE(), inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst,
     className, filenamePrefix, fileDir, functions, includes, includeDirs, libs,libPaths, p, simSettingsOpt, recordDecls, literals,Absyn.FUNCTIONARGS({},{}));
   timeSimCode := System.realtimeTock(ClockIndexes.RT_CLOCK_SIMCODE);
   ExecStat.execStat("SimCode");
@@ -253,8 +249,6 @@ algorithm
       Option<BackendDAE.BackendDAE> initDAE_lambda0;
       Boolean useHomotopy "true if homotopy(...) is used during initialization";
       list<BackendDAE.Equation> removedInitialEquationLst;
-      list<BackendDAE.Var> primaryParameters "already sorted";
-      list<BackendDAE.Var> allPrimaryParameters "already sorted";
 
     case (cache,graph,_,st as GlobalScript.SYMBOLTABLE(ast=p),FMUVersion,FMUType,filenameprefix)
       equation
@@ -279,11 +273,11 @@ algorithm
         dae = DAEUtil.transformationsBeforeBackend(cache,graph,dae);
         description = DAEUtil.daeDescription(dae);
         dlow = BackendDAECreate.lower(dae, cache, graph, BackendDAE.EXTRA_INFO(description,filenameprefix));
-        (dlow_1, initDAE, _, useHomotopy, initDAE_lambda0, removedInitialEquationLst, primaryParameters, allPrimaryParameters) = BackendDAEUtil.getSolvedSystem(dlow, inFileNamePrefix);
+        (dlow_1, initDAE, _, useHomotopy, initDAE_lambda0, removedInitialEquationLst) = BackendDAEUtil.getSolvedSystem(dlow, inFileNamePrefix);
         timeBackend = System.realtimeTock(ClockIndexes.RT_CLOCK_BACKEND);
 
         (libs,file_dir,timeSimCode,timeTemplates) =
-          generateModelCodeFMU(dlow_1, initDAE, useHomotopy, initDAE_lambda0, removedInitialEquationLst, primaryParameters, allPrimaryParameters, p, className, FMUVersion, FMUType, filenameprefix, inSimSettings);
+          generateModelCodeFMU(dlow_1, initDAE, useHomotopy, initDAE_lambda0, removedInitialEquationLst, p, className, FMUVersion, FMUType, filenameprefix, inSimSettings);
 
         //reset config flag
         Flags.setConfigBool(Flags.GENERATE_SYMBOLIC_LINEARIZATION, symbolicJacActivated);
@@ -351,8 +345,6 @@ algorithm
       Option<BackendDAE.BackendDAE> initDAE_lambda0;
       Boolean useHomotopy "true if homotopy(...) is used during initialization";
       list<BackendDAE.Equation> removedInitialEquationLst;
-      list<BackendDAE.Var> primaryParameters "already sorted";
-      list<BackendDAE.Var> allPrimaryParameters "already sorted";
 
     case (cache, graph, st as GlobalScript.SYMBOLTABLE(ast=p), filenameprefix) equation
       /* calculate stuff that we need to create SimCode data structure */
@@ -365,11 +357,11 @@ algorithm
       dae = DAEUtil.transformationsBeforeBackend(cache,graph,dae);
       description = DAEUtil.daeDescription(dae);
       dlow = BackendDAECreate.lower(dae, cache, graph, BackendDAE.EXTRA_INFO(description,filenameprefix));
-      (dlow_1, initDAE, _, useHomotopy, initDAE_lambda0, removedInitialEquationLst, primaryParameters, allPrimaryParameters) = BackendDAEUtil.getSolvedSystem(dlow,inFileNamePrefix);
+      (dlow_1, initDAE, _, useHomotopy, initDAE_lambda0, removedInitialEquationLst) = BackendDAEUtil.getSolvedSystem(dlow,inFileNamePrefix);
       timeBackend = System.realtimeTock(ClockIndexes.RT_CLOCK_BACKEND);
 
       (libs,file_dir,timeSimCode,timeTemplates) =
-        generateModelCodeXML(dlow_1, initDAE, useHomotopy, initDAE_lambda0, removedInitialEquationLst, primaryParameters, allPrimaryParameters, p, className, filenameprefix, inSimSettingsOpt);
+        generateModelCodeXML(dlow_1, initDAE, useHomotopy, initDAE_lambda0, removedInitialEquationLst, p, className, filenameprefix, inSimSettingsOpt);
       resultValues =
       {("timeTemplates",Values.REAL(timeTemplates)),
         ("timeSimCode",  Values.REAL(timeSimCode)),
@@ -402,8 +394,6 @@ public function generateModelCode "
   input Boolean inUseHomotopy "true if homotopy(...) is used during initialization";
   input Option<BackendDAE.BackendDAE> inInitDAE_lambda0;
   input list<BackendDAE.Equation> inRemovedInitialEquationLst;
-  input list<BackendDAE.Var> inPrimaryParameters "already sorted";
-  input list<BackendDAE.Var> inAllPrimaryParameters "already sorted";
   input Absyn.Program p;
   input Absyn.Path className;
   input String filenamePrefix;
@@ -434,7 +424,7 @@ algorithm
   fileDir := CevalScriptBackend.getFileDir(a_cref, p);
 
   (libs, libPaths, includes, includeDirs, recordDecls, functions, literals) := SimCodeUtil.createFunctions(p, inBackendDAE);
-  simCode := createSimCode(inBackendDAE, inInitDAE, inInlineData, inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inPrimaryParameters, inAllPrimaryParameters, className, filenamePrefix, fileDir, functions, includes, includeDirs, libs,libPaths, p, simSettingsOpt, recordDecls, literals, args);
+  simCode := createSimCode(inBackendDAE, inInitDAE, inInlineData, inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, className, filenamePrefix, fileDir, functions, includes, includeDirs, libs,libPaths, p, simSettingsOpt, recordDecls, literals, args);
   timeSimCode := System.realtimeTock(ClockIndexes.RT_CLOCK_SIMCODE);
   ExecStat.execStat("SimCode");
 
@@ -466,8 +456,6 @@ protected function createSimCode "
   input Boolean inUseHomotopy "true if homotopy(...) is used during initialization";
   input Option<BackendDAE.BackendDAE> inInitDAE_lambda0;
   input list<BackendDAE.Equation> inRemovedInitialEquationLst;
-  input list<BackendDAE.Var> inPrimaryParameters "already sorted";
-  input list<BackendDAE.Var> inAllPrimaryParameters "already sorted";
   input Absyn.Path inClassName;
   input String filenamePrefix;
   input String inString11;
@@ -493,7 +481,7 @@ algorithm
     case(_, _, _, _, _, _, _, _, _, _,_, _, _, _) equation
       // MULTI_RATE PARTITIONINIG
       true = Flags.isSet(Flags.MULTIRATE_PARTITION);
-    then HpcOmSimCodeMain.createSimCode(inBackendDAE, inInitDAE, inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inPrimaryParameters, inAllPrimaryParameters, inClassName, filenamePrefix, inString11, functions, externalFunctionIncludes, includeDirs, libs,libPaths, program, simSettingsOpt, recordDecls, literals, args);
+    then HpcOmSimCodeMain.createSimCode(inBackendDAE, inInitDAE, inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inClassName, filenamePrefix, inString11, functions, externalFunctionIncludes, includeDirs, libs,libPaths, program, simSettingsOpt, recordDecls, literals, args);
 
     case(_, _, _, _, _, _, _, _, _, _,_, _, _, _) equation
       true = Flags.isSet(Flags.HPCOM);
@@ -506,7 +494,7 @@ algorithm
       numProc = Flags.getConfigInt(Flags.NUM_PROC);
       true = numProc == 0;
       print("hpcom computes the ideal number of processors. If you want to set the number manually, use the flag +n=_ \n");
-    then HpcOmSimCodeMain.createSimCode(inBackendDAE, inInitDAE, inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inPrimaryParameters, inAllPrimaryParameters, inClassName, filenamePrefix, inString11, functions, externalFunctionIncludes, includeDirs, libs,libPaths,program, simSettingsOpt, recordDecls, literals, args);
+    then HpcOmSimCodeMain.createSimCode(inBackendDAE, inInitDAE, inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inClassName, filenamePrefix, inString11, functions, externalFunctionIncludes, includeDirs, libs,libPaths,program, simSettingsOpt, recordDecls, literals, args);
 
     case(_, _, _, _, _, _, _, _, _,_, _, _, _, _) equation
       true = Flags.isSet(Flags.HPCOM);
@@ -518,10 +506,10 @@ algorithm
 
       numProc = Flags.getConfigInt(Flags.NUM_PROC);
       true = (numProc > 0);
-    then HpcOmSimCodeMain.createSimCode(inBackendDAE, inInitDAE, inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inPrimaryParameters, inAllPrimaryParameters, inClassName, filenamePrefix, inString11, functions, externalFunctionIncludes, includeDirs, libs, libPaths,program,simSettingsOpt, recordDecls, literals, args);
+    then HpcOmSimCodeMain.createSimCode(inBackendDAE, inInitDAE, inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inClassName, filenamePrefix, inString11, functions, externalFunctionIncludes, includeDirs, libs, libPaths,program,simSettingsOpt, recordDecls, literals, args);
 
     else equation
-      (tmpSimCode, _) = SimCodeUtil.createSimCode(inBackendDAE, inInitDAE, inInlineData, inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inPrimaryParameters, inAllPrimaryParameters, inClassName, filenamePrefix, inString11, functions, externalFunctionIncludes, includeDirs, libs,libPaths,program, simSettingsOpt, recordDecls, literals, args, isFMU=isFMU, FMUVersion=FMUVersion);
+      (tmpSimCode, _) = SimCodeUtil.createSimCode(inBackendDAE, inInitDAE, inInlineData, inUseHomotopy, inInitDAE_lambda0, inRemovedInitialEquationLst, inClassName, filenamePrefix, inString11, functions, externalFunctionIncludes, includeDirs, libs,libPaths,program, simSettingsOpt, recordDecls, literals, args, isFMU=isFMU, FMUVersion=FMUVersion);
     then tmpSimCode;
   end matchcontinue;
 end createSimCode;
@@ -910,8 +898,6 @@ algorithm
       Option<BackendDAE.InlineData> inlineData;
       Boolean useHomotopy "true if homotopy(...) is used during initialization";
       list<BackendDAE.Equation> removedInitialEquationLst;
-      list<BackendDAE.Var> primaryParameters "already sorted";
-      list<BackendDAE.Var> allPrimaryParameters "already sorted";
       Real fsize;
 
     case (cache, graph, _, (st as GlobalScript.SYMBOLTABLE(ast=p)), filenameprefix, _, _, _) algorithm
@@ -958,7 +944,7 @@ algorithm
       end if;
 
       //BackendDump.printBackendDAE(dlow);
-      (dlow, initDAE, inlineData, useHomotopy, initDAE_lambda0, removedInitialEquationLst, primaryParameters, allPrimaryParameters) := BackendDAEUtil.getSolvedSystem(dlow,inFileNamePrefix);
+      (dlow, initDAE, inlineData, useHomotopy, initDAE_lambda0, removedInitialEquationLst) := BackendDAEUtil.getSolvedSystem(dlow,inFileNamePrefix);
       timeBackend := System.realtimeTock(ClockIndexes.RT_CLOCK_BACKEND);
 
       if Flags.isSet(Flags.SERIALIZED_SIZE) then
@@ -966,12 +952,10 @@ algorithm
         serializeNotify(initDAE, filenameprefix, "initDAE");
         serializeNotify(initDAE_lambda0, filenameprefix, "initDAE_lambda0");
         serializeNotify(removedInitialEquationLst, filenameprefix, "removedInitialEquationLst");
-        serializeNotify(primaryParameters, filenameprefix, "primaryParameters");
-        serializeNotify(allPrimaryParameters, filenameprefix, "allPrimaryParameters");
         ExecStat.execStat("Serialize solved system");
       end if;
 
-      (libs, file_dir, timeSimCode, timeTemplates) := generateModelCode(dlow, initDAE, inlineData, useHomotopy, initDAE_lambda0, removedInitialEquationLst, primaryParameters, allPrimaryParameters, p, className, filenameprefix, inSimSettingsOpt, args);
+      (libs, file_dir, timeSimCode, timeTemplates) := generateModelCode(dlow, initDAE, inlineData, useHomotopy, initDAE_lambda0, removedInitialEquationLst, p, className, filenameprefix, inSimSettingsOpt, args);
 
       resultValues := {("timeTemplates", Values.REAL(timeTemplates)),
                       ("timeSimCode", Values.REAL(timeSimCode)),

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -92,6 +92,7 @@ import GC;
 import Global;
 import Graph;
 import HashSet;
+import HashSetExp;
 import HpcOmSimCode;
 import Inline;
 import List;
@@ -151,8 +152,6 @@ public function createSimCode "entry point to create SimCode from BackendDAE."
   input Boolean inUseHomotopy "true if homotopy(...) is used during initialization";
   input Option<BackendDAE.BackendDAE> inInitDAE_lambda0;
   input list<BackendDAE.Equation> inRemovedInitialEquationLst;
-  input list<BackendDAE.Var> inPrimaryParameters "already sorted";
-  input list<BackendDAE.Var> inAllPrimaryParameters "already sorted";
   input Absyn.Path inClassName;
   input String filenamePrefix;
   input String inFileDir;
@@ -181,7 +180,7 @@ protected
   HashTableCrIListArray.HashTable varToArrayIndexMapping "maps each array-variable to a array of positions";
   HashTableCrILst.HashTable varToIndexMapping "maps each variable to an array position";
   Integer maxDelayedExpIndex, uniqueEqIndex, numberofEqns, numStateSets, numberOfJacobians, sccOffset;
-  Integer numberofLinearSys, numberofNonLinearSys, numberofMixedSys;
+  Integer numberofLinearSys, numberofNonLinearSys, numberofMixedSys, numberofFixedParameters;
   Option<SimCode.FmiModelStructure> modelStruct;
   SimCode.BackendMapping backendMapping;
   SimCode.ExtObjInfo extObjInfo;
@@ -194,8 +193,6 @@ protected
   //list<BackendDAE.Equation> paramAsserts, remEqLst;
   list<BackendDAE.Equation> removedInitialEquationLst;
   list<BackendDAE.TimeEvent> timeEvents;
-  list<BackendDAE.Var> allPrimaryParameters "already sorted";
-  list<BackendDAE.Var> primaryParameters "already sorted";
   BackendDAE.ZeroCrossingSet zeroCrossingsSet, sampleZCSet;
   DoubleEndedList<BackendDAE.ZeroCrossing> de_relations;
   list<BackendDAE.ZeroCrossing> zeroCrossings, sampleZC, relations;
@@ -340,7 +337,7 @@ algorithm
     if debug then execStat("simCode: createMaxValueEquations"); end if;
     ((uniqueEqIndex, parameterEquations)) := BackendDAEUtil.foldEqSystem(dlow, createVarNominalAssertFromVars, (uniqueEqIndex, {}));
     if debug then execStat("simCode: createVarNominalAssertFromVars"); end if;
-    (uniqueEqIndex, parameterEquations) := createParameterEquations(uniqueEqIndex, parameterEquations, inPrimaryParameters, inAllPrimaryParameters);
+    (uniqueEqIndex, parameterEquations, numberofFixedParameters) := createParameterEquations(uniqueEqIndex, parameterEquations, globalKnownVars);
     if debug then execStat("simCode: createParameterEquations"); end if;
     //((uniqueEqIndex, paramAssertSimEqs)) := BackendEquation.traverseEquationArray(BackendEquation.listEquation(paramAsserts), traversedlowEqToSimEqSystem, (uniqueEqIndex, {}));
     //parameterEquations := listAppend(parameterEquations, paramAssertSimEqs);
@@ -500,7 +497,7 @@ algorithm
 
     if Flags.getConfigBool(Flags.CALCULATE_SENSITIVITIES) then
       tmpSimVars := modelInfo.vars;
-      (sensitivityVars, countSenParams) := createSimVarsForSensitivities(tmpSimVars.stateVars, tmpSimVars.paramVars, inAllPrimaryParameters);
+      (sensitivityVars, countSenParams) := createSimVarsForSensitivities(tmpSimVars.stateVars, tmpSimVars.paramVars, numberofFixedParameters);
       sensitivityVars := rewriteIndex(sensitivityVars, 0);
       tmpSimVars.sensitivityVars := sensitivityVars;
       modelInfo.vars := tmpSimVars;
@@ -6468,12 +6465,13 @@ algorithm
 end makeSolved_SES_SIMPLE_ASSIGN_fromStartValue;
 
 protected function createParameterEquations
+"Traverses the globalKnownVars and creates simEqns for the variable if necessary."
   input Integer inUniqueEqIndex;
   input list<SimCode.SimEqSystem> acc;
-  input list<BackendDAE.Var> inPrimaryParameters "already sorted";
-  input list<BackendDAE.Var> inAllPrimaryParameters "already sorted";
+  input BackendDAE.Variables globalKnownVars;
   output Integer outUniqueEqIndex = inUniqueEqIndex;
   output list<SimCode.SimEqSystem> outParameterEquations = {};
+  output Integer nFixedParameters;
 protected
   list<SimCode.SimEqSystem> simvarasserts;
   list<DAE.Algorithm> varasserts;
@@ -6481,21 +6479,13 @@ protected
   BackendDAE.Var p;
   SimCode.SimEqSystem simEq;
 algorithm
+  (outUniqueEqIndex, outParameterEquations, varasserts, nFixedParameters, _) := BackendVariable.traverseBackendDAEVars(globalKnownVars, createSimEqsForGlobalKnownVars, (outUniqueEqIndex, outParameterEquations, {}, 0, HashSetExp.emptyHashSetSized(Util.nextPrime(globalKnownVars.numberOfVars))));
+
   if Flags.isSet(Flags.PARAM_DLOW_DUMP) then
-    BackendDump.dumpVarList(inPrimaryParameters, "parameters in order");
+    print("\nparameters in order (" + intString(listLength(outParameterEquations)) + ")\n" + UNDERLINE + "\n");
+    dumpSimEqSystemLst(listReverse(outParameterEquations), "\n");
+    print("\n");
   end if;
-
-  for p in inPrimaryParameters loop
-    (simEq, outUniqueEqIndex) := makeSolved_SES_SIMPLE_ASSIGN_fromStartValue(p, outUniqueEqIndex);
-    outParameterEquations := simEq::outParameterEquations;
-  end for;
-
-  // get min/max and nominal asserts
-  varasserts := {};
-  for p in inAllPrimaryParameters loop
-    varasserts2 := createVarAsserts(p);
-    varasserts := List.append_reverse(varasserts2, varasserts);
-  end for;
 
   varasserts := MetaModelica.Dangerous.listReverseInPlace(varasserts);
   (simvarasserts, outUniqueEqIndex) := List.mapFold(varasserts, dlowAlgToSimEqSystem, outUniqueEqIndex);
@@ -6504,6 +6494,88 @@ algorithm
   outParameterEquations := List.append_reverse(acc, outParameterEquations);
   outParameterEquations := listReverse(outParameterEquations);
 end createParameterEquations;
+
+
+protected function createSimEqsForGlobalKnownVars
+"Decides if a simEq is generated from the globalKnownVar and creates it.
+ author: ptaeuber"
+  input output BackendDAE.Var globalKnownVar;
+  input tuple<Integer, list<SimCode.SimEqSystem>, list<DAE.Algorithm>, Integer, HashSetExp.HashSet> inTuple;
+  output tuple<Integer, list<SimCode.SimEqSystem>, list<DAE.Algorithm>, Integer, HashSetExp.HashSet> outTuple;
+protected
+  Integer uniqueEqIndex, nFixedParameters;
+  SimCode.SimEqSystem simEq;
+  list<SimCode.SimEqSystem> parameterEquations;
+  list<DAE.Algorithm> varasserts, varasserts2;
+  HashSetExp.HashSet tplExpHT;
+algorithm
+  (uniqueEqIndex, parameterEquations, varasserts, nFixedParameters, tplExpHT) := inTuple;
+
+  // Get min/max and nominal asserts for fixed parameters
+  if BackendVariable.isParam(globalKnownVar) and BackendVariable.varFixed(globalKnownVar) then
+    varasserts2 := createVarAsserts(globalKnownVar);
+    varasserts := List.append_reverse(varasserts2, varasserts);
+    nFixedParameters := nFixedParameters + 1;
+  end if;
+
+  // Create SimCode Equation for special globalKnownVars
+  if (BackendVariable.isParam(globalKnownVar) and BackendVariable.varFixed(globalKnownVar) and (BackendVariable.isFinalOrProtectedVar(globalKnownVar) or BackendVariable.varHasNonConstantBindExpOrStartValue(globalKnownVar)))
+    or (BackendVariable.isVar(globalKnownVar) and not BackendVariable.isInput(globalKnownVar))
+    or (BackendVariable.isExtObj(globalKnownVar) and BackendVariable.varHasBindExp(globalKnownVar))
+   then
+
+    _ := match(globalKnownVar)
+      local
+        DAE.Exp call, tplExp, rec;
+        DAE.ElementSource source;
+        list<DAE.Exp> expl;
+        DAE.Type tp;
+
+      // tuple_cse = call
+      case BackendDAE.VAR(tplExp = SOME(tplExp as DAE.TUPLE(expl)))
+        algorithm
+          if BaseHashSet.has(tplExp, tplExpHT) then
+            outTuple := (uniqueEqIndex, parameterEquations, varasserts, nFixedParameters, tplExpHT);
+            return;
+          else
+            tp := Expression.typeof(tplExp);
+            SOME(call) := globalKnownVar.bindExp;
+            source := BackendVariable.getVarSource(globalKnownVar);
+            simEq := SimCode.SES_ALGORITHM(uniqueEqIndex, {DAE.STMT_TUPLE_ASSIGN(tp, expl, call, source)});
+            uniqueEqIndex := uniqueEqIndex+1;
+            tplExpHT := BaseHashSet.add(tplExp, tplExpHT);
+          end if;
+       then ();
+
+      // record_cse = call
+      case BackendDAE.VAR(tplExp = SOME(rec))
+        algorithm
+          if BaseHashSet.has(rec, tplExpHT) then
+            outTuple := (uniqueEqIndex, parameterEquations, varasserts, nFixedParameters, tplExpHT);
+            return;
+          else
+            tp := Expression.typeof(rec);
+            SOME(call) := globalKnownVar.bindExp;
+            source := BackendVariable.getVarSource(globalKnownVar);
+            simEq := SimCode.SES_ALGORITHM(uniqueEqIndex, {DAE.STMT_ASSIGN(tp, rec, call, source)});
+            uniqueEqIndex := uniqueEqIndex+1;
+            tplExpHT := BaseHashSet.add(rec, tplExpHT);
+          end if;
+       then ();
+
+      // 'normal' globalKnownVars
+      else
+        algorithm
+          (simEq, uniqueEqIndex) := makeSolved_SES_SIMPLE_ASSIGN_fromStartValue(globalKnownVar, uniqueEqIndex);
+       then ();
+      end match;
+
+    parameterEquations := simEq::parameterEquations;
+  end if;
+
+  outTuple := (uniqueEqIndex, parameterEquations, varasserts, nFixedParameters, tplExpHT);
+end createSimEqsForGlobalKnownVars;
+
 
 protected function createInitialAssignmentsFromStart
   input BackendDAE.Var inVar;
@@ -12879,7 +12951,7 @@ protected function createSimVarsForSensitivities
 "
   input list<SimCodeVar.SimVar> inStateSimVars;
   input list<SimCodeVar.SimVar> inParamSimVars;
-  input list<BackendDAE.Var> inPrimaryParameters;
+  input Integer nFixedParameters;
   output list<SimCodeVar.SimVar> outSimCodeVars;
   output Integer countSensitivityParams = 0;
 protected
@@ -12891,7 +12963,7 @@ protected
   list<SimCodeVar.SimVar> sensitivityParams = {};
 algorithm
   emptyVars := BackendVariable.emptyVars();
-  tmpVariables := BackendVariable.emptyVarsSized(listLength(inStateSimVars)*listLength(inPrimaryParameters));
+  tmpVariables := BackendVariable.emptyVarsSized(listLength(inStateSimVars)*nFixedParameters);
 
   for param in inParamSimVars loop
     // take for now only parameters that are changeable and topLevel

--- a/Compiler/Stubs/BackendDAEUtil.mo
+++ b/Compiler/Stubs/BackendDAEUtil.mo
@@ -15,8 +15,6 @@ function getSolvedSystem<A>
   output Boolean outUseHomotopy;
   output Option<A> outInitDAE_lambda0;
   output list<BackendDAE.Equation> outRemovedInitialEquationLst;
-  output list<BackendDAE.Var> outPrimaryParameters;
-  output list<BackendDAE.Var> outAllPrimaryParameters;
 algorithm
   assert(false, getInstanceName());
 end getSolvedSystem;

--- a/Compiler/Stubs/SimCodeMain.mo
+++ b/Compiler/Stubs/SimCodeMain.mo
@@ -26,8 +26,6 @@ function generateModelCode<T,A,B,C,D,E,F>
   input Boolean inUseHomotopy;
   input Option<T> inInitDAE_lambda0;
   input list<BackendDAE.Equation> inRemovedInitialEquationLst;
-  input B inPrimaryParameters;
-  input B inAllPrimaryParameters;
   input A p;
   input C className;
   input String filenamePrefix;

--- a/Compiler/Util/BaseHashTable.mo
+++ b/Compiler/Util/BaseHashTable.mo
@@ -614,7 +614,7 @@ algorithm
 end copy;
 
 public function clear
-  "Makes a copy of a hashtable."
+  "Clears the hashtable."
   input output HashTable ht;
 protected
   HashVector hv;

--- a/Compiler/Util/ExpandableArray.mo
+++ b/Compiler/Util/ExpandableArray.mo
@@ -78,6 +78,18 @@ algorithm
   end for;
 end clear;
 
+function copy
+  input ExpandableArray<T> inExarray;
+  input T dummy "This is needed to determine the type information, the actual value is not used";
+  output ExpandableArray<T> outExarray;
+algorithm
+  outExarray := new(inExarray.capacity[1], dummy);
+  outExarray.numberOfElements := arrayCopy(inExarray.numberOfElements);
+  outExarray.lastUsedIndex := arrayCopy(inExarray.lastUsedIndex);
+  outExarray.capacity := arrayCopy(inExarray.capacity);
+  outExarray.data := arrayCreate(1, arrayCopy(Dangerous.arrayGetNoBoundsChecking(inExarray.data, 1)));
+end copy;
+
 function get "O(1)
   Returns the value of the element at the given index.
   Fails if there is nothing assigned to the given index."

--- a/Compiler/Util/HashSetExp.mo
+++ b/Compiler/Util/HashSetExp.mo
@@ -1,0 +1,95 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2014, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package HashSetExp
+/* Below is the instance specific code. For each hashset the user must define:
+
+Key       - The key used to uniquely define elements in a hashset
+hashFunc   - A function that maps a key to a positive integer.
+keyEqual   - A comparison function between two keys, returns true if equal.
+*/
+
+/* HashSetExp instance specific code */
+
+public import BaseHashSet;
+public import DAE;
+protected import Expression;
+protected import ExpressionDump;
+
+public type Key = DAE.Exp;
+
+public type HashSetCrefFunctionsType = tuple<FuncHashCref,FuncCrefEqual,FuncCrefStr>;
+public type HashSet = tuple<
+  array<list<tuple<Key,Integer>>>,
+  tuple<Integer,Integer,array<Option<Key>>>,
+  Integer,
+  Integer,
+  HashSetCrefFunctionsType
+>;
+
+partial function FuncHashCref
+  input Key cr;
+  input Integer mod;
+  output Integer res;
+end FuncHashCref;
+
+partial function FuncCrefEqual
+  input Key cr1;
+  input Key cr2;
+  output Boolean res;
+end FuncCrefEqual;
+
+partial function FuncCrefStr
+  input Key cr;
+  output String res;
+end FuncCrefStr;
+
+public function emptyHashSet
+"
+  Returns an empty HashSet.
+  Using the default bucketsize..
+"
+  output HashSet hashSet;
+algorithm
+  hashSet := emptyHashSetSized(BaseHashSet.defaultBucketSize);
+end emptyHashSet;
+
+public function emptyHashSetSized
+"Returns an empty HashSet.
+ Using the bucketsize size"
+  input Integer size;
+  output HashSet hashSet;
+algorithm
+  hashSet := BaseHashSet.emptyHashSetWork(size,(Expression.hashExpMod,Expression.expEqual,ExpressionDump.printExpStr));
+end emptyHashSetSized;
+
+annotation(__OpenModelica_Interface="frontend");
+end HashSetExp;

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -195,6 +195,7 @@ if true then /* Suppress output */
     "../Util/GraphStream.mo",
     "../Util/GraphStreamExt.mo",
     "../Util/HashSet.mo",
+    "../Util/HashSetExp.mo",
     "../Util/HashSetString.mo",
     "../Util/HashTable2.mo",
     "../Util/HashTable3.mo",


### PR DESCRIPTION
See [ticket:3812](https://trac.openmodelica.org/OpenModelica/ticket/3812)

- constant cse-variables are stored in globalKnownVars and **only
  evaluated once** before simulation instead of in each simulation step
- also traverse globalKnownVars for function calls before
  traversing the systems
- SimEqns for parameters are created from the globalKnownVars
- constant variables (eg. cse-variables) are solved before initialization in
  updateBoundParameters in *_08bnd.c
- primaryParameters and allPrimaryParameters are removed
- improved dumps and documentation