### PR TITLE
Fix initialization of min/max/nominal attributes

### DIFF
--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -2671,7 +2671,7 @@ public function traversingincidenceRowExpSolvableFinder "Helper for statesAndVar
 algorithm
   (outExp, cont, outTpl) := matchcontinue (inExp, inTpl)
     local
-      list<Integer> p, p2, ilst;
+      list<Integer> p, ilst;
       AvlSetInt.Tree pa;
       DAE.ComponentRef cr;
       BackendDAE.Variables vars;
@@ -2726,18 +2726,8 @@ algorithm
       (_, tpl) = Expression.traverseExpTopDown(e1, traversingincidenceRowExpSolvableFinder, tpl);
     then (inExp, false, tpl);
 
-    // cref and $START.cref
-    case (DAE.CREF(componentRef=cr), (vars, pa, visitedPaths, ofunctionTree)) equation
-      (varslst, p) = BackendVariable.getVar(cr, vars);
-      (_, p2) = BackendVariable.getVar(ComponentReference.crefPrefixStart(cr), vars);
-
-      pa = incidenceRowExp1(varslst, p, pa, 0);
-      pa = incidenceRowExp1(varslst, p2, pa, 0);
-    then (inExp, true, (vars, pa, visitedPaths, ofunctionTree));
-
-    // only cref
-    case (DAE.CREF(componentRef=cr), (vars, pa, visitedPaths, ofunctionTree)) equation
-      (varslst, p) = BackendVariable.getVar(cr, vars);
+    case (DAE.CREF(componentRef=cr), (vars, pa, ofunctionTree)) equation
+      (varslst, p) = BackendVariable.getVarAndAttributes(cr, vars);
       pa = incidenceRowExp1(varslst, p, pa, 0);
     then (inExp, true, (vars, pa, visitedPaths, ofunctionTree));
 
@@ -2787,7 +2777,7 @@ public function traversingIncidenceRowExpFinderBaseClock "author: lochel
 algorithm
   (outExp,cont,outTpl) := matchcontinue (inExp,inTpl)
     local
-      list<Integer> p, p2;
+      list<Integer> p;
       AvlSetInt.Tree pa;
       DAE.ComponentRef cr;
       BackendDAE.Variables vars;
@@ -2795,15 +2785,7 @@ algorithm
 
     case (DAE.CREF(componentRef=cr), (vars, pa))
       equation
-        (_, p) = BackendVariable.getVar(cr, vars);
-        (_, p2) = BackendVariable.getVar(ComponentReference.crefPrefixStart(cr), vars);
-        pa = AvlSetInt.addList(pa, p);
-        pa = AvlSetInt.addList(pa, p2);
-      then (inExp, true, (vars, pa));
-
-    case (DAE.CREF(componentRef=cr), (vars, pa))
-      equation
-        (_, p) = BackendVariable.getVar(cr, vars);
+        (_, p) = BackendVariable.getVarAndAttributes(cr, vars);
       then (inExp, true, (vars, AvlSetInt.addList(pa, p)));
 
     case (DAE.CALL(path=Absyn.IDENT(name="sample"), expLst={_, e}), _)
@@ -2837,22 +2819,14 @@ public function traversingIncidenceRowExpFinderSubClock "author: lochel
 algorithm
   (outExp,cont,outTpl) := matchcontinue (inExp,inTpl)
     local
-      list<Integer> p, p2;
+      list<Integer> p;
       AvlSetInt.Tree pa, res;
       DAE.ComponentRef cr;
       BackendDAE.Variables vars;
 
     case (DAE.CREF(componentRef=cr), (vars, pa))
       equation
-        (_, p) = BackendVariable.getVar(cr, vars);
-        (_, p2) = BackendVariable.getVar(ComponentReference.crefPrefixStart(cr), vars);
-        res = AvlSetInt.addList(pa, p);
-        res = AvlSetInt.addList(res, p2);
-      then (inExp, true, (vars, res));
-
-    case (DAE.CREF(componentRef=cr), (vars, pa))
-      equation
-        (_, p) = BackendVariable.getVar(cr, vars);
+        (_, p) = BackendVariable.getVarAndAttributes(cr, vars);
         res = AvlSetInt.addList(pa, p);
       then (inExp, true, (vars, res));
 
@@ -2886,7 +2860,7 @@ public function traversingincidenceRowExpFinder "
 algorithm
   (outExp,cont,outTpl) := matchcontinue(inExp,inTpl)
     local
-      list<Integer> p, p2;
+      list<Integer> p;
       AvlSetInt.Tree pa,res;
       DAE.ComponentRef cr;
       BackendDAE.Variables vars;
@@ -2896,20 +2870,9 @@ algorithm
       Integer i;
       String str;
 
-    // cref and $START.cref
-    case (e as DAE.CREF(componentRef=cr), (vars, pa))
-      equation
-        (varslst, p) = BackendVariable.getVar(cr, vars);
-        (_, p2) = BackendVariable.getVar(ComponentReference.crefPrefixStart(cr), vars);
-
-        res = incidenceRowExp1(varslst, p, pa, 0);
-        res = incidenceRowExp1(varslst, p2, res, 0);
-      then (e, true, (vars, res));
-
-    // only cref
     case (e as DAE.CREF(componentRef = cr),(vars,pa))
       equation
-        (varslst,p) = BackendVariable.getVar(cr, vars);
+        (varslst,p) = BackendVariable.getVarAndAttributes(cr, vars);
         res = incidenceRowExp1(varslst,p,pa,0);
       then (e, true, (vars,res));
 
