### PR TITLE
Perform incomplete matching for over/underdet syst

### DIFF
--- a/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -1662,7 +1662,7 @@ algorithm
         b = i > 1;
         // bcall2(b,BackendDump.dumpBackendDAE,BackendDAE.DAE({syst},shared), "partitionIndependentBlocksHelper");
         // printPartition(b,ixs);
-        systs = if b then SynchronousFeatures.partitionIndependentBlocksSplitBlocks(i, syst, eqPartMap, rixs, mT, rmT, throwNoError) else {syst};
+        systs = if b then SynchronousFeatures.partitionIndependentBlocksSplitBlocks(i, syst, eqPartMap, rixs, mT, rmT, throwNoError, funcs) else {syst};
         // print("Number of partitioned systems: " + intString(listLength(systs)) + "\n");
         // List.map1_0(systs, BackendDump.dumpEqSystem, "System");
         GC.free(eqPartMap);

--- a/Compiler/BackEnd/Causalize.mo
+++ b/Compiler/BackEnd/Causalize.mo
@@ -100,6 +100,7 @@ algorithm
         esize_str = intString(neqns);
         vsize_str = intString(nvars);
         Error.addMessage(Error.UNDERDET_EQN_SYSTEM, {esize_str,vsize_str});
+        BackendDAEUtil.checkIncidenceMatrixSolvability(isyst, ishared.functionTree);
       then
         fail();
 
@@ -109,6 +110,7 @@ algorithm
         esize_str = intString(neqns) ;
         vsize_str = intString(nvars);
         Error.addMessage(Error.OVERDET_EQN_SYSTEM, {esize_str,vsize_str});
+        BackendDAEUtil.checkIncidenceMatrixSolvability(isyst, ishared.functionTree);
       then
         fail();
 

--- a/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/Compiler/BackEnd/SynchronousFeatures.mo
@@ -2600,7 +2600,7 @@ algorithm
   partitionCnt := partitionIndependentBlocks0(m, mT, rm, rmT, eqPartMap, varPartMap, reqsPartition, varsPartition, rvarsPartition);
 
   if partitionCnt > 1 then
-    (systs, outUnpartRemEqs) := partitionIndependentBlocksSplitBlocks(partitionCnt, syst, eqPartMap, reqsPartition, mT, rmT, false);
+    (systs, outUnpartRemEqs) := partitionIndependentBlocksSplitBlocks(partitionCnt, syst, eqPartMap, reqsPartition, mT, rmT, false, funcs);
   else
     (systs, outUnpartRemEqs) := ({syst}, {});
   end if;
@@ -3049,6 +3049,7 @@ public function partitionIndependentBlocksSplitBlocks
   input BackendDAE.IncidenceMatrix mT;
   input BackendDAE.IncidenceMatrix rmT;
   input Boolean throwNoError;
+  input DAE.FunctionTree funcs;
   output list<BackendDAE.EqSystem> systs = {};
   output list<BackendDAE.Equation> unpartRemovedEqs;
   output array<Integer> varPartMap;
@@ -3056,7 +3057,6 @@ protected
   array<list<BackendDAE.Equation>> ea, rea;
   array<list<BackendDAE.Var>> va;
   Integer i1, i2;
-  String s1, s2;
   Boolean b, b1 = true;
   BackendDAE.EqSystem syst;
   array<Integer> varsPartition;
@@ -3070,10 +3070,8 @@ algorithm
   i2 := BackendVariable.varsSize(inSyst.orderedVars);
 
   if i1 <> i2 and not throwNoError then
-  s1 := intString(i1);
-  s2 := intString(i2);
-  Error.addSourceMessage(if i1 > i2 then Error.OVERDET_EQN_SYSTEM else Error.UNDERDET_EQN_SYSTEM,
-    {s1, s2}, Absyn.dummyInfo);
+    Error.addSourceMessage(if i1 > i2 then Error.OVERDET_EQN_SYSTEM else Error.UNDERDET_EQN_SYSTEM, {String(i1), String(i2)}, Absyn.dummyInfo);
+    BackendDAEUtil.checkIncidenceMatrixSolvability(inSyst, funcs);
     fail();
   end if;
 

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -879,6 +879,10 @@ public constant Message CLASS_EXTENDS_TARGET_NOT_FOUND = MESSAGE(579, TRANSLATIO
   Util.gettext("Base class targeted by class extends %s not found in the inherited classes."));
 public constant Message ASSIGN_PARAM_FIXED_ERROR = MESSAGE(580, TRANSLATION(), ERROR(),
   Util.gettext("Trying to assign to parameter component %s(fixed=true) in %s := %s"));
+public constant Message EQN_NO_SPACE_TO_SOLVE = MESSAGE(581, SYMBOLIC(), WARNING(),
+  Util.gettext("Equation %s (size: %s) %s is not big enough to solve for enough variables.\n  Remaining unsolved variables are: %s\n  Already solved: %s\n  Equations used to solve those variables:%s"));
+public constant Message VAR_NO_REMAINING_EQN = MESSAGE(582, SYMBOLIC(), WARNING(),
+  Util.gettext("Variable %s does not have any remaining equation to be solved in.\n  The original equations were:%s"));
 
 public constant Message MATCH_SHADOWING = MESSAGE(5001, TRANSLATION(), ERROR(),
   Util.gettext("Local variable '%s' shadows another variable."));


### PR DESCRIPTION
This performs an incomplete matching after producing the message unbalanced
equation system, and instead of just a number differing OMC will try to
perform a sanity check to figure out if for example a variable is never
referenced in any equation or if two variables must be matched by the same
equation.