### PR TITLE
NFInst fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -779,6 +779,12 @@ protected
         then
           ();
 
+      case Class.DERIVED_CLASS()
+        algorithm
+          (inputs, outputs, locals) := collectParams(cls.baseClass);
+        then
+          ();
+
       else
         algorithm
           assert(false, getInstanceName() + " got non-instantiated function");

--- a/Compiler/NFFrontEnd/NFLookup.mo
+++ b/Compiler/NFFrontEnd/NFLookup.mo
@@ -248,16 +248,8 @@ algorithm
     try
       // Check if we have an element with the same name as the outer node in this scope.
       innerNode := InstNode.resolveOuter(Class.lookupElement(name, InstNode.getClass(cur_scope)));
-
-      if InstNode.isInner(innerNode) then
-        // Found an inner node, return it.
-        return;
-      else
-        // Found a node that's not inner, give a warning and continue looking.
-        Error.addMultiSourceMessage(Error.FOUND_NON_INNER,
-          {name}, {InstNode.info(outerNode), InstNode.info(innerNode)});
-        fail();
-      end if;
+      true := InstNode.isInner(innerNode);
+      return;
     else
       // Continue looking in the instance parent's scope.
       prev_scope := cur_scope;

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -735,8 +735,6 @@ public constant Message RAGGED_DIMENSION = MESSAGE(302, TRANSLATION(), ERROR(),
   Util.gettext("Ragged dimensions are not yet supported (from dimension '%s')"));
 public constant Message INVALID_TYPENAME_USE = MESSAGE(303, TRANSLATION(), ERROR(),
   Util.gettext("Type name '%s' is not allowed in this context."));
-public constant Message FOUND_NON_INNER = MESSAGE(304, TRANSLATION(), WARNING(),
-  Util.gettext("Ignoring non-inner %s when looking for inner."));
 public constant Message FOUND_WRONG_INNER_ELEMENT = MESSAGE(305, TRANSLATION(), ERROR(),
   Util.gettext("Found inner %s %s instead of expected %s."));
 public constant Message FOUND_OTHER_BASECLASS = MESSAGE(306, TRANSLATION(), ERROR(),


### PR DESCRIPTION
- Handle derived functions in NFFunction.collectParams.
- Remove the warning when finding an outer element when looking for
  an inner, since this is valid and commonly used.