### PR TITLE
[NF] Handle recursive functions.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -358,6 +358,8 @@ uniontype Call
           if not fn_typed then
             fnl := list(Function.typeFunction(f) for f in fnl);
             InstNode.setFuncCache(fn_node, CachedData.FUNCTION(fnl, true, special));
+            fnl := list(Function.typeFunctionBody(f) for f in fnl);
+            InstNode.setFuncCache(fn_node, CachedData.FUNCTION(fnl, true, special));
           end if;
 
 
@@ -413,6 +415,8 @@ uniontype Call
           // Type the function(s) if not already done.
           if not fn_typed then
             fnl := list(Function.typeFunction(f) for f in fnl);
+            InstNode.setFuncCache(fn_node, CachedData.FUNCTION(fnl, true, special));
+            fnl := list(Function.typeFunctionBody(f) for f in fnl);
             InstNode.setFuncCache(fn_node, CachedData.FUNCTION(fnl, true, special));
           end if;
 
@@ -477,6 +481,7 @@ uniontype Call
           // Type the function(s) if not already done.
           if not fn_typed then
             fn := Function.typeFunction(fn);
+            fn := Function.typeFunctionBody(fn);
             InstNode.setFuncCache(fn_node, CachedData.FUNCTION({fn}, true, special));
           end if;
 
@@ -557,6 +562,7 @@ uniontype Call
           // Type the function(s) if not already done.
           if not fn_typed then
             fn := Function.typeFunction(fn);
+            fn := Function.typeFunctionBody(fn);
             InstNode.setFuncCache(fn_node, CachedData.FUNCTION({fn}, true, special));
           end if;
 
@@ -634,6 +640,7 @@ uniontype Call
           // Type the function(s) if not already done.
           if not fn_typed then
             fn := Function.typeFunction(fn);
+            fn := Function.typeFunctionBody(fn);
             InstNode.setFuncCache(fn_node, CachedData.FUNCTION({fn}, true, special));
           end if;
 

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -99,6 +99,7 @@ uniontype TypingError
   end isError;
 end TypingError;
 
+public
 type EquationScope = enumeration(NORMAL, INITIAL, IF, IF_PARAMETER);
 type ClassScope = enumeration(CLASS, FUNCTION);
 
@@ -114,14 +115,6 @@ algorithm
   typeSections(cls);
   execStat("NFTyping.typeSections(" + name + ")");
 end typeClass;
-
-function typeFunction
-  input InstNode cls;
-algorithm
-  typeComponents(cls, ClassScope.FUNCTION);
-  typeBindings(cls, cls);
-  typeSections(cls);
-end typeFunction;
 
 function typeComponents
   input InstNode cls;
@@ -1407,7 +1400,6 @@ algorithm
   variability := if listEmpty(valr) then Variability.CONSTANT else listHead(valr);
 end typeTuple;
 
-protected
 function printRangeTypeError
   input Expression exp1;
   input Type ty1;


### PR DESCRIPTION
- Update the function cache before instantiating a function's
  expressions, to avoid instantiating it again in the case of
  a recursive call.
- Split the typing of functions so their signatures are typed
  first, then type their bodies only after updating the cache.