### PR TITLE
Moved check for balanced if-equations

### DIFF
--- a/Compiler/BackEnd/BackendDAECreate.mo
+++ b/Compiler/BackEnd/BackendDAECreate.mo
@@ -1447,6 +1447,7 @@ algorithm
         beqnslst = lowerEqnsLst(theneqns1,functionTree,{},false);
         (beqns,breqns,bieqns) = lowerEqns(elseenqs,functionTree,{},{},{},false);
         beqns = List.flatten({beqns,breqns,bieqns});
+        countEquationsInBranches(beqnslst, beqns, inSource);
       then
         BackendDAE.IF_EQUATION(explst, beqnslst, beqns, inSource, BackendDAE.EQ_ATTR_DEFAULT_UNKNOWN)::inEquations;
 
@@ -1458,6 +1459,55 @@ algorithm
         lowerIfEquation1(e,explst,eqns,eqnslst,elseenqs,conditions1,theneqns1,source,functionTree,inEquations);
   end matchcontinue;
 end lowerIfEquation;
+
+protected function countEquationsInBranches "
+Checks that the number of equations is the same in all branches
+of an if-equation"
+  input list<list<BackendDAE.Equation>> trueBranches;
+  input list<BackendDAE.Equation> falseBranch;
+  input DAE.ElementSource source;
+  output Integer nrOfEquations;
+algorithm
+  nrOfEquations := matchcontinue(trueBranches,falseBranch,source)
+    local
+      list<Boolean> b;
+      list<String> strs;
+      String str,eqstr;
+      list<Integer> nrOfEquationsBranches;
+
+    case (_, _, _)
+      equation
+        nrOfEquations = BackendEquation.equationLstSize(falseBranch);
+        nrOfEquationsBranches = List.map(trueBranches, BackendEquation.equationLstSize);
+        b = List.map1(nrOfEquationsBranches, intEq, nrOfEquations);
+        true = List.reduce(b,boolAnd);
+      then
+        nrOfEquations;
+
+    // An if-equation with non-parameter conditions must have an else-clause.
+    case (_, {}, _)
+      equation
+        Error.addSourceMessage(Error.IF_EQUATION_MISSING_ELSE, {},
+          ElementSource.getElementSourceFileInfo(source));
+      then
+        fail();
+
+    // If if-equation with non-parameter conditions must have the same number of
+    // equations in each branch.
+    case (_, _ :: _, _)
+      equation
+        nrOfEquations = BackendEquation.equationLstSize(falseBranch);
+        nrOfEquationsBranches = List.map(trueBranches, BackendEquation.equationLstSize);
+        eqstr = stringDelimitList(List.map(listAppend(trueBranches,{falseBranch}),BackendDump.dumpEqnsStr),"\n");
+        strs = List.map(nrOfEquationsBranches, intString);
+        str = stringDelimitList(strs,",");
+        str = "{" + str + "," + intString(nrOfEquations) + "}";
+        Error.addSourceMessage(Error.IF_EQUATION_UNBALANCED_2,{str,eqstr},ElementSource.getElementSourceFileInfo(source));
+      then
+        fail();
+
+  end matchcontinue;
+end countEquationsInBranches;
 
 protected function lowerIfEquation1
   input DAE.Exp cond;

--- a/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -2300,7 +2300,6 @@ algorithm
     // true case left with condition<>false
     case (_,_,_,_,_,_,_)
       equation
-        _ = countEquationsInBranches(theneqns,elseenqs,source);
         // simplify if eqution
         // if .. then a=.. elseif .. then a=... else a=.. end if;
         // to
@@ -2315,7 +2314,6 @@ algorithm
         eqns;
     case (_,_,_,_,_,_,_)
       equation
-        _ = countEquationsInBranches(theneqns,elseenqs,source);
         fbsExp = makeEquationLstToResidualExpLst(elseenqs);
         tbsExp = List.map(theneqns, makeEquationLstToResidualExpLst);
         eqns = makeEquationsFromResiduals(conditions, tbsExp, fbsExp, source, inEqAttr);
@@ -2551,55 +2549,6 @@ protected function makeIfExp
 algorithm
   oExp := DAE.IFEXP(cond,DAE.BCONST(true),else_);
 end makeIfExp;
-
-protected function countEquationsInBranches "
-Checks that the number of equations is the same in all branches
-of an if-equation"
-  input list<list<BackendDAE.Equation>> trueBranches;
-  input list<BackendDAE.Equation> falseBranch;
-  input DAE.ElementSource source;
-  output Integer nrOfEquations;
-algorithm
-  nrOfEquations := matchcontinue(trueBranches,falseBranch,source)
-    local
-      list<Boolean> b;
-      list<String> strs;
-      String str,eqstr;
-      list<Integer> nrOfEquationsBranches;
-
-    case (_, _, _)
-      equation
-        nrOfEquations = BackendEquation.equationLstSize(falseBranch);
-        nrOfEquationsBranches = List.map(trueBranches, BackendEquation.equationLstSize);
-        b = List.map1(nrOfEquationsBranches, intEq, nrOfEquations);
-        true = List.reduce(b,boolAnd);
-      then
-        nrOfEquations;
-
-    // An if-equation with non-parameter conditions must have an else-clause.
-    case (_, {}, _)
-      equation
-        Error.addSourceMessage(Error.IF_EQUATION_MISSING_ELSE, {},
-          ElementSource.getElementSourceFileInfo(source));
-      then
-        fail();
-
-    // If if-equation with non-parameter conditions must have the same number of
-    // equations in each branch.
-    case (_, _ :: _, _)
-      equation
-        nrOfEquations = BackendEquation.equationLstSize(falseBranch);
-        nrOfEquationsBranches = List.map(trueBranches, BackendEquation.equationLstSize);
-        eqstr = stringDelimitList(List.map(listAppend(trueBranches,{falseBranch}),BackendDump.dumpEqnsStr),"\n");
-        strs = List.map(nrOfEquationsBranches, intString);
-        str = stringDelimitList(strs,",");
-        str = "{" + str + "," + intString(nrOfEquations) + "}";
-        Error.addSourceMessage(Error.IF_EQUATION_UNBALANCED_2,{str,eqstr},ElementSource.getElementSourceFileInfo(source));
-      then
-        fail();
-
-  end matchcontinue;
-end countEquationsInBranches;
 
 protected function makeEquationLstToResidualExpLst
   input list<BackendDAE.Equation> eqLst;


### PR DESCRIPTION
The check for balanced if-equations is now performed during creation of
the BackendDAE structure instead of checked and ignored during
simplification of if-equations. This fixes ticket:4432.