### PR TITLE
Use ExpandableArray for BackendDAE.EquationArray

### DIFF
--- a/Compiler/BackEnd/BackendDAE.mo
+++ b/Compiler/BackEnd/BackendDAE.mo
@@ -38,6 +38,7 @@ encapsulated package BackendDAE
 import Absyn;
 import DAE;
 import DoubleEndedList;
+import ExpandableArray;
 import FCore;
 import HashTable3;
 import HashTableCG;
@@ -211,13 +212,7 @@ uniontype VariableArray "array of Equations are expandable, to amortize the cost
 end VariableArray;
 
 public
-uniontype EquationArray
-  record EQUATION_ARRAY
-    Integer size "size of the Equations in scalar form";
-    Integer numberOfElement "no. elements";
-    array<Option<Equation>> equOptArr;
-  end EQUATION_ARRAY;
-end EquationArray;
+type EquationArray = ExpandableArray<Equation>;
 
 public
 uniontype Var "variables"
@@ -381,6 +376,8 @@ uniontype Equation
     EquationAttributes attr;
   end FOR_EQUATION;
 
+  record DUMMY_EQUATION
+  end DUMMY_EQUATION;
 end Equation;
 
 public

--- a/Compiler/BackEnd/BackendDAECreate.mo
+++ b/Compiler/BackEnd/BackendDAECreate.mo
@@ -169,7 +169,7 @@ algorithm
                                                     ));
   BackendDAEUtil.checkBackendDAEWithErrorMsg(outBackendDAE);
   varSize := BackendVariable.varsSize(vars_1);
-  eqnSize := BackendDAEUtil.equationSize(eqnarr);
+  eqnSize := BackendEquation.equationArraySize(eqnarr);
   neqStr := intString(eqnSize);
   nvarStr := intString(varSize);
 

--- a/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -67,6 +67,7 @@ import DAEDump;
 import Debug;
 import Differentiate;
 import ElementSource;
+import ExpandableArray;
 import Expression;
 import ExpressionDump;
 import ExpressionSolve;
@@ -4113,7 +4114,6 @@ protected
   Integer ne,nv;
   array<Integer> w_vars, w_eqns;
   DAE.FunctionTree functionTree;
-  array<Option<BackendDAE.Equation>> equOptArr;
   list<tuple<Integer,Integer>> tplIndexWeight;
   list<Integer> indexs;
   list<BackendDAE.Var> var_lst;
@@ -4136,7 +4136,7 @@ algorithm
           end if;
 
           BackendDAE.VARIABLES(varArr = BackendDAE.VARIABLE_ARRAY(numberOfElements = nv)) := vars;
-          BackendDAE.EQUATION_ARRAY(equOptArr = equOptArr, numberOfElement = ne) := eqns;
+          ne := ExpandableArray.getNumberOfElements(eqns);
           //init weights
           w_vars := arrayCreate(nv, -1);
           w_eqns := arrayCreate(ne, -1);
@@ -4254,7 +4254,7 @@ algorithm
 
   for syst in inDAE.eqs loop
     BackendDAE.EQSYSTEM(orderedVars=vars,orderedEqs=eqns) := syst;
-    BackendDAE.EQUATION_ARRAY(numberOfElement = n) := eqns;
+    n := ExpandableArray.getNumberOfElements(eqns);
     update := false;
     indRemove := {};
 
@@ -4634,7 +4634,6 @@ protected
   Inline.Functiontuple fns = (SOME(functionTree),{DAE.NORM_INLINE(),DAE.AFTER_INDEX_RED_INLINE(), DAE.DEFAULT_INLINE()});
   Boolean inlined;
   BackendDAE.Equation eq, eqNew;
-  Option<BackendDAE.Equation> eqn;
   BackendDAE.EqSystem tmpEqs, tmpEqs1;
   list<Integer> idEqns;
   Boolean inlined1;
@@ -4644,7 +4643,6 @@ algorithm
   inlined1 := false;
   tmpEqs1 := BackendDAEUtil.createEqSystem( BackendVariable.listVar({}), BackendEquation.listEquation({}));
   BackendDAE.EQSYSTEM(orderedVars=vars,orderedEqs=eqns,matching=matching as BackendDAE.MATCHING(comps=comps),stateSets=stateSets,partitionKind=partitionKind) := syst;
-  //BackendDAE.EQUATION_ARRAY(equOptArr=equOptArr) := eqns;
   for comp in comps
   loop
       if BackendEquation.isEquationsSystem(comp) or BackendEquation.isTornSystem(comp)  or
@@ -4659,8 +4657,7 @@ algorithm
            eq := BackendEquation.equationNth1(eqns, id);
            //eqn := BackendInline.inlineEqOpt(SOME(eq), fns);
            //eqns := BackendEquation.setAtIndexFirst(id, eq, eqns);
-           (eqn, tmpEqs, inlined, shared) := BackendInline.inlineEqOptAppend(SOME(eq), fns, shared);
-           SOME(eqNew) := eqn;
+           (eqNew, tmpEqs, inlined, shared) := BackendInline.inlineEqAppend_debug(eq, fns, shared);
            if inlined or not BackendEquation.equationEqual(eq, eqNew)
            then
              tmpEqs1 := BackendDAEUtil.mergeEqSystems(tmpEqs, tmpEqs1);
