### PR TITLE
compareSimulationResults is deprecated

### DIFF
--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -2034,6 +2034,7 @@ algorithm
 
     case (cache,_,"compareSimulationResults",{Values.STRING(filename),Values.STRING(filename_1),Values.STRING(filename2),Values.REAL(x1),Values.REAL(x2),Values.ARRAY(valueLst=cvars)},st,_)
       equation
+        Error.addMessage(Error.DEPRECATED_API_CALL, {"compareSimulationResults", "diffSimulationResults"});
         filename = Util.absoluteOrRelative(filename);
         filename_1 = Util.testsuiteFriendlyPath(filename_1);
         filename_1 = Util.absoluteOrRelative(filename_1);

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -1008,6 +1008,8 @@ public constant Message TEMPLATE_ERROR_FUNC = MESSAGE(7014, TRANSLATION(), ERROR
   Util.gettext("Template error: A template call failed (a call with %s parameters: %s). One possible reason could be that a template imported function call failed (which should not happen for functions called from within template code; templates preserve pure 'match'/non-failing semantics)."));
 public constant Message FMU_EXPORT_NOT_SUPPORTED_CPP = MESSAGE(7015, SCRIPTING(), WARNING(),
   Util.gettext("Export of FMU type %s is not supported with Cpp target. FMU will be for Model Exchange (me)."));
+public constant Message DEPRECATED_API_CALL = MESSAGE(7016, SCRIPTING(), WARNING(),
+  Util.gettext("'%1' is deprecated. It is recommended to use '%2' instead."));
 
 protected import ErrorExt;
 


### PR DESCRIPTION
This introduces a warning to avoid inadvertently usage of compareSimulationResults.