### PR TITLE
enable discrete vars in symbolic jacobian

### DIFF
--- a/Compiler/FrontEnd/DAEDump.mo
+++ b/Compiler/FrontEnd/DAEDump.mo
@@ -1792,7 +1792,7 @@ algorithm
   end match;
 end ppStmtList;
 
-protected function ppStmtListStr "
+public function ppStmtListStr "
   Helper function to pp_stmt_str
 "
   input list<DAE.Statement> inAlgorithmStatementLst;

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -4905,12 +4905,7 @@ algorithm
 
     case({}, _, _, _, _, _) then listReverse(iVars);
 
-    // skip for dicrete variable
-    case(BackendDAE.VAR(varKind=BackendDAE.DISCRETE())::restVar, cref, _, _, _, _) equation
-     then
-       createAllDiffedSimVars(restVar, cref, inAllVars, inIndex, inMatrixName, iVars);
-
-     case(BackendDAE.VAR(varName=currVar, varKind=varkind, values = dae_var_attr)::restVar, cref, _, index, _, _) algorithm
+    case(BackendDAE.VAR(varName=currVar, varKind=varkind, values = dae_var_attr)::restVar, cref, _, index, _, _) algorithm
       try
         BackendVariable.getVarSingle(currVar, inAllVars);
         r1 := match (varkind)


### PR DESCRIPTION
- fixes differentiation rules for discrete parts
- fixes symbolic jacobian when records with Reals and non-Reals are involved 