### PR TITLE
Fix crash is default linear solver

### DIFF
--- a/SimulationRuntime/c/simulation/solver/linearSolverKlu.c
+++ b/SimulationRuntime/c/simulation/solver/linearSolverKlu.c
@@ -178,7 +178,7 @@ solveKlu(DATA *data, threadData_t *threadData, int sysNumber)
 {
   void *dataAndThreadData[2] = {data, threadData};
   LINEAR_SYSTEM_DATA* systemData = &(data->simulationInfo->linearSystemData[sysNumber]);
-  DATA_KLU* solverData = (DATA_KLU*)systemData->solverData;
+  DATA_KLU* solverData = (DATA_KLU*)systemData->solverData[0];
 
   int i, j, status = 0, success = 0, n = systemData->size, eqSystemNumber = systemData->equationIndex, indexes[2] = {1,eqSystemNumber};
   double tmpJacEvalTime;

--- a/SimulationRuntime/c/simulation/solver/linearSolverLapack.c
+++ b/SimulationRuntime/c/simulation/solver/linearSolverLapack.c
@@ -54,9 +54,9 @@ extern int dgesv_(int *n, int *nrhs, double *a, int *lda,
  */
 int allocateLapackData(int size, void** voiddata)
 {
-  DATA_LAPACK* data = (DATA_LAPACK*) malloc(sizeof(DATA_LAPACK));
+  DATA_LAPACK* data = (DATA_LAPACK*) calloc(1, sizeof(DATA_LAPACK));
 
-  data->ipiv = (int*) malloc(size*sizeof(int));
+  data->ipiv = (int*) calloc(size, sizeof(int));
   assertStreamPrint(NULL, 0 != data->ipiv, "Could not allocate data for linear solver lapack.");
   data->nrhs = 1;
   data->info = 0;
@@ -83,6 +83,9 @@ int freeLapackData(void **voiddata)
   _omc_destroyVector(data->x);
   _omc_destroyVector(data->b);
   _omc_destroyMatrix(data->A);
+
+  free(data);
+  voiddata[0] = 0;
 
   return 0;
 }
@@ -160,7 +163,7 @@ int solveLapack(DATA *data, threadData_t *threadData, int sysNumber)
   void *dataAndThreadData[2] = {data, threadData};
   int i, iflag = 1;
   LINEAR_SYSTEM_DATA* systemData = &(data->simulationInfo->linearSystemData[sysNumber]);
-  DATA_LAPACK* solverData = (DATA_LAPACK*)systemData->solverData;
+  DATA_LAPACK* solverData = (DATA_LAPACK*)systemData->solverData[0];
 
   int success = 1;
 

--- a/SimulationRuntime/c/simulation/solver/linearSolverLis.c
+++ b/SimulationRuntime/c/simulation/solver/linearSolverLis.c
@@ -197,7 +197,7 @@ solveLis(DATA *data, threadData_t *threadData, int sysNumber)
 {
   void *dataAndThreadData[2] = {data, threadData};
   LINEAR_SYSTEM_DATA* systemData = &(data->simulationInfo->linearSystemData[sysNumber]);
-  DATA_LIS* solverData = (DATA_LIS*)systemData->solverData;
+  DATA_LIS* solverData = (DATA_LIS*)systemData->solverData[0];
   int i, ret, success = 1, ni, iflag = 1, n = systemData->size, eqSystemNumber = systemData->equationIndex;
   char *lis_returncode[] = {"LIS_SUCCESS", "LIS_ILL_OPTION", "LIS_BREAKDOWN", "LIS_OUT_OF_MEMORY", "LIS_MAXITER", "LIS_NOT_IMPLEMENTED", "LIS_ERR_FILE_IO"};
   LIS_INT err;

--- a/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
+++ b/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
@@ -281,7 +281,7 @@ int allocateTotalPivotData(int size, void** voiddata)
   data->indRow =(int*) calloc(size,sizeof(int));
   data->indCol =(int*) calloc(size+1,sizeof(int));
 
-  *voiddata = (void*)data;
+  voiddata[1] = (void*)data;
   return 0;
 }
 
@@ -291,7 +291,7 @@ int allocateTotalPivotData(int size, void** voiddata)
  */
 int freeTotalPivotData(void** voiddata)
 {
-  DATA_TOTALPIVOT* data = (DATA_TOTALPIVOT*) *voiddata;
+  DATA_TOTALPIVOT* data = (DATA_TOTALPIVOT*) voiddata[1];
 
   /* memory for linear system */
   free(data->Ab);
@@ -301,6 +301,9 @@ int freeTotalPivotData(void** voiddata)
    /* used for pivot strategy */
   free(data->indRow);
   free(data->indCol);
+
+  free(voiddata[1]);
+  voiddata[1] = 0;
 
   return 0;
 }
@@ -383,7 +386,7 @@ int solveTotalPivot(DATA *data, threadData_t *threadData, int sysNumber)
   void *dataAndThreadData[2] = {data, threadData};
   int i, j;
   LINEAR_SYSTEM_DATA* systemData = &(data->simulationInfo->linearSystemData[sysNumber]);
-  DATA_TOTALPIVOT* solverData = (DATA_TOTALPIVOT*)systemData->solverData;
+  DATA_TOTALPIVOT* solverData = (DATA_TOTALPIVOT*) systemData->solverData[1];
   int n = systemData->size, status;
   double fdeps = 1e-8;
   double xTol = 1e-8;

--- a/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
+++ b/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
@@ -193,7 +193,7 @@ solveUmfPack(DATA *data, threadData_t *threadData, int sysNumber)
 {
   void *dataAndThreadData[2] = {data, threadData};
   LINEAR_SYSTEM_DATA* systemData = &(data->simulationInfo->linearSystemData[sysNumber]);
-  DATA_UMFPACK* solverData = (DATA_UMFPACK*)systemData->solverData;
+  DATA_UMFPACK* solverData = (DATA_UMFPACK*)systemData->solverData[0];
 
   int i, j, status = UMFPACK_OK, success = 0, ni=0, n = systemData->size, eqSystemNumber = systemData->equationIndex, indexes[2] = {1,eqSystemNumber};
   int casualTearingSet = systemData->strictTearingFunctionCall != NULL;
@@ -354,7 +354,7 @@ solveUmfPack(DATA *data, threadData_t *threadData, int sysNumber)
 int solveSingularSystem(LINEAR_SYSTEM_DATA* systemData)
 {
 
-  DATA_UMFPACK* solverData = (DATA_UMFPACK*) systemData->solverData;
+  DATA_UMFPACK* solverData = (DATA_UMFPACK*) systemData->solverData[0];
   double *Ux, *Rs, r_ii, *b, sum, *y, *z;
   int *Up, *Ui, *Q, do_recip, rank = 0, current_rank, current_unz, i, j, k, l,
       success = 0, status, stop = 0;

--- a/SimulationRuntime/c/simulation_data.h
+++ b/SimulationRuntime/c/simulation_data.h
@@ -335,7 +335,7 @@ typedef struct LINEAR_SYSTEM_DATA
   modelica_integer size;
   modelica_integer equationIndex;       /* index for EQUATION_INFO */
 
-  void *solverData;
+  void *solverData[2]; /* [1] is the totalPivot solver; [0] holds other solvers ; both are used for the default solver */
   modelica_real *x;                     /* solution vector x */
   modelica_real *A;                     /* matrix A */
   modelica_real *b;                     /* vector b */


### PR DESCRIPTION
If an expression makes a longjmp, the linear solver data was not
restored. This fix makes it so the solver data does not need to be
patched depending on which linear solver is running; it simply allocates
memory for an extra void* to hold the fallback solver's data.