### PR TITLE
Fix solving of array equations

### DIFF
--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -1842,7 +1842,7 @@ algorithm
         ty = Types.unliftArray(ty);
         es = List.map2(matrix,makeArray,ty,not Types.arrayType(ty));
       then es;
-    case DAE.CREF(componentRef=DAE.CREF_IDENT(),ty=DAE.T_ARRAY(dims=DAE.DIM_INTEGER(istop)::_))
+    case DAE.CREF(ty=DAE.T_ARRAY(dims=DAE.DIM_INTEGER(istop)::_))
       equation
         es = List.map(ExpressionSimplify.simplifyRange(1,1,istop), makeIntegerExp);
         es = List.map1r(es, makeASUBSingleSub, e);


### PR DESCRIPTION
- Do not solve crefL = crefR always for crefL,
  but consider the matching.
- Make getArrayOrRangeContents also work for
  qualified crefs.

This fixes [ticket:4634](https://trac.openmodelica.org/OpenModelica/ticket/4634)