### PR TITLE
NFInst improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFBinding.mo
+++ b/Compiler/NFFrontEnd/NFBinding.mo
@@ -47,7 +47,7 @@ public
   record RAW_BINDING
     Absyn.Exp bindingExp;
     InstNode scope;
-    Integer propagatedLevels;
+    Integer originLevel;
     SourceInfo info;
   end RAW_BINDING;
 
@@ -55,7 +55,7 @@ public
     Expression bindingExp;
     Boolean isProcessing;
     InstNode scope;
-    Integer propagatedLevels;
+    Integer originLevel;
     SourceInfo info;
   end UNTYPED_BINDING;
 
@@ -63,7 +63,7 @@ public
     Expression bindingExp;
     Type bindingType;
     Variability variability;
-    Integer propagatedLevels;
+    Integer originLevel;
     SourceInfo info;
   end TYPED_BINDING;
 
@@ -75,6 +75,7 @@ public
   function fromAbsyn
     input Option<Absyn.Exp> bindingExp;
     input SCode.Each eachPrefix;
+    input Integer level;
     input InstNode scope;
     input SourceInfo info;
     output Binding binding;
@@ -82,13 +83,13 @@ public
     binding := match bindingExp
       local
         Absyn.Exp exp;
-        Integer pd;
+        Integer lvl;
 
       case SOME(exp)
         algorithm
-          pd := if SCode.eachBool(eachPrefix) then -1 else 0;
+          lvl := if SCode.eachBool(eachPrefix) then -level else level;
         then
-          RAW_BINDING(exp, scope, pd, info);
+          RAW_BINDING(exp, scope, lvl, info);
 
       else UNBOUND();
     end match;
@@ -189,9 +190,9 @@ public
     output Boolean isEach;
   algorithm
     isEach := match binding
-      case RAW_BINDING() then binding.propagatedLevels == -1;
-      case UNTYPED_BINDING() then binding.propagatedLevels == -1;
-      case TYPED_BINDING() then binding.propagatedLevels == -1;
+      case RAW_BINDING() then binding.originLevel < 0;
+      case UNTYPED_BINDING() then binding.originLevel < 0;
+      case TYPED_BINDING() then binding.originLevel < 0;
       else false;
     end match;
   end isEach;

--- a/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -50,7 +50,7 @@ import NFComponent.Component;
 import Expression = NFExpression;
 import NFInstNode.InstNode;
 import NFInstNode.InstNodeType;
-import NFMod.Modifier;
+import NFModifier.Modifier;
 import Type = NFType;
 import BuiltinFuncs = NFBuiltinFuncs;
 import Pointer;
@@ -237,6 +237,7 @@ constant InstNode STATESELECT_NEVER =
       STATESELECT_NEVER_BINDING,
       NFComponent.CONSTANT_ATTR,
       Absyn.dummyInfo)),
+    0,
     STATESELECT_NODE);
 
 constant ComponentRef STATESELECT_NEVER_CREF =
@@ -252,6 +253,7 @@ constant InstNode STATESELECT_AVOID =
       STATESELECT_AVOID_BINDING,
       NFComponent.CONSTANT_ATTR,
       Absyn.dummyInfo)),
+    0,
     STATESELECT_NODE);
 
 constant ComponentRef STATESELECT_AVOID_CREF =
@@ -267,6 +269,7 @@ constant InstNode STATESELECT_DEFAULT =
       STATESELECT_DEFAULT_BINDING,
       NFComponent.CONSTANT_ATTR,
       Absyn.dummyInfo)),
+    0,
     STATESELECT_NODE);
 
 constant ComponentRef STATESELECT_DEFAULT_CREF =
@@ -282,6 +285,7 @@ constant InstNode STATESELECT_PREFER =
       STATESELECT_PREFER_BINDING,
       NFComponent.CONSTANT_ATTR,
       Absyn.dummyInfo)),
+    0,
     STATESELECT_NODE);
 
 constant ComponentRef STATESELECT_PREFER_CREF =
@@ -297,6 +301,7 @@ constant InstNode STATESELECT_ALWAYS =
       STATESELECT_ALWAYS_BINDING,
       NFComponent.CONSTANT_ATTR,
       Absyn.dummyInfo)),
+    0,
     STATESELECT_NODE);
 
 constant ComponentRef STATESELECT_ALWAYS_CREF =
@@ -321,6 +326,7 @@ constant InstNode TIME =
       Binding.UNBOUND(),
       NFComponent.INPUT_ATTR,
       Absyn.dummyInfo)),
+    0,
     InstNode.EMPTY_NODE());
 
 constant ComponentRef TIME_CREF = ComponentRef.CREF(TIME, {}, Type.REAL(), Origin.CREF, ComponentRef.EMPTY());

