### PR TITLE
Passing fixed=true where expected in the examples

### DIFF
--- a/Examples/BouncingBall.mo
+++ b/Examples/BouncingBall.mo
@@ -1,11 +1,11 @@
 model BouncingBall
   parameter Real e=0.7 "coefficient of restitution";
   parameter Real g=9.81 "gravity acceleration";
-  Real h(start=1) "height of ball";
-  Real v "velocity of ball";
-  Boolean flying(start=true) "true, if ball is flying";
+  Real h(fixed=true, start=1) "height of ball";
+  Real v(fixed=true) "velocity of ball";
+  Boolean flying(fixed=true, start=true) "true, if ball is flying";
   Boolean impact;
-  Real v_new;
+  Real v_new(fixed=true);
   Integer foo;
 
 equation

--- a/Examples/VanDerPol.mo
+++ b/Examples/VanDerPol.mo
@@ -1,8 +1,8 @@
 // Van der Pol model
 
 model VanDerPol  "Van der Pol oscillator model"
-  Real x(start = 1);
-  Real y(start = 1);
+  Real x(start = 1, fixed = true);
+  Real y(start = 1, fixed = true);
   parameter Real lambda = 0.3;
 equation
   der(x) = y;

--- a/Examples/dcmotor.mo
+++ b/Examples/dcmotor.mo
@@ -1,21 +1,19 @@
 model dcmotor
-  Modelica.Electrical.Analog.Basic.Resistor     resistor1(R = 10);
-  //Observe the difference between MSL 2.2 and 3.1 regarding the default values, in 3.1 there are no default values set, only start values
-  Modelica.Electrical.Analog.Basic.Inductor     inductor1(L = 0.2);
-  Modelica.Electrical.Analog.Basic.Ground       ground1;
-  Modelica.Mechanics.Rotational.Components.Inertia      load(J = 1);    // Modelica version 3.1
-  // Modelica.Mechanics.Rotational.Inertia         load(J = 1); // Modelica version 2.2
-  Modelica.Electrical.Analog.Basic.EMF          emf1;
-  Modelica.Blocks.Sources.Step                  step1;
+  import Modelica.Electrical.Analog.Basic;
+  Basic.Resistor resistor1(R = 10);
+  Basic.Inductor inductor1(L = 0.2, i.fixed=true);
+  Basic.Ground ground1;
+  Modelica.Mechanics.Rotational.Components.Inertia load(J = 1, phi.fixed=true, w.fixed=true);
+  Basic.EMF emf1(k=1.0);
+  Modelica.Blocks.Sources.Step step1;
   Modelica.Electrical.Analog.Sources.SignalVoltage signalVoltage1;
 equation
-  //connect(step1.outport, signalVoltage1.inPort);
   connect(step1.y, signalVoltage1.v);
   connect(signalVoltage1.p, resistor1.p);
   connect(resistor1.n, inductor1.p);
   connect(inductor1.n, emf1.p);
-  // connect(emf1.flange_b, load.flange_a); //Modelica version 2.2
-  connect(emf1.flange, load.flange_a); // Modelica version 3.1
+  connect(emf1.flange, load.flange_a);
   connect(signalVoltage1.n, ground1.p);
   connect(ground1.p, emf1.n);
+  annotation(uses(Modelica(version="3.2.2")));
 end dcmotor;


### PR DESCRIPTION
Most of the examples are old; we should showcase modern Modelica, and
leaving initialization partially undefined is not recommended.