### PR TITLE
[FMI] Set nominal to 1.0 as a default

### DIFF
--- a/Compiler/Template/CodegenFMU.tpl
+++ b/Compiler/Template/CodegenFMU.tpl
@@ -3058,7 +3058,7 @@ template ScalarVariableTypeFMU(String attrstr, String unit, String displayUnit, 
       <%attrstr%>.max = <%optInitValFMU(maxValue,"DBL_MAX")%>;
       <%attrstr%>.fixed = <%if isFixed then 1 else 0%>;
       <%attrstr%>.useNominal = <%if nominalValue then 1 else 0%>;
-      <%attrstr%>.nominal = <%optInitValFMU(nominalValue,"0.0")%>;
+      <%attrstr%>.nominal = <%optInitValFMU(nominalValue,"1.0")%>;
       <%attrstr%>.start = <%optInitValFMU(startValue,"0.0")%>;
       >>
     case T_BOOL(__) then

--- a/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/SimulationRuntime/c/simulation/solver/model_help.c
@@ -939,6 +939,7 @@ void initializeDataStruc(DATA *data, threadData_t *threadData)
 #else
   data->simulationInfo->nlsMethod = NLS_HOMOTOPY;
 #endif
+  data->simulationInfo->nlsLinearSolver = NLS_LS_LAPACK;
   data->simulationInfo->lsMethod = LS_LAPACK;
   data->simulationInfo->lssMethod = LS_UMFPACK;
   data->simulationInfo->mixedMethod = MIXED_SEARCH;


### PR DESCRIPTION
This improves scaling of non-linear solvers. Also set a default linear
solver for non-linear systems.