### PR TITLE
[MetaModelica] Use goto instead of done variable

### DIFF
--- a/SimulationRuntime/c/meta/meta_modelica_data.h
+++ b/SimulationRuntime/c/meta/meta_modelica_data.h
@@ -243,6 +243,7 @@ void mmc_catch_dummy_fn();
 #define MMC_CATCH_INTERNAL(X) } threadData->X = old_jumper;}
 #endif
 #define MMC_CATCH() MMC_CATCH_INTERNAL(mmc_jumper)}
+#define MMC_RESTORE_INTERNAL(X) threadData->X = old_jumper;
 
 #define MMC_THROW_INTERNAL() {longjmp(*threadData->mmc_jumper,1);}
 #define MMC_THROW() {longjmp(*((threadData_t*)pthread_getspecific(mmc_thread_data_key))->mmc_jumper,1);}


### PR DESCRIPTION
By using goto directly in match expressions, we avoid the static
analyzer telling we have an unused assignment to variable `done` in some
cases.

This fixes #1847 in an alternative way.