### PR TITLE
NFInst improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -529,7 +529,13 @@ public
       case (UNARY(), _)
         then UNARY(exp.operator, typeCastElements(exp.exp, ty));
 
-      else CAST(ty, exp);
+      else
+        algorithm
+          t := typeOf(exp);
+          t := Type.setArrayElementType(t, ty);
+        then
+          CAST(t, exp);
+
     end match;
   end typeCastElements;
 

--- a/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/Compiler/NFFrontEnd/NFScalarize.mo
@@ -137,6 +137,11 @@ algorithm
         ty := Type.arrayElementType(ty);
 
         while ExpressionIterator.hasNext(lhs_iter) loop
+          if not ExpressionIterator.hasNext(rhs_iter) then
+            Error.addInternalError(getInstanceName() + " could not expand rhs " +
+              Expression.toString(eq.rhs), eq.info);
+          end if;
+
           (lhs_iter, lhs) := ExpressionIterator.next(lhs_iter);
           (rhs_iter, rhs) := ExpressionIterator.next(rhs_iter);
           equations := Equation.EQUALITY(lhs, rhs, ty, info) :: equations;


### PR DESCRIPTION
- Fixed type of array cast expressions.
- Added internal error when Scalarize fails to expand equation.