### PR TITLE
Move checkForDiscreteChanges to simulation runtime

### DIFF
--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -13462,6 +13462,25 @@ algorithm
     else t1>t2;
 end simvarGraterThan;
 
+public function sortCrefBasedOnSimCodeIndex
+  input output list<DAE.ComponentRef> crs;
+  input SimCode.SimCode simCode;
+algorithm
+  crs := List.sort(crs, function crefSimCodeIndexGreaterThan(simCode=simCode));
+end sortCrefBasedOnSimCodeIndex;
+
+protected function crefSimCodeIndexGreaterThan
+  input DAE.ComponentRef cr1, cr2;
+  input SimCode.SimCode simCode;
+  output Boolean b;
+protected
+  SimCodeVar.SimVar v1, v2;
+algorithm
+  v1 := cref2simvar(cr1, simCode);
+  v2 := cref2simvar(cr2, simCode);
+  b := simvarGraterThan(v1, v2);
+end crefSimCodeIndexGreaterThan;
+
 public function lookupVR
   input DAE.ComponentRef cr;
   input SimCode.SimCode simCode;

--- a/Compiler/Template/CodegenFMU.tpl
+++ b/Compiler/Template/CodegenFMU.tpl
@@ -1106,23 +1106,22 @@ match platform
   >>
   else
   <<
-  <%fileNamePrefix%>_FMU:
-  <%\t%>$(MAKE) CC="$(CC)" $(MAINOBJ) <%fileNamePrefix%>_functions.h <%fileNamePrefix%>_literals.h $(OFILES) $(RUNTIMEFILES) 2>&1 | tee make.log
+  <%fileNamePrefix%>_FMU: $(MAINOBJ) <%fileNamePrefix%>_functions.h <%fileNamePrefix%>_literals.h $(OFILES) $(RUNTIMEFILES)
   <%\t%>mkdir -p ../binaries/$(FMIPLATFORM)
   ifeq (@LIBTYPE_DYNAMIC@,1)
-  <%\t%>$(LD) -o <%modelNamePrefix%>$(DLLEXT) $(MAINOBJ) $(OFILES) $(RUNTIMEFILES) <%dirExtra%> <%libsPos1%> <%libsPos2%> $(LDFLAGS)  2>&1 | tee -a make.log
-  <%\t%>cp <%fileNamePrefix%>$(DLLEXT) <%fileNamePrefix%>_FMU.libs config.log make.log ../binaries/$(FMIPLATFORM)/
+  <%\t%>$(LD) -o <%modelNamePrefix%>$(DLLEXT) $(MAINOBJ) $(OFILES) $(RUNTIMEFILES) <%dirExtra%> <%libsPos1%> <%libsPos2%> $(LDFLAGS)
+  <%\t%>cp <%fileNamePrefix%>$(DLLEXT) <%fileNamePrefix%>_FMU.libs config.log ../binaries/$(FMIPLATFORM)/
   endif
   <%\t%>head -n20 Makefile > ../binaries/$(FMIPLATFORM)/config.summary
   ifeq (@LIBTYPE_STATIC@,1)
   <%\t%>rm -f <%modelNamePrefix%>.a
   <%\t%>$(AR) -rsu <%modelNamePrefix%>.a $(MAINOBJ) $(OFILES) $(RUNTIMEFILES)
-  <%\t%>cp <%fileNamePrefix%>.a <%fileNamePrefix%>_FMU.libs config.log make.log ../binaries/$(FMIPLATFORM)/
+  <%\t%>cp <%fileNamePrefix%>.a <%fileNamePrefix%>_FMU.libs config.log ../binaries/$(FMIPLATFORM)/
   endif
   <%\t%>$(MAKE) distclean
   <%\t%>cd .. && rm -f ../<%fileNamePrefix%>.fmu && zip -r ../<%fmuTargetName%>.fmu *
   distclean: clean
-  <%\t%>rm -f Makefile config.status config.log make.log
+  <%\t%>rm -f Makefile config.status config.log
   clean:
   <%\t%>rm -f <%fileNamePrefix%>.def <%fileNamePrefix%>.o <%fileNamePrefix%>.a <%fileNamePrefix%>$(DLLEXT) $(MAINOBJ) $(OFILES) $(RUNTIMEFILES)
   >>

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -1027,6 +1027,12 @@ package SimCodeUtil
     output list<SimCode.SimEqSystem> eqs;
   end sortSimpleAssignmentBasedOnLhs;
 
