### PR TITLE
Redeclare improvement in nfinst.

### DIFF
--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -944,7 +944,9 @@ algorithm
         end if;
 
         checkOuterComponentMod(mod, comp, comp_node);
+        // Create a modifier from the original declaration.
         comp_mod := Modifier.fromElement(def, parent);
+        // Merge it with any modifier from the redeclare.
         comp_mod := Modifier.merge(comp_mod, mod.mod);
         inst_comp := InstNode.component(mod.element);
         inst_comp := Component.setModifier(comp_mod, inst_comp);

--- a/Compiler/NFFrontEnd/NFUnitCheck.mo
+++ b/Compiler/NFFrontEnd/NFUnitCheck.mo
@@ -488,6 +488,12 @@ algorithm
       end for;
     then (HtCr2U, HtS2U, HtU2S, expList);
 
+    case (DAE.IF_EQUATION(), _, _, _, _)
+      then (inHtCr2U, inHtS2U, inHtU2S, {});
+
+    case (DAE.INITIAL_IF_EQUATION(), _, _, _, _)
+      then (inHtCr2U, inHtS2U, inHtU2S, {});
+
     case (DAE.NORETCALL(), _, _, _, _) algorithm
       (_, (HtCr2U, HtS2U, HtU2S), expList) := insertUnitInEquation(inEq.exp, (inHtCr2U, inHtS2U, inHtU2S), NFUnit.MASTER({}), inargs);
     then (inHtCr2U, inHtS2U, inHtU2S, expList);
@@ -521,8 +527,7 @@ algorithm
     then (inHtCr2U, inHtS2U, inHtU2S, {});
 
     else equation
-      print(anyString(inEq));
-      Error.addInternalError("./Compiler/NFFrontEnd/NFUnitCheck.mo: function foldEquation failed on: " + DAEDump.dumpEquationStr(inEq), sourceInfo());
+      Error.addInternalError(getInstanceName() + " failed on: " + DAEDump.dumpEquationStr(inEq), sourceInfo());
     then fail();
   end match;
 end foldEquation2;


### PR DESCRIPTION
- Strip the modifier from the SCode.REDECL and add it to the
  Modifier.REDECLARE, so that it's merged in the correct order and
  instantiated in the correct scope.