### PR TITLE
move simple functions to static inline in model_help.[ch]

### DIFF
--- a/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/SimulationRuntime/c/simulation/solver/model_help.c
@@ -1256,43 +1256,12 @@ modelica_boolean LessZC(double a, double b, modelica_boolean direction)
   return direction ? (a - b <= eps) : (a - b <= -eps);
 }
 
-modelica_boolean LessEqZC(double a, double b, modelica_boolean direction)
-{
-  return !GreaterZC(a, b, !direction);
-}
-
 /* TODO: fix this */
 modelica_boolean GreaterZC(double a, double b, modelica_boolean direction)
 {
   double eps = tolZC * fmax(fabs(a), fabs(b)) + tolZC;
   return direction ? (a - b >= -eps ) : (a - b >= eps);
 }
-
-modelica_boolean GreaterEqZC(double a, double b, modelica_boolean direction)
-{
-  return !LessZC(a, b, !direction);
-}
-
-modelica_boolean Less(double a, double b)
-{
-  return a < b;
-}
-
-modelica_boolean LessEq(double a, double b)
-{
-  return a <= b;
-}
-
-modelica_boolean Greater(double a, double b)
-{
-  return a > b;
-}
-
-modelica_boolean GreaterEq(double a, double b)
-{
-  return a >= b;
-}
-
 
 /*! \fn _event_integer
  *

--- a/SimulationRuntime/c/simulation/solver/model_help.h
+++ b/SimulationRuntime/c/simulation/solver/model_help.h
@@ -150,18 +150,44 @@ modelica_real _event_div_real(modelica_real x1, modelica_real x2, modelica_integ
 /* functions used for relation which
  * are not used as zero-crossings
  */
-modelica_boolean Less(double a, double b);
-modelica_boolean LessEq(double a, double b);
-modelica_boolean Greater(double a, double b);
-modelica_boolean GreaterEq(double a, double b);
+static OMC_INLINE modelica_boolean Less(double a, double b)
+{
+  return a < b;
+}
+
+static OMC_INLINE modelica_boolean LessEq(double a, double b)
+{
+  return a <= b;
+}
+
+static OMC_INLINE modelica_boolean Greater(double a, double b)
+{
+  return a > b;
+}
+
+static OMC_INLINE modelica_boolean GreaterEq(double a, double b)
+{
+  return a >= b;
+}
+
+
+
 
 /* functions used to evaluate relation in
  * zero-crossing with hysteresis effect
  */
 modelica_boolean LessZC(double a, double b, modelica_boolean);
-modelica_boolean LessEqZC(double a, double b, modelica_boolean);
 modelica_boolean GreaterZC(double a, double b, modelica_boolean);
-modelica_boolean GreaterEqZC(double a, double b, modelica_boolean);
+static OMC_INLINE modelica_boolean GreaterEqZC(double a, double b, modelica_boolean direction)
+{
+  return !LessZC(a, b, !direction);
+}
+
+static OMC_INLINE modelica_boolean LessEqZC(double a, double b, modelica_boolean direction)
+{
+  return !GreaterZC(a, b, !direction);
+}
+
 
 extern int measure_time_flag;
 


### PR DESCRIPTION
avoids unnecessary function calls and could help compiler to optimize relations