### PR TITLE
[C-code] Binding equations disable optimization 

### DIFF
--- a/SimulationRuntime/c/openmodelica.h
+++ b/SimulationRuntime/c/openmodelica.h
@@ -178,10 +178,12 @@ static inline int sign(double v)
 #define OMC_LABEL_UNUSED __attribute__((unused))
 #endif
 
+#if !defined(OMC_DISABLE_OPT)
 #if defined(__clang__)
 #define OMC_DISABLE_OPT __attribute__((optnone))
 #elif defined(__GNUC__)
 #define OMC_DISABLE_OPT __attribute__((optimize(0)))
+#endif
 #endif
 
 #if defined(__cplusplus)


### PR DESCRIPTION
The number of binding equations is huge and only executes once,
typically only setting a variable to a constant value and checking
assertions. This disables optimizations for most of those equations.