### PR TITLE
Remove $_old(.)

### DIFF
--- a/Compiler/BackEnd/CommonSubExpression.mo
+++ b/Compiler/BackEnd/CommonSubExpression.mo
@@ -871,7 +871,6 @@ algorithm
     local
       Absyn.Path path;
     case DAE.ASUB() then true;
-    case DAE.CALL(path=Absyn.IDENT("$_old")) then true;
     case DAE.CALL(path=Absyn.IDENT("$_round")) then true;
     case DAE.CALL(path=Absyn.IDENT("$getPart")) then true;
     case DAE.CALL(path=Absyn.IDENT("abs")) then true;

--- a/Compiler/BackEnd/ExpressionSolve.mo
+++ b/Compiler/BackEnd/ExpressionSolve.mo
@@ -1070,7 +1070,7 @@ protected function unifyFunCallsWork
      equation
       tp = Expression.typeof(e1);
       e2 = Expression.crefExp(ComponentReference.makeCrefIdent(BackendDAE.symSolverDT, DAE.T_REAL_DEFAULT, {}));
-      e3 = Expression.makePureBuiltinCall("$_old", {e1}, tp);
+      e3 = Expression.makePureBuiltinCall("pre", {e1}, tp);
       e3 = Expression.expSub(e1,e3);
       e = Expression.expDiv(e3,e2);
      then (e,true, iT);
@@ -1482,7 +1482,7 @@ algorithm
     false = expHasCref(inExp2, inExp3);
     tp = Expression.typeof(e1);
     e2 = Expression.crefExp(ComponentReference.makeCrefIdent(BackendDAE.symSolverDT, DAE.T_REAL_DEFAULT, {}));
-    lhs = Expression.makePureBuiltinCall("$_old", {e1}, tp);
+    lhs = Expression.makePureBuiltinCall("pre", {e1}, tp);
     lhs = Expression.expAdd(Expression.expMul(inExp2,e2), lhs);
   then(e1, lhs, true, ieqnForNewVars, inewVarsCrefs, idepth + 1);
 

--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -6638,8 +6638,6 @@ algorithm
       then (inExp,false,inTpl);
     case (DAE.CALL(path = Absyn.IDENT(name = "$_round")), _)
       then (inExp,false,inTpl);
-    case (DAE.CALL(path = Absyn.IDENT(name = "$_old")), _)
-      then (inExp,false,inTpl);
 
     case (DAE.CREF(componentRef = cr1), (cr,false))
       equation

--- a/Compiler/Template/CodegenCFunctions.tpl
+++ b/Compiler/Template/CodegenCFunctions.tpl
@@ -5548,8 +5548,6 @@ template daeExpCall(Exp call, Context context, Text &preExp, Text &varDecls, Tex
     '(data->simulationInfo->clocksData[clockIndex].cnt == 0)'
   case CALL(path=IDENT(name="$_clkfire"), expLst={arg as ICONST(__)}) then
     'fireClock(data, threadData, <%intSub(arg.integer,1)%>, data->localData[0]->timeValue)'
-  case CALL(path=IDENT(name="$_old"), expLst={arg as CREF(__)}) then
-    crefOld(arg.componentRef,1)
   // if arg >= 0 then 1 else -1
   case CALL(path=IDENT(name="$_signNoNull"), expLst={e1}) then
     let var1 = daeExp(e1, context, &preExp, &varDecls, &auxFunction)


### PR DESCRIPTION
`$_old(.)` is not handled in the back end properly and may introduce loops. It seems that it is also not necessary, and pre values can be used instead.