### PR TITLE
Use nominal value as start value for iteration vars

### DIFF
--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -730,7 +730,7 @@ public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSL
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are over specified. %s."));
 public constant Message INITIALIZATION_ITERATION_VARIABLES = MESSAGE(498, TRANSLATION(), WARNING(),
-  Util.gettext("There are iteration variables with default zero start attribute. %s."));
+  Util.gettext("There are iteration variables with default zero start attribute or nominal value as start attribute. %s."));
 public constant Message UNBOUND_PARAMETER_WITH_START_VALUE_WARNING = MESSAGE(499, TRANSLATION(), WARNING(),
   Util.gettext("Parameter %s has no value, and is fixed during initialization (fixed=true), using available start value (start=%s) as default value."));
 public constant Message UNBOUND_PARAMETER_WARNING = MESSAGE(500, TRANSLATION(), WARNING(),


### PR DESCRIPTION
If there is no start value but a nominal value, print a
warning and use the nominal value rather than 0.0