### PR TITLE
Fix csv export for variables of type string

### DIFF
--- a/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
+++ b/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
@@ -74,8 +74,8 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
     fprintf(fout, formatint, (data->localData[0])->integerVars[i]);
   for(i = 0; i < data->modelData->nVariablesBoolean; i++) if(!data->modelData->booleanVarsData[i].filterOutput)
     fprintf(fout, formatbool, (data->localData[0])->booleanVars[i]);
-  for(i = 0; i < data->modelData->nVariablesString; i++) if(!data->modelData->stringVarsData[i].filterOutput)
-    fprintf(fout, formatstring, MMC_STRINGDATA((data->localData[0])->stringVars[i]));
+  //for(i = 0; i < data->modelData->nVariablesString; i++) if(!data->modelData->stringVarsData[i].filterOutput)
+  //  fprintf(fout, formatstring, MMC_STRINGDATA((data->localData[0])->stringVars[i]));
 
   for(i = 0; i < data->modelData->nAliasReal; i++) if(!data->modelData->realAlias[i].filterOutput && data->modelData->realAlias[i].aliasType != 1) {
     if (data->modelData->realAlias[i].aliasType == 2) {
@@ -103,10 +103,10 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
       fprintf(fout, formatbool, (data->localData[0])->booleanVars[data->modelData->booleanAlias[i].nameID]);
     }
   }
-  for(i = 0; i < data->modelData->nAliasString; i++) if(!data->modelData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != 1) {
-    /* there would no negation of a string happen */
-    fprintf(fout, formatstring, MMC_STRINGDATA((data->localData[0])->stringVars[data->modelData->stringAlias[i].nameID]));
-  }
+  //for(i = 0; i < data->modelData->nAliasString; i++) if(!data->modelData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != 1) {
+  //  /* there would no negation of a string happen */
+  //  fprintf(fout, formatstring, MMC_STRINGDATA((data->localData[0])->stringVars[data->modelData->stringAlias[i].nameID]));
+  //}
   fseek(fout, -1, SEEK_CUR); // removes the eol comma separator
   fprintf(fout, "\n");
   rt_accumulate(SIM_TIMER_OUTPUT);
@@ -131,8 +131,8 @@ void omc_csv_init(simulation_result *self, DATA *data, threadData_t *threadData)
     fprintf(fout, format, mData->integerVarsData[i].info.name);
   for(i = 0; i < mData->nVariablesBoolean; i++) if(!mData->booleanVarsData[i].filterOutput)
     fprintf(fout, format, mData->booleanVarsData[i].info.name);
-  for(i = 0; i < mData->nVariablesString; i++) if(!mData->stringVarsData[i].filterOutput)
-    fprintf(fout, format, mData->stringVarsData[i].info.name);
+  //for(i = 0; i < mData->nVariablesString; i++) if(!mData->stringVarsData[i].filterOutput)
+  //  fprintf(fout, format, mData->stringVarsData[i].info.name);
 
   for(i = 0; i < mData->nAliasReal; i++) if(!mData->realAlias[i].filterOutput && data->modelData->realAlias[i].aliasType != 1)
     fprintf(fout, format, mData->realAlias[i].info.name);
@@ -140,8 +140,8 @@ void omc_csv_init(simulation_result *self, DATA *data, threadData_t *threadData)
     fprintf(fout, format, mData->integerAlias[i].info.name);
   for(i = 0; i < mData->nAliasBoolean; i++) if(!mData->booleanAlias[i].filterOutput && data->modelData->booleanAlias[i].aliasType != 1)
     fprintf(fout, format, mData->booleanAlias[i].info.name);
-  for(i = 0; i < mData->nAliasString; i++) if(!mData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != 1)
-    fprintf(fout, format, mData->stringAlias[i].info.name);
+  //for(i = 0; i < mData->nAliasString; i++) if(!mData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != 1)
+  //  fprintf(fout, format, mData->stringAlias[i].info.name);
   fseek(fout, -1, SEEK_CUR); // removes the eol comma separator
   fprintf(fout,"\n");
   self->storage = fout;

