### PR TITLE
Collapse arrays of crefs

### DIFF
--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -7498,7 +7498,9 @@ protected function allPreOptimizationModules
     (BackendDAEOptimize.residualForm, "residualForm"),
     (BackendDAEOptimize.simplifyAllExpressions, "simplifyAllExpressions"),
     (BackendDump.dumpDAE, "dumpDAE"),
-      (XMLDump.dumpDAEXML, "dumpDAEXML")
+    (XMLDump.dumpDAEXML, "dumpDAEXML"),
+    // This should indeed be at the end
+    (BackendDAETransform.collapseArrayExpressions, "collapseArrayExpressions")
   };
 end allPreOptimizationModules;
 
@@ -7544,7 +7546,9 @@ protected function allPostOptimizationModules
     // TODO: move the following modules to the correct position
     (BackendDump.dumpComponentsGraphStr, "dumpComponentsGraphStr"),
     (BackendDump.dumpDAE, "dumpDAE"),
-    (XMLDump.dumpDAEXML, "dumpDAEXML")
+    (XMLDump.dumpDAEXML, "dumpDAEXML"),
+    // This should indeed be at the end
+    (BackendDAETransform.collapseArrayExpressions, "collapseArrayExpressions")
   };
 end allPostOptimizationModules;
 
@@ -7564,7 +7568,9 @@ protected function allInitOptimizationModules
     (ExpressionSolve.solveSimpleEquations, "solveSimpleEquations"),
     (BackendDAEOptimize.simplifyAllExpressions, "simplifyAllExpressions"),
     (SymbolicJacobian.inputDerivativesUsed, "inputDerivativesUsed"),
-    (DynamicOptimization.removeLoops, "extendDynamicOptimization")
+    (DynamicOptimization.removeLoops, "extendDynamicOptimization"),
+    // This should indeed be at the end
+    (BackendDAETransform.collapseArrayExpressions, "collapseArrayExpressions")
   };
 end allInitOptimizationModules;
 

--- a/Compiler/BackEnd/BackendVarTransform.mo
+++ b/Compiler/BackEnd/BackendVarTransform.mo
@@ -44,6 +44,7 @@ public import HashTable2;
 public import HashTable3;
 
 protected import Absyn;
+protected import BackendDAETransform;
 protected import BaseHashTable;
 protected import BaseHashSet;
 protected import BackendEquation;
@@ -1620,20 +1621,15 @@ public function replaceEquations
     output Boolean outBoolean;
   end FuncTypeExp_ExpToBoolean;
 algorithm
-  (outEqns,replacementPerformed) := matchcontinue(inEqns,repl,inFuncTypeExpExpToBooleanOption)
-    local
-      list<BackendDAE.Equation> eqns;
-    case(_,_,_)
-      equation
-        // Do not do empty replacements; it just takes time ;)
-        false = isReplacementEmpty(repl);
-        (eqns,replacementPerformed) = replaceEquations2(inEqns,repl,inFuncTypeExpExpToBooleanOption,{},false);
-      then
-        (eqns,replacementPerformed);
-    else
-      then
-        (inEqns,false);
-  end matchcontinue;
+  if isReplacementEmpty(repl) then
+    outEqns := inEqns;
+    replacementPerformed := false;
+  else
+    (outEqns,replacementPerformed) := replaceEquations2(inEqns,repl,inFuncTypeExpExpToBooleanOption,{},false);
+    if replacementPerformed and false /* Seems to break some modules */ then
+      (outEqns,_) := BackendDAETransform.traverseBackendDAEExpsEqnLstWithSymbolicOperation(outEqns,BackendDAETransform.collapseArrayCrefExp,0/*dummy*/);
+    end if;
+  end if;
 end replaceEquations;
 
 protected function replaceEquations2

--- a/Compiler/FrontEnd/ComponentReference.mo
+++ b/Compiler/FrontEnd/ComponentReference.mo
@@ -801,6 +801,14 @@ algorithm
   comp := CompareWithGenericSubscript.compare(cr1,cr2);
 end crefCompareGeneric;
 
+public function crefCompareIntSubscript "A sorting function for crefs"
+  input DAE.ComponentRef cr1;
+  input DAE.ComponentRef cr2;
+  output Integer comp;
+algorithm
+  comp := CompareWithIntSubscript.compare(cr1,cr2);
+end crefCompareIntSubscript;
+
 public function crefCompareGenericNotAlphabetic "A sorting function for crefs"
   input DAE.ComponentRef cr1;
   input DAE.ComponentRef cr2;

--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -944,18 +944,40 @@ alternative names: subsriptExp (but already taken), subscriptToAsub"
 protected
   DAE.Exp s;
 algorithm
+  exp := applyExpSubscriptsFoldCheckSimplify(exp, inSubs);
+end applyExpSubscripts;
+
+
+public function applyExpSubscriptsFoldCheckSimplify "
+author: PA
+Takes an arbitrary expression and applies subscripts to it. This is done by creating asub
+expressions given the original expression and then simplify them.
+Note: The subscripts must be INDEX
+
+alternative names: subsriptExp (but already taken), subscriptToAsub
+
+This version of the function also returns a boolean stating if simplify
+improved anything (can be used as a heuristic if you want to apply
+the subscript when scalarizing)"
+  input output DAE.Exp exp;
+  input list<DAE.Subscript> inSubs;
+  input output Boolean checkSimplify = false;
+protected
+  Boolean b;
+  DAE.Exp s;
+algorithm
   for sub in inSubs loop
     // Apply one subscript at a time, so simplify works fine on it.
     //s := subscriptIndexExp(sub);
     try
       s := getSubscriptExp(sub);