@@ -4737,7 +4734,7 @@ algorithm
     compOrders := {};
     ii := 1;
     BackendDAE.EQSYSTEM(orderedVars=vars,orderedEqs=eqns,matching=matching as BackendDAE.MATCHING(comps=comps),stateSets=stateSets,partitionKind=partitionKind) := syst;
-    BackendDAE.EQUATION_ARRAY(numberOfElement=ne) := eqns;
+    ne := ExpandableArray.getNumberOfElements(eqns);
     BackendDAE.VARIABLES(numberOfVars= nv) := vars;
 
     for comp in comps loop
@@ -5131,7 +5128,7 @@ algorithm
     outIndx := outIndx + 1;
     outUpdate := update;
     if not para then
-      BackendDAE.EQUATION_ARRAY(numberOfElement=ne) := inEqns;
+      ne := ExpandableArray.getNumberOfElements(inEqns);
       BackendDAE.VARIABLES(numberOfVars= nv) := inVars;
       ass1 := ne :: ass1;
       ass2 := nv :: ass2;

--- a/Compiler/BackEnd/BackendDAETransform.mo
+++ b/Compiler/BackEnd/BackendDAETransform.mo
@@ -94,7 +94,7 @@ algorithm
     case syst as BackendDAE.EQSYSTEM(mT=SOME(mt), matching=BackendDAE.MATCHING(ass1=ass1, ass2=ass2)) algorithm
       comps_m := Sorting.TarjanTransposed(mt, ass2);
 
-      markarray := arrayCreate(BackendDAEUtil.equationArraySize(inSystem.orderedEqs), -1);
+      markarray := arrayCreate(BackendEquation.getNumberOfEquations(inSystem.orderedEqs), -1);
       comps := analyseStrongComponentsScalar(comps_m, inSystem, inShared, ass1, ass2, mapEqnIncRow, mapIncRowEqn, 1, markarray);
       GC.free(markarray);
       ass1 := varAssignmentNonScalar(ass1, mapIncRowEqn);

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -670,7 +670,7 @@ public function dumpEquationArray "function dumpEquationArray"
   input BackendDAE.EquationArray inEqns;
   input String heading;
 algorithm
-  print("\n" + heading + " (" + intString(listLength(BackendEquation.equationList(inEqns))) + ", " + intString(BackendDAEUtil.equationSize(inEqns)) + ")\n" + UNDERLINE + "\n");
+  print("\n" + heading + " (" + intString(listLength(BackendEquation.equationList(inEqns))) + ", " + intString(BackendEquation.equationArraySize(inEqns)) + ")\n" + UNDERLINE + "\n");
   printEquationArray(inEqns);
   print("\n");
 end dumpEquationArray;
@@ -3988,7 +3988,7 @@ protected
   GraphML.GraphInfo graphInfo;
   Integer graphIdx;
 algorithm
-  numEqs := BackendDAEUtil.equationArraySize(eqsIn);
+  numEqs := BackendEquation.getNumberOfEquations(eqsIn);
   numVars := BackendVariable.varsSize(varsIn);
   varRange := List.intRange(numVars);
   eqRange := List.intRange(numEqs);

--- a/Compiler/BackEnd/CommonSubExpression.mo
+++ b/Compiler/BackEnd/CommonSubExpression.mo
@@ -187,7 +187,7 @@ algorithm
       end if;
 
       // Phase 3: Substitution
-      orderedEqs_new := BackendEquation.emptyEqnsSized(orderedEqs.numberOfElement + ExpandableArray.getNumberOfElements(exarray));
+      orderedEqs_new := BackendEquation.emptyEqnsSized(ExpandableArray.getNumberOfElements(orderedEqs) + ExpandableArray.getNumberOfElements(exarray));
       (HT, exarray, orderedEqs_new) := BackendEquation.traverseEquationArray(orderedEqs, wrapFunctionCalls_substitution, (HT, exarray, orderedEqs_new));
 
       if Flags.isSet(Flags.DUMP_CSE_VERBOSE) then

--- a/Compiler/BackEnd/DumpGraphML.mo
+++ b/Compiler/BackEnd/DumpGraphML.mo
@@ -86,8 +86,8 @@ algorithm
         graphInfo = GraphML.createGraphInfo();
         (graphInfo,(_,graph)) = GraphML.addGraph("G",false,graphInfo);
         ((_,_,(graphInfo,graph))) = BackendVariable.traverseBackendDAEVars(vars,addVarGraph,(numberMode,1,(graphInfo,graph)));
-        neqns = BackendDAEUtil.equationArraySize(eqns);
-        //neqns = BackendDAEUtil.equationSize(eqns);
+        neqns = BackendEquation.getNumberOfEquations(eqns);
+        //neqns = BackendEquation.equationArraySize(eqns);
         eqnsids = List.intRange(neqns);
         ((graphInfo,graph)) = List.fold3(eqnsids,addEqnGraph,eqns,mapIncRowEqn,numberMode,(graphInfo,graph));
         ((_,_,graphInfo)) = List.fold(eqnsids,addEdgesGraph,(1,m,graphInfo));
@@ -101,8 +101,8 @@ algorithm
         graphInfo = GraphML.createGraphInfo();
         (graphInfo,(_,graph)) = GraphML.addGraph("G",false,graphInfo);
         ((_,_,(graphInfo,graph))) = BackendVariable.traverseBackendDAEVars(vars,addVarGraph,(numberMode,1,(graphInfo,graph)));
