### PR TITLE
Do not prefer vars with start value for tearing by default

### DIFF
--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -1321,7 +1321,7 @@ constant ConfigFlag DYNAMIC_TEARING_FOR_INITIALIZATION = CONFIG_FLAG(104, "dynam
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Enable Dynamic Tearing also for the initialization system."));
 constant ConfigFlag PREFER_TVARS_WITH_START_VALUE = CONFIG_FLAG(105, "preferTVarsWithStartValue",
-  NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
+  NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Prefer tearing variables with start value for initialization."));
 constant ConfigFlag EQUATIONS_PER_FILE = CONFIG_FLAG(106, "equationsPerFile",
   NONE(), EXTERNAL(), INT_FLAG(2000), NONE(),


### PR DESCRIPTION
Although it is reasonable to prefer tearing variables with start values, this has the effect that slightly changes in the model (adding start values) lead to different tearing sets, which may behave very unlike. Since this makes analysis and reproducibility hard, I think this flag should not be enabled by default. (Consider the worst case: someone adding a new start value in a model and the model stops simulating.)

Furthermore the positive effect of a prefer by default on the coverage test is not confirmed yet because the coverage summary did not exist when I introduced that flag.

@casella What is your opinion?