### PR TITLE
Avoid empty autoconf statements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,8 +159,6 @@ AC_ARG_WITH(msys, [  --with-msys[=no]              Point to an msys installation
     CPPFLAGS="$CPPFLAGS -I$withval/$MINGWNUM/include -I$withval/$MINGWNUM/include/tre"
     LDFLAGS="$LDFLAGS -L$withval/$MINGWNUM/lib"
     echo "Got: $CPPFLAGS"
-  ],
-  [
   ]
 )
 


### PR DESCRIPTION
This fixes bugs in older autoconf (RedHat 6). Fixes ticket:4326.