### PR TITLE
fix for ticket:4459 and ticket:4491

### DIFF
--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -8,6 +8,9 @@ OMBUILDDIR=$(CURDIR)/build
 endif
 
 ifeq ($(BUILDTYPE),)
+BUILDTYPE=$(BuildType)
+endif
+ifeq ($(BUILDTYPE),)
 BUILDTYPE=Debug
 endif
 

--- a/SimulationRuntime/cpp/Makefile.omdev.mingw
+++ b/SimulationRuntime/cpp/Makefile.omdev.mingw
@@ -22,10 +22,11 @@ CMAKE = $(OMDEVMSYS)/bin/cmake/bin/cmake -DCMAKE_VERBOSE_MAKEFILE:Bool=ON
 OMDEVMSYS=$(shell cygpath $$OMDEV)
 
 ifeq ($(BUILDTYPE),)
-	BUILDTYPE=Debug
+BUILDTYPE=$(BuildType)
 endif
-
-
+ifeq ($(BUILDTYPE),)
+BUILDTYPE=Debug
+endif
 
 ifeq (MINGW32,$(findstring MINGW32,$(shell uname)))
 	IS_MINGW32 = -DIS_MINGW32=ON
@@ -154,7 +155,7 @@ runtimeCpp:
 
 runtimeCPPmsvc: getMSVCversion
 	test -f """${VSCOMNTOOLS}/../../VC/vcvarsall.bat"""
-	echo 'Build the cppRuntime with MSVC'
+	echo 'Build the cppRuntime with MSVC' buildtype: $(BUILDTYPE)
 	#rm -rf Build_MSVC
 	mkdir -p Build_MSVC
 	echo call '"${VSCOMNTOOLS}\\..\\..\\VC\\vcvarsall.bat"' > Build_MSVC/build.bat


### PR DESCRIPTION
- support both BuildType and BUILDTYPE on command line
- update 3rdParty/ModelicaExternalC tables C source code to the latest version from MSL:
  https://github.com/modelica/Modelica/commit/8209e73d7739ebcacd779f0d189d0a2885dfe105