### PR TITLE
OPC-UA: Trigger an event when changing inputs

### DIFF
--- a/SimulationRuntime/c/simulation/solver/embedded_server.c
+++ b/SimulationRuntime/c/simulation/solver/embedded_server.c
@@ -42,7 +42,7 @@
 #define DLL_EXT ".so"
 #endif
 
-void* no_embedded_server_init(DATA *data, double tout, double step, const char *argv_0, void (*omc_real_time_sync_update)(DATA *data, double scaling), int port)
+void* no_embedded_server_init(DATA *data, double tout, double step, const char *argv_0, void (*omc_real_time_sync_update)(DATA *data, double scaling), int port, int *didEventStep)
 {
   return NULL;
 }
@@ -55,7 +55,7 @@ void no_embedded_server_update(void *handle, double tout)
 {
 }
 
-void* (*embedded_server_init)(DATA *data, double tout, double step, const char *argv_0, void (*omc_real_time_sync_update)(DATA *data, double scaling), int port) = no_embedded_server_init;
+void* (*embedded_server_init)(DATA *data, double tout, double step, const char *argv_0, void (*omc_real_time_sync_update)(DATA *data, double scaling), int port, int *didEventStep) = no_embedded_server_init;
 void (*embedded_server_deinit)(void*) = no_embedded_server_deinit;
 // Tells the embedded server that a simulation step has passed; the server
 // can read/write values from/to the simulator

--- a/SimulationRuntime/c/simulation/solver/embedded_server.h
+++ b/SimulationRuntime/c/simulation/solver/embedded_server.h
@@ -37,7 +37,7 @@
 extern "C" {
 #endif
 
-extern void* (*embedded_server_init)(DATA *data, double tout, double step, const char *argv_0, void (*omc_real_time_sync_update)(DATA *data, double scaling), int port);
+extern void* (*embedded_server_init)(DATA *data, double tout, double step, const char *argv_0, void (*omc_real_time_sync_update)(DATA *data, double scaling), int port, int *didEventStep);
 extern void (*embedded_server_deinit)(void *handle);
 /* Tells the embedded server that a simulation step has passed; the server
  * can read/write values from/to the simulator

--- a/SimulationRuntime/c/simulation/solver/solver_main.c
+++ b/SimulationRuntime/c/simulation/solver/solver_main.c
@@ -705,7 +705,7 @@ int solver_main(DATA* data, threadData_t *threadData, const char* init_initMetho
       }
     }
   }
-  data->embeddedServerState = embedded_server_init(data, data->localData[0]->timeValue, solverInfo.currentStepSize, argv_0, omc_real_time_sync_update, port);
+  data->embeddedServerState = embedded_server_init(data, data->localData[0]->timeValue, solverInfo.currentStepSize, argv_0, omc_real_time_sync_update, port, &solverInfo.didEventStep);
 #endif
   if(0 == retVal) {
     retVal = -1;

--- a/SimulationRuntime/opc/ua/omc_opc_ua.h
+++ b/SimulationRuntime/opc/ua/omc_opc_ua.h
@@ -47,7 +47,7 @@
   #endif
 #endif
 
-OPC_UA_EXPORT void* omc_embedded_server_init(DATA *data, double t, double step, const char *argv_0, void (*omc_real_time_sync_update)(DATA *data, double scaling), int port);
+OPC_UA_EXPORT void* omc_embedded_server_init(DATA *data, double t, double step, const char *argv_0, void (*omc_real_time_sync_update)(DATA *data, double scaling), int port, int *didEventStep);
 OPC_UA_EXPORT void omc_embedded_server_deinit(void*);
 OPC_UA_EXPORT void omc_embedded_server_update(void*, double t);
 


### PR DESCRIPTION
This should make dassl and other solvers not discard changes as was
done previously.