### PR TITLE
inner/outer handling for nfinst.

### DIFF
--- a/Compiler/FrontEnd/SCode.mo
+++ b/Compiler/FrontEnd/SCode.mo
@@ -3871,6 +3871,24 @@ algorithm
   end match;
 end isNotBuiltinClass;
 
+public function getElementNamedAnnotation
+  "Returns the annotation with the given name in the element, or fails if no
+   such annotation could be found."
+  input Element element;
+  input String name;
+  output Absyn.Exp exp;
+protected
+  Annotation ann;
+algorithm
+  ann := match element
+    case EXTENDS(ann = SOME(ann)) then ann;
+    case CLASS(cmt = COMMENT(annotation_ = SOME(ann))) then ann;
+    case COMPONENT(comment = COMMENT(annotation_ = SOME(ann))) then ann;
+  end match;
+
+  exp := getNamedAnnotation(ann, name);
+end getElementNamedAnnotation;
+
 public function getNamedAnnotation
   "Checks if the given annotation contains an entry with the given name with the
    value true."

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -167,7 +167,7 @@ function flattenComponent
 
   import Origin = NFComponentRef.Origin;
 protected
-  Component c = InstNode.component(component);
+  Component c;
   ComponentRef new_pre;
   Type ty;
   Option<Expression> binding_exp;
@@ -176,6 +176,19 @@ protected
   list<Dimension> dims;
   Equation binding_eq;
 algorithm
+  if InstNode.isInnerOuterNode(component) then
+    // If we get an outer component, flatten it if it's also inner.
+    if InstNode.isInner(component) then
+      c := InstNode.component(InstNode.resolveOuter(component));
+    else
+      // If it's only outer we skip it since we don't want outer component in the DAE.
+      return;
+    end if;
+  else
+    // A non-outer component, proceed as normal.
+    c := InstNode.component(component);
+  end if;
+
   _ := match c
     case Component.TYPED_COMPONENT()
       algorithm

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -36,7 +36,7 @@ import Expression = NFExpression;
 import Pointer;
 import NFInstNode.InstNode;
 import Type = NFType;
-import NFPrefixes.Variability;
+import NFPrefixes.{Variability, InnerOuter};
 
 protected
 import Inst = NFInst;
@@ -769,7 +769,7 @@ protected
     output DAE.VarDirection direction;
   protected
     DAE.ConnectorType cty;