+  function sortCrefBasedOnSimCodeIndex
+    input list<DAE.ComponentRef> inCrefs;
+    input SimCode.SimCode simCode;
+    output list<DAE.ComponentRef> crs;
+  end sortCrefBasedOnSimCodeIndex;
+
   function lookupVR
     input DAE.ComponentRef cr;
     input SimCode.SimCode simCode;

--- a/SimulationRuntime/c/Makefile.common
+++ b/SimulationRuntime/c/Makefile.common
@@ -52,6 +52,7 @@ RUNTIMESIMRESULTS_HEADERS = ./simulation/results/simulation_result.h
 
 RUNTIMESIMSOLVER_HEADERS = ./simulation/solver/delay.h \
 ./simulation/solver/epsilon.h \
+./simulation/solver/fmi_events.h \
 ./simulation/solver/mixedSystem.h \
 ./simulation/solver/linearSystem.h \
 ./simulation/solver/linearSolverLapack.h \

--- a/SimulationRuntime/c/Makefile.objs
+++ b/SimulationRuntime/c/Makefile.objs
@@ -59,7 +59,7 @@ else
 SOLVER_OBJS_MIXED_SYSTEMS=mixedSystem$(OBJ_EXT) mixedSearchSolver$(OBJ_EXT)
 endif
 
-SOLVER_OBJS_FMU=delay$(OBJ_EXT) $(SOLVER_OBJS_LINEAR_SYSTEMS) $(SOLVER_OBJS_MIXED_SYSTEMS) $(SOLVER_OBJS_NONLINEAR_SYSTEMS) omc_math$(OBJ_EXT) model_help$(OBJ_EXT) stateset$(OBJ_EXT) synchronous$(OBJ_EXT)
+SOLVER_OBJS_FMU=delay$(OBJ_EXT) $(SOLVER_OBJS_LINEAR_SYSTEMS) $(SOLVER_OBJS_MIXED_SYSTEMS) $(SOLVER_OBJS_NONLINEAR_SYSTEMS) fmi_events$(OBJ_EXT) omc_math$(OBJ_EXT) model_help$(OBJ_EXT) stateset$(OBJ_EXT) synchronous$(OBJ_EXT)
 ifeq ($(OMC_FMI_RUNTIME),)
 SOLVER_OBJS_MINIMAL=$(SOLVER_OBJS_FMU) events$(OBJ_EXT) external_input$(OBJ_EXT) solver_main$(OBJ_EXT) real_time_sync$(OBJ_EXT) embedded_server$(OBJ_EXT)
 
