### PR TITLE
[OSX] Fix builds when using a single thread

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -491,18 +491,18 @@ $(LIBMODELICAEXTERNALC):
 	$(MAKE) -C "$(MODELICAEXTERNALC)/BuildProjects/autotools"
 	$(MAKE) -C "$(MODELICAEXTERNALC)/BuildProjects/autotools" install
 	test ! `uname` = Darwin || install_name_tool -id @rpath/libModelicaExternalC.0.dylib "$@"
+	test ! `uname` = Darwin || (install_name_tool -id @rpath/libModelicaStandardTables.0.dylib "$@" && install_name_tool -change "$(LIBMODELICAMATIO:%.dylib=%.0.dylib)" @rpath/libModelicaMatIO.0.dylib "$@" && install_name_tool -change "$(LIBMODELICAZLIB:%.dylib=%.0.dylib)" @rpath/libzlib.0.dylib "$@")
+	test ! `uname` = Darwin || (install_name_tool -id @rpath/libzlib.0.dylib "$@" && install_name_tool -change "$(LIBMODELICAZLIB:%.dylib=%.0.dylib)" @rpath/libzlib.0.dylib "$@")
+	test ! `uname` = Darwin || (install_name_tool -id @rpath/libModelicaIO.0.dylib "$@" && install_name_tool -change "$(LIBMODELICAMATIO:%.dylib=%.0.dylib)" @rpath/libModelicaMatIO.0.dylib "$@" && install_name_tool -change "$(LIBMODELICAZLIB:%.dylib=%.0.dylib)" @rpath/libzlib.0.dylib "$@")
+	test ! `uname` = Darwin || (install_name_tool -id @rpath/libModelicaMatIO.0.dylib "$@" && install_name_tool -change "$(LIBMODELICAZLIB:%.dylib=%.0.dylib)" @rpath/libzlib.0.dylib "$@")
 	@test -f "$@"
 $(LIBMODELICASTANDARDTABLES): $(LIBMODELICAEXTERNALC)
-	test ! `uname` = Darwin || (install_name_tool -id @rpath/libModelicaStandardTables.0.dylib "$@" && install_name_tool -change "$(LIBMODELICAMATIO:%.dylib=%.0.dylib)" @rpath/libModelicaMatIO.0.dylib "$@" && install_name_tool -change "$(LIBMODELICAZLIB:%.dylib=%.0.dylib)" @rpath/libzlib.0.dylib "$@")
 	@test -f "$@"
 $(LIBMODELICAZLIB): $(LIBMODELICAEXTERNALC)
-	test ! `uname` = Darwin || (install_name_tool -id @rpath/libzlib.0.dylib "$@" && install_name_tool -change "$(LIBMODELICAZLIB:%.dylib=%.0.dylib)" @rpath/libzlib.0.dylib "$@")
 	@test -f "$@"
 $(LIBMODELICAIO): $(LIBMODELICAEXTERNALC)
-	test ! `uname` = Darwin || (install_name_tool -id @rpath/libModelicaIO.0.dylib "$@" && install_name_tool -change "$(LIBMODELICAMATIO:%.dylib=%.0.dylib)" @rpath/libModelicaMatIO.0.dylib "$@" && install_name_tool -change "$(LIBMODELICAZLIB:%.dylib=%.0.dylib)" @rpath/libzlib.0.dylib "$@")
 	@test -f "$@"
 $(LIBMODELICAMATIO): $(LIBMODELICAEXTERNALC)
-	test ! `uname` = Darwin || (install_name_tool -id @rpath/libModelicaMatIO.0.dylib "$@" && install_name_tool -change "$(LIBMODELICAZLIB:%.dylib=%.0.dylib)" @rpath/libzlib.0.dylib "$@")
 	@test -f "$@"
 
 git-clean:


### PR DESCRIPTION
With a single thread, install_name_tool did not execute for the
MSL external libraries (except for libModelicaExternalC.dylib).