-    DAE.VarInnerOuter io;
+    InnerOuter io;
     DAE.VarVisibility vis;
   algorithm
     Component.Attributes.ATTRIBUTES(
@@ -793,16 +793,12 @@ protected
     end match;
 
     // Function components may not be inner/outer.
-    () := match io
-      case DAE.VarInnerOuter.NOT_INNER_OUTER() then ();
-      else
-        algorithm
-          Error.addSourceMessage(Error.INNER_OUTER_FORMAL_PARAMETER,
-            {DAEDump.unparseVarInnerOuter(io), InstNode.name(component)},
-            InstNode.info(component));
-        then
-          fail();
-    end match;
+    if io <> InnerOuter.NOT_INNER_OUTER then
+      Error.addSourceMessage(Error.INNER_OUTER_FORMAL_PARAMETER,
+        {Prefixes.innerOuterString(io), InstNode.name(component)},
+        InstNode.info(component));
+      fail();
+    end if;
 
     // Formal parameters must be public, other function variables must be protected.
     () := match (direction, vis)

--- a/Compiler/NFFrontEnd/NFMod.mo
+++ b/Compiler/NFFrontEnd/NFMod.mo
@@ -50,6 +50,7 @@ import SCode;
 protected
 import Error;
 import List;
+import SCodeDump;
 
 constant Modifier EMPTY_MOD = NOMOD();
 
@@ -408,12 +409,13 @@ public
 
   function toString
     input Modifier mod;
+    input Boolean printName = true;
     output String string;
   algorithm
     string := match mod
       local
         list<Modifier> submods;
-        String subs_str;
+        String subs_str, binding_str, binding_sep;
 
       case NOMOD() then "";
       case MODIFIER()
@@ -421,13 +423,19 @@ public
           submods := ModTable.listValues(mod.subModifiers);
           if not listEmpty(submods) then
             subs_str := "(" + stringDelimitList(list(toString(s) for s in submods), ", ") + ")";
+            binding_sep := " = ";
           else
             subs_str := "";
+            binding_sep := if printName then " = " else "= ";
           end if;
-        then
-          mod.name + subs_str + Binding.toString(mod.binding, " = ");
 
-      case REDECLARE() then "redeclare";
+          binding_str := Binding.toString(mod.binding, binding_sep);
+        then
+          if printName then mod.name + subs_str + binding_str else subs_str + binding_str;
+
+      case REDECLARE()
+        then SCodeDump.unparseElementStr(InstNode.definition(mod.element));
+
     end match;
   end toString;
 

--- a/Compiler/NFFrontEnd/NFPrefixes.mo
+++ b/Compiler/NFFrontEnd/NFPrefixes.mo
@@ -40,6 +40,13 @@ type Variability = enumeration(
   CONTINUOUS
 );
 
+type InnerOuter = enumeration(
+  NOT_INNER_OUTER,
+  INNER,
+  OUTER,
+  INNER_OUTER
+);
+
 function variabilityFromSCode
   input SCode.Variability scodeVar;
   output Variability var;
@@ -87,6 +94,30 @@ function variabilityMin
   input Variability var2;
   output Variability var = if var1 > var2 then var2 else var1;
 end variabilityMin;
+
+function innerOuterFromSCode
+  input Absyn.InnerOuter scodeIO;
+  output InnerOuter io;
+algorithm
+  io := match scodeIO
+    case Absyn.NOT_INNER_OUTER() then InnerOuter.NOT_INNER_OUTER;
+    case Absyn.INNER() then InnerOuter.INNER;
+    case Absyn.OUTER() then InnerOuter.OUTER;
+    case Absyn.INNER_OUTER() then InnerOuter.INNER_OUTER;
+  end match;
+end innerOuterFromSCode;
+
+function innerOuterString
+  input InnerOuter io;
+  output String str;
+algorithm
+  str := match io
+    case InnerOuter.INNER then "inner";
+    case InnerOuter.OUTER then "outer";
+    case InnerOuter.INNER_OUTER then "inner outer";
+    else "";
+  end match;
+end innerOuterString;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFPrefixes;

--- a/Compiler/Util/Array.mo
+++ b/Compiler/Util/Array.mo
@@ -621,6 +621,33 @@ algorithm
   outArray := arrayUpdate(inArray, inIndex, listAppend(inArray[inIndex], inElements));
 end appendToElement;
 
+function appendList<T>
+  "Returns a new array with the list elements added to the end of the given array."
+  input array<T> arr;
+  input list<T> lst;
+  output array<T> outArray;
+protected
+  Integer arr_len = arrayLength(arr), lst_len;
+  T e;
+  list<T> rest;
+algorithm
+  if listEmpty(lst) then
+    outArray := arr;
+  elseif arr_len == 0 then
+    outArray := listArray(lst);
+  else
+    lst_len := listLength(lst);
+    outArray := arrayCreateNoInit(arr_len + lst_len, arr[1]);
+    copy(arr, outArray);
+
+    rest := lst;
+    for i in arr_len+1:arr_len+lst_len loop
+      e :: rest := rest;
+      arrayUpdateNoBoundsChecking(outArray, i, e);
+    end for;
+  end if;
+end appendList;
+
 function copy<T>
   "Copies all values from inArraySrc to inArrayDest. Fails if inArraySrc is
    larger than inArrayDest.

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -735,6 +735,20 @@ public constant Message RAGGED_DIMENSION = MESSAGE(302, TRANSLATION(), ERROR(),
   Util.gettext("Ragged dimensions are not yet supported (from dimension '%s')"));
 public constant Message INVALID_TYPENAME_USE = MESSAGE(303, TRANSLATION(), ERROR(),
   Util.gettext("Type name '%s' is not allowed in this context."));
+public constant Message FOUND_NON_INNER = MESSAGE(304, TRANSLATION(), WARNING(),
+  Util.gettext("Ignoring non-inner %s when looking for inner."));
+public constant Message FOUND_WRONG_INNER_ELEMENT = MESSAGE(305, TRANSLATION(), ERROR(),
+  Util.gettext("Found inner %s %s instead of expected %s."));
+public constant Message FOUND_OTHER_BASECLASS = MESSAGE(306, TRANSLATION(), ERROR(),
+  Util.gettext("Found other base class for extends %s after instantiating extends."));
+public constant Message OUTER_ELEMENT_MOD = MESSAGE(307, TRANSLATION(), ERROR(),
+  Util.gettext("Modifier '%s' found on outer element %s."));
+public constant Message OUTER_LONG_CLASS = MESSAGE(308, TRANSLATION(), ERROR(),
+  Util.gettext("Illegal outer class %s, outer classes may only be declared using short-class definitions."));
+public constant Message MISSING_INNER_ADDED = MESSAGE(309, TRANSLATION(), WARNING(),
+  Util.gettext("An inner declaration for outer %s %s could not be found and was automatically generated."));
+public constant Message MISSING_INNER_MESSAGE = MESSAGE(310, TRANSLATION(), NOTIFICATION(),
+  Util.gettext("The diagnostics message for the missing inner is: %s"));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),


### PR DESCRIPTION
- Implemented handling of inner/outer, including automatic generation
  of inner elements when missing.
- Moved setting the type of a component from instComponent to
  instClass, to allow lookup in a component's parent component
  during instantiation.
- Fixed scoping of builtin variables (i.e. time), to avoid them
  being incorrectly prefixed.
- Fixed lookup of self-referencing extends and added check for
  inherited base classes.