### PR TITLE
NFFrontEnd record fix

### DIFF
--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -911,12 +911,28 @@ algorithm
   dfunc := match cls
     case Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE(components = comps), sections = sections)
       algorithm
+        elems := {};
+
+        for c in func.inputs loop
+          elems := convertFunctionParam(c) :: elems;
+        end for;
+
+        for c in func.outputs loop
+          elems := convertFunctionParam(c) :: elems;
+        end for;
+
+        for c in func.locals loop
+          elems := convertFunctionParam(c) :: elems;
+        end for;
+
+        // elems := list(convertFunctionParam(c) for c in func.locals) :: elems;
         elems := match sections
-          case Sections.SECTIONS() then convertAlgorithms(sections.algorithms, {});
-          else {};
+          case Sections.SECTIONS() then convertAlgorithms(sections.algorithms, elems);
+          else elems;
         end match;
 
-        elems := convertFunctionParams(comps, elems);
+        elems := listReverse(elems);
+
         def := DAE.FunctionDefinition.FUNCTION_DEF(elems);
       then
         Function.toDAE(func, {def});
@@ -929,26 +945,6 @@ algorithm
 
   end match;
 end convertFunction;
-
-function convertSections
-  input Sections sections;
-  output list<DAE.Element> elems;
-algorithm
-  elems := {};
-end convertSections;
-
-function convertFunctionParams
-  input array<InstNode> components;
-  input output list<DAE.Element> elems;
-protected
-  InstNode node;
-  Component comp;
-  Type ty;
-algorithm
-  for i in arrayLength(components):-1:1 loop
-    elems := convertFunctionParam(components[i]) :: elems;
-  end for;
-end convertFunctionParams;
 
 function convertFunctionParam
   input InstNode node;

--- a/Compiler/NFFrontEnd/NFRecord.mo
+++ b/Compiler/NFFrontEnd/NFRecord.mo
@@ -58,8 +58,10 @@ import Types;
 import Typing = NFTyping;
 import NFInstUtil;
 import NFPrefixes.Variability;
+import NFPrefixes.Visibility;
 import NFFunction.Function;
 import ClassTree = NFClassTree.ClassTree;
+import ComplexType = NFComplexType;
 
 public
 
@@ -70,6 +72,7 @@ function newDefaultConstructor
 protected
   Class cls;
   list<InstNode> inputs, outputs, locals;
+  InstNode out_rec;
   DAE.FunctionAttributes attr;
   Pointer<Boolean> collected;
   Absyn.Path con_path;
@@ -78,8 +81,22 @@ algorithm
   attr := DAE.FUNCTION_ATTRIBUTES_DEFAULT;
   // attr := makeAttributes(node, inputs, outputs);
   collected := Pointer.create(false);
-  con_path := Absyn.suffixPath(path,"'$constructor'");
-  fn := Function.FUNCTION(con_path, node, inputs, {}, locals, {}, Type.UNKNOWN(), attr, collected);
+  con_path := Absyn.suffixPath(path,"'$ctor'");
+
+  // create a TYPED_COMPONENT here since this output "defualt constructed" record is not part
+  // the class node. So it will not be typed later by typeFunction. Insted of changing things
+  // there just handle it here.
+  out_rec := InstNode.COMPONENT_NODE("$out" + InstNode.name(node),
+    Visibility.PUBLIC,
+    Pointer.createImmutable(Component.TYPED_COMPONENT(
+      node,
+      Type.COMPLEX(node, ComplexType.CLASS()),
+      Binding.UNBOUND(),
+      NFComponent.OUTPUT_ATTR,
+      Absyn.dummyInfo)),
+    node);
+
+  fn := Function.FUNCTION(con_path, node, inputs, {out_rec}, locals, {}, Type.UNKNOWN(), attr, collected);
 end newDefaultConstructor;
 
 


### PR DESCRIPTION
  - create a typed component for the return type of default constuctors.
  - when converting a function to old DAE structures use the splitted inputs, outputs and locals instead of the components from the class node so that the auto generated return component is picked up. It is not added to the classInst.