### PR TITLE
NFInst improvements.

### DIFF
--- a/Compiler/FrontEnd/Absyn.mo
+++ b/Compiler/FrontEnd/Absyn.mo
@@ -4184,28 +4184,16 @@ algorithm
 end crefSetLastSubs;
 
 public function crefHasSubscripts "This function finds if a cref has subscripts"
-  input ComponentRef inComponentRef;
-  output Boolean outHasSubscripts;
+  input ComponentRef cref;
+  output Boolean hasSubscripts;
 algorithm
-  outHasSubscripts := match (inComponentRef)
-    local
-      Ident i;
-      Boolean b;
-      ComponentRef c;
-
-    case CREF_IDENT(subscripts = {}) then false;
-
-    case CREF_QUAL(subscripts = {},componentRef = c)
-      equation
-        b = crefHasSubscripts(c);
-      then
-        b;
-
-    case CREF_FULLYQUALIFIED(componentRef = c)
-      equation
-        b = crefHasSubscripts(c);
-      then
-        b;
+  hasSubscripts := match cref
+    case CREF_IDENT() then not listEmpty(cref.subscripts);
+    case CREF_QUAL(subscripts = {}) then crefHasSubscripts(cref.componentRef);
+    case CREF_FULLYQUALIFIED() then crefHasSubscripts(cref.componentRef);
+    case WILD() then false;
+    case ALLWILD() then false;
+    else true;
   end match;
 end crefHasSubscripts;
 

--- a/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -55,6 +55,8 @@ import Type = NFType;
 import BuiltinFuncs = NFBuiltinFuncs;
 import Pointer;
 import NFPrefixes.Variability;
+import ComponentRef = NFComponentRef;
+import NFComponentRef.Origin;
 
 encapsulated package Elements
   import SCode;
@@ -106,25 +108,31 @@ end Elements;
 // InstNodes for the builtin types. These have empty class trees to prevent
 // access to the attributes via dot notation (which is not needed for
 // modifiers and illegal in other cases).
-constant InstNode REAL_TYPE_NODE = InstNode.CLASS_NODE("Real",
+constant InstNode REAL_NODE = InstNode.CLASS_NODE("Real",
   Elements.REAL,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.REAL(), NFClassTree.EMPTY, Modifier.NOMOD())),
   Pointer.createImmutable(NFInstNode.CachedData.NO_CACHE()),
   InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
 
-constant InstNode INT_TYPE_NODE = InstNode.CLASS_NODE("Integer",
+constant InstNode INTEGER_NODE = InstNode.CLASS_NODE("Integer",
   Elements.INTEGER,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.INTEGER(), NFClassTree.EMPTY, Modifier.NOMOD())),
   Pointer.createImmutable(NFInstNode.CachedData.FUNCTION({NFBuiltinFuncs.INTEGER}, true, false)),
   InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
 
-constant InstNode BOOLEAN_TYPE_NODE = InstNode.CLASS_NODE("Boolean",
+constant ComponentRef INTEGER_CREF =
+  ComponentRef.CREF(INTEGER_NODE, {}, Type.INTEGER(), Origin.CREF, ComponentRef.EMPTY());
+
+constant InstNode BOOLEAN_NODE = InstNode.CLASS_NODE("Boolean",
   Elements.BOOLEAN,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.BOOLEAN(), NFClassTree.EMPTY, Modifier.NOMOD())),
   Pointer.createImmutable(NFInstNode.CachedData.NO_CACHE()),
   InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
 
