### PR TITLE
[NF] Fix NFTypeCheck.matchDimensions segfault.

### DIFF
--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -652,7 +652,7 @@ uniontype Function
       inputnode :: inputs := inputs;
       comp := InstNode.component(inputnode);
 
-      (margexp, mty, matchKind) := TypeCheck.matchTypes(ty, Component.getType(comp), argexp);
+      (margexp, mty, matchKind) := TypeCheck.matchTypes(ty, Component.getType(comp), argexp, allowUnknown = true);
       correct := TypeCheck.isCompatibleMatch(matchKind);
       if TypeCheck.isCastMatch(matchKind) then
         funcMatchKind := CAST_MATCH;

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -1636,11 +1636,10 @@ algorithm
   if Dimension.isEqualKnown(dim1, dim2) then
     compatibleDim := dim1;
   elseif allowUnknown then
-    if Dimension.isKnown(dim1) then
-      compatibleDim := dim1;
-    else
-      compatibleDim := dim2;
-    end if;
+    compatibleDim := if Dimension.isKnown(dim1) then dim1 else dim2;
+  else
+    compatibleDim := dim1;
+    compatible := false;
   end if;
 end matchDimensions;
 

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -2000,7 +2000,8 @@ algorithm
         (e1, ty1) := typeExp(st.lhs, st.info, ExpOrigin.LHS());
         (e2, ty2) := typeExp(st.rhs, st.info, ExpOrigin.RHS());
 
-        (e2,_, mk) := TypeCheck.matchTypes(ty2, ty1, e2);
+        // TODO: Should probably only be allowUnknown = true if in a function.
+        (e2,_, mk) := TypeCheck.matchTypes(ty2, ty1, e2, allowUnknown = true);
 
         if TypeCheck.isIncompatibleMatch(mk) then
           Error.addSourceMessage(Error.ASSIGN_TYPE_MISMATCH_ERROR,


### PR DESCRIPTION
- Fix NFTypeCheck.matchDimensions so it actually fails when the
  dimensions don't match, and always assigns all outputs.