--- a/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
+++ b/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
@@ -52,10 +52,10 @@ extern "C" {
 void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
 {
   FILE *fout = (FILE*) self->storage;
-  const char* format = "%.16g,";
-  const char* formatint = "%i,";
-  const char* formatbool = "%i,";
-  const char* formatstring = "\"%s\",";
+  const char* format = ",%.16g";
+  const char* formatint = ",%i";
+  const char* formatbool = ",%i";
+  const char* formatstring = ",\"%s\"";
   int i;
   modelica_real value = 0;
   double cpuTimeValue = 0;
@@ -65,7 +65,7 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
   cpuTimeValue = rt_accumulated(SIM_TIMER_TOTAL);
   rt_tick(SIM_TIMER_TOTAL);
 
-  fprintf(fout, format, data->localData[0]->timeValue);
+  fprintf(fout, "%.16g", data->localData[0]->timeValue);
   if(self->cpuTime)
     fprintf(fout, format, cpuTimeValue);
   for(i = 0; i < data->modelData->nVariablesReal; i++) if(!data->modelData->realVarsData[i].filterOutput)
@@ -107,7 +107,6 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
   //  /* there would no negation of a string happen */
   //  fprintf(fout, formatstring, MMC_STRINGDATA((data->localData[0])->stringVars[data->modelData->stringAlias[i].nameID]));
   //}
-  fseek(fout, -1, SEEK_CUR); // removes the eol comma separator
   fprintf(fout, "\n");
   rt_accumulate(SIM_TIMER_OUTPUT);
 }
@@ -117,12 +116,12 @@ void omc_csv_init(simulation_result *self, DATA *data, threadData_t *threadData)
   int i;
   const MODEL_DATA *mData = data->modelData;
 
-  const char* format = "\"%s\",";
+  const char* format = ",\"%s\"";
   FILE *fout = fopen(self->filename, "w");
 
   assertStreamPrint(threadData, 0!=fout, "Error, couldn't create output file: [%s] because of %s", self->filename, strerror(errno));
 
-  fprintf(fout, format, "time");
+  fprintf(fout, "\"time\"");
   if(self->cpuTime)
     fprintf(fout, format, "$cpuTime");
   for(i = 0; i < mData->nVariablesReal; i++) if(!mData->realVarsData[i].filterOutput)
@@ -142,8 +141,7 @@ void omc_csv_init(simulation_result *self, DATA *data, threadData_t *threadData)
     fprintf(fout, format, mData->booleanAlias[i].info.name);
   //for(i = 0; i < mData->nAliasString; i++) if(!mData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != 1)
   //  fprintf(fout, format, mData->stringAlias[i].info.name);
-  fseek(fout, -1, SEEK_CUR); // removes the eol comma separator
-  fprintf(fout,"\n");
+  fprintf(fout, "\n");
   self->storage = fout;
 }
 

--- a/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
+++ b/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
@@ -75,7 +75,7 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
   for(i = 0; i < data->modelData->nVariablesBoolean; i++) if(!data->modelData->booleanVarsData[i].filterOutput)
     fprintf(fout, formatbool, (data->localData[0])->booleanVars[i]);
   for(i = 0; i < data->modelData->nVariablesString; i++) if(!data->modelData->stringVarsData[i].filterOutput)
-    fprintf(fout, formatstring, (data->localData[0])->stringVars[i]);
+    fprintf(fout, formatstring, MMC_STRINGDATA((data->localData[0])->stringVars[i]));
 
   for(i = 0; i < data->modelData->nAliasReal; i++) if(!data->modelData->realAlias[i].filterOutput && data->modelData->realAlias[i].aliasType != 1) {
     if (data->modelData->realAlias[i].aliasType == 2) {
@@ -105,7 +105,7 @@ void omc_csv_emit(simulation_result *self, DATA *data, threadData_t *threadData)
   }
   for(i = 0; i < data->modelData->nAliasString; i++) if(!data->modelData->stringAlias[i].filterOutput && data->modelData->stringAlias[i].aliasType != 1) {
     /* there would no negation of a string happen */
-    fprintf(fout, formatstring, (data->localData[0])->stringVars[data->modelData->stringAlias[i].nameID]);
+    fprintf(fout, formatstring, MMC_STRINGDATA((data->localData[0])->stringVars[data->modelData->stringAlias[i].nameID]));
   }
   fseek(fout, -1, SEEK_CUR); // removes the eol comma separator
   fprintf(fout, "\n");


### PR DESCRIPTION
@adeas31 @adrpo The csv export is broken for variables of type string. Should we skip exporting them or fix the export?
The issue is that the import (OMPlot) doesn't accept csv files that contain string variables.
