### PR TITLE
NFInst improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -117,7 +117,7 @@ end Elements;
 // modifiers and illegal in other cases).
 constant InstNode ANYTYPE_NODE = InstNode.CLASS_NODE("polymorphic",
   Elements.ANY, Visibility.PUBLIC,
-  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.ANY_TYPE("unknown"), NFClassTree.EMPTY,
+  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.POLYMORPHIC(""), NFClassTree.EMPTY,
     Modifier.NOMOD(), Restriction.TYPE())),
   arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
   InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());

--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -355,7 +355,7 @@ uniontype Class
       case PARTIAL_BUILTIN() then cls.ty;
       case INSTANCED_BUILTIN()
         then match cls.ty
-          case Type.ANY_TYPE("unknown") then Type.ANY_TYPE(InstNode.name(clsNode));
+          case Type.POLYMORPHIC("") then Type.POLYMORPHIC(InstNode.name(clsNode));
           else cls.ty;
         end match;
       else Type.UNKNOWN();

--- a/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/Compiler/NFFrontEnd/NFClassTree.mo
@@ -953,6 +953,17 @@ public
       end match;
     end enumerateComponents2;
 
+    function getExtends
+      input ClassTree tree;
+      output array<InstNode> exts;
+    algorithm
+      exts := match tree
+        case PARTIAL_TREE() then tree.exts;
+        case EXPANDED_TREE() then tree.exts;
+        case INSTANTIATED_TREE() then tree.exts;
+      end match;
+    end getExtends;
+
   protected
 
     function instExtendsComps
@@ -971,17 +982,6 @@ public
         index := index + comp_count;
       end if;
     end instExtendsComps;
-
-    function getExtends
-      input ClassTree tree;
-      output array<InstNode> exts;
-    algorithm
-      exts := match tree
-        case PARTIAL_TREE() then tree.exts;
-        case EXPANDED_TREE() then tree.exts;
-        case INSTANTIATED_TREE() then tree.exts;
-      end match;
-    end getExtends;
 
     function getDuplicates
       input ClassTree tree;

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -1048,7 +1048,7 @@ protected
       case Type.CLOCK() then true;
       case Type.ENUMERATION() then true;
       case Type.ENUMERATION_ANY() then true;
-      case Type.ANY_TYPE() then true;
+      case Type.POLYMORPHIC() then true;
       case Type.ARRAY() then isValidParamType(ty.elementType);
       case Type.COMPLEX() then isValidParamState(ty.cls);
     end match;

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -1173,8 +1173,9 @@ algorithm
     case Class.EXPANDED_CLASS(elements = cls_tree)
       algorithm
         // Instantiate expressions in the extends nodes.
-        sections := ClassTree.foldExtends(cls_tree,
-          function instExpressions(scope = scope), sections);
+        for ext in ClassTree.getExtends(cls_tree) loop
+          sections := instExpressions(ext, ext, sections);
+        end for;
 
         // Instantiate expressions in the local components.
         ClassTree.applyLocalComponents(cls_tree,
@@ -1463,7 +1464,12 @@ protected
   Type ty;
   Component comp;
 algorithm
-  (cref, found_scope) := Lookup.lookupComponent(absynCref, scope, info);
+  (cref, found_scope) := match absynCref
+    case Absyn.ComponentRef.WILD() then (ComponentRef.WILD(), scope);
+    case Absyn.ComponentRef.ALLWILD() then (ComponentRef.WILD(), scope);
+    else Lookup.lookupComponent(absynCref, scope, info);
+  end match;
+
   cref := instCrefSubscripts(cref, scope, info);
 
   crefExp := match cref

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -40,10 +40,6 @@ public
   import Subscript = NFSubscript;
   import ComplexType = NFComplexType;
 
-  record ANY_TYPE
-    String b;
-  end ANY_TYPE;
-
   record INTEGER
   end INTEGER;
 
@@ -96,6 +92,13 @@ public
   record METABOXED "Used for MetaModelica generic types"
     Type ty;
   end METABOXED;
+
+  record POLYMORPHIC
+    String name;
+  end POLYMORPHIC;
+
+  record ANY
+  end ANY;
 
   // TODO: Fix constants in uniontypes and use these wherever applicable to
   // speed up comparisons using referenceEq.
@@ -406,13 +409,14 @@ public
         "(" + stringDelimitList(ty.literals, ", ") + ")";
       case Type.ENUMERATION_ANY() then "enumeration(:)";
       case Type.CLOCK() then "Clock";
-      case Type.ANY_TYPE() then "Any";
       case Type.ARRAY() then toString(ty.elementType) + "[" + stringDelimitList(List.map(ty.dimensions, Dimension.toString), ", ") + "]";
       case Type.TUPLE() then "(" + stringDelimitList(List.map(ty.types, toString), ", ") + ")";
       case Type.FUNCTION() then "function( output " + toString(ty.resultType) + " )";
       case Type.NORETCALL() then "()";
       case Type.UNKNOWN() then "unknown()";
       case Type.COMPLEX() then InstNode.name(ty.cls);
+      case Type.POLYMORPHIC() then "<" + ty.name + ">";
+      case Type.ANY() then "$ANY$";
       else
         algorithm
           assert(false, getInstanceName() + " got unknown type: " + anyString(ty));
@@ -454,7 +458,8 @@ public
       case Type.COMPLEX()
         // TODO: Use proper ClassInf.State here.
         then DAE.Type.T_COMPLEX(ClassInf.MODEL(Absyn.IDENT(InstNode.name(ty.cls))), {}, NONE());
-      case Type.ANY_TYPE() then DAE.T_METAPOLYMORPHIC(ty.b);
+      case Type.POLYMORPHIC() then DAE.T_METAPOLYMORPHIC(ty.name);
+      case Type.ANY() then DAE.T_ANYTYPE(NONE());
       else
         algorithm
           assert(false, getInstanceName() + " got unknown type: " + anyString(ty));

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -1689,19 +1689,22 @@ algorithm
       then (actualType,
         if allowUnknown then MatchKind.UNKNOWN_EXPECTED else MatchKind.NOT_COMPATIBLE);
 
-    case (_, Type.ANY_TYPE())
+    case (_, Type.POLYMORPHIC())
       algorithm
         expression := Expression.BOX(expression);
         // matchKind := MatchKind.GENERIC(expectedType.b,actualType);
       then
         (Type.METABOXED(actualType), MatchKind.GENERIC);
 
-    case (Type.ANY_TYPE(), _)
+    case (Type.POLYMORPHIC(), _)
       algorithm
         // expression := Expression.UNBOX(expression, Expression.typeOf(expression));
         // matchKind := MatchKind.GENERIC(expectedType.b,actualType);
       then
         (expectedType, MatchKind.GENERIC);
+
+    // Expected type is any, any actual type matches.
+    case (_, Type.ANY()) then (expectedType, MatchKind.EXACT);
 
     // Anything else is not compatible.
     else (Type.UNKNOWN(), MatchKind.NOT_COMPATIBLE);

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -1208,7 +1208,7 @@ algorithm
       then (cref, Type.UNKNOWN(), Variability.CONTINUOUS);
 
     case ComponentRef.WILD()
-      then (cref, Type.UNKNOWN(), Variability.CONTINUOUS);
+      then (cref, Type.ANY(), Variability.CONTINUOUS);
 
     else
       algorithm


### PR DESCRIPTION
- Handle wildcard crefs in NFInst.instCref.
- Renamed Type.ANY_TYPE to POLYMORPHIC, and added Type.ANY that's type
  compatible with any other type (used for wildcards).
- Fixed scope when instantiating inherited sections.