### PR TITLE
Fix for fileNamePrefix not a valid C identifier

### DIFF
--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -5620,8 +5620,8 @@ end simulationParModelicaKernelsFile;
 ::=
   let &staticPrototypes = buffer ""
   <<
-  #ifndef <%stringReplace(filePrefix,".","_")%>__H
-  #define <%stringReplace(filePrefix,".","_")%>__H
+  #ifndef <%makeC89Identifier(filePrefix)%>__H
+  #define <%makeC89Identifier(filePrefix)%>__H
   <%commonHeader(filePrefix)%>
   #include "simulation/simulation_runtime.h"
   #ifdef __cplusplus

--- a/Compiler/Template/CodegenCFunctions.tpl
+++ b/Compiler/Template/CodegenCFunctions.tpl
@@ -201,8 +201,8 @@ template functionsHeaderFile(String filePrefix,
  "Generates the contents of the main C file for the function case."
 ::=
   <<
-  #ifndef <%stringReplace(filePrefix,".","_")%>__H
-  #define <%stringReplace(filePrefix,".","_")%>__H
+  #ifndef <%makeC89Identifier(filePrefix)%>__H
+  #define <%makeC89Identifier(filePrefix)%>__H
   <%commonHeader(filePrefix)%>
   #ifdef __cplusplus
   extern "C" {
@@ -301,8 +301,8 @@ template functionHeadersParModelica(String filePrefix, list<Function> functions)
  "Generates the content of the C file for functions in the simulation case."
 ::=
   <<
-  #ifndef <%stringReplace(filePrefix,".","_")%>__H
-  #define <%stringReplace(filePrefix,".","_")%>__H
+  #ifndef <%makeC89Identifier(filePrefix)%>__H
+  #define <%makeC89Identifier(filePrefix)%>__H
   //#include "helper.cl"
 
   <%parallelFunctionHeadersImpl(functions)%>

--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -9550,32 +9550,6 @@ template testdimension(Dimension d)
   else '-1'
 end testdimension;
 
-/*
-template underscorePath(Path path)
- "Generate paths with components separated by underscores.
-  Replaces also the . in identifiers with _.
-  The dot might happen for world.gravityAccleration"
-::=
-  match path
-  case QUALIFIED(__) then
-    '<%replaceDotAndUnderscore(name)%>_<%underscorePath(path)%>'
-  case IDENT(__) then
-    replaceDotAndUnderscore(name)
-  case FULLYQUALIFIED(__) then
-    underscorePath(path)
-end underscorePath;
-*/
-
-template replaceDotAndUnderscore(String str)
- "Replace _ with __ and dot in identifiers with _"
-::=
-  match str
-  case name then
-    let str_dots = System.stringReplace(name,".", "_")
-    let str_underscores = System.stringReplace(str_dots, "_", "__")
-    '<%str_underscores%>'
-end replaceDotAndUnderscore;
-
 template functionInitial(list<SimEqSystem> startValueEquations, Text &varDecls, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
 ::=
   let eqPart = (startValueEquations |> eq as SES_SIMPLE_ASSIGN(__) =>

--- a/Compiler/Template/CodegenUtilSimulation.tpl
+++ b/Compiler/Template/CodegenUtilSimulation.tpl
@@ -52,11 +52,7 @@ import CodegenUtil.*;
 template modelNamePrefix(SimCode simCode)
 ::=
   match simCode
-  case simCode as SIMCODE(__) then
-    System.stringReplace(fileNamePrefix,".", "_")
-  // underscorePath(mi.name)
-  // case simCode as SIMCODE(modelInfo=mi as MODELINFO(__)) then
-  // underscorePath(mi.name)
+  case simCode as SIMCODE(__) then makeC89Identifier(fileNamePrefix)
 end modelNamePrefix;
 
 template fileNamePrefix(SimCode simCode)

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -1287,6 +1287,11 @@ package System
     output String res;
   end stringReplace;
 
+  function makeC89Identifier
+    input String str;
+    output String res;
+  end makeC89Identifier;
+
   function tmpTick
     output Integer tickNo;
   end tmpTick;

--- a/Compiler/Util/System.mo
+++ b/Compiler/Util/System.mo
@@ -147,6 +147,13 @@ public function stringReplace
   external "C" res=System_stringReplace(str,source,target) annotation(Library = "omcruntime");
 end stringReplace;
 
+public function makeC89Identifier "Replaces unknown characters with _"
+  input String str;
+  output String res;
+
+  external "C" res=System_makeC89Identifier(str) annotation(Library = "omcruntime");
+end makeC89Identifier;
+
 public function toupper
   input String inString;
   output String outString;

--- a/Compiler/runtime/System_omc.c
+++ b/Compiler/runtime/System_omc.c
@@ -78,6 +78,21 @@ extern const char* System_stringReplace(const char* str, const char* source, con
   return res;
 }
 
+extern const char* System_makeC89Identifier(const char* str)
+{
+  int i=0, len=strlen(str);
+  char *res = omc_alloc_interface.malloc_strdup(str);
+  if (!((res[0]>='a' && res[0]<='z') || (res[0]>='A' && res[0]<='Z'))) {
+    res[0] = '_';
+  }
+  for (i=1; i<len; i++) {
+    if (!((res[i]>='a' && res[i]<='z') || (res[i]>='A' && res[i]<='Z') || (res[i]>='0' && res[i]<='9'))) {
+      res[i] = '_';
+    }
+  }
+  return res;
+}
+
 extern int System_stringFind(const char* str, const char* searchStr)
 {
   const char *found = strstr(str, searchStr);


### PR DESCRIPTION
Previously, we only handled dots in the prefix; now we replace all
invalid characters in C identifiers with an underscore.