### PR TITLE
Avoid expanding equations

### DIFF
--- a/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -5668,6 +5668,7 @@ protected
 
   array<list<Integer>> mapEqnIncRow;
   array<Integer> mapIncRowEqn;
+  Integer systemNumber=0, numberOfSystems;
 algorithm
   daeOut := daeIn;
 
@@ -5675,7 +5676,9 @@ algorithm
   BackendDAE.SHARED(functionTree = funcTree) := shared;
   systsNew := {};
   //traverse the simulation-DAE systems
+  numberOfSystems := listLength(systs);
   for syst in systs loop
+    systemNumber := systemNumber+1;
     BackendDAE.EQSYSTEM(orderedVars = vars, orderedEqs=eqs, matching=matching) := syst;
     BackendDAE.MATCHING(ass1=ass1, ass2=ass2, comps=comps) := matching;
 
@@ -5773,7 +5776,7 @@ algorithm
       syst := BackendDAETransform.strongComponentsScalar(syst,shared,mapEqnIncRow,mapIncRowEqn);
       syst.removedEqs := BackendEquation.emptyEqns();
     else
-      print("No output variables in this system\n");
+      Error.addCompilerNotification("No output variables in this system ("+String(systemNumber)+"/"+String(numberOfSystems)+")");
     end if;
 
     systsNew := syst::systsNew;

--- a/Compiler/BackEnd/RemoveSimpleEquations.mo
+++ b/Compiler/BackEnd/RemoveSimpleEquations.mo
@@ -537,7 +537,7 @@ algorithm
     simpleContainer := List.listArrayReverse(simpleContainerIn);
     // collect and handle sets
     (vars, eqnslst, shared, repl) := handleSets(arrayLength(simpleContainer), 1, simpleContainer, iMT, iUnreplaceable, iVars, iEqnslst, ishared, iRepl);
-      //BackendVarTransform.dumpReplacements(repl);
+    //BackendVarTransform.dumpReplacements(repl);
 
     // perform replacements and try again
     (eqnslst, b1) := BackendVarTransform.replaceEquations(eqnslst, repl, SOME(BackendVarTransform.skipPreChangeEdgeOperator));
@@ -1154,8 +1154,8 @@ algorithm
   ds := Expression.dimensionsSizes(dims);
   subslst := List.map(ds, Expression.dimensionSizeSubscripts);
   subslst := Expression.rangesToSubscripts(subslst);
-  elst1 := List.map1r(subslst, Expression.applyExpSubscripts, lhs);
-  elst2 := List.map1r(subslst, Expression.applyExpSubscripts, rhs);
+  (elst1,true) := List.mapFold(subslst, function Expression.applyExpSubscriptsFoldCheckSimplify(exp=lhs), false);
+  (elst2,true) := List.mapFold(subslst, function Expression.applyExpSubscriptsFoldCheckSimplify(exp=rhs), false) "Do not expand equation if it doesn't help with anything... Like x=f(...); => x[1]=f()[1], ..., x[n]=f()[n]";
   outTpl := List.threadFold2(elst1, elst2, simpleEquationAcausal, eqnAttributes, true, inTpl);
 end simpleArrayEquationAcausal;
 

--- a/Compiler/BackEnd/RemoveSimpleEquations.mo
+++ b/Compiler/BackEnd/RemoveSimpleEquations.mo
@@ -1149,13 +1149,23 @@ protected
   list<Integer> ds;
   list<list<DAE.Subscript>> subslst;
   list<DAE.Exp> elst1, elst2;
+  Boolean hasInlineAfterIndexReduction, expandLhs, expandRhs;
 algorithm
   dims := Expression.arrayDimension(ty);
   ds := Expression.dimensionsSizes(dims);
   subslst := List.map(ds, Expression.dimensionSizeSubscripts);
   subslst := Expression.rangesToSubscripts(subslst);
-  (elst1,true) := List.mapFold(subslst, function Expression.applyExpSubscriptsFoldCheckSimplify(exp=lhs), false);
-  (elst2,true) := List.mapFold(subslst, function Expression.applyExpSubscriptsFoldCheckSimplify(exp=rhs), false) "Do not expand equation if it doesn't help with anything... Like x=f(...); => x[1]=f()[1], ..., x[n]=f()[n]";
+  (,hasInlineAfterIndexReduction) := Expression.traverseExpTopDown(lhs, Expression.findCallIsInlineAfterIndexReduction, false);
+  (,hasInlineAfterIndexReduction) := Expression.traverseExpTopDown(rhs, Expression.findCallIsInlineAfterIndexReduction, hasInlineAfterIndexReduction);
+  (elst1,expandLhs) := List.mapFold(subslst, function Expression.applyExpSubscriptsFoldCheckSimplify(exp=lhs), false);
+  (elst2,expandRhs) := List.mapFold(subslst, function Expression.applyExpSubscriptsFoldCheckSimplify(exp=rhs), false);
+  if not hasInlineAfterIndexReduction then
+    // If inlining after index reduction or i, we need to expand equations to pass sorting+matching
+    // Note: We *should* be looking for the derivative annotation here, but it's not available directly
+    //       and better would be if sorting+matching could expand/split equations when necessary
+    true := expandLhs and expandRhs "Do not expand equation if it doesn't help with anything... Like x=f(...); => x[1]=f()[1], ..., x[n]=f()[n]";
+  else
+  end if;
   outTpl := List.threadFold2(elst1, elst2, simpleEquationAcausal, eqnAttributes, true, inTpl);
 end simpleArrayEquationAcausal;
 

--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -13117,5 +13117,19 @@ algorithm
   end match;
 end isInvariantExpNoTraverse;
 
+public function findCallIsInlineAfterIndexReduction
+  input output DAE.Exp e;
+  output Boolean cont;
+  input output Boolean res;
+algorithm
+  if not res then
+    res := match e
+      case DAE.CALL(attr=DAE.CALL_ATTR(inlineType=DAE.AFTER_INDEX_RED_INLINE())) then true;
+      else false;
+    end match;
+  end if;
+  cont := not res;
+end findCallIsInlineAfterIndexReduction;
+
 annotation(__OpenModelica_Interface="frontend");
 end Expression;


### PR DESCRIPTION
- In RemoveSimpleEquations, use the vectorization limit to prevent
  expansion of equations.
- In the backend variable replacements, collapse arrays of crefs into
  a single array cref if possible

This fixes the performance problem reported in ticket:4453