### PR TITLE
Improve element visibility in nfinst.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -55,6 +55,7 @@ import Type = NFType;
 import BuiltinFuncs = NFBuiltinFuncs;
 import Pointer;
 import NFPrefixes.Variability;
+import NFPrefixes.Visibility;
 import ComponentRef = NFComponentRef;
 import NFComponentRef.Origin;
 import Restriction = NFRestriction;
@@ -115,21 +116,21 @@ end Elements;
 // access to the attributes via dot notation (which is not needed for
 // modifiers and illegal in other cases).
 constant InstNode ANYTYPE_NODE = InstNode.CLASS_NODE("polymorphic",
-  Elements.ANY,
+  Elements.ANY, Visibility.PUBLIC,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.ANY_TYPE("unknown"), NFClassTree.EMPTY,
     Modifier.NOMOD(), Restriction.TYPE())),
   arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
   InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
 
 constant InstNode REAL_NODE = InstNode.CLASS_NODE("Real",
-  Elements.REAL,
+  Elements.REAL, Visibility.PUBLIC,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.REAL(), NFClassTree.EMPTY,
     Modifier.NOMOD(), Restriction.TYPE())),
   arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
   InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
 
 constant InstNode INTEGER_NODE = InstNode.CLASS_NODE("Integer",
-  Elements.INTEGER,
+  Elements.INTEGER, Visibility.PUBLIC,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.INTEGER(), NFClassTree.EMPTY,
     Modifier.NOMOD(), Restriction.TYPE())),
   listArray({NFInstNode.CachedData.FUNCTION({NFBuiltinFuncs.INTEGER}, true, false), NFInstNode.CachedData.NO_CACHE(), NFInstNode.CachedData.NO_CACHE()}),
@@ -139,7 +140,7 @@ constant ComponentRef INTEGER_CREF =
   ComponentRef.CREF(INTEGER_NODE, {}, Type.INTEGER(), Origin.CREF, ComponentRef.EMPTY());
 
 constant InstNode BOOLEAN_NODE = InstNode.CLASS_NODE("Boolean",
-  Elements.BOOLEAN,
+  Elements.BOOLEAN, Visibility.PUBLIC,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.BOOLEAN(), NFClassTree.EMPTY,
     Modifier.NOMOD(), Restriction.TYPE())),
   arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