@@ -71,7 +71,7 @@ SOLVER_OBJS=$(SOLVER_OBJS_MINIMAL) kinsolSolver$(OBJ_EXT) linearSolverKlu$(OBJ_E
 else
 SOLVER_OBJS=$(SOLVER_OBJS_MINIMAL)
 endif
-SOLVER_HFILES = dassl.h delay.h epsilon.h events.h external_input.h ida_solver.h linearSystem.h mixedSystem.h model_help.h nonlinearSystem.h nonlinearValuesList.h radau.h sym_solver_ssc.h solver_main.h stateset.h
+SOLVER_HFILES = dassl.h delay.h epsilon.h events.h external_input.h fmi_events.h ida_solver.h linearSystem.h mixedSystem.h model_help.h nonlinearSystem.h nonlinearValuesList.h radau.h sym_solver_ssc.h solver_main.h stateset.h
 
 INITIALIZATION_OBJS = initialization$(OBJ_EXT)
 INITIALIZATION_HFILES = initialization.h

--- a/SimulationRuntime/c/openmodelica_func.h
+++ b/SimulationRuntime/c/openmodelica_func.h
@@ -209,14 +209,6 @@ int (*function_ZeroCrossings)(DATA *data, threadData_t*, double* gout);
  */
 int (*function_updateRelations)(DATA *data, threadData_t*, int evalZeroCross);
 
-/*! \fn checkForDiscreteChanges
- *
- *  This function checks if any discrete variable changed
- *
- *  \param [ref] [data]
- */
-int (*checkForDiscreteChanges)(DATA *data, threadData_t*);
-
 /*! \var zeroCrossingDescription
  *
  * This variable contains a description string for zero crossing condition.

--- a/SimulationRuntime/c/simulation/solver/events.c
+++ b/SimulationRuntime/c/simulation/solver/events.c
@@ -527,6 +527,7 @@ void saveZeroCrossingsAfterEvent(DATA *data, threadData_t *threadData)
   TRACE_POP
 }
 
+
 #ifdef __cplusplus
 }
 #endif

--- a/SimulationRuntime/c/simulation/solver/fmi_events.c
+++ b/SimulationRuntime/c/simulation/solver/fmi_events.c
@@ -1,0 +1,112 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2014, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+#include "simulation/solver/fmi_events.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int checkForDiscreteChanges(DATA *data, threadData_t *threadData)
+{
+  TRACE_PUSH
+  MODEL_DATA *modelData = data->modelData;
+  long i=0, realStartIndex=modelData->nVariablesReal - modelData->nDiscreteReal, realStopIndex=modelData->nVariablesReal;
+
+  if (ACTIVE_STREAM(LOG_EVENTS_V)) {
+    /* We log all changed variables. This takes some extra time because we always iterate over all variables, and duplicates code */
+    int needToIterate = 0;
+    infoStreamPrint(LOG_EVENTS_V, 1, "check for discrete changes at time=%.12g", data->localData[0]->timeValue);
+
+    if ((!modelData->nDiscreteReal) && (!modelData->nVariablesInteger) &&  (!modelData->nVariablesBoolean) && (!modelData->nVariablesString)) {
+      return 0;
+    }
+    for (i=realStartIndex; i<realStopIndex; i++) {
+      modelica_real v1 = data->simulationInfo->realVarsPre[i];
+      modelica_real v2 = data->localData[0]->realVars[i];
+      if (v1 != v2) {
+        infoStreamPrint(LOG_EVENTS_V, 0, "discrete var changed: %s from %g to %g", modelData->realVarsData[i].info.name, v1, v2);
+        needToIterate = 1;
+      }
+    }
+    for (i=0; i<modelData->nVariablesInteger; i++) {
+      modelica_integer v1 = data->simulationInfo->integerVarsPre[i];
+      modelica_integer v2 = data->localData[0]->integerVars[i];
+      if (v1 != v2) {
+        infoStreamPrint(LOG_EVENTS_V, 0, "discrete var changed: %s from %ld to %ld", modelData->integerVarsData[i].info.name, (long) v1, (long) v2);
+        needToIterate = 1;
+      }
+    }
+    for (i=0; i<modelData->nVariablesBoolean; i++) {
+      modelica_boolean v1 = data->simulationInfo->booleanVarsPre[i];
+      modelica_boolean v2 = data->localData[0]->booleanVars[i];
+      if (v1 != v2) {
+        infoStreamPrint(LOG_EVENTS_V, 0, "discrete var changed: %s from %d to %d", modelData->booleanVarsData[i].info.name, v1, v2);
+        needToIterate = 1;
+      }
+    }
+    for (i=0; i<modelData->nVariablesString; i++) {
+      modelica_string v1 = data->simulationInfo->stringVarsPre[i];
+      modelica_string v2 = data->localData[0]->stringVars[i];
+      if (0 != strcmp(MMC_STRINGDATA(v1),MMC_STRINGDATA(v2))) {
+        infoStreamPrint(LOG_EVENTS_V, 0, "discrete var changed: %s from %s to %s", modelData->stringVarsData[i].info.name, v1, v2);
+        needToIterate = 1;
+      }
+    }
+    if (ACTIVE_STREAM(LOG_EVENTS_V)) messageClose(LOG_EVENTS_V);
+    return needToIterate;
+  } else {
+    /* Just check if variables changed */
+    if (0 != memcmp(data->simulationInfo->realVarsPre + realStartIndex, data->localData[0]->realVars + realStartIndex, modelData->nDiscreteReal*sizeof(modelica_real))) {
+      return 1;
+    }
+    if (0 != memcmp(data->simulationInfo->integerVarsPre, data->localData[0]->integerVars, modelData->nVariablesInteger*sizeof(modelica_integer))) {
+      return 1;
+    }
+    if (0 != memcmp(data->simulationInfo->booleanVarsPre, data->localData[0]->booleanVars, modelData->nVariablesBoolean*sizeof(modelica_boolean))) {
+      return 1;
+    }
+    for (i=0; i<modelData->nVariablesString; i++) {
+      modelica_string v1 = data->simulationInfo->stringVarsPre[i];
+      modelica_string v2 = data->localData[0]->stringVars[i];
+      if (0 != strcmp(MMC_STRINGDATA(v1),MMC_STRINGDATA(v2))) {
+        return 1;
+      }
+    }
+    return 0;
+  }
+
+
+  TRACE_POP
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/SimulationRuntime/c/simulation/solver/fmi_events.h
+++ b/SimulationRuntime/c/simulation/solver/fmi_events.h
@@ -35,21 +35,12 @@
 #define _EVENTS_H_
 
 #include "simulation_data.h"