-      (exp,_) := ExpressionSimplify.simplify(makeASUB(exp,{s}));
+      (exp,b) := ExpressionSimplify.simplify(makeASUB(exp,{s}));
+      checkSimplify := b or checkSimplify;
     else
       // skipped DAE.WHOLEDIM
     end try;
   end for;
-end applyExpSubscripts;
-
+end applyExpSubscriptsFoldCheckSimplify;
 
 public function subscriptExp
 "@mahge

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -764,6 +764,7 @@ constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG(12, "preOptModules",
     }),
   SOME(STRING_DESC_OPTION({
     ("clockPartitioning", Util.gettext("Does the clock partitioning.")),
+    ("collapseArrayExpressions", collapseArrayExpressionsText),
     ("comSubExp", Util.gettext("replaces common sub expressions")),
     ("dumpDAE", Util.gettext("dumps the DAE representation of the current transformation state")),
     ("dumpDAEXML", Util.gettext("dumps the DAE as xml representation of the current transformation state")),
@@ -854,7 +855,8 @@ constant ConfigFlag POST_OPT_MODULES = CONFIG_FLAG(16, "postOptModules",
     "removeConstants",
     "simplifyTimeIndepFuncCalls",
     "simplifyAllExpressions",
-    "findZeroCrossings"
+    "findZeroCrossings",
+    "collapseArrayExpressions"
     }),
   SOME(STRING_DESC_OPTION({
     ("addScaledVars_states", Util.notrans("added var_norm = var/nominal, where var is state")),
@@ -862,6 +864,7 @@ constant ConfigFlag POST_OPT_MODULES = CONFIG_FLAG(16, "postOptModules",
     ("addTimeAsState", Util.gettext("Experimental feature: this replaces each occurrence of variable time with a new introduced state $time with equation der($time) = 1.0")),
     ("calculateStateSetsJacobians", Util.gettext("Generates analytical jacobian for dynamic state selection sets.")),
     ("calculateStrongComponentJacobians", Util.gettext("Generates analytical jacobian for torn linear and non-linear strong components. By default non-linear components with user-defined function calls are skipped. See also debug flags: NLSanalyticJacobian and forceNLSanalyticJacobian")),
+    ("collapseArrayExpressions", collapseArrayExpressionsText),
     ("constantLinearSystem", Util.gettext("Evaluates constant linear systems (a*x+b*y=c; d*x+e*y=f; a,b,c,d,e,f are constants) at compile-time.")),
     ("countOperations", Util.gettext("Count the mathematical operations of the system.")),
     ("cseBinary", Util.gettext("Common Sub-expression Elimination")),
@@ -1201,16 +1204,20 @@ constant ConfigFlag PARTLINTORN = CONFIG_FLAG(76, "partlintorn",
   NONE(), EXTERNAL(), INT_FLAG(0), NONE(),
   Util.gettext("Sets the limit for partitionin of linear torn systems."));
 
+constant Util.TranslatableContent collapseArrayExpressionsText = Util.gettext("Simplifies {x[1],x[2],x[3]} → x for arrays of whole variable references (simplifies code generation).");
+
 constant ConfigFlag INIT_OPT_MODULES = CONFIG_FLAG(77, "initOptModules",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({
     "simplifyComplexFunction",
     "tearingSystem",
     "calculateStrongComponentJacobians",
     "solveSimpleEquations",
-    "simplifyAllExpressions"
+    "simplifyAllExpressions",
+    "collapseArrayExpressions"
     }),
   SOME(STRING_DESC_OPTION({
     ("calculateStrongComponentJacobians", Util.gettext("Generates analytical jacobian for torn linear and non-linear strong components. By default non-linear components with user-defined function calls are skipped. See also debug flags: NLSanalyticJacobian and forceNLSanalyticJacobian")),
+    ("collapseArrayExpressions", collapseArrayExpressionsText),
     ("constantLinearSystem", Util.gettext("Evaluates constant linear systems (a*x+b*y=c; d*x+e*y=f; a,b,c,d,e,f are constants) at compile-time.")),
     ("extendDynamicOptimization", Util.gettext("Move loops to constraints.")),
     ("inlineHomotopy", Util.gettext("Experimental: Inlines the homotopy expression to allow symbolic simplifications.")),
@@ -1223,7 +1230,7 @@ constant ConfigFlag INIT_OPT_MODULES = CONFIG_FLAG(77, "initOptModules",
     ("simplifyLoops", Util.notrans("Simplifies algebraic loops. This modules requires +simplifyLoops.")),
     ("solveSimpleEquations", Util.notrans("Solves simple equations")),
     ("tearingSystem", Util.notrans("For method selection use flag tearingMethod.")),
-	("wrapFunctionCalls", Util.gettext("This module introduces variables for each function call and substitutes all these calls with the newly introduced variables."))
+    ("wrapFunctionCalls", Util.gettext("This module introduces variables for each function call and substitutes all these calls with the newly introduced variables."))
     })),
   Util.gettext("Sets the initialization optimization modules to use in the back end. See --help=optmodules for more info."));
 


### PR DESCRIPTION
This helps performance in the backend slightly. It is only done while
performing replacements for now. It should possibly be an optimization
module running a few times during the backend to clean up the system
of equations. It should probably also run on function bodies.