### PR TITLE
Ignore imports in NFClassTree.expandExtends2.

### DIFF
--- a/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/Compiler/NFFrontEnd/NFClassTree.mo
@@ -959,6 +959,8 @@ public
             tree := addInheritedComponent(name, componentIndex + entry.index, tree, duplicates);
           then
             ();
+
+        else ();
       end match;
     end expandExtends2;
   end ClassTree;


### PR DESCRIPTION
- Fixes some more ScalableTestSuite models.