-#include "simulation/solver/solver_main.h"
-#include "util/list.h"
-#include "simulation/solver/fmi_events.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern int maxBisectionIterations;
-void checkForSampleEvent(DATA *data, SOLVER_INFO* solverInfo);
-int checkEvents(DATA* data, threadData_t *threadData, LIST* eventLst, modelica_boolean useRootFinding, double *eventTime);
-
-void handleEvents(DATA* data, threadData_t *threadData, LIST* eventLst, double *eventTime, SOLVER_INFO* solverInfo);
-
-double findRoot(DATA *data, threadData_t *threadData, LIST *eventList);
+int checkForDiscreteChanges(DATA* data, threadData_t *threadData);
 
 #ifdef __cplusplus
 }

--- a/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/SimulationRuntime/c/simulation/solver/model_help.c
@@ -104,7 +104,7 @@ void updateDiscreteSystem(DATA *data, threadData_t *threadData)
   debugStreamPrint(LOG_EVENTS_V, 0, "updated discrete System");
 
   relationChanged = checkRelations(data);
-  discreteChanged = data->callback->checkForDiscreteChanges(data, threadData);
+  discreteChanged = checkForDiscreteChanges(data, threadData);
   while(discreteChanged || data->simulationInfo->needToIterate || relationChanged)
   {
     if(data->simulationInfo->needToIterate) {
@@ -131,7 +131,7 @@ void updateDiscreteSystem(DATA *data, threadData_t *threadData)
     }
 
     relationChanged = checkRelations(data);
-    discreteChanged = data->callback->checkForDiscreteChanges(data, threadData);
+    discreteChanged = checkForDiscreteChanges(data, threadData);
   }
   storeRelations(data);
 

--- a/SimulationRuntime/fmi/export/fmi1/fmu1_model_interface.c
+++ b/SimulationRuntime/fmi/export/fmi1/fmu1_model_interface.c
@@ -35,6 +35,7 @@
 #include "simulation/solver/linearSystem.h"
 #include "simulation/solver/mixedSystem.h"
 #include "simulation/solver/delay.h"
+#include "simulation/solver/fmi_events.h"
 #include "simulation/simulation_info_json.h"
 #include "simulation/simulation_input_xml.h"
 
@@ -736,7 +737,7 @@ fmiStatus fmiEventUpdate(fmiComponent c, fmiBoolean intermediateResults, fmiEven
       if((i == 0) || (comp->fmuData->simulationInfo->nextSampleTimes[i] < comp->fmuData->simulationInfo->nextSampleEvent))
         comp->fmuData->simulationInfo->nextSampleEvent = comp->fmuData->simulationInfo->nextSampleTimes[i];
 
-    if(comp->fmuData->callback->checkForDiscreteChanges(comp->fmuData, threadData) || comp->fmuData->simulationInfo->needToIterate || checkRelations(comp->fmuData) || eventInfo->stateValuesChanged)
+    if (checkForDiscreteChanges(comp->fmuData, threadData) || comp->fmuData->simulationInfo->needToIterate || checkRelations(comp->fmuData) || eventInfo->stateValuesChanged)
     {
       intermediateResults = fmiTrue;
       if (comp->loggingOn)


### PR DESCRIPTION
We should not need to generate code for this function since all it does
is compare two vectors to each other to set a flag if a discrete value
changed.