### PR TITLE
Some fixes for array expansion

### DIFF
--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -6228,7 +6228,9 @@ algorithm
     // {z1,z2,..} = rhsexp -> solved for {z1,z2,..}
     // => tmp = rhsexp;
     // z1 = tmp[1]; z2 = tmp[2] ....
-    case (_, (BackendDAE.ARRAY_EQUATION(dimSize=ds, left=(e1 as DAE.ARRAY()), right=e2, source=source))::{}, _, _, _, _) equation
+    case (_, (BackendDAE.ARRAY_EQUATION(dimSize=ds, left=e1, right=e2, source=source))::{}, _, _, _, _)
+    guard Expression.isMatrix(e1) or Expression.isArray(e1)
+    equation
       // Flattne multi-dimensional ARRAY{ARRAY} expressions
       expLst = Expression.flattenArrayExpToList(e1);
       // Replace the der() operators


### PR DESCRIPTION
@lochel @wibraun I would appreciate it if someone could have a look at properly fixing the Chemical models in [the coverage](http://libraries.openmodelica.org/branches/history/master/2017-07-24%2022:48:15..2017-07-25%2011:50:02.html). I just got weird errors when I tried to add assertions or algorithm statements without variables as output to the list of equations... Probably needs to be added/moved to removed equations or something? At the moment, sorting/matching/index reduction fails for equations like "{} = f(...)", but if it's moved to a proper location (always move 0-length equations to removed equations, perhaps already in the backend dae create functions?). My code is just an ugly hack to get the coverage running again.