### PR TITLE
Warn about iteration variables with no nominal attribute

### DIFF
--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -452,6 +452,40 @@ algorithm
   outTpl := (varNo + 1, buffer);
 end var1String;
 
+public function varListStringIndented
+  input list<BackendDAE.Var> inVars;
+  input String heading;
+  output String outString;
+algorithm
+  outString := match(inVars, heading)
+    local
+      String buffer;
+
+    case (_, "") equation
+      ((_, buffer)) = List.fold(inVars, var1StringIndented, (1, ""));
+    then buffer;
+
+    else equation
+      ((_, buffer)) = List.fold(inVars, var1StringIndented, (1, ""));
+      buffer = heading + "\n" + buffer;
+    then buffer;
+  end match;
+end varListStringIndented;
+
+protected function var1StringIndented
+  input BackendDAE.Var inVar;
+  input tuple<Integer /*inVarNo*/, String /*buffer*/> inTpl;
+  output tuple<Integer /*outVarNo*/, String /*buffer*/> outTpl;
+protected
+  Integer varNo;
+  String buffer;
+algorithm
+  (varNo, buffer) := inTpl;
+  buffer := buffer + "   " + intString(varNo) + ": ";
+  buffer := buffer + varString(inVar) + "\n";
+  outTpl := (varNo + 1, buffer);
+end var1StringIndented;
+
 protected function printExternalObjectClasses "dump classes of external objects"
   input BackendDAE.ExternalObjectClasses cls;
 algorithm

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -513,7 +513,9 @@ constant DebugFlag NF_UNITCHECK = DEBUG_FLAG(168, "frontEndUnitCheck", false,
 constant DebugFlag DISABLE_COLORING = DEBUG_FLAG(169, "disableColoring", false,
   Util.gettext("Disables coloring algorithm while spasity detection."));
 constant DebugFlag MERGE_ALGORITHM_SECTIONS = DEBUG_FLAG(170, "mergeAlgSections", false,
-  Util.gettext("Disables coloring algorithm while spasity detection."));
+  Util.gettext("Disables coloring algorithm while sparsity detection."));
+constant DebugFlag WARN_NO_NOMINAL = DEBUG_FLAG(171, "warnNoNominal", false,
+  Util.gettext("Prints the iteration variables in the initialization and simulation DAE, which do not have a nominal value."));
 
 
 // This is a list of all debug flags, to keep track of which flags are used. A
@@ -691,7 +693,8 @@ constant list<DebugFlag> allDebugFlags = {
   EVAL_PARAM_DUMP,
   NF_UNITCHECK,
   DISABLE_COLORING,
-  MERGE_ALGORITHM_SECTIONS
+  MERGE_ALGORITHM_SECTIONS,
+  WARN_NO_NOMINAL
 };
 
 public


### PR DESCRIPTION
Activate warning with: -d=warnNoNominal
see [ticket:4512](https://trac.openmodelica.org/OpenModelica/ticket/4512)