--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -64,7 +64,7 @@ constant Component INT_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NO
 
 constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
   Visibility.PUBLIC,
-  Pointer.createImmutable(INT_COMPONENT), InstNode.EMPTY_NODE());
+  Pointer.createImmutable(INT_COMPONENT), 0, InstNode.EMPTY_NODE());
 
 // Default Real parameter.
 constant Component REAL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
@@ -72,7 +72,7 @@ constant Component REAL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_N
 
 constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
   Visibility.PUBLIC,
-  Pointer.createImmutable(REAL_COMPONENT), InstNode.EMPTY_NODE());
+  Pointer.createImmutable(REAL_COMPONENT), 0, InstNode.EMPTY_NODE());
 
 // Default Boolean parameter.
 constant Component BOOL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
@@ -80,7 +80,7 @@ constant Component BOOL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_N
 
 constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
   Visibility.PUBLIC,
-  Pointer.createImmutable(BOOL_COMPONENT), InstNode.EMPTY_NODE());
+  Pointer.createImmutable(BOOL_COMPONENT), 0, InstNode.EMPTY_NODE());
 
 // Default String parameter.
 constant Component STRING_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
@@ -88,7 +88,7 @@ constant Component STRING_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY
 
 constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
   Visibility.PUBLIC,
-  Pointer.createImmutable(STRING_COMPONENT), InstNode.EMPTY_NODE());
+  Pointer.createImmutable(STRING_COMPONENT), 0, InstNode.EMPTY_NODE());
 
 // Default enumeration(:) parameter.
 constant Component ENUM_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
@@ -96,7 +96,7 @@ constant Component ENUM_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_N
 
 constant InstNode ENUM_PARAM = InstNode.COMPONENT_NODE("e",
   Visibility.PUBLIC,
-  Pointer.createImmutable(ENUM_COMPONENT), InstNode.EMPTY_NODE());
+  Pointer.createImmutable(ENUM_COMPONENT), 0, InstNode.EMPTY_NODE());
 
 // Integer(e)
 constant Function INTEGER = Function.FUNCTION(Path.IDENT("Integer"),

--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -293,7 +293,7 @@ uniontype Call
     outIters := {};
     iter_scope := scope;
     for Absiter in inIters loop
-      binding := Binding.fromAbsyn(Absiter.range, SCode.NOT_EACH(), iter_scope, info);
+      binding := Binding.fromAbsyn(Absiter.range, SCode.NOT_EACH(), 0, iter_scope, info);
       binding := Inst.instBinding(binding);
       (iter_scope, iter) := Inst.addIteratorToScope(Absiter.name, binding, info, iter_scope);
       outIters := iter::outIters;
@@ -646,6 +646,7 @@ uniontype Call
   algorithm
     ty := match call
       case TYPED_CALL(attributes = CallAttributes.CALL_ATTR(ty = ty)) then ty;
+      case TYPED_MAP_CALL() then call.ty;
       else Type.UNKNOWN();
     end match;
   end typeOf;

--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -32,7 +32,7 @@
 encapsulated package NFClass
 
 import NFInstNode.InstNode;
-import NFMod.Modifier;
+import NFModifier.Modifier;
 import NFStatement.Statement;
 import SCode.Element;
 import Type = NFType;

--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -36,7 +36,7 @@ import Binding = NFBinding;
 import NFClass.Class;
 import Dimension = NFDimension;
 import NFInstNode.InstNode;
-import NFMod.Modifier;
+import NFModifier.Modifier;
 import SCode.Element;
 import SCode;
 import Type = NFType;

--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -44,7 +44,7 @@ import ExecStat.execStat;
 import ElementSource;
 import ComponentRef = NFComponentRef;
 import Type = NFType;
-import NFMod.Modifier;
+import NFModifier.Modifier;
 import Expression = NFExpression;
 import NFComponent.Component;
 import Prefixes = NFPrefixes;

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -56,7 +56,7 @@ import NFCall.Call;
 import NFClass.Class;
 import NFClassTree.ClassTree;
 import NFComponent.Component;
-import NFMod.Modifier;
+import NFModifier.Modifier;
 import Sections = NFSections;
 import Prefixes = NFPrefixes;
 import NFPrefixes.Visibility;
@@ -224,7 +224,7 @@ algorithm
               end if;
 
               new_pre := ComponentRef.prefixCref(comp_node, ty, {}, prefix);
-              binding := flattenBinding(c.binding, prefix);
+              binding := flattenBinding(c.binding, prefix, comp_node);
 
               if Type.isArray(ty) and Binding.isBound(binding) and Component.isVar(c) then
                 comps := (new_pre, Binding.UNBOUND()) :: comps;
@@ -298,6 +298,7 @@ end flattenArray;
 function flattenBinding
   input output Binding binding;
   input ComponentRef prefix;
+  input InstNode component;
 algorithm
   () := match binding
     local
@@ -307,8 +308,8 @@ algorithm
 
     case Binding.TYPED_BINDING()
       algorithm
-        if binding.propagatedLevels > 0 then
-          subs := List.flatten(ComponentRef.subscriptsN(prefix, binding.propagatedLevels));
+        if binding.originLevel > 0 then
+          subs := List.flatten(ComponentRef.subscriptsN(prefix, InstNode.level(component) - binding.originLevel));
           binding.bindingExp := Expression.subscript(binding.bindingExp, subs);
         end if;
       then

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -33,7 +33,6 @@ encapsulated package NFInstNode
 
 import NFComponent.Component;
 import NFClass.Class;
-import NFMod.Modifier;
 import SCode;
 import Absyn;
 import Type = NFType;
@@ -200,6 +199,7 @@ uniontype InstNode
     String name;
     Visibility visibility;
     Pointer<Component> component;
+    Integer level;
     InstNode parent;
   end COMPONENT_NODE;
 
@@ -259,7 +259,7 @@ uniontype InstNode
   algorithm
     SCode.COMPONENT(name = name, prefixes = SCode.PREFIXES(visibility = vis)) := definition;
     node := COMPONENT_NODE(name, Prefixes.visibilityFromSCode(vis),
-      Pointer.create(Component.new(definition)), parent);
+      Pointer.create(Component.new(definition)), 0, parent);
   end newComponent;
 
   function newExtends
