### PR TITLE
Fix for #4521.

### DIFF
--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -13125,5 +13125,23 @@ algorithm
   cont := not res;
 end findCallIsInlineAfterIndexReduction;
 
+public function tupleHead
+  input DAE.Exp exp;
+  input DAE.Properties prop;
+  output DAE.Exp outExp;
+  output DAE.Properties outProp;
+algorithm
+  (outExp, outProp) := match (exp, prop)
+    local
+      DAE.Type ty;
+
+    case (DAE.Exp.TUPLE(_ :: _), DAE.Properties.PROP_TUPLE())
+      then (listHead(exp.PR), Types.propTupleFirstProp(prop));
+    case (_, DAE.Properties.PROP_TUPLE(type_ = DAE.T_TUPLE(types = ty :: _)))
+      then (DAE.Exp.TSUB(exp, 1, ty), Types.propTupleFirstProp(prop));
+    else (exp, prop);
+  end match;
+end tupleHead;
+
 annotation(__OpenModelica_Interface="frontend");
 end Expression;

--- a/Compiler/FrontEnd/Mod.mo
+++ b/Compiler/FrontEnd/Mod.mo
@@ -166,6 +166,9 @@ algorithm
         (cache,subs_1) = elabSubmods(cache, env, ih, pre, subs, impl, inModScope, info);
         // print("Mod.elabMod: calling elabExp on mod exp: " + Dump.printExpStr(e) + " in env: " + FGraph.printGraphPathStr(env) + "\n");
         (cache,e_1,prop,_) = Static.elabExp(cache, env, e, impl, NONE(), Config.splitArrays(), pre, info); // Vectorize only if arrays are expanded
+        // Modifiers always apply to single components, so if the expression is
+        // a tuple (i.e. from a function call) select the first tuple element.
+        (e_1, prop) = Expression.tupleHead(e_1, prop);
         (cache, e_1, prop) = Ceval.cevalIfConstant(cache, env, e_1, prop, impl, info);
         (e_val, cache) = elabModValue(cache, env, e_1, prop, impl, info);
         (cache,e_2) = PrefixUtil.prefixExp(cache, env, ih, e_1, pre)


### PR DESCRIPTION
- Select the first tuple element when a tuple is used as a modifier.