### PR TITLE
Revert "Use nominal value as start value for iteration vars"

### DIFF
--- a/Compiler/BackEnd/Initialization.mo
+++ b/Compiler/BackEnd/Initialization.mo
@@ -248,7 +248,7 @@ algorithm
     end if;
 
     // warn about iteration variables with default zero start attribute
-    (initdae, b) := warnAboutIterationVariablesWithDefaultZeroStartAttribute(initdae);
+    b := warnAboutIterationVariablesWithDefaultZeroStartAttribute(initdae);
     if b and (not Flags.isSet(Flags.INITIALIZATION)) then
       Error.addMessage(Error.INITIALIZATION_ITERATION_VARIABLES, {msg});
     end if;
@@ -624,39 +624,39 @@ end collectPreVariablesTraverseExp2;
 
 protected function warnAboutIterationVariablesWithDefaultZeroStartAttribute "author: lochel
   This function ... read the function name."
-  input output BackendDAE.BackendDAE inDAE;
+  input BackendDAE.BackendDAE inDAE;
   output Boolean outWarning;
-protected
-  list<BackendDAE.EqSystem> eqs;
 algorithm
-  (eqs, outWarning) := warnAboutIterationVariablesWithDefaultZeroStartAttribute0(inDAE.eqs, Flags.isSet(Flags.INITIALIZATION));
-  inDAE.eqs := eqs;
+  outWarning := warnAboutIterationVariablesWithDefaultZeroStartAttribute0(inDAE.eqs, Flags.isSet(Flags.INITIALIZATION));
 end warnAboutIterationVariablesWithDefaultZeroStartAttribute;
 
 protected function warnAboutIterationVariablesWithDefaultZeroStartAttribute0 "author: lochel"
-  input output list<BackendDAE.EqSystem> inEqs;
+  input list<BackendDAE.EqSystem> inEqs;
   input Boolean inShowWarnings;
   output Boolean outWarning = false;
 protected
   Boolean warn;
-  BackendDAE.Variables orderedVars;
 algorithm
   for eqs in inEqs loop
-    (orderedVars, warn) := warnAboutIterationVariablesWithDefaultZeroStartAttribute1(eqs, inShowWarnings);
-    eqs.orderedVars := orderedVars;
+    warn := warnAboutIterationVariablesWithDefaultZeroStartAttribute1(eqs, inShowWarnings);
     outWarning := outWarning or warn;
+
+    // If we found an iteration variable with default zero start attribute but
+    // -d=initialization wasn't given, we don't need to continue searching.
+    if warn and not inShowWarnings then
+      return;
+    end if;
   end for;
 end warnAboutIterationVariablesWithDefaultZeroStartAttribute0;
 
 protected function warnAboutIterationVariablesWithDefaultZeroStartAttribute1 "author: lochel"
   input BackendDAE.EqSystem inEqSystem;
   input Boolean inShowWarnings;
-  output BackendDAE.Variables orderedVars = inEqSystem.orderedVars;
   output Boolean outWarning = false "True if any warnings were printed.";
 protected
   BackendDAE.StrongComponents comps;
   list<Integer> vlst = {};
-  list<BackendDAE.Var> vars, vars1={}, vars2={};
+  list<BackendDAE.Var> vars;
   String err;
 algorithm
   BackendDAE.EQSYSTEM(matching=BackendDAE.MATCHING(comps=comps)) := inEqSystem;
@@ -681,34 +681,19 @@ algorithm
       // Filter out the variables that are missing start values.
       vars := List.map1r(vlst, BackendVariable.getVarAt, inEqSystem.orderedVars);
       //vars := list(BackendVariable.getVarAt(inEqSystem.orderedVars, idx) for idx in vlst);
-
-      for v in vars loop
-        if not BackendVariable.varHasStartValue(v) then
-          // If the variable has a nominal value, use it as start value
-          if BackendVariable.varHasNominalValue(v) then
-            v := BackendVariable.setVarStartValue(v, DAE.RCONST(BackendVariable.varNominal(v)));
-            orderedVars := BackendVariable.addVar(v, inEqSystem.orderedVars);
-            vars2 := v::vars2;
-          else
-            vars1 := v::vars1;
-          end if;
-        end if;
-      end for;
+      vars := list(v for v guard(not BackendVariable.varHasStartValue(v)) in vars);
+      //vars := List.filterOnTrue(vars, BackendVariable.varHasStartValue);
 
       // Print a warning if we found any variables with missing start values.
-      if not listEmpty(vars1) then
+      if not listEmpty(vars) then
         outWarning := true;
 
         if inShowWarnings then
-          Error.addCompilerWarning("Iteration variables with default zero start attribute in " + err + warnAboutVars2(vars1));
-        end if;
-      end if;
-
-      if not listEmpty(vars2) then
-        outWarning := true;
-
-        if inShowWarnings then
-          Error.addCompilerWarning("Iteration variables with nominal value as start attribute in " + err + warnAboutVars2(vars2));
+          Error.addCompilerWarning("Iteration variables with default zero start attribute in " + err + warnAboutVars2(vars));
+        else
+          // If -d=initialization wasn't given we don't need to continue searching
+          // once we've found one.
+          return;
         end if;
       end if;
     end if;

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -730,7 +730,7 @@ public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSL
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are over specified. %s."));
 public constant Message INITIALIZATION_ITERATION_VARIABLES = MESSAGE(498, TRANSLATION(), WARNING(),
-  Util.gettext("There are iteration variables with default zero start attribute or nominal value as start attribute. %s."));
+  Util.gettext("There are iteration variables with default zero start attribute. %s."));
 public constant Message UNBOUND_PARAMETER_WITH_START_VALUE_WARNING = MESSAGE(499, TRANSLATION(), WARNING(),
   Util.gettext("Parameter %s has no value, and is fixed during initialization (fixed=true), using available start value (start=%s) as default value."));
 public constant Message UNBOUND_PARAMETER_WARNING = MESSAGE(500, TRANSLATION(), WARNING(),


### PR DESCRIPTION
This reverts commit e7045ec96e1d12fd46b0b363b779d29bf05d50a1.
Since there is no influence on the coverage test. The ThermoSysPro
model which started to work has got a new start value
(start=nominal) in the model, which leads to a different
tearing set.