### PR TITLE
Added optional Susan debugging help

### DIFF
--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -520,7 +520,8 @@ constant DebugFlag IGNORE_CYCLES = DEBUG_FLAG(172, "ignoreCycles", false,
   Util.gettext("Ignores cycles between constant/parameter components."));
 constant DebugFlag ALIAS_CONFLICTS = DEBUG_FLAG(173, "aliasConflicts", false,
   Util.gettext("Dumps alias sets with different start or nominal values."));
-
+constant DebugFlag SUSAN_MATCHCONTINUE_DEBUG = DEBUG_FLAG(174, "susanDebug", false,
+  Util.gettext("Makes Susan generate code using try/else to better debug which function broke the expected match semantics."));
 
 // This is a list of all debug flags, to keep track of which flags are used. A
 // flag can not be used unless it's in this list, and the list is checked at
@@ -700,7 +701,8 @@ constant list<DebugFlag> allDebugFlags = {
   MERGE_ALGORITHM_SECTIONS,
   WARN_NO_NOMINAL,
   IGNORE_CYCLES,
-  ALIAS_CONFLICTS
+  ALIAS_CONFLICTS,
+  SUSAN_MATCHCONTINUE_DEBUG
 };
 
 public

--- a/Compiler/Util/StackOverflow.mo
+++ b/Compiler/Util/StackOverflow.mo
@@ -78,6 +78,14 @@ end stripAddresses;
 
 public
 
+function triggerStackOverflow
+  external "C" mmc_do_stackoverflow(OpenModelica.threadData()) annotation(Documentation(info="<html>
+<p>Fakes a stack overflow (useful for debugging; forces earlier exit
+since most functions do not catch stack overflow, and gives you a
+stacktrace of the position you triggered this from).</p>
+</html>"));
+end triggerStackOverflow;
+
 function generateReadableMessage
   input Integer numFrames=1000;
   input Integer numSkip=4;

--- a/Compiler/susan_codegen/TplCodegen.tpl
+++ b/Compiler/susan_codegen/TplCodegen.tpl
@@ -57,8 +57,20 @@ template mmDeclaration(MMDeclaration it) ::=
        protected
          <%typedIdents(mf.locals)%>
        >>%>
-       algorithm
+       algorithm<%if debugSusan() then
+       <<
+
+       try
+       >>
+         %>
          <%sts |> it => '<%mmExp(it, ":=")%>;' ;separator="\n"%>
+       <%if debugSusan() then
+       <<
+       else
+         Tpl.fakeStackOverflow();
+       end try;
+       >>
+       %>
        >>
     %>
     end <%name%>;
@@ -70,7 +82,12 @@ template mmMatchFunBody(TypedIdents inArgs, TypedIdents outArgs, TypedIdents loc
   <%typedIdentsEx(inArgs, "input", "in_")%>
 
   <%typedIdentsEx(outArgs, "output", "out_")%>
-algorithm
+algorithm<% if debugSusan() then
+<<
+
+try
+>>
+%>
   <%match outArgs
    case {(nm,_)} then 'out_<%nm%>'
    case outArgs  then <<(<%outArgs |> (nm,_)=> 'out_<%nm%>' ;separator=", "%>)>>
@@ -91,7 +108,14 @@ algorithm
             case oas then '(<%oas |> (nm,_)=> nm ;separator=", "%>)'
            %>;
   >>;separator="\n"%>
-  end match;
+  end match;<% if debugSusan() then
+<<
+
+else
+  Tpl.fakeStackOverflow();
+end try;
+>>
+%>
 >>
 end mmMatchFunBody;
 

--- a/Compiler/susan_codegen/TplCodegenTV.mo
+++ b/Compiler/susan_codegen/TplCodegenTV.mo
@@ -24,6 +24,10 @@ package Tpl
       Boolean lastHasNewLine "True when the last string in the list has new-line at the end.";
     end ST_STRING_LIST;
   end StringToken;
+
+  function debugSusan
+    output Boolean b;
+  end debugSusan;
 end Tpl;
 
 package TplAbsyn

--- a/SimulationRuntime/c/meta/meta_modelica_segv.c
+++ b/SimulationRuntime/c/meta/meta_modelica_segv.c
@@ -232,3 +232,10 @@ void mmc_init_stackoverflow(threadData_t *threadData)
   threadData->stackBottom = 0x1; /* Dummy until Windows detects the stack bottom */
 }
 #endif
+
+void mmc_do_stackoverflow(threadData_t *threadData)
+{
+  /* Do the jump */
+  mmc_setStacktraceMessages_threadData(threadData, 1, MMC_SEGV_TRACE_NFRAMES);
+  longjmp(*threadData->mmc_stack_overflow_jumper, 1);
+}

--- a/SimulationRuntime/c/meta/meta_modelica_segv.h
+++ b/SimulationRuntime/c/meta/meta_modelica_segv.h
@@ -64,6 +64,8 @@ void mmc_init_stackoverflow(threadData_t *threadData);
 /* Does not work very well with many stack frames because we are close to the stack end when we need this data... */
 #define MMC_SEGV_TRACE_NFRAMES 1024
 
+void mmc_do_stackoverflow(threadData_t *threadData);
+
 static inline void mmc_check_stackoverflow(threadData_t *threadData)
 {
 #if __has_builtin(__builtin_frame_address) || defined(__GNUC__)
@@ -74,9 +76,7 @@ static inline void mmc_check_stackoverflow(threadData_t *threadData)
   if ((void*) &addr < threadData->stackBottom)
 #endif
   {
-    /* Do the jump */
-    mmc_setStacktraceMessages_threadData(threadData, 1, MMC_SEGV_TRACE_NFRAMES);
-    longjmp(*threadData->mmc_stack_overflow_jumper, 1);
+    mmc_do_stackoverflow(threadData);
   }
 }
 


### PR DESCRIPTION
There is a new flag -d=susanDebug which can generate a different
MetaModelica from the Susan code. It will give a stack-trace of the
point where a failure happens.

Use the debug-flag when compiling the Susan code to add extra try/catch
blocks everywhere (this slows down the code considerably and is not
intended for use in the production executable; only for debugging).