### PR TITLE
Handle vectorization of matrix slightly better

### DIFF
--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -10988,6 +10988,7 @@ algorithm
         b1 = (ds < Config.vectorizationLimit());
         b2 = (ds2 < Config.vectorizationLimit());
         true = boolAnd(b1, b2) or Config.vectorizationLimit() == 0;
+        true = listEmpty(ComponentReference.crefLastSubs(cr));
         e = createCrefArray2d(cr, 1, ds, ds2, exptp, t,crefIdType);
       then
         e;

--- a/Compiler/SimCode/SimCodeMain.mo
+++ b/Compiler/SimCode/SimCodeMain.mo
@@ -556,6 +556,7 @@ protected
     res := (false,{});
     try
       SimCodeUtil.resetFunctionIndex();
+      SimCodeFunctionUtil.codegenResetTryThrowIndex();
       if Config.acceptMetaModelicaGrammar() or Flags.isSet(Flags.GEN_DEBUG_SYMBOLS) then
         Tpl.textFileConvertLines(Tpl.tplCallWithFailErrorNoArg(func), file);
       else
@@ -576,6 +577,7 @@ protected
     res := (false,{});
     try
       SimCodeUtil.resetFunctionIndex();
+      SimCodeFunctionUtil.codegenResetTryThrowIndex();
       Tpl.tplCallWithFailErrorNoArg(func);
       res := (true,SimCodeUtil.getFunctionIndex());
     else
@@ -593,6 +595,7 @@ protected
     res := (false,{});
     try
       SimCodeUtil.resetFunctionIndex();
+      SimCodeFunctionUtil.codegenResetTryThrowIndex();
       func();
       res := (true,SimCodeUtil.getFunctionIndex());
     else


### PR DESCRIPTION
This partially resolves ticket:2469. Code generation still does not
fully work unless `-v=1` is used.