@@ -284,7 +284,7 @@ uniontype InstNode
     input InstNode parent;
     output InstNode node;
   algorithm
-    node := COMPONENT_NODE(name, Visibility.PUBLIC, Pointer.create(component), parent);
+    node := COMPONENT_NODE(name, Visibility.PUBLIC, Pointer.create(component), 0, parent);
   end fromComponent;
 
   function isClass
@@ -481,6 +481,7 @@ uniontype InstNode
       case COMPONENT_NODE()
         algorithm
           node.parent := parent;
+          node.level := level(parent) + 1;
         then
           ();
 
@@ -1099,6 +1100,17 @@ uniontype InstNode
       else ();
     end match;
   end protectComponent;
+
+  function level
+    input InstNode node;
+    output Integer level;
+  algorithm
+    level := match node
+      case COMPONENT_NODE() then node.level;
+      else 0;
+    end match;
+  end level;
+
 end InstNode;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/Compiler/NFFrontEnd/NFLookup.mo
+++ b/Compiler/NFFrontEnd/NFLookup.mo
@@ -45,7 +45,6 @@ import NFClass.Class;
 import NFInstNode.InstNode;
 import NFLookupState.LookupState;
 import Type = NFType;
-import NFMod.Modifier;
 import ComponentRef = NFComponentRef;
 
 protected

--- a/Compiler/NFFrontEnd/NFPackage.mo
+++ b/Compiler/NFFrontEnd/NFPackage.mo
@@ -82,7 +82,6 @@ public
 
     for c in Constants.listKeys(constants) loop
       binding := Component.getBinding(InstNode.component(ComponentRef.node(c)));
-      //binding := Typing.typeBinding(binding);
       comps := (c, binding) :: comps;
     end for;
 

--- a/Compiler/NFFrontEnd/NFRecord.mo
+++ b/Compiler/NFFrontEnd/NFRecord.mo
@@ -45,7 +45,6 @@ import Dimension = NFDimension;
 import Expression = NFExpression;
 import NFExpression.CallAttributes;
 import NFInstNode.InstNode;
-import NFMod.Modifier;
 import Type = NFType;
 import Subscript = NFSubscript;
 
@@ -83,9 +82,9 @@ algorithm
   collected := Pointer.create(false);
   con_path := Absyn.suffixPath(path,"'$ctor'");
 
-  // create a TYPED_COMPONENT here since this output "defualt constructed" record is not part
-  // the class node. So it will not be typed later by typeFunction. Insted of changing things
-  // there just handle it here.
+  // create a TYPED_COMPONENT here since this output "default constructed" record is not part
+  // of the class node. So it will not be typed later by typeFunction. Instead of changing
+  // things there just handle it here.
   out_rec := InstNode.COMPONENT_NODE("$out" + InstNode.name(node),
     Visibility.PUBLIC,
     Pointer.createImmutable(Component.TYPED_COMPONENT(
@@ -95,6 +94,7 @@ algorithm
       Binding.UNBOUND(),
       NFComponent.OUTPUT_ATTR,
       Absyn.dummyInfo)),
+    0,
     node);
 
   fn := Function.FUNCTION(con_path, node, inputs, {out_rec}, locals, {}, Type.UNKNOWN(), attr, collected);

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -2425,10 +2425,10 @@ algorithm
       algorithm
         comp_ty := componentType;
 
