### PR TITLE
[NF] Fix for builtin calls

### DIFF
--- a/Compiler/FrontEnd/Absyn.mo
+++ b/Compiler/FrontEnd/Absyn.mo
@@ -2947,6 +2947,19 @@ algorithm
   end match;
 end pathLastIdent;
 
+public function pathLast
+  "Returns the last ident (after last dot) in a path"
+  input output Path path;
+algorithm
+  path := match path
+    local
+      Path p;
+    case QUALIFIED(path = p) then pathLast(p);
+    case IDENT() then path;
+    case FULLYQUALIFIED(path = p) then pathLast(p);
+  end match;
+end pathLast;
+
 public function pathFirstIdent "Returns the first ident (before first dot) in a path"
   input Path inPath;
   output Ident outIdent;

--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -632,8 +632,9 @@ protected
     output DAE.Exp daeCall;
   algorithm
     daeCall := match call
+
       case TYPED_CALL()
-        then DAE.CALL(Function.name(call.fn),
+        then DAE.CALL(Function.nameConsiderBuiltin(call.fn),
           list(Expression.toDAE(e) for e in call.arguments),
           CallAttributes.toDAE(call.attributes));
 

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -339,6 +339,19 @@ uniontype Function
     output Absyn.Path path = fn.path;
   end name;
 
+  function nameConsiderBuiltin "Handles the DAE.mo structure where builtin calls are replaced by their simpler name"
+    input Function fn;
+    output Absyn.Path path;
+  algorithm
+    path := match fn.attributes.isBuiltin
+      local
+        String name;
+      case DAE.FUNCTION_BUILTIN(name=SOME(name)) then Absyn.IDENT(name);
+      case DAE.FUNCTION_BUILTIN() then Absyn.pathLast(fn.path);
+      else fn.path;
+    end match;
+  end nameConsiderBuiltin;
+
   function signatureString
     "Constructs a signature string for a function, e.g. Real func(Real x, Real y)"
     input Function fn;


### PR DESCRIPTION
Calls like Modelica.Math.sin need to be replaced with sin in the DAE
structure.