### PR TITLE
compute time events during runtime instead of precalculation (cpp)

### DIFF
--- a/SimulationRuntime/cpp/Core/System/SystemDefaultImplementation.cpp
+++ b/SimulationRuntime/cpp/Core/System/SystemDefaultImplementation.cpp
@@ -52,7 +52,8 @@ SystemDefaultImplementation::SystemDefaultImplementation(IGlobalSettings *global
   , _dimTimeEvent      (0)
   , _dimClock        (0)
   , _dimAE        (0)
-  , _time_event_counter  (NULL)
+  , _timeEventData  (NULL)
+  , _currTimeEvents (NULL)
   , _clockInterval  (NULL)
   , _clockShift     (NULL)
   , _clockTime      (NULL)
@@ -91,7 +92,8 @@ SystemDefaultImplementation::SystemDefaultImplementation(SystemDefaultImplementa
   , _dimTimeEvent      (0)
   , _dimClock        (0)
   , _dimAE        (0)
-  , _time_event_counter  (NULL)
+  , _timeEventData  (NULL)
+  , _currTimeEvents (NULL)
   , _clockInterval  (NULL)
   , _clockShift     (NULL)
   , _clockTime      (NULL)
@@ -135,7 +137,8 @@ SystemDefaultImplementation::~SystemDefaultImplementation()
   */
   if(_conditions) delete [] _conditions ;
   if(_time_conditions) delete [] _time_conditions ;
-  if(_time_event_counter) delete [] _time_event_counter;
+  if(_timeEventData) delete [] _timeEventData;
+  if(_currTimeEvents) delete [] _currTimeEvents;
   if(_conditions0) delete [] _conditions0;
   if(_clockInterval) delete [] _clockInterval;
   if(_clockShift) delete [] _clockShift;
@@ -230,19 +233,13 @@ void SystemDefaultImplementation::initialize()
     _conditions0= new bool[_dimZeroFunc];
 
     memset(_conditions,false,(_dimZeroFunc)*sizeof(bool));
-	_event_system = dynamic_cast<IEvent*>(this);
+  _event_system = dynamic_cast<IEvent*>(this);
   }
   if(_dimTimeEvent > 0)
   {
     if(_time_conditions) delete [] _time_conditions ;
-    if(_time_event_counter) delete [] _time_event_counter;
     _time_conditions = new bool[_dimTimeEvent];
-
-
-    _time_event_counter = new int[_dimTimeEvent];
-
     memset(_time_conditions,false,(_dimTimeEvent)*sizeof(bool));
-    memset(_time_event_counter,0,(_dimTimeEvent)*sizeof(int));
   }
   if (_dimClock > 0)
   {
@@ -275,6 +272,12 @@ void SystemDefaultImplementation::setTime(const double& t)
 {
   _simTime = t;
 };
+
+// Get current integration time
+double SystemDefaultImplementation::getTime()
+{
+  return _simTime;
+}
 
 /// getter for variables of different types
 void SystemDefaultImplementation::getBoolean(bool* z)
@@ -471,7 +474,7 @@ void SystemDefaultImplementation::getRHS(double* f)
 
 void SystemDefaultImplementation::getResidual(double* f)
 {
-	 std::copy(__daeResidual, __daeResidual+_dimRHS, f);
+   std::copy(__daeResidual, __daeResidual+_dimRHS, f);
 }
 
 void  SystemDefaultImplementation::intDelay(vector<unsigned int> expr, vector<double> delay_max)
@@ -655,6 +658,68 @@ void SystemDefaultImplementation::setStringStartValue(string& var,string val,boo
   var=val;
   _string_start_values.setStartValue(var,val,overwriteOldValue);
 }
+
+/**
+    Computes whether time event conditions are active at current time
+    @param The current time
+*/
+void SystemDefaultImplementation::computeTimeEventConditions(double currTime)
+{
+  for (int i=0; i< _dimTimeEvent; i++)
+  {
+    if (std::abs(_currTimeEvents[i] - currTime) <= 1e4*UROUND)
+    {
+      _time_conditions[i] = true;
+    }
+    else
+    {
+      _time_conditions[i] = false;
+    }
+  }
+}
+
+/**
+    Sets all time event conditions to false
+*/
+void SystemDefaultImplementation::resetTimeConditions()
+{
+  for (int i=0; i< _dimTimeEvent; i++)
+  {
+  _time_conditions[i] = false;
+  }
+}
+
+/**
+    Computes the next time events for each time event sampler
+    @param The current Time
+    @param The definition of the time event samplers (starttime, intervall)
+    @param An array of the next time events for each sampler
+    @return the closest time event
+*/
+double SystemDefaultImplementation::computeNextTimeEvents(double currTime, std::pair<double, double>* timeEventPairs)
+{
+  double closestTimeEvent = std::numeric_limits<double>::max();
+  double nextTimeEvent = 0;
+  double pastIntervalls;
+  for (  int timerIdx = 0; timerIdx < _dimTimeEvent ; timerIdx++)
+  {
+    //the time event samples started already
+    if(timeEventPairs[timerIdx].first <= currTime)
+    {
+      pastIntervalls = std::floor((currTime - timeEventPairs[timerIdx].first + 1e4*UROUND) / timeEventPairs[timerIdx].second);
+      _currTimeEvents[timerIdx] = timeEventPairs[timerIdx].first + (pastIntervalls) * timeEventPairs[timerIdx].second;
+      nextTimeEvent = _currTimeEvents[timerIdx] + timeEventPairs[timerIdx].second;
+    }
+    else
+    {
+      nextTimeEvent = timeEventPairs[timerIdx].first;
+      _currTimeEvents[timerIdx] = 1.0;
+    }
+    closestTimeEvent = std::min(closestTimeEvent, nextTimeEvent);
+  }
+  return closestTimeEvent;
+}
+
 /** @} */ // end of coreSystem
 
 /*

--- a/SimulationRuntime/cpp/Include/Core/SimController/SimManager.h
+++ b/SimulationRuntime/cpp/Include/Core/SimController/SimManager.h
@@ -25,7 +25,6 @@ public:
     void runSingleStep();
 
 private:
-    void computeEndTimes(std::vector<std::pair<double,int> > &tStopsSub);
     void computeSampleCycles();
 
     void runSingleProcess();

--- a/SimulationRuntime/cpp/Include/Core/System/ITime.h
+++ b/SimulationRuntime/cpp/Include/Core/System/ITime.h
@@ -10,10 +10,13 @@ class ITime
 public:
   virtual ~ITime() {};
   virtual int getDimTimeEvent() const = 0;
+  virtual std::pair<double, double>* getTimeEventData() const = 0;
   // gibt die Time events (Startzeit und Frequenz) zurück
-  virtual void getTimeEvent(time_event_type& time_events) = 0;
-  // Wird vom Solver zur Behandlung der Time events aufgerufen (wenn zero_sign[i] = 0  kein time event,zero_sign[i] = n  Anzahl von vorgekommen time events )
-  virtual void handleTimeEvent(int* time_events) = 0;
+  virtual void initTimeEventData() = 0;
+  virtual void computeTimeEventConditions(double currTime) = 0;
+  virtual double computeNextTimeEvents(double currTime) = 0;
+  virtual void resetTimeConditions() = 0;
+
   /// Set current integration time
   virtual void setTime(const double& time) = 0;
 };

--- a/SimulationRuntime/cpp/Include/Core/System/SystemDefaultImplementation.h
+++ b/SimulationRuntime/cpp/Include/Core/System/SystemDefaultImplementation.h
@@ -122,6 +122,7 @@ public:
   void initialize();
   /// Set current integration time
   void setTime(const double& t);
+  double getTime();
 
   IGlobalSettings* getGlobalSettings();
 
@@ -130,6 +131,10 @@ public:
 
   shared_ptr<ISimData> getSimData();
   shared_ptr<ISimVars> getSimVars();
+
+  double computeNextTimeEvents(double currTime, std::pair<double, double>* timeEventPairs);
+  void computeTimeEventConditions(double currTime);
+  void resetTimeConditions();
 
   virtual double& getRealStartValue(double& var);
   virtual bool& getBoolStartValue(bool& var);
@@ -143,7 +148,6 @@ public:
   virtual void setIntStartValue(int& var,int val,bool overwriteOldValue);
   virtual void setStringStartValue(string& var,string val);
   virtual void setStringStartValue(string& var,string val,bool overwriteOldValue);
-
 protected:
     void Assert(bool cond, const string& msg);
     void Terminate(string msg);
@@ -176,8 +180,10 @@ protected:
         _dimClock,            ///< Dimension (=Anzahl) Clocks (active)
         _dimAE;               ///< Number (dimension) of algebraic equations (e.g. constraints from an algebraic loop)
 
-    int
-    * _time_event_counter;
+    std::pair<double, double>*
+        _timeEventData;
+    double* _currTimeEvents;
+
     double *_clockInterval;   ///< time interval between clock ticks
     double *_clockShift;      ///< time before first activation
     double *_clockTime;       ///< time of clock ticks
@@ -200,7 +206,7 @@ protected:
    double
         *__z,                 ///< "Extended state vector", containing all states and algebraic variables of all types
         *__zDot,              ///< "Extended vector of derivatives", containing all right hand sides of differential and algebraic equations
-	    *__daeResidual;
+      *__daeResidual;
     typedef std::deque<double> buffer_type;
     typedef std::iterator_traits<buffer_type::iterator>::difference_type difference_type;
     map<unsigned int, buffer_type> _delay_buffer;
@@ -211,7 +217,7 @@ protected:
     IEvent* _event_system; //this pointer to event system
     string _modelName;
 
-	bool _sparse;
-	bool _useAnalyticalJacobian;
+  bool _sparse;
+  bool _useAnalyticalJacobian;
 };
 /** @} */ // end of coreSystem


### PR DESCRIPTION
changed handling of time events in cpp runtime
now we have:
- initTimeEventData() to initialize the time event definition from the model (starttime, interval)
- computeNextTimeEvent() to compute the time for the upcoming time event
- computeTimeEventConditions() to compute the conditions for the time events at a certain point in time
- resetTimeEvents

This is also implemented in the FMUWrapper 1 and 2. Time events havent been available so far for FMI.
Discrete Time FMUs are not yet tested.
Hudson is fine with that except clockedSolverTest.mos needs reference update (we now write the right limit of a time event step instead the left limit as before, now its like in Dymola)
