### PR TITLE
Remove name from class extends SCode.ClassDef.

### DIFF
--- a/Compiler/FFrontEnd/FGraphBuild.mo
+++ b/Compiler/FFrontEnd/FGraphBuild.mo
@@ -136,7 +136,7 @@ algorithm
         FNode.addChildRef(inParentRef, name, nr);
         // add constrained by node
         g = mkConstrainClass(cls, nr, inKind, g);
-        g = mkClassChildren(cdef, nr, inKind, g);
+        g = mkClassChildren(name, cdef, nr, inKind, g);
       then
         g;
 
@@ -318,6 +318,7 @@ end mkBindingNode;
 
 protected function mkClassChildren
 "Extends the graph with a class's components."
+  input String name;
   input SCode.ClassDef inClassDef;
   input Ref inParentRef;
   input Kind inKind;
@@ -334,7 +335,6 @@ algorithm
       Ref nr;
       Absyn.TypeSpec ts;
       Absyn.Path p;
-      Name name;
       SCode.Mod m;
       Absyn.ArrayDim ad;
       list<SCode.Equation> eqs, ieqs;
@@ -365,9 +365,9 @@ algorithm
       then
         g;
 
-    case (SCode.CLASS_EXTENDS(baseClassName = name, composition = cdef, modifications = m), _, _, g)
+    case (SCode.CLASS_EXTENDS(composition = cdef, modifications = m), _, _, g)
       equation
-        g = mkClassChildren(cdef, inParentRef, inKind, g);
+        g = mkClassChildren(name, cdef, inParentRef, inKind, g);
         g = mkModNode(FNode.modNodeName, m, FCore.MS_CLASS_EXTENDS(name), inParentRef, inKind, g);
       then
         g;

--- a/Compiler/FFrontEnd/FResolve.mo
+++ b/Compiler/FFrontEnd/FResolve.mo
@@ -436,7 +436,7 @@ algorithm
     case (r, g)
       equation
         true = FNode.isRefClassExtends(r);
-        FCore.CL(e = SCode.CLASS(classDef = SCode.CLASS_EXTENDS(baseClassName = id))) = FNode.refData(r);
+        FCore.CL(e = SCode.CLASS(name = id)) = FNode.refData(r);
         // get the parent where the extends are!
         p::_ = FNode.parents(FNode.fromRef(r));
         // search ONLY in extends!
@@ -449,7 +449,7 @@ algorithm
     case (r, g)
       equation
         true = FNode.isRefClassExtends(r);
-        FCore.CL(e = SCode.CLASS(classDef = SCode.CLASS_EXTENDS(baseClassName = id))) = FNode.refData(r);
+        FCore.CL(e = SCode.CLASS(name = id)) = FNode.refData(r);
         // get the parent where the extends are!
         p::_ = FNode.parents(FNode.fromRef(r));
         // search ONLY in extends!

--- a/Compiler/FrontEnd/InstExtends.mo
+++ b/Compiler/FrontEnd/InstExtends.mo
@@ -501,7 +501,7 @@ algorithm
         SCode.CLASS(_,prefixes2,encapsulatedPrefix2,partialPrefix2,restriction2,SCode.PARTS(els2,nEqn2,inEqn2,nAlg2,inAlg2,inCons2,clats,externalDecl2),comment2,info2) = cl;
 
         SCode.CLASS(_, prefixes1, encapsulatedPrefix1, partialPrefix1, restriction1, classExtendsCdef, comment1, info1) = classExtendsElt;
-        SCode.CLASS_EXTENDS(_,mods,SCode.PARTS(els1,nEqn1,inEqn1,nAlg1,inAlg1,inCons1,_,externalDecl1)) = classExtendsCdef;
+        SCode.CLASS_EXTENDS(mods,SCode.PARTS(els1,nEqn1,inEqn1,nAlg1,inAlg1,inCons1,_,externalDecl1)) = classExtendsCdef;
 
         classDef = SCode.PARTS(els2,nEqn2,inEqn2,nAlg2,inAlg2,inCons2,clats,externalDecl2);
         compelt = SCode.CLASS(name2,prefixes2,encapsulatedPrefix2,partialPrefix2,restriction2,classDef,comment2,info2);
