### PR TITLE
Expand arrays in record when generating simcode

### DIFF
--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -11946,6 +11946,18 @@ algorithm
 end makeVectorCall;
 
 
+public function expandCrefs
+  input output DAE.Exp exp;
+  input output Integer dummy=0 "For traversal";
+algorithm
+  exp := match exp
+    local
+      DAE.Type ty;
+    case DAE.CREF(ty=DAE.T_ARRAY(ty=ty)) then makeArray(list(makeCrefExp(cr, ty) for cr in ComponentReference.expandCref(exp.componentRef, true)), exp.ty, not Types.isArray(ty));
+    else exp;
+  end match;
+end expandCrefs;
+
 public function expandExpression
  " mahge:
    Expands a given expression to a list of expression. this means flattening any records in the

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -5997,6 +5997,7 @@ algorithm
         // check all crefs are on the lhs
         ht = HashSet.emptyHashSet();
         ht = List.fold(crefs, BaseHashSet.add, ht);
+        expLst = Expression.traverseExpList(expLst, Expression.expandCrefs, 0) "The routines generate bad code for arrays inside the record unless we expand them";
         List.foldAllValue(expLst, createSingleComplexEqnCode3, true, ht);
         (e2_1, _) = Expression.extendArrExp(e2, false);
 
@@ -6027,6 +6028,7 @@ algorithm
         // check all crefs are on the rhs => turn
         ht = HashSet.emptyHashSet();
         ht = List.fold(crefs, BaseHashSet.add, ht);
+        expLst = Expression.traverseExpList(expLst, Expression.expandCrefs, 0) "The routines generate bad code for arrays inside the record unless we expand them";
         List.foldAllValue(expLst, createSingleComplexEqnCode3, true, ht);
         (e1_1, _) = Expression.extendArrExp(e1, false);
         // true = ComponentReference.crefEqualNoStringCompare(cr, cr2);


### PR DESCRIPTION
This avoids a problem with generating scalar assignments for arrays in
a record variable in simulation context (code generation fails).