-        neqns = BackendDAEUtil.equationArraySize(eqns);
-        //neqns = BackendDAEUtil.equationSize(eqns);
+        neqns = BackendEquation.getNumberOfEquations(eqns);
+        //neqns = BackendEquation.equationArraySize(eqns);
         eqnsids = List.intRange(neqns);
         mapIncRowEqn = Array.createIntRange(arrayLength(m));
         ((graphInfo,graph)) = List.fold3(eqnsids,addEqnGraph,eqns,mapIncRowEqn,numberMode,(graphInfo,graph));
@@ -122,8 +122,8 @@ algorithm
         graphInfo = GraphML.createGraphInfo();
         (graphInfo,(_,graph)) = GraphML.addGraph("G",false,graphInfo);
         ((_,_,_,(graphInfo,graph))) = BackendVariable.traverseBackendDAEVars(vars,addVarGraphMatch,(numberMode,1,vec1,(graphInfo,graph)));
-        //neqns = BackendDAEUtil.equationArraySize(eqns);
-        neqns = BackendDAEUtil.equationSize(eqns);
+        //neqns = BackendEquation.getNumberOfEquations(eqns);
+        neqns = BackendEquation.equationArraySize(eqns);
         eqnsids = List.intRange(neqns);
         eqnsflag = arrayCreate(neqns,false);
         ((graphInfo,graph)) = List.fold3(eqnsids,addEqnGraphMatch,eqns,(vec2,mapIncRowEqn,eqnsflag),numberMode,(graphInfo,graph));
@@ -141,7 +141,7 @@ algorithm
         graphInfo = GraphML.createGraphInfo();
         (graphInfo,(_,graph)) = GraphML.addGraph("G",false,graphInfo);
         ((_,_,(graphInfo,graph))) = BackendVariable.traverseBackendDAEVars(vars,addVarGraph,(numberMode,1,(graphInfo,graph)));
-        neqns = BackendDAEUtil.equationSize(eqns);
+        neqns = BackendEquation.equationArraySize(eqns);
         eqnsids = List.intRange(neqns);
         ((graphInfo,graph)) = List.fold3(eqnsids,addEqnGraph,eqns,mapIncRowEqn,numberMode,(graphInfo,graph));
         ((_,_,_,_,graphInfo)) = List.fold(eqnsids,addDirectedNumEdgesGraph,(1,m,vec2,vec3,graphInfo));

--- a/Compiler/BackEnd/DumpHTML.mo
+++ b/Compiler/BackEnd/DumpHTML.mo
@@ -413,7 +413,7 @@ algorithm
   tags := addHeadingTag(2, varlen_str, {});
   tags := printVarList(vars, prefixId, tags);
   eqnsl := BackendEquation.equationList(eqns);
-  eqnlen_str := "Equations (" + intString(listLength(eqnsl)) + ", " + intString(BackendDAEUtil.equationSize(eqns)) + ")";
+  eqnlen_str := "Equations (" + intString(listLength(eqnsl)) + ", " + intString(BackendEquation.equationArraySize(eqns)) + ")";
   tags := addHeadingTag(2, eqnlen_str, tags);
   tags := dumpEqns(eqnsl, prefixId, tags);
   //dumpOption(m, dumpIncidenceMatrix);

--- a/Compiler/BackEnd/HpcOmMemory.mo
+++ b/Compiler/BackEnd/HpcOmMemory.mo
@@ -49,6 +49,7 @@ import BaseHashTable;
 import ComponentReference;
 import Config;
 import Error;
+import ExpandableArray;
 import Expression;
 import Flags;
 import GraphML;
@@ -2454,12 +2455,10 @@ import Util;
     output array<list<Integer>> oMapping; //eqIdx -> list<scVarIdx>
   protected
     BackendDAE.EquationArray orderedEqs;
-    array<Option<BackendDAE.Equation>> equOptArr;
     list<Option<BackendDAE.Equation>> equOptList;
   algorithm
     BackendDAE.EQSYSTEM(orderedEqs=orderedEqs) := iEqSystem;
-    BackendDAE.EQUATION_ARRAY(equOptArr=equOptArr) := orderedEqs;
-    equOptList := arrayList(equOptArr);
+    equOptList := arrayList(ExpandableArray.getData(orderedEqs));
     oMapping := listArray(List.map1Option(equOptList, getEqSCVarMapping0, iHt));
   end getEqSCVarMappingByEqSystem;
 

--- a/Compiler/BackEnd/HpcOmTaskGraph.mo
+++ b/Compiler/BackEnd/HpcOmTaskGraph.mo
@@ -48,6 +48,7 @@ protected import BackendVariable;
 protected import ComponentReference;
 protected import DAEDump;
 protected import Error;
+protected import ExpandableArray;
 protected import Expression;
 protected import Flags;
 protected import HpcOmBenchmark;
@@ -140,7 +141,7 @@ public function createTaskGraph0 "author: marcusw, waurich
 protected
   BackendDAE.StrongComponents comps;
   BackendDAE.Variables vars;
-  Integer numberOfEqs;
+  BackendDAE.EquationArray orderedEqs;
   DAE.FunctionTree sharedFuncs;
   TaskGraphMeta iGraphData;
   TaskGraphMeta tmpGraphData;
@@ -156,7 +157,7 @@ protected
   array<String> compNames;
   array<String> compDescs;
   list<Integer> eventEqLst, eventVarLst, rootVars;