@@ -524,7 +524,7 @@ algorithm
         SCode.CLASS(_,prefixes2,encapsulatedPrefix2,partialPrefix2,restriction2,SCode.DERIVED(derivedTySpec, derivedMod, attrs),comment2,info2) = cl;
 
         SCode.CLASS(_, prefixes1, encapsulatedPrefix1, partialPrefix1, restriction1, classExtendsCdef, comment1, info1) = classExtendsElt;
-        SCode.CLASS_EXTENDS(_,mods,SCode.PARTS(els1,nEqn1,inEqn1,nAlg1,inAlg1,inCons1,_,externalDecl1)) = classExtendsCdef;
+        SCode.CLASS_EXTENDS(mods,SCode.PARTS(els1,nEqn1,inEqn1,nAlg1,inAlg1,inCons1,_,externalDecl1)) = classExtendsCdef;
 
         classDef = SCode.DERIVED(derivedTySpec, derivedMod, attrs);
         compelt = SCode.CLASS(name2,prefixes2,encapsulatedPrefix2,partialPrefix2,restriction2,classDef,comment2,info2);
@@ -1025,7 +1025,6 @@ algorithm
       Option<SCode.Comment> c;
       Absyn.TypeSpec ts,ts_1;
       SCode.Attributes attr;
-      String name;
       SCode.Mod mod,mod_1;
       FCore.Graph env;
       SCode.ClassDef cd,cd_1;
@@ -1042,7 +1041,7 @@ algorithm
       then if referenceEq(elts,elts_1) and referenceEq(ne,ne_1) and referenceEq(ie,ie_1) and referenceEq(na,na_1) and referenceEq(ia,ia_1) and referenceEq(nc,nc_1)
            then inCd else SCode.PARTS(elts_1,ne_1,ie_1,na_1,ia_1,nc_1,clats,ed);
 
-    case (env,SCode.CLASS_EXTENDS(name,mod,cd as SCode.PARTS(elts,ne,ie,na,ia,nc,clats,ed)))
+    case (env,SCode.CLASS_EXTENDS(mod,cd as SCode.PARTS(elts,ne,ie,na,ia,nc,clats,ed)))
       equation
         mod_1 = fixModifications(cache,env,mod,inTree);
         elts_1 = fixList(cache,env,elts,tree,fixElement);
@@ -1054,7 +1053,7 @@ algorithm
         cd_1 = if referenceEq(elts,elts_1) and referenceEq(ne,ne_1) and referenceEq(ie,ie_1) and referenceEq(na,na_1) and referenceEq(ia,ia_1) and referenceEq(nc,nc_1)
              then cd else SCode.PARTS(elts_1,ne_1,ie_1,na_1,ia_1,nc_1,clats,ed);
       then if referenceEq(cd,cd_1) and referenceEq(mod,mod_1)
-           then inCd else SCode.CLASS_EXTENDS(name,mod_1,cd_1);
+           then inCd else SCode.CLASS_EXTENDS(mod_1,cd_1);
 
     case (env,SCode.DERIVED(ts,mod,attr))
       equation

--- a/Compiler/FrontEnd/NFEnvExtends.mo
+++ b/Compiler/FrontEnd/NFEnvExtends.mo
@@ -1259,7 +1259,6 @@ public function extendEnvWithClassExtends
 algorithm
   outEnv := match(inClassExtends, inEnv)
     local
-      SCode.Ident bc;
       SCode.Partial pp;
       SCode.Encapsulated ep;
       SCode.Restriction res;
@@ -1269,7 +1268,7 @@ algorithm
       SCode.Mod mods;
       SCode.ClassDef cdef;
       SCode.Element cls, ext;
-      String el_str, env_str, err_msg;
+      String name, el_str, env_str, err_msg;
       SCode.Comment cmt;
 
     // When a 'class extends X' is encountered we insert a 'class X extends
