### PR TITLE
[FMI] Escape the model's description attribute

### DIFF
--- a/Compiler/Template/CodegenFMU1.tpl
+++ b/Compiler/Template/CodegenFMU1.tpl
@@ -87,11 +87,11 @@ case SIMCODE(modelInfo = MODELINFO(varInfo = vi as VARINFO(__), vars = SIMVARS(s
   let numberOfEventIndicators = getNumberOfEventIndicators(simCode)
   <<
   fmiVersion="<%fmiVersion%>"
-  modelName="<%modelName%>"
-  modelIdentifier="<%modelIdentifier%>"
+  modelName="<%Util.escapeModelicaStringToXmlString(modelName)%>"
+  modelIdentifier="<%Util.escapeModelicaStringToXmlString(modelIdentifier)%>"
   guid="{<%guid%>}"
-  description="<%description%>"
-  generationTool="<%generationTool%>"
+  description="<%Util.escapeModelicaStringToXmlString(description)%>"
+  generationTool="<%Util.escapeModelicaStringToXmlString(generationTool)%>"
   generationDateAndTime="<%generationDateAndTime%>"
   variableNamingConvention="<%variableNamingConvention%>"
   numberOfContinuousStates="<%numberOfContinuousStates%>"

--- a/Compiler/Template/CodegenFMU2.tpl
+++ b/Compiler/Template/CodegenFMU2.tpl
@@ -118,11 +118,11 @@ case SIMCODE(modelInfo = MODELINFO(varInfo = vi as VARINFO(__), vars = SIMVARS(s
   let numberOfEventIndicators = getNumberOfEventIndicators(simCode)
   <<
   fmiVersion="<%fmiVersion%>"
-  modelName="<%modelName%>"
+  modelName="<%Util.escapeModelicaStringToXmlString(modelName)%>"
   guid="{<%guid%>}"
-  description="<%description%>"
-  generationTool="<%generationTool%>"
-  generationDateAndTime="<%generationDateAndTime%>"
+  description="<%Util.escapeModelicaStringToXmlString(description)%>"
+  generationTool="<%Util.escapeModelicaStringToXmlString(generationTool)%>"
+  generationDateAndTime="<%Util.escapeModelicaStringToXmlString(generationDateAndTime)%>"
   variableNamingConvention="<%variableNamingConvention%>"
   numberOfEventIndicators="<%numberOfEventIndicators%>"
   >>
@@ -136,7 +136,7 @@ case SIMCODE(__) then
   let modelIdentifier = modelNamePrefix(simCode)
   <<
   <CoSimulation
-    modelIdentifier="<%modelIdentifier%>"
+    modelIdentifier="<%Util.escapeModelicaStringToXmlString(modelIdentifier)%>"
     needsExecutionTool="false"
     canHandleVariableCommunicationStepSize="true"
     canInterpolateInputs="false"


### PR DESCRIPTION
Models with a class comment containing `<` or `>` would cause parser
errors when loading the generated FMU.