### PR TITLE
fix prototype to avoid a warning from C compiler

### DIFF
--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -2837,7 +2837,7 @@ template getIterationVars(list<ComponentRef> crefs, String indexName)
   ;separator="\n")
   <<
 
-  void getIterationVars<%indexName%>(void *inData, double *array)
+  void getIterationVars<%indexName%>(struct DATA *inData, double *array)
   {
     DATA* data = (DATA*) inData;
     <%vars%>


### PR DESCRIPTION
fixes annoying warnings during model compilation like this:
```
Modelica_trunk_Modelica.Electrical.Analog.Examples.CharacteristicThyristors_02nls.c:1015:43: warning: incompatible pointer types assigning to 'void (*)(struct DATA *, double *)' from 'void (void *, double *)' [-Wincompatible-pointer-types]
  nonLinearSystemData[0].getIterationVars = getIterationVarsNLS23;
                                          ^ ~~~~~~~~~~~~~~~~~~~~~
```