### PR TITLE
Cache the FMI configure results

### DIFF
--- a/Compiler/SimCode/SimCodeMain.mo
+++ b/Compiler/SimCode/SimCodeMain.mo
@@ -293,6 +293,7 @@ algorithm
         if not Config.getRunningTestsuite() then
           resstr = System.pwd() + System.pathDelimiter() + resstr;
         end if;
+        ExecStat.execStat("translateModelFMU complete");
       then
         (cache, Values.STRING(resstr), st, dlow_1, libs, file_dir, resultValues);
     else

--- a/Compiler/Template/CodegenFMU.tpl
+++ b/Compiler/Template/CodegenFMU.tpl
@@ -1073,17 +1073,17 @@ match platform
   else
   <<
   <%fileNamePrefix%>_FMU:
-  <%\t%>$(MAKE) $(MAINOBJ) <%fileNamePrefix%>_functions.h <%fileNamePrefix%>_literals.h $(OFILES) $(RUNTIMEFILES) > make.log
+  <%\t%>$(MAKE) CC="$(CC)" $(MAINOBJ) <%fileNamePrefix%>_functions.h <%fileNamePrefix%>_literals.h $(OFILES) $(RUNTIMEFILES) 2>&1 | tee make.log
   <%\t%>mkdir -p ../binaries/$(FMIPLATFORM)
   ifeq (@LIBTYPE_DYNAMIC@,1)
-  <%\t%>$(LD) -o <%modelNamePrefix%>$(DLLEXT) $(MAINOBJ) $(OFILES) $(RUNTIMEFILES) <%dirExtra%> <%libsPos1%> <%libsPos2%> $(LDFLAGS)
+  <%\t%>$(LD) -o <%modelNamePrefix%>$(DLLEXT) $(MAINOBJ) $(OFILES) $(RUNTIMEFILES) <%dirExtra%> <%libsPos1%> <%libsPos2%> $(LDFLAGS)  2>&1 | tee -a make.log
   <%\t%>cp <%fileNamePrefix%>$(DLLEXT) <%fileNamePrefix%>_FMU.libs config.log make.log ../binaries/$(FMIPLATFORM)/
   endif
   <%\t%>head -n20 Makefile > ../binaries/$(FMIPLATFORM)/config.summary
   ifeq (@LIBTYPE_STATIC@,1)
   <%\t%>rm -f <%modelNamePrefix%>.a
   <%\t%>$(AR) -rsu <%modelNamePrefix%>.a $(MAINOBJ) $(OFILES) $(RUNTIMEFILES)
-  <%\t%>cp <%fileNamePrefix%>.a <%fileNamePrefix%>_FMU.libs config.log ../binaries/$(FMIPLATFORM)/
+  <%\t%>cp <%fileNamePrefix%>.a <%fileNamePrefix%>_FMU.libs config.log make.log ../binaries/$(FMIPLATFORM)/
   endif
   <%\t%>$(MAKE) distclean
   <%\t%>cd .. && rm -f ../<%fileNamePrefix%>.fmu && zip -r ../<%fileNamePrefix%>.fmu *

--- a/Compiler/Template/CodegenFMUCpp.tpl
+++ b/Compiler/Template/CodegenFMUCpp.tpl
@@ -685,12 +685,12 @@ case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simula
   MODELICA_SYSTEM_LIB=<%fileNamePrefix%>
   CALCHELPERMAINFILE=OMCpp$(MODELICA_SYSTEM_LIB)CalcHelperMain.cpp
 
-  $(MODEL_NAME).fmu: $(MODELICA_SYSTEM_LIB)$(DLLEXT)
+  $(MODELICA_SYSTEM_LIB).fmu: $(MODELICA_SYSTEM_LIB)$(DLLEXT)
   <%\t%>rm -rf binaries
   <%\t%>mkdir -p "binaries/$(PLATFORM)"
   <%\t%>mv $(MODELICA_SYSTEM_LIB)$(DLLEXT) "binaries/$(PLATFORM)/"
-  <%\t%>rm -f $(MODEL_NAME).fmu
-  <%\t%>zip -r "$(MODEL_NAME).fmu" modelDescription.xml binaries
+  <%\t%>rm -f $(MODELICA_SYSTEM_LIB).fmu
+  <%\t%>zip -r "$(MODELICA_SYSTEM_LIB).fmu" modelDescription.xml binaries
   <%\t%>rm -rf binaries
 
   $(MODELICA_SYSTEM_LIB)$(DLLEXT):
@@ -802,7 +802,7 @@ case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simula
 
   .PHONY: <%modelName%>.fmu $(CPPFILES) clean
 
-  <%modelName%>.fmu: $(OFILES)
+  <%fileNamePrefix%>.fmu: $(OFILES)
   <%\t%>$(CXX) -shared -o <%fileNamePrefix%>$(DLLEXT) $(OFILES) $(LDFLAGS) $(LIBS)
   <%\t%><%mkdir%> -p "binaries/$(PLATFORM)"
   <%\t%>cp $(BINARIES) "binaries/$(PLATFORM)/"
@@ -812,12 +812,12 @@ case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simula
   <%\t%>cp $(SUNDIALS_LIBRARIES_KINSOL) "binaries/$(PLATFORM)/"
   <%\t%>cp $(OMHOME)/share/omc/runtime/cpp/licenses/sundials.license "documentation/"
   endif
-  <%\t%>rm -f <%modelName%>.fmu
+  <%\t%>rm -f <%fileNamePrefix%>.fmu
   ifeq ($(USE_FMU_SUNDIALS),ON)
-  <%\t%>zip -r "<%modelName%>.fmu" modelDescription.xml binaries documentation
+  <%\t%>zip -r "<%fileNamePrefix%>.fmu" modelDescription.xml binaries documentation
   <%\t%>rm -rf documentation
   else
-  <%\t%>zip -r "<%modelName%>.fmu" modelDescription.xml binaries
+  <%\t%>zip -r "<%fileNamePrefix%>.fmu" modelDescription.xml binaries
   endif
 
   clean:


### PR DESCRIPTION
This was previously done for Windows and now for Linux/OSX as well.
The "dynamic" and "static" platforms now skip running the configure
script since we know what the results (should) be.