### PR TITLE
Revert "Alternative treatment of shiftSample also considering event c…

### DIFF
--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -9470,7 +9470,7 @@ case SIMCODE(modelInfo = MODELINFO(__), modelStructure = fmims) then
           <<
           <%preExp%>
           _clockInterval[<%i%>] = <%interval%> * <%fnom%>.0 / <%fres%>.0;
-          _clockShift[<%i%>] = <%snom%>.0 / <%sres%>.0 / <%fnom%>.0 * <%fres%>.0;
+          _clockShift[<%i%>] = <%snom%>.0 / <%sres%>.0;
           _clockTime[<%i%>] = _simTime + _clockShift[<%i%>] * _clockInterval[<%i%>];
           _clockStart[<%i%>] = true;
           _clockSubactive[<%i%>] = false;


### PR DESCRIPTION
…locks"

This reverts commit 6554061cfcd98080c64f4756464dc3f1895a78f8.
Due to failed verification for:
    Modelica_Synchronous.Examples.Elementary.BooleanSignals.BackSample
    Modelica_Synchronous.Examples.Elementary.BooleanSignals.Hold
    Modelica_Synchronous.Examples.Elementary.BooleanSignals.ShiftSample
    Modelica_Synchronous.Examples.Elementary.ClockSignals.ShiftSample
    Modelica_Synchronous.Examples.Elementary.IntegerSignals.BackSample
    Modelica_Synchronous.Examples.Elementary.IntegerSignals.Hold
    Modelica_Synchronous.Examples.Elementary.IntegerSignals.ShiftSample
    Modelica_Synchronous.Examples.Elementary.RealSignals.BackSample
    Modelica_Synchronous.Examples.Elementary.RealSignals.FractionalDelay
    Modelica_Synchronous.Examples.Elementary.RealSignals.Hold
    Modelica_Synchronous.Examples.Elementary.RealSignals.HoldWithDAeffects1
    Modelica_Synchronous.Examples.Elementary.RealSignals.HoldWithDAeffects2
    Modelica_Synchronous.Examples.Elementary.RealSignals.ShiftSample