### PR TITLE
Make Evaluate=false have an effect

### DIFF
--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -1389,6 +1389,24 @@ algorithm
   end match;
 end hasVarEvaluateAnnotation;
 
+public function hasVarEvaluateAnnotationFalse
+  "Returns true if var has Evaluate=false annotation
+   author: ptaeuber"
+  input BackendDAE.Var inVar;
+  output Boolean isFalse;
+protected
+  SCode.Annotation ann;
+  Absyn.Exp val;
+algorithm
+  try
+    BackendDAE.VAR(comment=SOME(SCode.COMMENT(annotation_ = SOME(ann)))) := inVar;
+    (val,_) := SCode.getNamedAnnotation(ann, "Evaluate");
+    isFalse := stringEqual(Dump.printExpStr(val), "false");
+  else
+    isFalse := false;
+  end try;
+end hasVarEvaluateAnnotationFalse;
+
 public function hasAnnotation"checks if the variable has an annotation"
   input BackendDAE.Var inVar;
   output Boolean hasAnnot;

--- a/Compiler/BackEnd/EvaluateParameter.mo
+++ b/Compiler/BackEnd/EvaluateParameter.mo
@@ -847,8 +847,13 @@ algorithm
             else e;
           end match;
           v = BackendVariable.setBindExp(v, SOME(e));
-          (repl, replEvaluate) = addConstExpReplacement(e, cr, repl, replEvaluate);
-          v = if Expression.isConst(e) then BackendVariable.setVarFinal(v, true) else v;
+
+          // Add evaluated expression if constant to the replacements
+          // unless the user suggests not to evaluate the variable with annotation(Evaluate=false)
+          if not BackendVariable.hasVarEvaluateAnnotationFalse(v) then
+            (repl, replEvaluate) = addConstExpReplacement(e, cr, repl, replEvaluate);
+            v = if Expression.isConst(e) then BackendVariable.setVarFinal(v, true) else v;
+          end if;
         end if;
       end if;
       // apply replacements in variable attributes


### PR DESCRIPTION
Parameters with annotation(Evaluate=false) should not be replaced in the system, even if they can be evaluated to constants.