### PR TITLE
 implemented heap sort for arrays

### DIFF
--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -5002,6 +5002,7 @@ protected
   DAE.ComponentRef cref;
   Integer size, i, j;
   list<Integer> intLst;
+  array<Integer> intArr;
   list<DAE.ComponentRef> crefs;
 algorithm
   //create HT
@@ -5028,7 +5029,9 @@ algorithm
          j := BaseHashTable.get(cr, ht);
          intLst := j :: intLst;
        end for;
-       intLst := List.sort(intLst, intGt);
+       intArr := listArray(intLst);
+       Array.heapSort(intArr);
+       intLst := arrayList(intArr);
        outSparse := (i, intLst) :: outSparse;
     end for;
     outSparse := List.sort(outSparse, Util.compareTupleIntGt);
@@ -5045,6 +5048,7 @@ protected
   DAE.ComponentRef cref;
   Integer size, i, j;
   list<Integer> intLst;
+  array<Integer> intArr;
   list<DAE.ComponentRef> crefs;
 algorithm
   //create HT
@@ -5071,7 +5075,9 @@ algorithm
          j := BaseHashTable.get(cr, ht);
          intLst := j :: intLst;
        end for;
-       intLst := List.sort(intLst, intGt);
+       intArr := listArray(intLst);
+       Array.heapSort(intArr);
+       intLst := arrayList(intArr);
        outSparse := (i, intLst) :: outSparse;
        i := i + 1;
     end for;

--- a/Compiler/Util/Array.mo
+++ b/Compiler/Util/Array.mo
@@ -84,11 +84,11 @@ end mapNoCopy_1;
 
 protected function downheap
   input output array<Integer> inArray;
+  input Integer n;
   input Integer vIn;
 protected
   Integer v = vIn;
   Integer w = 2*v+1;
-  Integer n = arrayLength(inArray);
   Integer tmp;
 algorithm
   while w<n loop
@@ -114,16 +114,15 @@ protected
   Integer n = arrayLength(inArray);
   Integer tmp;
 algorithm
-  for v in (intDiv(arrayLength(inArray),2)-1):-1:0 loop
-    downheap(inArray, v);
+  for v in (intDiv(n,2)-1):-1:0 loop
+    inArray := downheap(inArray, n, v);
   end for;
-  while n>1 loop
-    n := n - 1;
+  for v in n:-1:2 loop
     tmp := inArray[1];
-    inArray[1] := inArray[n+1];
-    inArray[n+1] := tmp;
-    downheap(inArray, 0);
-  end while;
+    inArray[1] := inArray[v];
+    inArray[v] := tmp;
+    inArray := downheap(inArray, v-1, 0);
+  end for;
 end heapSort;
 
 function findFirstOnTrue<T>

--- a/Compiler/Util/Array.mo
+++ b/Compiler/Util/Array.mo
@@ -82,6 +82,50 @@ algorithm
   end for;
 end mapNoCopy_1;
 
+protected function downheap
+  input output array<Integer> inArray;
+  input Integer vIn;
+protected
+  Integer v = vIn;
+  Integer w = 2*v+1;
+  Integer n = arrayLength(inArray);
+  Integer tmp;
+algorithm
+  while w<n loop
+    if w+1 < n then
+      if inArray[w+2]>inArray[w+1] then
+        w := w + 1;
+      end if;
+    end if;
+    if inArray[v+1]>=inArray[w+1] then
+      return;
+    end if;
+    tmp := inArray[v+1];
+    inArray[v+1] := inArray[w+1];
+    inArray[w+1] := tmp;
+    v := w;
+    w := 2*v + 1;
+  end while;
+end downheap;
+
+public function heapSort
+  input output array<Integer> inArray;
+protected
+  Integer n = arrayLength(inArray);
+  Integer tmp;
+algorithm
+  for v in (intDiv(arrayLength(inArray),2)-1):-1:0 loop
+    downheap(inArray, v);
+  end for;
+  while n>1 loop
+    n := n - 1;
+    tmp := inArray[1];
+    inArray[1] := inArray[n+1];
+    inArray[n+1] := tmp;
+    downheap(inArray, 0);
+  end while;
+end heapSort;
+
 function findFirstOnTrue<T>
   input array<T> inArray;
   input FuncType inPredicate;


### PR DESCRIPTION
reduces memory usage in `ScalableTestSuite.Electrical.DistributionSystemAC.ScaledExperiments.DistributionSystemLinearIndividual_N_28_M_28` from 950MB to 280MB in `simCode: created linear, non-linear and system jacobian parts`