-constant InstNode STRING_TYPE_NODE = InstNode.CLASS_NODE("String",
+constant ComponentRef BOOLEAN_CREF =
+  ComponentRef.CREF(BOOLEAN_NODE, {}, Type.INTEGER(), Origin.CREF, ComponentRef.EMPTY());
+
+constant InstNode STRING_NODE = InstNode.CLASS_NODE("String",
   Elements.STRING,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.STRING(), NFClassTree.EMPTY, Modifier.NOMOD())),
   Pointer.createImmutable(NFInstNode.CachedData.FUNCTION({
@@ -133,7 +141,10 @@ constant InstNode STRING_TYPE_NODE = InstNode.CLASS_NODE("String",
     NFBuiltinFuncs.STRING_REAL_FORMAT}, true, false)),
   InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
 
-constant InstNode ENUM_TYPE_NODE = InstNode.CLASS_NODE("enumeration",
+constant ComponentRef STRING_CREF =
+  ComponentRef.CREF(STRING_NODE, {}, Type.INTEGER(), Origin.CREF, ComponentRef.EMPTY());
+
+constant InstNode ENUM_NODE = InstNode.CLASS_NODE("enumeration",
   Elements.ENUMERATION,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.ENUMERATION_ANY(), NFClassTree.EMPTY, Modifier.NOMOD())),
   Pointer.createImmutable(NFInstNode.CachedData.NO_CACHE()),
@@ -142,11 +153,14 @@ constant InstNode ENUM_TYPE_NODE = InstNode.CLASS_NODE("enumeration",
 constant Type STATESELECT_TYPE = Type.ENUMERATION(
   Absyn.IDENT("StateSelect"), {"never", "avoid", "default", "prefer", "always"});
 
-constant InstNode STATESELECT_TYPE_NODE = InstNode.CLASS_NODE("StateSelect",
+constant InstNode STATESELECT_NODE = InstNode.CLASS_NODE("StateSelect",
   Elements.STATESELECT,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(STATESELECT_TYPE, NFClassTree.EMPTY, Modifier.NOMOD())),
   Pointer.createImmutable(NFInstNode.CachedData.NO_CACHE()),
   InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
+
+constant ComponentRef STATESELECT_CREF =
+  ComponentRef.CREF(STATESELECT_NODE, {}, STATESELECT_TYPE, Origin.CREF, ComponentRef.EMPTY());
 
 constant Binding STATESELECT_NEVER_BINDING =
   Binding.TYPED_BINDING(
@@ -196,7 +210,10 @@ constant InstNode STATESELECT_NEVER =
       STATESELECT_NEVER_BINDING,
       NFComponent.CONST_ATTR,
       Absyn.dummyInfo)),
-    STATESELECT_TYPE_NODE);
+    STATESELECT_NODE);
+
+constant ComponentRef STATESELECT_NEVER_CREF =
+  ComponentRef.CREF(STATESELECT_NEVER, {}, STATESELECT_TYPE, Origin.CREF, STATESELECT_CREF);
 
 constant InstNode STATESELECT_AVOID =
   InstNode.COMPONENT_NODE("avoid",
@@ -206,7 +223,10 @@ constant InstNode STATESELECT_AVOID =
       STATESELECT_AVOID_BINDING,
       NFComponent.CONST_ATTR,
       Absyn.dummyInfo)),
-    STATESELECT_TYPE_NODE);
+    STATESELECT_NODE);
+
+constant ComponentRef STATESELECT_AVOID_CREF =
+  ComponentRef.CREF(STATESELECT_AVOID, {}, STATESELECT_TYPE, Origin.CREF, STATESELECT_CREF);
 
 constant InstNode STATESELECT_DEFAULT =
   InstNode.COMPONENT_NODE("default",
@@ -216,7 +236,10 @@ constant InstNode STATESELECT_DEFAULT =
       STATESELECT_DEFAULT_BINDING,
       NFComponent.CONST_ATTR,
       Absyn.dummyInfo)),
-    STATESELECT_TYPE_NODE);
+    STATESELECT_NODE);
+
+constant ComponentRef STATESELECT_DEFAULT_CREF =
+  ComponentRef.CREF(STATESELECT_DEFAULT, {}, STATESELECT_TYPE, Origin.CREF, STATESELECT_CREF);
 
 constant InstNode STATESELECT_PREFER =
   InstNode.COMPONENT_NODE("prefer",
@@ -226,7 +249,10 @@ constant InstNode STATESELECT_PREFER =
       STATESELECT_PREFER_BINDING,
       NFComponent.CONST_ATTR,
       Absyn.dummyInfo)),
-    STATESELECT_TYPE_NODE);
+    STATESELECT_NODE);
+
+constant ComponentRef STATESELECT_PREFER_CREF =
+  ComponentRef.CREF(STATESELECT_PREFER, {}, STATESELECT_TYPE, Origin.CREF, STATESELECT_CREF);
 
 constant InstNode STATESELECT_ALWAYS =
   InstNode.COMPONENT_NODE("always",
@@ -236,7 +262,10 @@ constant InstNode STATESELECT_ALWAYS =
       STATESELECT_ALWAYS_BINDING,
       NFComponent.CONST_ATTR,
       Absyn.dummyInfo)),
-    STATESELECT_TYPE_NODE);
+    STATESELECT_NODE);
+
+constant ComponentRef STATESELECT_ALWAYS_CREF =
+  ComponentRef.CREF(STATESELECT_ALWAYS, {}, STATESELECT_TYPE, Origin.CREF, STATESELECT_CREF);
 
 constant Type ASSERTIONLEVEL_TYPE = Type.ENUMERATION(
   Absyn.IDENT("AssertionLevel"), {"error", "warning"});
