### PR TITLE
Warn of conflicting alias variables

### DIFF
--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -1040,6 +1040,8 @@ public constant Message FMU_EXPORT_NOT_SUPPORTED_CPP = MESSAGE(7015, SCRIPTING()
   Util.gettext("Export of FMU type %s is not supported with Cpp target. FMU will be for Model Exchange (me)."));
 public constant Message DEPRECATED_API_CALL = MESSAGE(7016, SCRIPTING(), WARNING(),
   Util.gettext("'%1' is deprecated. It is recommended to use '%2' instead."));
+public constant Message CONFLICTING_ALIAS_SET = MESSAGE(7017, SYMBOLIC(), WARNING(),
+  Util.gettext("The model contains alias variables with conflicting start and/or nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts."));
 
 protected import ErrorExt;
 

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -258,7 +258,7 @@ constant DebugFlag DUMP_PP_REPL = DEBUG_FLAG(42, "dumpPPrepl", false,
 constant DebugFlag DUMP_EA_REPL = DEBUG_FLAG(43, "dumpEArepl", false,
   Util.gettext("Dump the found replacements for evaluate annotations (evaluate=true) parameters."));
 constant DebugFlag DEBUG_ALIAS = DEBUG_FLAG(44, "debugAlias", false,
-  Util.gettext("Dump the found alias variables."));
+  Util.gettext("Dumps some information about the process of removeSimpleEquations."));
 constant DebugFlag TEARING_DUMP = DEBUG_FLAG(45, "tearingdump", false,
   Util.gettext("Dumps tearing information."));
 constant DebugFlag JAC_DUMP = DEBUG_FLAG(46, "symjacdump", false,
@@ -518,6 +518,8 @@ constant DebugFlag WARN_NO_NOMINAL = DEBUG_FLAG(171, "warnNoNominal", false,
   Util.gettext("Prints the iteration variables in the initialization and simulation DAE, which do not have a nominal value."));
 constant DebugFlag IGNORE_CYCLES = DEBUG_FLAG(172, "ignoreCycles", false,
   Util.gettext("Ignores cycles between constant/parameter components."));
+constant DebugFlag ALIAS_CONFLICTS = DEBUG_FLAG(173, "aliasConflicts", false,
+  Util.gettext("Dumps alias sets with different start or nominal values."));
 
 
 // This is a list of all debug flags, to keep track of which flags are used. A
@@ -697,7 +699,8 @@ constant list<DebugFlag> allDebugFlags = {
   DISABLE_COLORING,
   MERGE_ALGORITHM_SECTIONS,
   WARN_NO_NOMINAL,
-  IGNORE_CYCLES
+  IGNORE_CYCLES,
+  ALIAS_CONFLICTS
 };
 
 public


### PR DESCRIPTION
Now a warning is printed if there are alias variables
with different start or nominal values.
To print the conflicting sets and the chosen values
you can use -d=aliasConflicts.

[ticket:4329](https://trac.openmodelica.org/OpenModelica/ticket/4329)