-  Integer numberOfVars, numberOfEqs;
+  Integer numberOfVars;
   array<ComponentInfo> compInformations;
 
   Integer eqSysIdx;
@@ -166,14 +167,14 @@ protected
   BackendDAE.Matching matching;
   BackendDAE.IncidenceMatrix incidenceMatrix;
 algorithm
-  BackendDAE.EQSYSTEM(matching=matching, orderedVars=vars, orderedEqs=BackendDAE.EQUATION_ARRAY(numberOfElement=numberOfEqs)) := iSyst;
+  BackendDAE.EQSYSTEM(matching=matching, orderedVars=vars, orderedEqs=orderedEqs) := iSyst;
   comps := BackendDAEUtil.getCompsOfMatching(matching);
   BackendDAE.SHARED(functionTree=sharedFuncs) := iShared;
   (iGraph,iGraphData,eqSysIdx) := iGraphInfo;
 
   (_,incidenceMatrix,_) := BackendDAEUtil.getIncidenceMatrix(iSyst, BackendDAE.NORMAL(), SOME(sharedFuncs));
   numberOfVars := BackendVariable.varsSize(vars);
-  (tmpGraph,tmpGraphData) := getEmptyTaskGraph(listLength(comps), numberOfVars, numberOfEqs);
+  (tmpGraph,tmpGraphData) := getEmptyTaskGraph(listLength(comps), numberOfVars, ExpandableArray.getNumberOfElements(orderedEqs));
   TASKGRAPHMETA(inComps=inComps, compNames=compNames, exeCosts=exeCosts, commCosts=commCosts, nodeMark=nodeMark, varCompMapping=varCompMapping, eqCompMapping=eqCompMapping, compParamMapping=compParamMapping, compInformations=compInformations) := tmpGraphData;
   //print("createTaskGraph0 try to get varCompMapping\n");
   (varCompMapping,eqCompMapping) := getVarEqCompMapping(comps, eqSysIdx, 0, 0, varCompMapping, eqCompMapping);
@@ -798,16 +799,16 @@ protected function getEventNodeEqs "author: Waurich TUD 2013-06
 protected
   BackendDAE.StrongComponents comps;
   BackendDAE.Matching matching;
+  BackendDAE.EquationArray orderedEqs;
   list<Integer> eventEqs;
   list<Integer> eventEqsIn;
-  Integer numOfEqs;
   Integer offset;
 algorithm
-  BackendDAE.EQSYSTEM(orderedEqs = BackendDAE.EQUATION_ARRAY(numberOfElement=numOfEqs),matching=matching) := systIn;
+  BackendDAE.EQSYSTEM(orderedEqs=orderedEqs,matching=matching) := systIn;
   comps := BackendDAEUtil.getCompsOfMatching(matching);
   (eventEqsIn,offset) := eventInfoIn;
   eventEqs := getEventNodeEqs1(comps,offset,{});
-  offset := offset+numOfEqs;
+  offset := offset+ExpandableArray.getNumberOfElements(orderedEqs);
   eventEqs := listAppend(eventEqs,eventEqsIn);
   eventInfoOut := (eventEqs,offset);
 end getEventNodeEqs;
@@ -2550,16 +2551,17 @@ protected
   BackendDAE.StrongComponents comps;
   BackendDAE.Variables orderedVars;
   BackendDAE.Matching matching;
+  BackendDAE.EquationArray orderedEqs;
   list<Integer> eventEqs;
   list<Integer> eventEqsIn;
   Integer numOfEqs;
   Integer offset;
 algorithm
-  BackendDAE.EQSYSTEM(orderedEqs = BackendDAE.EQUATION_ARRAY(numberOfElement=numOfEqs),orderedVars=orderedVars,matching=matching) := systIn;
+  BackendDAE.EQSYSTEM(orderedEqs=orderedEqs,orderedVars=orderedVars,matching=matching) := systIn;
   comps := BackendDAEUtil.getCompsOfMatching(matching);
   (eventEqsIn,offset) := eventInfoIn;
   eventEqs := getDiscreteNodesEqs1(comps,offset,orderedVars,{});
-  offset := offset+numOfEqs;
+  offset := offset+ExpandableArray.getNumberOfElements(orderedEqs);
   eventEqs := listAppend(eventEqs,eventEqsIn);
   eventInfoOut := (eventEqs,offset);
 end getDiscreteNodesEqs;

--- a/Compiler/BackEnd/IndexReduction.mo
+++ b/Compiler/BackEnd/IndexReduction.mo
@@ -616,9 +616,9 @@ algorithm
     // all equations are differentiated
     syst := inSystem;
     BackendDAE.EQSYSTEM(orderedVars=v, orderedEqs=eqns, m=SOME(m), mT=SOME(mt)) := syst;
-    numEqs := BackendDAEUtil.equationArraySize(eqns);
+    numEqs := BackendEquation.getNumberOfEquations(eqns);
     (v1,eqns_1,changedVars,outOrgEqnsLst) := replaceDifferentiatedEqns(inEqnsTpl,v,eqns,mt,imapIncRowEqn,{},inOrgEqnsLst);
-    numEqs1 := BackendDAEUtil.equationArraySize(eqns_1);
+    numEqs1 := BackendEquation.getNumberOfEquations(eqns_1);
     eqnslst := if intGt(numEqs1,numEqs) then List.intRange2(numEqs+1,numEqs1) else {};
     // set the assignments for the changed vars and for the assigned equations to -1
     assEqs := List.map1r(changedVars,arrayGet,inAss1);