@@ -244,12 +273,14 @@ constant Type ASSERTIONLEVEL_TYPE = Type.ENUMERATION(
 constant InstNode TIME =
   InstNode.COMPONENT_NODE("time",
     Pointer.createImmutable(Component.TYPED_COMPONENT(
-      REAL_TYPE_NODE,
+      REAL_NODE,
       Type.REAL(),
       Binding.UNBOUND(),
       NFComponent.INPUT_ATTR,
       Absyn.dummyInfo)),
     InstNode.EMPTY_NODE());
+
+constant ComponentRef TIME_CREF = ComponentRef.CREF(TIME, {}, Type.REAL(), Origin.CREF, ComponentRef.EMPTY());
 
 annotation(__OpenModelica_Interface="frontend");
 end NFBuiltin;

--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -32,6 +32,7 @@
 encapsulated uniontype NFComponentRef
 protected
   import NFComponent.Component;
+  import Absyn;
   import DAE;
   import Subscript = NFSubscript;
   import Type = NFType;
@@ -70,12 +71,63 @@ public
     output ComponentRef cref = CREF(node, subs, ty, origin, EMPTY());
   end fromNode;
 
+  function fromAbsyn
+    input InstNode node;
+    input list<Absyn.Subscript> subs;
+    input Origin origin = Origin.CREF;
+    input ComponentRef restCref = EMPTY();
+    output ComponentRef cref;
+  protected
+    list<Subscript> sl;
+  algorithm
+    sl := list(Subscript.RAW_SUBSCRIPT(s) for s in subs);
+    cref := CREF(node, sl, Type.UNKNOWN(), origin, restCref);
+  end fromAbsyn;
+
+  function fromBuiltin
+    input InstNode node;
+    input Type ty;
+    output ComponentRef cref = CREF(node, {}, ty, Origin.SCOPE, EMPTY());
+  end fromBuiltin;
+
+  function isEmpty
+    input ComponentRef cref;
+    output Boolean isEmpty;
+  algorithm
+    isEmpty := match cref
+      case EMPTY() then true;
+      else false;
+    end match;
+  end isEmpty;
+
+  function node
+    input ComponentRef cref;
+    output InstNode node;
+  algorithm
+    CREF(node = node) := cref;
+  end node;
+
   function rest
     input ComponentRef cref;
     output ComponentRef restCref;
   algorithm
     CREF(restCref = restCref) := cref;
   end rest;
+
+  function append
+    input output ComponentRef cref;
+    input ComponentRef restCref;
+  algorithm
+    cref := match cref
+      case CREF()
+        algorithm
+          cref.restCref := append(cref.restCref, restCref);
+        then
+          cref;
+
+      case EMPTY() then restCref;
+    end match;
+  end append;
 
   function getType
     input ComponentRef cref;

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -191,7 +191,7 @@ uniontype Function
     output ComponentRef functionRef;
     output Absyn.Path functionPath;
   protected
-    list<InstNode> nodes;
+    ComponentRef cref;
     InstNode found_scope;
   algorithm
     try
@@ -203,14 +203,15 @@ uniontype Function
     end try;
 
     // Look up the function and create a cref for it.
-    (node, nodes, found_scope) := Lookup.lookupFunctionName(functionName, scope, info);
+    (cref, found_scope) := Lookup.lookupFunctionName(functionName, scope, info);
+    node := ComponentRef.node(cref);
 
     for s in InstNode.scopeList(found_scope) loop
       functionPath := Absyn.QUALIFIED(InstNode.name(s), functionPath);
     end for;
 
     functionRef := ComponentRef.fromNodeList(InstNode.scopeList(found_scope));
-    functionRef := Inst.makeCref(functionName, nodes, scope, info, functionRef);
+    functionRef := ComponentRef.append(cref, functionRef);
   end lookupFunction;
 
   public

--- a/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/Compiler/NFFrontEnd/NFSubscript.mo
@@ -38,6 +38,11 @@ protected
 
 public
   import Expression = NFExpression;
+  import Absyn;
+
+  record RAW_SUBSCRIPT
+    Absyn.Subscript subscript;
+  end RAW_SUBSCRIPT;
 
   record UNTYPED
     Expression exp;


### PR DESCRIPTION
- Changed Lookup.lookupCref to return a ComponentRef instead of a
  list of nodes, to handle inner/outer better.
- Implemented collapsing of crefs with outer components in them,
  and correct scoping of such crefs.
- Improved Lookup.lookupBuiltinCref to disallow e.g. Boolean[1] or
  Boolean.foo.
- Fixed Absyn.crefHasSubscripts so it doesn't fail on some crefs..