### PR TITLE
Don't generate unnecessary start value equations

### DIFF
--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -2056,6 +2056,32 @@ public function emptyVarsSized
   output BackendDAE.Variables outVariables = emptyVars(size);
 end emptyVarsSized;
 
+public function isCrefInVarList "O(n)"
+  input DAE.ComponentRef inCref;
+  input list<BackendDAE.Var> inVars;
+  output Boolean isInList = false;
+algorithm
+  for v in inVars loop
+    if ComponentReference.crefEqual(BackendVariable.varCref(v), inCref) then
+      isInList := true;
+      return;
+    end if;
+  end for;
+end isCrefInVarList;
+
+public function areAllCrefsInVarList "O(n^2)"
+  input list<DAE.ComponentRef> inCrefs;
+  input list<BackendDAE.Var> inVars;
+  output Boolean isInList = true;
+algorithm
+  for cref in inCrefs loop
+    if not isCrefInVarList(cref, inVars) then
+      isInList := false;
+      return;
+    end if;
+  end for;
+end areAllCrefsInVarList;
+
 public function varList
   "Takes a BackendDAE.Variables and returns a list of all variables in it,
    useful for e.g. dumping.

--- a/Compiler/BackEnd/Initialization.mo
+++ b/Compiler/BackEnd/Initialization.mo
@@ -2022,32 +2022,6 @@ algorithm
   end match;
 end collectInitialVarsEqnsSystem;
 
-protected function isCrefPrimaryParameter
-  input DAE.ComponentRef inCref;
-  input list<BackendDAE.Var> inAllPrimaryParameters;
-  output Boolean isPrimary = false;
-algorithm
-  for v in inAllPrimaryParameters loop
-    if ComponentReference.crefEqual(BackendVariable.varCref(v), inCref) then
-      isPrimary := true;
-      return;
-    end if;
-  end for;
-end isCrefPrimaryParameter;
-
-protected function areCrefsPrimaryParameters
-  input list<DAE.ComponentRef> inCrefs;
-  input list<BackendDAE.Var> inAllPrimaryParameters;
-  output Boolean isPrimary = true;
-algorithm
-  for cref in inCrefs loop
-    if not isCrefPrimaryParameter(cref, inAllPrimaryParameters) then
-      isPrimary := false;
-      return;
-    end if;
-  end for;
-end areCrefsPrimaryParameters;
-
 protected function collectInitialVars "author: lochel
   This function collects all the vars for the initial system.
   TODO: return additional equations for pre-variables"
@@ -2095,7 +2069,7 @@ algorithm
       startExp = BackendVariable.varStartValue(var);
       parameters = Expression.getAllCrefs(startExp);
 
-      if not areCrefsPrimaryParameters(parameters, allPrimaryParameters) then
+      if not BackendVariable.areAllCrefsInVarList(parameters, allPrimaryParameters) then
         eqn = BackendDAE.EQUATION(Expression.crefExp(startCR), startExp, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL);
         eqns = BackendEquation.addEquation(eqn, eqns);
 
@@ -2286,7 +2260,7 @@ algorithm
       startExp = BackendVariable.varStartValue(var);
       parameters = Expression.getAllCrefs(startExp);
 
-      if not areCrefsPrimaryParameters(parameters, allPrimaryParameters) then
+      if not BackendVariable.areAllCrefsInVarList(parameters, allPrimaryParameters) then
         eqn = BackendDAE.EQUATION(Expression.crefExp(startCR), startExp, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL);
         eqns = BackendEquation.addEquation(eqn, eqns);
 
@@ -2332,7 +2306,7 @@ algorithm
       startExp = BackendVariable.varStartValue(var);
       parameters = Expression.getAllCrefs(startExp);
 
-      if not areCrefsPrimaryParameters(parameters, allPrimaryParameters) then
+      if not BackendVariable.areAllCrefsInVarList(parameters, allPrimaryParameters) then
         eqn = BackendDAE.EQUATION(Expression.crefExp(startCR), startExp, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL);
         eqns = BackendEquation.addEquation(eqn, eqns);
 


### PR DESCRIPTION
These unnecessary start value equations cause division by zero errors in some cases.