@@ -1226,7 +1226,7 @@ algorithm
   if Flags.isSet(Flags.BLT_DUMP) then
     BackendDump.dumpStateOrder(so);
   end if;
-  outArg := (so,arrayCreate(BackendDAEUtil.equationArraySize(eqns),{}),mapEqnIncRow,mapIncRowEqn,BackendDAEUtil.equationArraySize(eqns));
+  outArg := (so,arrayCreate(BackendEquation.getNumberOfEquations(eqns),{}),mapEqnIncRow,mapIncRowEqn,BackendEquation.getNumberOfEquations(eqns));
 end getStructurallySingularSystemHandlerArg;
 
 // =============================================================================
@@ -2028,8 +2028,8 @@ algorithm
         end if;
         // generate incidence matrix from system and equations of that level and the states of that level
         nv = BackendVariable.varsSize(vars);
-        ne = BackendDAEUtil.equationSize(eqns);
-        neqnarr = BackendDAEUtil.equationArraySize(eqns);
+        ne = BackendEquation.equationArraySize(eqns);
+        neqnarr = BackendEquation.getNumberOfEquations(eqns);
         ne1 = ne + neqns;
         indexmap = arrayCreate(nfreeStates  + nv,-1);
         invindexmap = arrayCreate(nfreeStates,-1);
@@ -2082,7 +2082,7 @@ algorithm
         // get indicenceMatrix from Enhanced
         m = incidenceMatrixfromEnhanced2(me,vars);
         nv = BackendVariable.varsSize(vars);
-        ne = BackendDAEUtil.equationSize(eqns);
+        ne = BackendEquation.equationArraySize(eqns);
         mT = BackendDAEUtil.transposeMatrix(m,nv);
         // match the variables not the equations, to have prevered states unmatched
         Matching.matchingExternalsetIncidenceMatrix(ne,nv,mT);
@@ -2542,7 +2542,7 @@ algorithm
         nassigned := nassigned+1;
         range := List.intRange2(nassigned,nunassigned);
         nv := BackendVariable.varsSize(vars);
-        ne := BackendDAEUtil.equationSize(eqns);
+        ne := BackendEquation.equationArraySize(eqns);
         (varlst,oStateSets) := selectDummyDerivatives2new(dstates1,states1,range,assigend1,vars,nv,eqns,ne,mapIncRowEqn1,level,oStateSets);
         dummyStates := List.map(varlst,BackendVariable.varCref);
         outDummyStates := listAppend(outDummyStates,dummyStates);
@@ -3862,7 +3862,7 @@ algorithm
   m := incidenceMatrixfromEnhanced2(me, vars);
   // match the equations, umatched are constrained equations
   nv := BackendVariable.varsSize(vars);
-  ne := BackendDAEUtil.equationSize(eqns);
+  ne := BackendEquation.equationArraySize(eqns);
   vec1 := arrayCreate(nv,-1);
   vec2 := arrayCreate(ne,-1);
   Matching.matchingExternalsetIncidenceMatrix(nv,ne,m);

--- a/Compiler/BackEnd/Initialization.mo
+++ b/Compiler/BackEnd/Initialization.mo
@@ -1274,7 +1274,7 @@ algorithm
 
     // nVars = nEqns
     nVars := BackendVariable.varsSize(inEqSystem.orderedVars);
-    nEqns := BackendDAEUtil.equationSize(inEqSystem.orderedEqs);
+    nEqns := BackendEquation.equationArraySize(inEqSystem.orderedEqs);
     syst := BackendDAEUtil.createEqSystem(inEqSystem.orderedVars, inEqSystem.orderedEqs);
     funcs := BackendDAEUtil.getFunctions(inShared);
     (m_, _, _, mapIncRowEqn) := BackendDAEUtil.incidenceMatrixScalar(syst, BackendDAE.SOLVABLE(), SOME(funcs));
@@ -1509,7 +1509,7 @@ algorithm
 
     case currRedundantEqn::restRedundantEqns equation
       _ = BackendVariable.varsSize(inVars);
-      _ = BackendDAEUtil.equationSize(inEqns);
+      _ = BackendEquation.equationArraySize(inEqns);
     //BackendDump.dumpMatchingVars(vecVarToEqs);
     //BackendDump.dumpMatchingEqns(vecEqsToVar);
     //BackendDump.dumpVariables(inVars, "inVars");
@@ -1816,7 +1816,7 @@ algorithm
 
     case _ equation
       nVars = BackendVariable.varsSize(vars);
-      nEqns = BackendDAEUtil.equationSize(inEqnsOrig);
+      nEqns = BackendEquation.equationArraySize(inEqnsOrig);
       true = intLe(counter, nEqns-nVars);
       eqn = BackendEquation.equationNth1(inEqns, inUnassignedEqn);
       BackendDAE.EQUATION(exp=lhs, scalar=rhs) = eqn;
@@ -1831,7 +1831,7 @@ algorithm
 
     case _ equation
       nVars = BackendVariable.varsSize(vars);
-      nEqns = BackendDAEUtil.equationSize(inEqnsOrig);
+      nEqns = BackendEquation.equationArraySize(inEqnsOrig);
       true = intGt(counter, nEqns-nVars);
 
       Error.addCompilerError("Initialization problem is structural singular. Please, check the initial conditions.");
