### PR TITLE
C SimulationRuntime: make unmodified object constant

### DIFF
--- a/SimulationRuntime/c/util/boolean_array.c
+++ b/SimulationRuntime/c/util/boolean_array.c
@@ -635,13 +635,13 @@ m_boolean* boolean_array_element_addr(const boolean_array_t* source,int ndims,..
  * k is one based
  */
 void cat_boolean_array(int k, boolean_array_t* dest, int n,
-                    boolean_array_t* first,...)
+                    const boolean_array_t* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    boolean_array_t **elts = (boolean_array_t**)malloc(sizeof(boolean_array_t *) * n);
+    const boolean_array_t **elts = (const boolean_array_t**)malloc(sizeof(boolean_array_t *) * n);
 
     assert(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -649,7 +649,7 @@ void cat_boolean_array(int k, boolean_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,boolean_array_t*);
+        elts[i] = va_arg(ap,const boolean_array_t*);
     }
     va_end(ap);
 
@@ -697,13 +697,13 @@ void cat_boolean_array(int k, boolean_array_t* dest, int n,
  * k is one based
  */
 void cat_alloc_boolean_array(int k, boolean_array_t* dest, int n,
-                          boolean_array_t* first,...)
+                          const boolean_array_t* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    boolean_array_t **elts = (boolean_array_t**)malloc(sizeof(boolean_array_t *) * n);
+    const boolean_array_t **elts = (const boolean_array_t**)malloc(sizeof(boolean_array_t *) * n);
 
     assert(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -711,7 +711,7 @@ void cat_alloc_boolean_array(int k, boolean_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,boolean_array_t*);
+        elts[i] = va_arg(ap,const boolean_array_t*);
     }
     va_end(ap);
 

--- a/SimulationRuntime/c/util/boolean_array.h
+++ b/SimulationRuntime/c/util/boolean_array.h
@@ -159,9 +159,9 @@ extern m_boolean* boolean_array_element_addr1(const boolean_array_t* source,int 
 extern m_boolean* boolean_array_element_addr2(const boolean_array_t* source,int ndims,int dim1,int dim2);
 
 extern void cat_boolean_array(int k,boolean_array_t* dest, int n,
-                       boolean_array_t* first,...);
+                       const boolean_array_t* first,...);
 extern void cat_alloc_boolean_array(int k,boolean_array_t* dest, int n,
-                             boolean_array_t* first,...);
+                             const boolean_array_t* first,...);
 
 extern void promote_boolean_array(const boolean_array_t* a, int n,boolean_array_t* dest);
 extern void promote_scalar_boolean_array(modelica_boolean s,int n,

--- a/SimulationRuntime/c/util/integer_array.c
+++ b/SimulationRuntime/c/util/integer_array.c
@@ -635,13 +635,13 @@ modelica_integer* integer_array_element_addr(const integer_array_t * source,int 
  * k is one based
  */
 void cat_integer_array(int k, integer_array_t* dest, int n,
-                    integer_array_t* first,...)
+                    const integer_array_t* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    integer_array_t **elts = (integer_array_t**)malloc(sizeof(integer_array_t *) * n);
+    const integer_array_t **elts = (const integer_array_t**)malloc(sizeof(integer_array_t *) * n);
 
     omc_assert_macro(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -649,7 +649,7 @@ void cat_integer_array(int k, integer_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,integer_array_t*);
+        elts[i] = va_arg(ap,const integer_array_t*);
     }
     va_end(ap);
 
@@ -697,13 +697,13 @@ void cat_integer_array(int k, integer_array_t* dest, int n,
  * k is one based
  */
 void cat_alloc_integer_array(int k, integer_array_t* dest, int n,
-                          integer_array_t* first,...)
+                          const integer_array_t* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    integer_array_t **elts = (integer_array_t**)malloc(sizeof(integer_array_t *) * n);
+    const integer_array_t **elts = (const integer_array_t**)malloc(sizeof(integer_array_t *) * n);
 
     omc_assert_macro(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -711,7 +711,7 @@ void cat_alloc_integer_array(int k, integer_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,integer_array_t*);
+        elts[i] = va_arg(ap,const integer_array_t*);
     }
     va_end(ap);
 

--- a/SimulationRuntime/c/util/integer_array.h
+++ b/SimulationRuntime/c/util/integer_array.h
@@ -164,9 +164,9 @@ extern modelica_integer* integer_array_element_addr2(const integer_array_t * sou
                                                      int dim1,int dim2);
 
 extern void cat_integer_array(int k,integer_array_t* dest, int n,
-                              integer_array_t* first,...);
+                              const integer_array_t* first,...);
 extern void cat_alloc_integer_array(int k,integer_array_t* dest, int n,
-                                    integer_array_t* first,...);
+                                    const integer_array_t* first,...);
 
 extern void range_alloc_integer_array(modelica_integer start, modelica_integer stop,
                                       modelica_integer inc,integer_array_t* dest);

--- a/SimulationRuntime/c/util/real_array.c
+++ b/SimulationRuntime/c/util/real_array.c
@@ -620,13 +620,13 @@ modelica_real* real_array_element_addr(const real_array_t * source,int ndims,...
  * k is one based
  */
 void cat_real_array(int k, real_array_t* dest, int n,
-                    real_array_t* first,...)
+                    const real_array_t* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    real_array_t **elts = (real_array_t**)malloc(sizeof(real_array_t *) * n);
+    const real_array_t **elts = (const real_array_t**)malloc(sizeof(real_array_t *) * n);
 
     omc_assert_macro(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -634,7 +634,7 @@ void cat_real_array(int k, real_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,real_array_t*);
+        elts[i] = va_arg(ap,const real_array_t*);
     }
     va_end(ap);
 
@@ -682,13 +682,13 @@ void cat_real_array(int k, real_array_t* dest, int n,
  * k is one based
  */
 void cat_alloc_real_array(int k, real_array_t* dest, int n,
-                          real_array_t* first,...)
+                          const real_array_t* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    real_array_t **elts = (real_array_t**)malloc(sizeof(real_array_t *) * n);
+    const real_array_t **elts = (const real_array_t**)malloc(sizeof(real_array_t *) * n);
 
     omc_assert_macro(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -696,7 +696,7 @@ void cat_alloc_real_array(int k, real_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,real_array_t*);
+        elts[i] = va_arg(ap,const real_array_t*);
     }
     va_end(ap);
 

--- a/SimulationRuntime/c/util/real_array.h
+++ b/SimulationRuntime/c/util/real_array.h
@@ -151,8 +151,8 @@ extern modelica_real* real_array_element_addr(const real_array_t * source,int nd
 extern modelica_real* real_array_element_addr1(const real_array_t * source,int ndims,int dim1);
 extern modelica_real* real_array_element_addr2(const real_array_t * source,int ndims,int dim1,int dim2);
 
-extern void cat_real_array(int k,real_array_t* dest, int n, real_array_t* first,...);
-extern void cat_alloc_real_array(int k,real_array_t* dest, int n, real_array_t* first,...);
+extern void cat_real_array(int k,real_array_t* dest, int n, const real_array_t* first,...);
+extern void cat_alloc_real_array(int k,real_array_t* dest, int n, const real_array_t* first,...);
 
 extern void range_alloc_real_array(modelica_real start,modelica_real stop,modelica_real inc,
                             real_array_t* dest);

--- a/SimulationRuntime/c/util/string_array.c
+++ b/SimulationRuntime/c/util/string_array.c
@@ -588,13 +588,13 @@ modelica_string* string_array_element_addr(const string_array_t * source,
  * k is one based
  */
 void cat_string_array(int k, string_array_t* dest, int n,
-                    string_array_t* first,...)
+                    const string_array_t* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    string_array_t **elts = (string_array_t**)malloc(sizeof(string_array_t *) * n);
+    const string_array_t **elts = (const string_array_t**)malloc(sizeof(string_array_t *) * n);
 
     assert(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -602,7 +602,7 @@ void cat_string_array(int k, string_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,string_array_t*);
+        elts[i] = va_arg(ap,const string_array_t*);
     }
     va_end(ap);
 
@@ -650,13 +650,13 @@ void cat_string_array(int k, string_array_t* dest, int n,
  * k is one based
  */
 void cat_alloc_string_array(int k, string_array_t* dest, int n,
-                          string_array_t* first,...)
+                          const string_array_t* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    string_array_t **elts = (string_array_t**)malloc(sizeof(string_array_t *) * n);
+    const string_array_t **elts = (const string_array_t**)malloc(sizeof(string_array_t *) * n);
 
     assert(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -664,7 +664,7 @@ void cat_alloc_string_array(int k, string_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,string_array_t*);
+        elts[i] = va_arg(ap,const string_array_t*);
     }
     va_end(ap);
 

--- a/SimulationRuntime/c/util/string_array.h
+++ b/SimulationRuntime/c/util/string_array.h
@@ -140,9 +140,9 @@ extern modelica_string* string_array_element_addr2(const string_array_t * source
                                                      int dim1,int dim2);
 
 extern void cat_string_array(int k,string_array_t* dest, int n,
-                             string_array_t* first,...);
+                             const string_array_t* first,...);
 extern void cat_alloc_string_array(int k,string_array_t* dest, int n,
-                                   string_array_t* first,...);
+                                   const string_array_t* first,...);
 
 extern void promote_string_array(const string_array_t * a, int n,string_array_t* dest);
 extern void promote_scalar_string_array(modelica_string s,int n,


### PR DESCRIPTION
Simulation code compiles fine, but does not link (macOS) due to missing symbol:
```
Undefined symbols for architecture x86_64:
  "_ModelicaStandardTables_CombiTimeTable_init2", referenced from:
      _omc_Modelica_Blocks_Types_ExternalCombiTimeTable_constructor in ModelicaTest.Blocks.BooleanTable_functions.o
```
@sjoelund Do you have an idea why `init2` is not defined?