### PR TITLE
NFInst improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -677,7 +677,7 @@ algorithm
         unrollForLoop(eq.iterator, body, elements);
 
     case Equation.IF()
-      then convertIfEquation(eq.branches, eq.info, isInitial = false) :: elements;
+      then convertIfEquation(eq.branches, eq.info, isInitial = true) :: elements;
 
     case Equation.ASSERT()
       algorithm

--- a/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/Compiler/NFFrontEnd/NFScalarize.mo
@@ -190,8 +190,11 @@ algorithm
     end if;
   end for;
 
-  // Add the scalarized if equation to the list of equations if we got this far.
-  equations := Equation.IF(listReverseInPlace(bl), info) :: equations;
+  // Add the scalarized if equation to the list of equations if we got this far,
+  // and there are any branches still remaining.
+  if not listEmpty(bl) then
+    equations := Equation.IF(listReverseInPlace(bl), info) :: equations;
+  end if;
 end scalarizeIfEquation;
 
 function scalarizeBranch

--- a/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -241,6 +241,17 @@ algorithm
         case Operator.GREATEREQ() then Expression.BOOLEAN(r1 >= r2);
       end match;
 
+    case Expression.RELATION(exp1 = Expression.ENUM_LITERAL(index = i1),
+                             exp2 = Expression.ENUM_LITERAL(index = i2))
+      then Expression.BOOLEAN(match exp.operator
+        case Operator.LESS()      then i1 < i2;
+        case Operator.LESSEQ()    then i1 <= i2;
+        case Operator.GREATER()   then i1 > i2;
+        case Operator.GREATEREQ() then i1 >= i2;
+        case Operator.EQUAL()     then i1 == i2;
+        case Operator.NEQUAL()    then i1 <> i2;
+      end match);
+
     case Expression.IF(condition=Expression.BOOLEAN(value=b1))
       then if b1 then exp.trueBranch else exp.falseBranch;
 


### PR DESCRIPTION
- Handle enumeration relations in NFSimplifyExp.
- Fix case for if-equation in NFConvertDAE.convertInitialEquation
  so that it generates an initial if-equation instead of a normal one.
- Fix NFScalarize.scalarizeIfEquation to handle the case where an
  if-equation is completely removed due to all conditions being false.