@@ -1839,7 +1839,7 @@ algorithm
 
     case _ equation
       nVars = BackendVariable.varsSize(vars);
-      nEqns = BackendDAEUtil.equationSize(inEqnsOrig);
+      nEqns = BackendEquation.equationArraySize(inEqnsOrig);
       true = intLe(counter, nEqns-nVars);
 
       eqn = BackendEquation.equationNth1(inEqns, inUnassignedEqn);
@@ -1857,7 +1857,7 @@ algorithm
 
     case _ equation
       nVars = BackendVariable.varsSize(vars);
-      nEqns = BackendDAEUtil.equationSize(inEqnsOrig);
+      nEqns = BackendEquation.equationArraySize(inEqnsOrig);
       true = intLe(counter, nEqns-nVars);
       eqn = BackendEquation.equationNth1(inEqns, inUnassignedEqn);
       BackendDAE.EQUATION(exp=lhs, scalar=rhs) = eqn;
@@ -1884,7 +1884,7 @@ algorithm
     case _ equation
       //true = listEmpty(inM[inUnassignedEqn]);
       nVars = BackendVariable.varsSize(vars);
-      nEqns = BackendDAEUtil.equationSize(inEqnsOrig);
+      nEqns = BackendEquation.equationArraySize(inEqnsOrig);
       true = intLe(counter, nEqns-nVars);
       eqn = BackendEquation.equationNth1(inEqns, inUnassignedEqn);
       BackendDAE.EQUATION(exp=lhs, scalar=rhs) = eqn;

--- a/Compiler/BackEnd/Matching.mo
+++ b/Compiler/BackEnd/Matching.mo
@@ -424,7 +424,7 @@ algorithm
          u1=u2 is kept. This is not the case for the original pantilides algorithm, where
          the original equation is removed from the system.";
         eqns = BackendEquation.getEqnsFromEqSystem(syst);
-        nf_1 = BackendDAEUtil.equationSize(eqns) "and try again, restarting. This could be optimized later. It should not
+        nf_1 = BackendEquation.equationArraySize(eqns) "and try again, restarting. This could be optimized later. It should not
                                    be necessary to restart the matching, according to Bernard Bachmann. Instead one
                                    could continue the matching as usual. This was tested (2004-11-22) and it does not
                                    work to continue without restarting.

--- a/Compiler/BackEnd/OpenTURNS.mo
+++ b/Compiler/BackEnd/OpenTURNS.mo
@@ -508,7 +508,7 @@ protected
   BackendDAE.Variables vars;
 algorithm
   BackendDAE.EQSYSTEM(orderedVars = vars, orderedEqs=eqns) := eqs;
-  notZero := BackendVariable.varsSize(vars) > 0 and BackendDAEUtil.equationArraySize(eqns) > 0;
+  notZero := BackendVariable.varsSize(vars) > 0 and BackendEquation.getNumberOfEquations(eqns) > 0;
 end eqnSystemNotZero;
 
 protected function stripCorrelationVarsAndEqns " help function "

--- a/Compiler/BackEnd/SymbolicImplicitSolver.mo
+++ b/Compiler/BackEnd/SymbolicImplicitSolver.mo
@@ -172,11 +172,9 @@ protected function symSolverUpdateSyst
   output BackendDAE.Variables oKnVars = inKnVars;
 protected
   array<Option<BackendDAE.Equation>> equOptArr;
-  Option<BackendDAE.Equation> oeqn;
   BackendDAE.Equation eqn;
   BackendDAE.Variables vars;
   BackendDAE.EquationArray eqns;
-  Integer n;
   list<DAE.ComponentRef> crlst;
 algorithm
   oSyst := match iSyst
@@ -184,17 +182,14 @@ algorithm
       BackendDAE.EqSystem syst;
     case syst as BackendDAE.EQSYSTEM(orderedVars=vars, orderedEqs=eqns)
       algorithm
-        BackendDAE.EQUATION_ARRAY(equOptArr=equOptArr) := eqns;
-        n := arrayLength(equOptArr);
         crlst := {};
         // for every equation in the input equation system
-        for i in 1:n loop
-          oeqn := arrayGet(equOptArr, i);
-          if isSome(oeqn) then
-            SOME(eqn) := oeqn;
+        for i in 1:ExpandableArray.getLastUsedIndex(eqns) loop
+          if ExpandableArray.occupied(i, eqns) then
+            eqn := ExpandableArray.get(i, eqns);
             // traverse all expression of the equation and replace der(x)
             (eqn, (crlst, _)) := BackendEquation.traverseExpsOfEquation(eqn, symSolverUpdateEqn, (crlst, syst.orderedVars));
-            arrayUpdate(equOptArr, i, SOME(eqn));
+            ExpandableArray.update(i, eqn, eqns);
           end if;
         end for;
         // change state variables to algebraic variables since der(x) is replaced by the difference quotient

--- a/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/Compiler/BackEnd/SynchronousFeatures.mo
@@ -229,7 +229,7 @@ algorithm
             solverMethod := "ImplicitEuler";
           end if;
           // replace der(x) with $DER.x and collect derVars x
-          for i in 1:BackendDAEUtil.equationArraySize(eqs) loop
+          for i in 1:BackendEquation.getNumberOfEquations(eqs) loop
             eq := BackendEquation.equationNth1(eqs, i);
             (eq, derVars) := BackendEquation.traverseExpsOfEquation(eq, getDerVars1, derVars);
             lstEqs := eq :: lstEqs;