@@ -3021,18 +2984,9 @@ algorithm
         res = incidenceRowExp1withInput(varslst,p,pa,0);
       then (inExp,false,(vars,res));
 
-    case (DAE.CREF(componentRef=cr), (vars, pa))
-      equation
-        (varslst, p) = BackendVariable.getVar(cr, vars);
-        res = incidenceRowExp1withInput(varslst, p, pa, 0);
-
-        (varslst, p) = BackendVariable.getVar(ComponentReference.crefPrefixStart(cr), vars);
-        res = incidenceRowExp1withInput(varslst, p, res, 0);
-      then (inExp, true, (vars, res));
-
     case (DAE.CREF(componentRef = cr),(vars,pa))
       equation
-        (varslst,p) = BackendVariable.getVar(cr, vars);
+        (varslst,p) = BackendVariable.getVarAndAttributes(cr, vars);
         res = incidenceRowExp1withInput(varslst,p,pa,0);
       then (inExp, true, (vars, res));
 

--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -2823,9 +2823,36 @@ protected
   list<BackendDAE.Var> varList;
   list<Integer> intList;
 algorithm
+  // variable itself
   (outVarList, outIntList) := getVar(inCref, inVariables);
+
+  // start attribute
   try
     (varList, intList) := BackendVariable.getVar(ComponentReference.crefPrefixStart(inCref), inVariables);
+    outVarList := listAppend(varList, outVarList);
+    outIntList := listAppend(intList, outIntList);
+  else
+  end try;
+
+  // min attribute
+  try
+    (varList, intList) := BackendVariable.getVar(ComponentReference.crefPrefixMin(inCref), inVariables);
+    outVarList := listAppend(varList, outVarList);
+    outIntList := listAppend(intList, outIntList);
+  else
+  end try;
+
+  // max attribute
+  try
+    (varList, intList) := BackendVariable.getVar(ComponentReference.crefPrefixMax(inCref), inVariables);
+    outVarList := listAppend(varList, outVarList);
+    outIntList := listAppend(intList, outIntList);
+  else
+  end try;
+
+  // nominal attribute
+  try
+    (varList, intList) := BackendVariable.getVar(ComponentReference.crefPrefixNominal(inCref), inVariables);
     outVarList := listAppend(varList, outVarList);
     outIntList := listAppend(intList, outIntList);
   else

--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -2814,6 +2814,24 @@ algorithm
   end try;
 end containsCref;
 
+public function getVarAndAttributes
+  input DAE.ComponentRef inCref;
+  input BackendDAE.Variables inVariables;
+  output list<BackendDAE.Var> outVarList;
+  output list<Integer> outIntList;
+protected
+  list<BackendDAE.Var> varList;
+  list<Integer> intList;
+algorithm
+  (outVarList, outIntList) := getVar(inCref, inVariables);
+  try
+    (varList, intList) := BackendVariable.getVar(ComponentReference.crefPrefixStart(inCref), inVariables);
+    outVarList := listAppend(varList, outVarList);
+    outIntList := listAppend(intList, outIntList);
+  else
+  end try;
+end getVarAndAttributes;
+
 public function getVar
 "author: PA
   Return a variable(s) and its index(es) in the vector.

--- a/Compiler/FrontEnd/ComponentReference.mo
+++ b/Compiler/FrontEnd/ComponentReference.mo
@@ -2086,6 +2086,30 @@ algorithm
   outCref := makeCrefQual(DAE.startNamePrefix, DAE.T_UNKNOWN_DEFAULT, {}, inCref);
 end crefPrefixStart;
 
+public function crefPrefixMin
+  "Appends $MIN to a cref, so a => $MIN.a"
+  input DAE.ComponentRef inCref;
+  output DAE.ComponentRef outCref;
+algorithm
+  outCref := makeCrefQual(DAE.minNamePrefix, DAE.T_UNKNOWN_DEFAULT, {}, inCref);
+end crefPrefixMin;
+
+public function crefPrefixMax
+  "Appends $MAX to a cref, so a => $MAX.a"
+  input DAE.ComponentRef inCref;
+  output DAE.ComponentRef outCref;
+algorithm
+  outCref := makeCrefQual(DAE.maxNamePrefix, DAE.T_UNKNOWN_DEFAULT, {}, inCref);
+end crefPrefixMax;
+
+public function crefPrefixNominal
+  "Appends $NOMINAL to a cref, so a => $NOMINAL.a"
+  input DAE.ComponentRef inCref;
+  output DAE.ComponentRef outCref;
+algorithm
+  outCref := makeCrefQual(DAE.nominalNamePrefix, DAE.T_UNKNOWN_DEFAULT, {}, inCref);
+end crefPrefixNominal;
+
 public function crefPrefixString
   "Prefixes a cref with a string identifier, e.g.:
     crefPrefixString(a, b.c) => a.b.c"

--- a/Compiler/FrontEnd/DAE.mo
+++ b/Compiler/FrontEnd/DAE.mo
@@ -64,6 +64,9 @@ public constant String derivativeNamePrefix = "$DER";
 public constant String preNamePrefix = "$PRE";
 public constant String previousNamePrefix = "$CLKPRE";
 public constant String startNamePrefix = "$START";
+public constant String minNamePrefix = "$MIN";
+public constant String maxNamePrefix = "$MAX";
+public constant String nominalNamePrefix = "$NOMINAL";
 
 
 public uniontype VarKind


### PR DESCRIPTION
This is about fixing initialization of attributes that depend on secondary parameters. Start attributes were already fixed with #1573.

---

**TODO**

- [ ] Fix min attributes
- [ ] Fix max attributes
- [ ] Fix nominal attributes
- [ ] Testing