### PR TITLE
Add an extra step before daeExp in Susan

### DIFF
--- a/Compiler/Stubs/SimCodeUtil.mo
+++ b/Compiler/Stubs/SimCodeUtil.mo
@@ -1,6 +1,7 @@
 encapsulated package SimCodeUtil
 
 import SimCode;
+import SimCodeFunction;
 import SimCodeVar;
 
 function sortEqSystems<T>
@@ -30,6 +31,14 @@ function cref2simvar<A,B>
 algorithm
   assert(false, getInstanceName());
 end cref2simvar;
+
+function codegenExpSanityCheck
+  input output DAE.Exp e;
+  input SimCodeFunction.Context context;
+algorithm
+  /* Do nothing */
+end codegenExpSanityCheck;
+
 
 annotation(__OpenModelica_Interface="backend");
 end SimCodeUtil;

--- a/Compiler/Template/CodegenCFunctions.tpl
+++ b/Compiler/Template/CodegenCFunctions.tpl
@@ -4303,7 +4303,7 @@ end getTempDeclMatchOutputName;
  "Generates code for an expression.
   used in Compiler/Template/CodegenQSS.tpl"
 ::=
-  match exp
+  match codegenExpSanityCheck(exp, context)
   case e as ICONST(__)          then '((modelica_integer) <%integer%>)' /* Yes, we need to cast int to long on 64-bit arch... */
   case e as RCONST(__)          then real
   case e as SCONST(__)          then daeExpSconst(string, &preExp, &varDecls)

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -985,6 +985,12 @@ package SimCodeUtil
     input SimCode.SimCode simCode;
     output Boolean outIsTooBig;
   end isModelTooBigForCSharpInOneFile;
+
+  function codegenExpSanityCheck
+    input DAE.Exp inExp;
+    input SimCodeFunction.Context context;
+    output DAE.Exp outExp;
+  end codegenExpSanityCheck;
 end SimCodeUtil;
 
 package SimCodeFunctionUtil


### PR DESCRIPTION
We now check if arrays are stored in contiguous memory before blindly
creating an array that assumes so.