@@ -264,7 +264,7 @@ algorithm
           syst.orderedEqs := BackendEquation.listEquation(listReverse(lstEqs));
           if solverMethod == "SemiImplicitEuler" then
             // access previous values of clocked continuous states
-            for i in 1:BackendDAEUtil.equationArraySize(eqs) loop
+            for i in 1:BackendEquation.getNumberOfEquations(eqs) loop
               eq := BackendEquation.equationNth1(eqs, i);
               (eq, _) := BackendEquation.traverseExpsOfEquation(eq, shiftDerVars1, derVars);
               eqs := BackendEquation.setAtIndex(eqs, i, eq);
@@ -427,11 +427,11 @@ algorithm
       arrayUpdate(isDerVarArr, idx, true);
     end for;
   end for;
-  for i in 1:BackendDAEUtil.equationArraySize(inSyst.orderedEqs) loop
+  for i in 1:BackendEquation.getNumberOfEquations(inSyst.orderedEqs) loop
     eq := BackendEquation.equationNth1(inSyst.orderedEqs, i);
     (_, prevVars) := BackendEquation.traverseExpsOfEquation(eq, collectPrevVars, prevVars);
   end for;
-  for i in 1:BackendDAEUtil.equationArraySize(inSyst.removedEqs) loop
+  for i in 1:BackendEquation.getNumberOfEquations(inSyst.removedEqs) loop
     eq := BackendEquation.equationNth1(inSyst.removedEqs, i);
     (_, prevVars) := BackendEquation.traverseExpsOfEquation(eq, collectPrevVars, prevVars);
   end for;
@@ -565,7 +565,7 @@ algorithm
       case syst as BackendDAE.EQSYSTEM(orderedEqs = eqs)
         algorithm
           lstEqs := {};
-          for i in 1:BackendDAEUtil.equationArraySize(eqs) loop
+          for i in 1:BackendEquation.getNumberOfEquations(eqs) loop
             eq := BackendEquation.equationNth1(eqs, i);
             (eq, outHoldComps) := BackendEquation.traverseExpsOfEquation(eq, removeHoldExp1, outHoldComps);
             lstEqs := eq::lstEqs;
@@ -1530,7 +1530,7 @@ protected
   Integer partitionIdx;
   SourceInfo source;
 algorithm
-  for i in 1:BackendDAEUtil.equationArraySize(eqs) loop
+  for i in 1:BackendEquation.getNumberOfEquations(eqs) loop
     eq := BackendEquation.equationNth1(eqs, i);
     partitionIdx := arrayGet(partitions, i);
     DAE.SOURCE(info = source) := BackendEquation.equationSource(eq);
@@ -1582,8 +1582,8 @@ protected
   BackendDAE.Equation eq;
   Integer i;
 algorithm
-  outClockEqsMask := arrayCreate(BackendDAEUtil.equationArraySize(inEqs), true);
-  for i in 1:BackendDAEUtil.equationArraySize(inEqs) loop
+  outClockEqsMask := arrayCreate(BackendEquation.getNumberOfEquations(inEqs), true);
+  for i in 1:BackendEquation.getNumberOfEquations(inEqs) loop
     eq := BackendEquation.equationNth1(inEqs, i);
     if isClockEquation(eq) then
       clockEqs := eq::clockEqs;
@@ -1927,7 +1927,7 @@ algorithm
   end if;
 
   //Partitioning finished
-  clockedEqs := arrayCreate(BackendDAEUtil.equationArraySize(eqs), NONE());
+  clockedEqs := arrayCreate(BackendEquation.getNumberOfEquations(eqs), NONE());
   clockedVars := arrayCreate(BackendVariable.varsSize(vars), NONE());
   clockedPartitions := arrayCreate(if partitionCnt > 0 then partitionCnt else 1, NONE());
   //Detect clocked equations and variables
@@ -2343,7 +2343,7 @@ algorithm
   ea := arrayCreate(n, {});
   rea := arrayCreate(n, {});
   va := arrayCreate(n, {});
-  i1 := BackendDAEUtil.equationSize(inSyst.orderedEqs);
+  i1 := BackendEquation.equationArraySize(inSyst.orderedEqs);
   i2 := BackendVariable.varsSize(inSyst.orderedVars);
 
   if i1 <> i2 and not throwNoError then
@@ -2414,7 +2414,7 @@ algorithm
   vars := BackendVariable.listVar1(vl);
   arr := BackendEquation.listEquation(el);
   remArr := BackendEquation.listEquation(rel);
-  i1 := BackendDAEUtil.equationSize(arr);
+  i1 := BackendEquation.equationArraySize(arr);
   i2 := BackendVariable.varsSize(vars);
 
   // Can this even be triggered? We check that all variables are defined somewhere, so everything should be balanced already?
@@ -2443,7 +2443,7 @@ protected
   list<BackendDAE.Equation> lst;
   BackendDAE.Equation eq;
 algorithm
-  for i in BackendDAEUtil.equationArraySize(arr):-1:1 loop
+  for i in BackendEquation.getNumberOfEquations(arr):-1:1 loop
     ix := ixs[i];
     eq := BackendEquation.equationNth1(arr, i);
     if ix == 0 then