-        if binding.propagatedLevels > 0 then
+        if binding.originLevel >= 0 then
           parent := component;
 
-          for i in 1:binding.propagatedLevels loop
+          for i in 1:InstNode.level(component) - binding.originLevel loop
             parent := InstNode.parent(component);
             dims := Type.arrayDims(InstNode.getType(parent));
             comp_ty := Type.liftArrayLeftList(comp_ty, dims);
@@ -2443,7 +2443,7 @@ algorithm
              Type.toString(binding.bindingType)}, binding.info);
           fail();
         elseif isCastMatch(ty_match) then
-          binding := Binding.TYPED_BINDING(exp, ty, binding.variability, binding.propagatedLevels, binding.info);
+          binding := Binding.TYPED_BINDING(exp, ty, binding.variability, binding.originLevel, binding.info);
         end if;
       then
         ();

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -45,7 +45,7 @@ import Equation = NFEquation;
 import NFClass.Class;
 import Expression = NFExpression;
 import NFInstNode.InstNode;
-import NFMod.Modifier;
+import NFModifier.Modifier;
 import Statement = NFStatement;
 import NFType.Type;
 import Operator = NFOperator;
@@ -79,7 +79,7 @@ import DAEUtil;
 import MetaModelica.Dangerous.listReverseInPlace;
 import ComplexType = NFComplexType;
 import Restriction = NFRestriction;
-import NFMod.ModTable;
+import NFModifier.ModTable;
 
 uniontype TypingError
   record NO_ERROR end NO_ERROR;
@@ -431,7 +431,8 @@ algorithm
           // to get the dimension we're looking for.
           case Binding.UNTYPED_BINDING()
             algorithm
-              prop_dims := InstNode.countDimensions(InstNode.parent(component), binding.propagatedLevels);
+              prop_dims := InstNode.countDimensions(InstNode.parent(component),
+                InstNode.level(component) - binding.originLevel);
               dim := typeExpDim(binding.bindingExp, index + prop_dims, ExpOrigin.DIMENSION(), info);
             then
               dim;
@@ -439,7 +440,8 @@ algorithm
           // A typed binding, get the dimension from the binding's type.
           case Binding.TYPED_BINDING()
             algorithm
-              prop_dims := InstNode.countDimensions(InstNode.parent(component), binding.propagatedLevels);
+              prop_dims := InstNode.countDimensions(InstNode.parent(component),
+                InstNode.level(component) - binding.originLevel);
               dim := nthDimensionBoundsChecked(binding.bindingType, index + prop_dims);
             then
               dim;
@@ -565,7 +567,7 @@ algorithm
       algorithm
         (exp, ty, var) := typeExp(exp, binding.info, origin);
       then
-        Binding.TYPED_BINDING(exp, ty, var, binding.propagatedLevels, binding.info);
+        Binding.TYPED_BINDING(exp, ty, var, binding.originLevel, binding.info);
 
     case Binding.TYPED_BINDING() then binding;
     case Binding.UNBOUND() then binding;
@@ -714,7 +716,7 @@ algorithm
         exp := Ceval.evalExp(binding.bindingExp, Ceval.EvalTarget.ATTRIBUTE(binding.bindingExp, binding.info));
         exp := SimplifyExp.simplifyExp(exp);
       then
-        Binding.TYPED_BINDING(exp, binding.bindingType, binding.variability, binding.propagatedLevels, binding.info);
+        Binding.TYPED_BINDING(exp, binding.bindingType, binding.variability, binding.originLevel, binding.info);
 
     else
       algorithm

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -116,7 +116,7 @@ if true then /* Suppress output */
     "../NFFrontEnd/NFInstUtil.mo",
     "../NFFrontEnd/NFLookup.mo",
     "../NFFrontEnd/NFLookupState.mo",
-    "../NFFrontEnd/NFMod.mo",
+    "../NFFrontEnd/NFModifier.mo",
     "../NFFrontEnd/NFOperator.mo",
     "../NFFrontEnd/NFPrefixes.mo",
     "../NFFrontEnd/NFRangeIterator.mo",


### PR DESCRIPTION
- Rename NFMod to NFModifier, since that's the actual package name.
- Add instance tree hierarchy level to components, and have bindings
  keep track of which level they're from instead of keeping track of
  how many levels they've been pushed down.
- Added Expression.SUBSCRIPTED_EXP to handle subscripting of
  expressions that can't be scalarized.
- Add missing cases for Call.UNTYPED_MAP_CALL and CAll.TYPED_MAP_CALL
  to some Expression functions.