### PR TITLE
speed up and memory enhance ResolveLoops.getShortPathsBetweenEqCrossNodes

### DIFF
--- a/Compiler/BackEnd/CommonSubExpression.mo
+++ b/Compiler/BackEnd/CommonSubExpression.mo
@@ -1936,6 +1936,8 @@ algorithm
       cseLst := commonSubExpressionFind(m, mT, vars, eqs);
           //if not listEmpty(cseLst) then print("update "+stringDelimitList(List.map(cseLst, printCSE), "\n")+"\n");end if;
       syst := commonSubExpressionUpdate(cseLst, m, mT, sysIn);
+      GC.free(m);
+      GC.free(mT);
       syst.orderedEqs := eqs;
           //print("done this eqSystem\n");
           //BackendDump.dumpEqSystem(syst, "eqSystem");


### PR DESCRIPTION
half memory, double speed for large models