@@ -149,7 +150,7 @@ constant ComponentRef BOOLEAN_CREF =
   ComponentRef.CREF(BOOLEAN_NODE, {}, Type.INTEGER(), Origin.CREF, ComponentRef.EMPTY());
 
 constant InstNode STRING_NODE = InstNode.CLASS_NODE("String",
-  Elements.STRING,
+  Elements.STRING, Visibility.PUBLIC,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.STRING(), NFClassTree.EMPTY,
     Modifier.NOMOD(), Restriction.TYPE())),
   listArray({ NFInstNode.CachedData.FUNCTION({
@@ -167,7 +168,7 @@ constant ComponentRef STRING_CREF =
   ComponentRef.CREF(STRING_NODE, {}, Type.INTEGER(), Origin.CREF, ComponentRef.EMPTY());
 
 constant InstNode ENUM_NODE = InstNode.CLASS_NODE("enumeration",
-  Elements.ENUMERATION,
+  Elements.ENUMERATION, Visibility.PUBLIC,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.ENUMERATION_ANY(), NFClassTree.EMPTY,
     Modifier.NOMOD(), Restriction.ENUMERATION())),
   arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
@@ -177,7 +178,7 @@ constant Type STATESELECT_TYPE = Type.ENUMERATION(
   Absyn.IDENT("StateSelect"), {"never", "avoid", "default", "prefer", "always"});
 
 constant InstNode STATESELECT_NODE = InstNode.CLASS_NODE("StateSelect",
-  Elements.STATESELECT,
+  Elements.STATESELECT, Visibility.PUBLIC,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(STATESELECT_TYPE, NFClassTree.EMPTY,
     Modifier.NOMOD(), Restriction.ENUMERATION())),
   arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
@@ -228,6 +229,7 @@ constant Binding STATESELECT_ALWAYS_BINDING =
 
 constant InstNode STATESELECT_NEVER =
   InstNode.COMPONENT_NODE("never",
+    Visibility.PUBLIC,
     Pointer.createImmutable(Component.TYPED_COMPONENT(
       InstNode.EMPTY_NODE(),
       STATESELECT_TYPE,
@@ -241,6 +243,7 @@ constant ComponentRef STATESELECT_NEVER_CREF =
 
 constant InstNode STATESELECT_AVOID =
   InstNode.COMPONENT_NODE("avoid",
+    Visibility.PUBLIC,
     Pointer.createImmutable(Component.TYPED_COMPONENT(
       InstNode.EMPTY_NODE(),
       STATESELECT_TYPE,
@@ -254,6 +257,7 @@ constant ComponentRef STATESELECT_AVOID_CREF =
 
 constant InstNode STATESELECT_DEFAULT =
   InstNode.COMPONENT_NODE("default",
+    Visibility.PUBLIC,
     Pointer.createImmutable(Component.TYPED_COMPONENT(
       InstNode.EMPTY_NODE(),
       STATESELECT_TYPE,
@@ -267,6 +271,7 @@ constant ComponentRef STATESELECT_DEFAULT_CREF =
 
 constant InstNode STATESELECT_PREFER =
   InstNode.COMPONENT_NODE("prefer",
+    Visibility.PUBLIC,
     Pointer.createImmutable(Component.TYPED_COMPONENT(
       InstNode.EMPTY_NODE(),
       STATESELECT_TYPE,
@@ -280,6 +285,7 @@ constant ComponentRef STATESELECT_PREFER_CREF =
 
 constant InstNode STATESELECT_ALWAYS =
   InstNode.COMPONENT_NODE("always",
+    Visibility.PUBLIC,
     Pointer.createImmutable(Component.TYPED_COMPONENT(
       InstNode.EMPTY_NODE(),
       STATESELECT_TYPE,
@@ -302,6 +308,7 @@ constant Expression ASSERTIONLEVEL_WARNING = Expression.ENUM_LITERAL(
 
 constant InstNode TIME =
   InstNode.COMPONENT_NODE("time",
+    Visibility.PUBLIC,
     Pointer.createImmutable(Component.TYPED_COMPONENT(
       REAL_NODE,
       Type.REAL(),

--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -50,6 +50,7 @@ import DAE;
 import Builtin = NFBuiltin;
 import Binding = NFBinding;
 import Pointer;
+import NFPrefixes.Visibility;
 
 // Dummy SCode component, since we usually don't need the definition for anything.
 constant SCode.Element DUMMY_ELEMENT = SCode.COMPONENT("dummy",
@@ -62,6 +63,7 @@ constant Component INT_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NO
   Type.INTEGER(), Binding.UNBOUND(), Component.Attributes.DEFAULT(), Absyn.dummyInfo);
 
 constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
+  Visibility.PUBLIC,
   Pointer.createImmutable(INT_COMPONENT), InstNode.EMPTY_NODE());
 
 // Default Real parameter.
@@ -69,6 +71,7 @@ constant Component REAL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_N
   Type.REAL(), Binding.UNBOUND(), Component.Attributes.DEFAULT(), Absyn.dummyInfo);
 
 constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
+  Visibility.PUBLIC,
   Pointer.createImmutable(REAL_COMPONENT), InstNode.EMPTY_NODE());
 
 // Default Boolean parameter.
@@ -76,6 +79,7 @@ constant Component BOOL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_N
   Type.BOOLEAN(), Binding.UNBOUND(), Component.Attributes.DEFAULT(), Absyn.dummyInfo);
 
 constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
+  Visibility.PUBLIC,
   Pointer.createImmutable(BOOL_COMPONENT), InstNode.EMPTY_NODE());
 
 // Default String parameter.
@@ -83,6 +87,7 @@ constant Component STRING_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY
   Type.STRING(), Binding.UNBOUND(), Component.Attributes.DEFAULT(), Absyn.dummyInfo);
 
 constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
+  Visibility.PUBLIC,
   Pointer.createImmutable(STRING_COMPONENT), InstNode.EMPTY_NODE());
 
 // Default enumeration(:) parameter.
@@ -90,6 +95,7 @@ constant Component ENUM_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_N
   Type.ENUMERATION_ANY(), Binding.UNBOUND(), Component.Attributes.DEFAULT(), Absyn.dummyInfo);
 
 constant InstNode ENUM_PARAM = InstNode.COMPONENT_NODE("e",
+  Visibility.PUBLIC,
   Pointer.createImmutable(ENUM_COMPONENT), InstNode.EMPTY_NODE());
 
 // Integer(e)
@@ -100,7 +106,7 @@ constant Function INTEGER = Function.FUNCTION(Path.IDENT("Integer"),
 
 // String(r, significantDigits=d, minimumLength=0, leftJustified=true)
 constant InstNode STRING_NODE = NFInstNode.CLASS_NODE("String", DUMMY_ELEMENT,
-  Pointer.createImmutable(Class.NOT_INSTANTIATED()),
+  Visibility.PUBLIC, Pointer.createImmutable(Class.NOT_INSTANTIATED()),
   arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
   InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
 

--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -52,7 +52,6 @@ uniontype Class
     record PREFIXES
       SCode.Encapsulated encapsulatedPrefix;
       SCode.Partial partialPrefix;
-      SCode.Visibility visibility;
       SCode.Final finalPrefix;
       Absyn.InnerOuter innerOuter;
       SCode.Replaceable replaceablePrefix;
@@ -313,17 +312,6 @@ uniontype Class
       else {};
     end match;
   end getDimensions;
-
-  function isProtected
-    input Class cls;
-    output Boolean isProtected;
-  algorithm
-    isProtected := match cls
-      case EXPANDED_CLASS(prefixes = Prefixes.PREFIXES(visibility = SCode.Visibility.PROTECTED())) then true;
-      case DERIVED_CLASS(prefixes = Prefixes.PREFIXES(visibility = SCode.Visibility.PROTECTED())) then true;
-      else false;
-    end match;
-  end isProtected;
 
   function getAttributes
     input Class cls;

--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -55,8 +55,7 @@ constant Component.Attributes INPUT_ATTR =
     Parallelism.NON_PARALLEL,
     Variability.CONTINUOUS,
     Direction.INPUT,
-    InnerOuter.NOT_INNER_OUTER,
-    Visibility.PUBLIC
+    InnerOuter.NOT_INNER_OUTER
   );
 
 constant Component.Attributes OUTPUT_ATTR =
@@ -65,18 +64,7 @@ constant Component.Attributes OUTPUT_ATTR =
     Parallelism.NON_PARALLEL,
     Variability.CONTINUOUS,
     Direction.OUTPUT,
-    InnerOuter.NOT_INNER_OUTER,
-    Visibility.PUBLIC
-  );
-
-constant Component.Attributes PROTECTED_ATTR =
-  Component.Attributes.ATTRIBUTES(
-    ConnectorType.POTENTIAL,
-    Parallelism.NON_PARALLEL,
-    Variability.CONTINUOUS,
-    Direction.NONE,
-    InnerOuter.NOT_INNER_OUTER,
-    Visibility.PROTECTED
+    InnerOuter.NOT_INNER_OUTER
   );
 
 constant Component.Attributes CONSTANT_ATTR =
@@ -85,8 +73,7 @@ constant Component.Attributes CONSTANT_ATTR =
     Parallelism.NON_PARALLEL,
     Variability.CONSTANT,
     Direction.NONE,
-    InnerOuter.NOT_INNER_OUTER,
-    Visibility.PUBLIC
+    InnerOuter.NOT_INNER_OUTER
   );
 
 uniontype Component
@@ -98,7 +85,6 @@ uniontype Component
       Variability variability;
       Direction direction;
       InnerOuter innerOuter;
-      Visibility visibility;
     end ATTRIBUTES;
 
     record DEFAULT end DEFAULT;
@@ -409,26 +395,6 @@ uniontype Component
     input Component component;
     output Boolean isVar = variability(component) == Variability.CONTINUOUS;
   end isVar;
-
-  function visibility
-    input Component component;
-    output Visibility visibility;
-  algorithm
-    visibility := match component
-      case COMPONENT_DEF() then
-        if SCode.isElementProtected(component.definition) then
-          Visibility.PROTECTED else Visibility.PUBLIC;
-      case UNTYPED_COMPONENT(attributes = Attributes.ATTRIBUTES(visibility = visibility)) then visibility;
-      case TYPED_COMPONENT(attributes = Attributes.ATTRIBUTES(visibility = visibility)) then visibility;
-      // Iterators and enumeration literals can't be accessed in a way where visibility matters.
-      else Visibility.PUBLIC;
-    end match;
-  end visibility;
-
-  function isPublic
-    input Component component;
-    output Boolean isInput = visibility(component) == Visibility.PUBLIC;
-  end isPublic;
 
   function isRedeclare
     input Component component;

--- a/Compiler/NFFrontEnd/NFConnector.mo
+++ b/Compiler/NFFrontEnd/NFConnector.mo
@@ -107,12 +107,20 @@ public
 
   function isOutside
     input Connector conn;
-    output Boolean isOutside = conn.face == Face.OUTSIDE;
+    output Boolean isOutside;
+  protected
+    Face f = conn.face; // Needed due to #4502
+  algorithm
+    isOutside := f == Face.OUTSIDE;
   end isOutside;
 
   function isInside
     input Connector conn;
-    output Boolean isInside = conn.face == Face.INSIDE;
+    output Boolean isInside;
+  protected
+    Face f = conn.face; // Needed due to #4502
+  algorithm
+    isInside := f == Face.INSIDE;
   end isInside;
 
   function name

--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -58,6 +58,7 @@ import MetaModelica.Dangerous.listReverseInPlace;
 import Sections = NFSections;
 import Function = NFFunction.Function;
 import ClassTree = NFClassTree;
+import NFPrefixes.Visibility;
 
 public
 function convert
@@ -118,7 +119,7 @@ algorithm
 
   binding_exp := convertBinding(binding);
   var_attr := convertVarAttributes(Class.getTypeAttributes(cls), ty);
-  daeVar := makeDAEVar(cref, ty, binding_exp, attr, var_attr, info);
+  daeVar := makeDAEVar(cref, ty, binding_exp, attr, InstNode.visibility(comp_node), var_attr, info);
 end convertComponent;
 
 function makeDAEVar
@@ -126,6 +127,7 @@ function makeDAEVar
   input Type ty;
   input Option<DAE.Exp> binding;
   input Component.Attributes attr;
+  input Visibility vis;
   input Option<DAE.VariableAttributes> vattr;
   input SourceInfo info;
   output DAE.Element var;
@@ -146,7 +148,7 @@ algorithm
           Prefixes.variabilityToDAE(attr.variability),
           Prefixes.directionToDAE(attr.direction),
           Prefixes.parallelismToDAE(attr.parallelism),
-          Prefixes.visibilityToDAE(attr.visibility),
+          Prefixes.visibilityToDAE(vis),
           dty,
           binding,
           {},
@@ -159,7 +161,7 @@ algorithm
 
     else
       DAE.VAR(dcref, DAE.VarKind.VARIABLE(), DAE.VarDirection.BIDIR(),
-        DAE.VarParallelism.NON_PARALLEL(), DAE.VarVisibility.PUBLIC(), dty,
+        DAE.VarParallelism.NON_PARALLEL(), Prefixes.visibilityToDAE(vis), dty,
         binding, {}, DAE.ConnectorType.NON_CONNECTOR(), source, vattr, NONE(),
         Absyn.NOT_INNER_OUTER());
 
@@ -397,7 +399,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " git untyped binding");
+        assert(false, getInstanceName() + " got untyped binding");
       then
         fail();
 
@@ -416,7 +418,7 @@ algorithm
     case "always" then DAE.StateSelect.ALWAYS();
     else
       algorithm
-        assert(false, getInstanceName() + " got unknown StateSelect literal");
+        assert(false, getInstanceName() + " got unknown StateSelect literal " + name);
       then
         fail();
   end match;
@@ -972,7 +974,7 @@ algorithm
         var_attr := convertVarAttributes(Class.getTypeAttributes(cls), ty);
         attr := comp.attributes;
       then
-        makeDAEVar(cref, ty, binding, attr, var_attr, info);
+        makeDAEVar(cref, ty, binding, attr, InstNode.visibility(node), var_attr, info);
 
     else
       algorithm

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -784,8 +784,8 @@ protected
     Component.Attributes.ATTRIBUTES(
       connectorType = cty,
       direction = direction,
-      innerOuter = io,
-      visibility = vis) := Component.getAttributes(InstNode.component(component));
+      innerOuter = io) := Component.getAttributes(InstNode.component(component));
+    vis := InstNode.visibility(component);
 
     // Function components may not be connectors.
     if cty <> ConnectorType.POTENTIAL then

--- a/Compiler/NFFrontEnd/NFLookupState.mo
+++ b/Compiler/NFFrontEnd/NFLookupState.mo
@@ -321,24 +321,14 @@ uniontype LookupState
     input LookupState currentState;
   algorithm
     () := match currentState
-      local
-        Boolean is_protected;
-
       // The first part of a name is allowed to be protected, it's only
       // accessing a protected element via dot-notation that's illegal.
       case BEGIN() then ();
 
       else
         algorithm
-          is_protected := match node
-            // TODO: Implement attributes for classes and return the actual
-            // visibility here.
-            case InstNode.CLASS_NODE() then false;
-            case InstNode.COMPONENT_NODE() then not Component.isPublic(InstNode.component(node));
-          end match;
-
           // A protected element generates an error.
-          if is_protected then
+          if InstNode.isProtected(node) then
             Error.addSourceMessage(Error.PROTECTED_ACCESS,
               {InstNode.name(node)}, InstNode.info(node));
             fail();

--- a/Compiler/NFFrontEnd/NFRecord.mo
+++ b/Compiler/NFFrontEnd/NFRecord.mo
@@ -102,19 +102,22 @@ algorithm
     case Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE(components = components))
       algorithm
         for i in arrayLength(components):-1:1 loop
+          n := components[i];
           comp := InstNode.component(components[i]);
-          if Component.isPublic(comp) then
+
+          if InstNode.isProtected(n) then
+            locals := n :: locals;
+          else
+            comp := InstNode.component(n);
             if Component.isConst(comp) then
               if not Component.hasBinding(comp) then
-                inputs := components[i]::inputs;
+                inputs := n :: inputs;
               else
-                locals := components[i]::locals;
+                locals := n :: locals;
               end if;
             else
-              inputs := components[i]::inputs;
+              inputs := n :: inputs;
             end if;
-          else
-            locals := components[i]::locals;
           end if;
         end for;
       then


### PR DESCRIPTION
- Move visibility to InstNode so that it's always available for any
  class or component.
- Fix attribute propagation so that components don't inherited
  visibility from their parents.
- Turn on visibility check in lookup for classes (fixes ticket:2296).
- Fixed stream connection handling having undefined behaviour
  due to ticket:4502.