--- a/Compiler/BackEnd/Uncertainties.mo
+++ b/Compiler/BackEnd/Uncertainties.mo
@@ -174,7 +174,7 @@ algorithm
 
               printSep(getMathematicaText("== Initial system =="));
         //      printSep(getMathematicaText("Equations (Function calls represent more than one equation"));
-        //      printSep(equationsToMathematicaGrid(List.intRange(BackendDAEUtil.equationSize(allEqs)),allEqs,allVars,globalKnownVars,mapIncRowEqn));
+        //      printSep(equationsToMathematicaGrid(List.intRange(BackendEquation.equationArraySize(allEqs)),allEqs,allVars,globalKnownVars,mapIncRowEqn));
 
         //      printSep(getMathematicaText("All variables"));
         //      printSep(variablesToMathematicaGrid(List.intRange(BackendVariable.varsSize(allVars)),allVars));
@@ -188,7 +188,7 @@ algorithm
 
               printSep(getMathematicaText("After Symbolic Elimination"));
               printSep(getMathematicaText("Equations (Function calls represent more than one equation)"));
-              printSep(equationsToMathematicaGrid(List.intRange(BackendDAEUtil.equationSize(allEqs)),allEqs,allVars,globalKnownVars,mapIncRowEqn));
+              printSep(equationsToMathematicaGrid(List.intRange(BackendEquation.equationArraySize(allEqs)),allEqs,allVars,globalKnownVars,mapIncRowEqn));
               printSep(getMathematicaText("Variables"));
               printSep(variablesToMathematicaGrid(List.intRange(BackendVariable.varsSize(allVars)),allVars));
 

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -2383,7 +2383,7 @@ protected
   Integer i = 1;
   Integer size;
 algorithm
-  size := BackendDAEUtil.equationArraySize(eqns);
+  size := BackendEquation.getNumberOfEquations(eqns);
   res := {};
   while i <= size loop
     b:= match BackendEquation.equationNth1(eqns, i)

--- a/Compiler/Util/ExpandableArray.mo
+++ b/Compiler/Util/ExpandableArray.mo
@@ -63,12 +63,12 @@ function clear "O(n)
   input output ExpandableArray<T> exarray;
 protected
   Integer n = Dangerous.arrayGetNoBoundsChecking(exarray.numberOfElements, 1);
-  Integer capacity = Dangerous.arrayGetNoBoundsChecking(exarray.capacity, 1);
+  Integer lastUsedIndex = Dangerous.arrayGetNoBoundsChecking(exarray.lastUsedIndex, 1);
   array<Option<T>> data = Dangerous.arrayGetNoBoundsChecking(exarray.data, 1);
 algorithm
   Dangerous.arrayUpdateNoBoundsChecking(exarray.numberOfElements, 1, 0);
   Dangerous.arrayUpdateNoBoundsChecking(exarray.lastUsedIndex, 1, 0);
-  for i in 1:capacity loop
+  for i in 1:lastUsedIndex loop
     if isSome(Dangerous.arrayGetNoBoundsChecking(data, i)) then
       n := n-1;
       Dangerous.arrayUpdateNoBoundsChecking(data, i, NONE());
@@ -174,6 +174,14 @@ algorithm
   if index >= 1 and index <= lastUsedIndex and isSome(Dangerous.arrayGetNoBoundsChecking(data, index)) then
     arrayUpdate(data, index, NONE());
     Dangerous.arrayUpdateNoBoundsChecking(exarray.numberOfElements, 1, numberOfElements-1);
+
+    if index == lastUsedIndex then
+      lastUsedIndex := lastUsedIndex-1;
+      while lastUsedIndex > 0 and isNone(Dangerous.arrayGetNoBoundsChecking(data, lastUsedIndex)) loop
+        lastUsedIndex := lastUsedIndex-1;
+      end while;
+      Dangerous.arrayUpdateNoBoundsChecking(exarray.lastUsedIndex, 1, lastUsedIndex);
+    end if;
   else
     fail();
   end if;
@@ -222,7 +230,7 @@ protected
   Integer lastUsedIndex = Dangerous.arrayGetNoBoundsChecking(exarray.lastUsedIndex, 1);
   array<Option<T>> data = Dangerous.arrayGetNoBoundsChecking(exarray.data, 1);
 algorithm
-  if numberOfElements == 0 then
+  if numberOfElements == 0 or numberOfElements == lastUsedIndex then
     return;
   end if;
 
@@ -237,7 +245,7 @@ algorithm
     end if;
   end for;
 
-  Dangerous.arrayUpdateNoBoundsChecking(exarray.lastUsedIndex, 1, numberOfElements);
+  Dangerous.arrayUpdateNoBoundsChecking(exarray.lastUsedIndex, 1, lastUsedIndex);
 end compress;
 
 function shrink "O(n)
@@ -297,6 +305,11 @@ function getNumberOfElements
   input ExpandableArray<T> exarray;
   output Integer numberOfElements = Dangerous.arrayGetNoBoundsChecking(exarray.numberOfElements, 1);
 end getNumberOfElements;
+
+function getLastUsedIndex
+  input ExpandableArray<T> exarray;
+  output Integer lastUsedIndex = Dangerous.arrayGetNoBoundsChecking(exarray.lastUsedIndex, 1);
+end getLastUsedIndex;
 
 function getCapacity
   input ExpandableArray<T> exarray;


### PR DESCRIPTION
This removes redundant definitions of expandable array data structures and simplifies the implementation of package BackendEquation.