@@ -1281,27 +1280,27 @@ algorithm
     // added to the class environment's extends table. The rest of the work is
     // done later in updateClassExtends when we have a complete environment.
     case (SCode.CLASS(
+        name = name,
         prefixes = prefixes,
         encapsulatedPrefix = ep,
         partialPrefix = pp,
         restriction = res,
         classDef = SCode.CLASS_EXTENDS(
-          baseClassName = bc,
           modifications = mods,
           composition = cdef),
         cmt=cmt, info = info), _)
       equation
         // Construct a new PARTS class with the data from the class extends.
-        cls = SCode.CLASS(bc, prefixes, ep, pp, res, cdef, cmt, info);
+        cls = SCode.CLASS(name, prefixes, ep, pp, res, cdef, cmt, info);
 
         // Construct the class environment and add the new extends to it.
         cls_env = NFSCodeEnv.makeClassEnvironment(cls, false);
-        ext = SCode.EXTENDS(Absyn.IDENT(bc), SCode.PUBLIC(), mods, NONE(), info);
+        ext = SCode.EXTENDS(Absyn.IDENT(name), SCode.PUBLIC(), mods, NONE(), info);
         cls_env = addClassExtendsInfoToEnv(ext, cls_env);
 
         // Finally add the class to the environment.
         env = NFSCodeEnv.extendEnvWithItem(
-          NFSCodeEnv.newClassItem(cls, cls_env, NFSCodeEnv.CLASS_EXTENDS()), inEnv, bc);
+          NFSCodeEnv.newClassItem(cls, cls_env, NFSCodeEnv.CLASS_EXTENDS()), inEnv, name);
       then env;
 
     case (_, _)

--- a/Compiler/FrontEnd/NFSCodeDependency.mo
+++ b/Compiler/FrontEnd/NFSCodeDependency.mo
@@ -2035,49 +2035,37 @@ end updateItemEnv;
 
 protected function collectUsedClassDef
   "Collects the contents of a class definition."
-  input SCode.ClassDef inClassDef;
-  input Env inEnv;
+  input output SCode.ClassDef classDef;
+  input output Env env;
   input NFSCodeEnv.Frame inClassEnv;
   input Absyn.Path inClassName;
   input Absyn.Path inAccumPath;
-  output SCode.ClassDef outClass;
-  output Env outEnv;
 algorithm
-  (outClass, outEnv) :=
-  match(inClassDef, inEnv, inClassEnv, inClassName, inAccumPath)
+  () := match classDef
     local
       list<SCode.Element> el;
-      list<SCode.Equation> neq, ieq;
-      list<SCode.AlgorithmSection> nal, ial;
-      list<SCode.ConstraintSection> nco;
-      Option<SCode.ExternalDecl> ext_decl;
-      list<SCode.Annotation> annl;
-      Option<SCode.Comment> cmt;
-      SCode.Ident bc;
-      SCode.Mod mods;
-      Env env;
-      list<Absyn.NamedArg> clats;
+      SCode.ClassDef cdef;
 
-    case (SCode.PARTS(el, neq, ieq, nal, ial, nco, clats, ext_decl), _, _, _, _)
-      equation
-        (el, env) =
-          collectUsedElements(el, inEnv, inClassEnv, inClassName, inAccumPath);
+    case SCode.PARTS(elementLst = el)
+      algorithm
+        (el, env) := collectUsedElements(el, env, inClassEnv, inClassName, inAccumPath);
+        classDef.elementLst := el;
       then
-        (SCode.PARTS(el, neq, ieq, nal, ial, nco, clats, ext_decl), env);
+        ();
 
-    case (SCode.CLASS_EXTENDS(bc, mods,
-        SCode.PARTS(el, neq, ieq, nal, ial, nco, clats, ext_decl)), _, _, _, _)
-      equation
-        (el, env) =
-          collectUsedElements(el, inEnv, inClassEnv, inClassName, inAccumPath);
+    case SCode.CLASS_EXTENDS(composition = cdef)
+      algorithm
+        (cdef, env) := collectUsedClassDef(cdef, env, inClassEnv, inClassName, inAccumPath);
+        classDef.composition := cdef;
       then
-        (SCode.CLASS_EXTENDS(bc, mods,
-          SCode.PARTS(el, neq, ieq, nal, ial, nco, clats, ext_decl)), env);
+        ();
 
