### PR TITLE
Improve detection of invalid each in NFInst.

### DIFF
--- a/Compiler/FrontEnd/MetaModelicaBuiltin.mo
+++ b/Compiler/FrontEnd/MetaModelicaBuiltin.mo
@@ -664,7 +664,7 @@ function arrayEmpty<A> "O(1)"
   input array<A> arr;
   output Boolean isEmpty;
 algorithm
-  isEmpty := arrayLength(str) == 0;
+  isEmpty := arrayLength(arr) == 0;
   annotation(__OpenModelica_EarlyInline = true, __OpenModelica_BuiltinPtr = true);
 end arrayEmpty;
 

--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -313,6 +313,17 @@ uniontype Class
     end match;
   end getDimensions;
 
+  function hasDimensions
+    input Class cls;
+    output Boolean hasDims;
+  algorithm
+    hasDims := match cls
+      case DERIVED_CLASS()
+        then not listEmpty(cls.dims) or hasDimensions(InstNode.getClass(cls.baseClass));
+      else false;
+    end match;
+  end hasDimensions;
+
   function getAttributes
     input Class cls;
     output Component.Attributes attr;

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -971,7 +971,6 @@ algorithm
         checkOuterComponentMod(comp_mod, comp, comp_node);
 
         dims := list(Dimension.RAW_DIM(d) for d in def.attributes.arrayDims);
-        Modifier.checkEach(comp_mod, listEmpty(dims), InstNode.name(comp_node));
         binding := Modifier.binding(comp_mod);
         comp_mod := Modifier.propagate(comp_mod);
         condition := Binding.fromAbsyn(def.condition, SCode.Each.NOT_EACH(), parent, info);
@@ -984,6 +983,9 @@ algorithm
 
         // Instantiate the type of the component.
         (cls, cls_attr) := instTypeSpec(def.typeSpec, comp_mod, attr, scope, comp_node, def.info);
+
+        Modifier.checkEach(comp_mod, listEmpty(dims) and
+          not Class.hasDimensions(InstNode.getClass(cls)), InstNode.name(comp_node));
 
         if not referenceEq(attr, cls_attr) then
           comp_node := InstNode.componentApply(comp_node, Component.setAttributes, cls_attr);

--- a/Compiler/NFFrontEnd/NFMod.mo
+++ b/Compiler/NFFrontEnd/NFMod.mo
@@ -435,7 +435,7 @@ public
           Error.addSourceMessage(Error.EACH_ON_NON_ARRAY,
             {elementName}, mod.info);
         then
-          fail();
+          ();
 
       else ();
     end match;


### PR DESCRIPTION
- Take the dimensions of a component's type into account when checking
  whether each is used on an array or not.
- Don't fail when an invalid use of each is found, since the MSL
  uses each incorrectly.