-    case (SCode.ENUMERATION(), _, _, _, _)
-      then (inClassDef, {inClassEnv});
+    else
+      algorithm
+        env := {inClassEnv};
+      then
+        ();
 
-    else (inClassDef, {inClassEnv});
   end match;
 end collectUsedClassDef;
 

--- a/Compiler/FrontEnd/NFSCodeFlattenImports.mo
+++ b/Compiler/FrontEnd/NFSCodeFlattenImports.mo
@@ -127,7 +127,6 @@ algorithm
       SCode.Mod mods;
       SCode.Attributes attr;
       Env env;
-      SCode.Ident bc;
       SCode.ClassDef cdef;
 
     case (SCode.PARTS(el, neql, ieql, nal, ial, nco, clats, extdecl), _, _)
@@ -145,12 +144,12 @@ algorithm
       then
         (SCode.PARTS(el, neql, ieql, nal, ial, nco, clats, extdecl), env);
 
-    case (SCode.CLASS_EXTENDS(bc, mods, cdef), _, _)
+    case (SCode.CLASS_EXTENDS(mods, cdef), _, _)
       equation
         (cdef, env) = flattenClassDef(cdef, inEnv, inInfo);
         mods = flattenModifier(mods, env, inInfo);
       then
-        (SCode.CLASS_EXTENDS(bc, mods, cdef), env);
+        (SCode.CLASS_EXTENDS(mods, cdef), env);
 
     case (SCode.DERIVED(ty, mods, attr), env, _)
       equation

--- a/Compiler/FrontEnd/SCodeDump.mo
+++ b/Compiler/FrontEnd/SCodeDump.mo
@@ -235,10 +235,10 @@ algorithm
         res;
 
     case SCode.CLASS(name = n, partialPrefix = pp, prefixes = SCode.PREFIXES(innerOuter = io, redeclarePrefix = rdp, replaceablePrefix = rpp),
-                     classDef = SCode.CLASS_EXTENDS(baseClassName = str))
+                     classDef = SCode.CLASS_EXTENDS())
       equation
         ioStr = Dump.unparseInnerouterStr(io) + redeclareStr(rdp) + replaceablePrefixStr(rpp) + partialStr(pp);
-        res = stringAppendList({ioStr, "class extends ",n," extends ", str, ";"});
+        res = stringAppendList({ioStr, "class extends ",n,";"});
       then
         res;
 

--- a/Compiler/FrontEnd/SCodeUtil.mo
+++ b/Compiler/FrontEnd/SCodeUtil.mo
@@ -439,7 +439,6 @@ algorithm
       list<SCode.Enum> lst_1;
       list<Absyn.EnumLiteral> lst;
       SCode.Comment scodeCmt;
-      String name;
       Absyn.Path path;
       list<Absyn.Path> pathLst;
       list<String> typeVars;
@@ -501,7 +500,7 @@ algorithm
       then
         (SCode.OVERLOAD(pathLst),scodeCmt);
 
-    case (Absyn.CLASS_EXTENDS(baseClassName = name,modifications = cmod,ann=ann,comment = cmtString,parts = parts),_)
+    case (Absyn.CLASS_EXTENDS(modifications = cmod,ann=ann,comment = cmtString,parts = parts),_)
       equation
         // fprintln(Flags.TRANSLATE "translating model extends " + name + " ... end " + name + ";");
         els = translateClassdefElements(parts);
@@ -515,7 +514,7 @@ algorithm
         decl = translateClassdefExternaldecls(parts);
         decl = translateAlternativeExternalAnnotation(decl,scodeCmt);
       then
-        (SCode.CLASS_EXTENDS(name,mod,SCode.PARTS(els,eqs,initeqs,als,initals,cos,{},decl)),scodeCmt);
+        (SCode.CLASS_EXTENDS(mod,SCode.PARTS(els,eqs,initeqs,als,initals,cos,{},decl)),scodeCmt);
 
     case (Absyn.PDER(functionName = path,vars = vars, comment=cmt),_)
       equation


### PR DESCRIPTION
- Removed the baseClassName field from SCode.ClassDef.CLASS_EXTENDS,
  since it can never be different from the name already in the class
  element it belongs to.