### PR TITLE
[NF] Variability fixes and other improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -60,7 +60,7 @@ constant SCode.Element DUMMY_ELEMENT = SCode.COMPONENT("dummy",
 
 // Default Integer parameter.
 constant Component INT_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.INTEGER(), Binding.UNBOUND(), Binding.UNBOUND(), Component.Attributes.DEFAULT(), Absyn.dummyInfo);
+  Type.INTEGER(), Binding.UNBOUND(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR, Absyn.dummyInfo);
 
 constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
   Visibility.PUBLIC,
@@ -68,7 +68,7 @@ constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
 
 // Default Real parameter.
 constant Component REAL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.REAL(), Binding.UNBOUND(), Binding.UNBOUND(), Component.Attributes.DEFAULT(), Absyn.dummyInfo);
+  Type.REAL(), Binding.UNBOUND(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR, Absyn.dummyInfo);
 
 constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
   Visibility.PUBLIC,
@@ -76,7 +76,7 @@ constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
 
 // Default Boolean parameter.
 constant Component BOOL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.BOOLEAN(), Binding.UNBOUND(), Binding.UNBOUND(), Component.Attributes.DEFAULT(), Absyn.dummyInfo);
+  Type.BOOLEAN(), Binding.UNBOUND(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR, Absyn.dummyInfo);
 
 constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
   Visibility.PUBLIC,
@@ -84,7 +84,7 @@ constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
 
 // Default String parameter.
 constant Component STRING_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.STRING(), Binding.UNBOUND(), Binding.UNBOUND(), Component.Attributes.DEFAULT(), Absyn.dummyInfo);
+  Type.STRING(), Binding.UNBOUND(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR, Absyn.dummyInfo);
 
 constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
   Visibility.PUBLIC,
@@ -92,7 +92,7 @@ constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
 
 // Default enumeration(:) parameter.
 constant Component ENUM_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.ENUMERATION_ANY(), Binding.UNBOUND(), Binding.UNBOUND(), Component.Attributes.DEFAULT(), Absyn.dummyInfo);
+  Type.ENUMERATION_ANY(), Binding.UNBOUND(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR, Absyn.dummyInfo);
 
 constant InstNode ENUM_PARAM = InstNode.COMPONENT_NODE("e",
   Visibility.PUBLIC,

--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -42,6 +42,7 @@ import Typing = NFTyping;
 import NFCall.Call;
 import Dimension = NFDimension;
 import Type = NFType;
+import NFTyping.ExpOrigin;
 
 uniontype EvalTarget
   record DIMENSION
@@ -95,7 +96,7 @@ algorithm
 
     case Expression.CREF(cref = cref as ComponentRef.CREF(node = c as InstNode.COMPONENT_NODE()))
       algorithm
-        Typing.typeComponentBinding(c);
+        Typing.typeComponentBinding(c, ExpOrigin.CLASS);
         binding := Component.getBinding(InstNode.component(c));
         exp1 := evalBinding(binding, exp, target);
       then

--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -47,6 +47,15 @@ protected
 import Binding = NFBinding;
 
 public
+
+constant Class.Prefixes DEFAULT_PREFIXES = Class.Prefixes.PREFIXES(
+  SCode.Encapsulated.NOT_ENCAPSULATED(),
+  SCode.Partial.NOT_PARTIAL(),
+  SCode.Final.NOT_FINAL(),
+  Absyn.InnerOuter.NOT_INNER_OUTER(),
+  SCode.Replaceable.NOT_REPLACEABLE()
+);
+
 uniontype Class
   uniontype Prefixes
     record PREFIXES
@@ -56,8 +65,6 @@ uniontype Class
       Absyn.InnerOuter innerOuter;
       SCode.Replaceable replaceablePrefix;
     end PREFIXES;
-
-    record DEFAULT end DEFAULT;
 
     function isEqual
       input Prefixes prefs1;
@@ -140,7 +147,7 @@ uniontype Class
   algorithm
     cls := match cls
       case PARTIAL_CLASS()
-        then EXPANDED_CLASS(cls.elements, cls.modifier, Prefixes.DEFAULT(),
+        then EXPANDED_CLASS(cls.elements, cls.modifier, DEFAULT_PREFIXES,
           Restriction.UNKNOWN());
     end match;
   end initExpandedClass;
@@ -330,7 +337,7 @@ uniontype Class
   algorithm
     attr := match cls
       case DERIVED_CLASS() then cls.attributes;
-      else Component.Attributes.DEFAULT();
+      else NFComponent.DEFAULT_ATTR;
     end match;
   end getAttributes;
 

--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -158,7 +158,10 @@ public
     input ComponentRef cref;
     output String name;
   algorithm
-    name := InstNode.name(node(cref));
+    name := match cref
+      case CREF() then InstNode.name(cref.node);
+      else "";
+    end match;
   end firstName;
 
   function rest
@@ -538,7 +541,20 @@ public
     end match;
   end isPackageConstant;
 
+  function stripSubscripts
+    "Strips the subscripts from the last name in a cref, e.g. a[2].b[3] => a[2].b"
+    input ComponentRef cref;
+    output ComponentRef strippedCref;
+  algorithm
+    strippedCref := match cref
+      case CREF()
+        then CREF(cref.node, {}, cref.ty, cref.origin, cref.restCref);
+      else cref;
+    end match;
+  end stripSubscripts;
+
   function stripSubscriptsAll
+    "Strips all subscripts from a cref."
     input ComponentRef cref;
     output ComponentRef strippedCref;
   algorithm

--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -159,7 +159,7 @@ algorithm
       then
         DAE.VAR(
           dcref,
-          Prefixes.variabilityToDAE(attr.variability),
+          Prefixes.variabilityToDAE(attr.variability, ty),
           Prefixes.directionToDAE(dir),
           Prefixes.parallelismToDAE(attr.parallelism),
           Prefixes.visibilityToDAE(vis),
@@ -566,8 +566,8 @@ protected
 algorithm
   (conds, branches) := List.unzipReverse(ifBranches);
   dbranches := if isInitial then
-    listReverse(convertInitialEquations(b) for b in branches) else
-    listReverse(convertEquations(b) for b in branches);
+    list(convertInitialEquations(b) for b in branches) else
+    list(convertEquations(b) for b in branches);
 
   // Transform the last branch to an else-branch if its condition is true.
   if Expression.isTrue(listHead(conds)) then

--- a/Compiler/NFFrontEnd/NFDimension.mo
+++ b/Compiler/NFFrontEnd/NFDimension.mo
@@ -225,5 +225,27 @@ public
     end match;
   end toString;
 
+  function sizeExp
+    "Returns the size of a dimension as an expression."
+    input Dimension dim;
+    input ComponentRef cref;
+    input Integer index;
+    output Expression sizeExp;
+  algorithm
+    sizeExp := match dim
+      local
+        Type ty;
+
+      case INTEGER() then Expression.INTEGER(dim.size);
+      case BOOLEAN() then Expression.BOOLEAN(true);
+      case ENUM(enumType = ty as Type.ENUMERATION())
+        then Expression.makeEnumLiteral(ty, listLength(ty.literals));
+      case EXP() then dim.exp;
+      case UNKNOWN()
+        then Expression.SIZE(Expression.CREF(Type.INTEGER(), ComponentRef.stripSubscripts(cref)),
+                             SOME(Expression.INTEGER(index)));
+    end match;
+  end sizeExp;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFDimension;

--- a/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -47,7 +47,7 @@ annotation(Documentation(info="<html>
 end der;
 
 impure function initial "True if in initialization phase"
-  output Boolean isInitial;
+  discrete output Boolean isInitial;
 external "builtin";
 annotation(__OpenModelica_Impure=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'initial()'\">initial()</a>
@@ -55,7 +55,7 @@ annotation(__OpenModelica_Impure=true, Documentation(info="<html>
 end initial;
 
 impure function terminal "True after successful analysis"
-  output Boolean isTerminal;
+  discrete output Boolean isTerminal;
 external "builtin";
 annotation(__OpenModelica_Impure=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'terminal()'\">terminal()</a>
@@ -440,7 +440,7 @@ end diagonal;
 
 function cardinality "Number of connectors in connection"
   input Real c;
-  output Integer numOccurances;
+  parameter output Integer numOccurances;
   external "builtin";
   annotation(Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'cardinality()'\">cardinality()</a>
@@ -476,8 +476,6 @@ function fill "Returns an array with all elements equal"
 end fill;
 
 function noEvent "Turn off event triggering"
-  input Real x;
-  output Real y;
   external "builtin";
   annotation(Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'noEvent()'\">noEvent()</a>
@@ -558,7 +556,7 @@ end activeState;
 
 function ndims<T> "Number of array dimensions"
   input T a;
-  constant output Integer d;
+  parameter output Integer d;
   external "builtin";
   annotation(Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'ndims()'\">ndims()</a>

--- a/Compiler/NFFrontEnd/NFOperator.mo
+++ b/Compiler/NFFrontEnd/NFOperator.mo
@@ -417,5 +417,51 @@ public
     symbol(op);
   end toString;
 
+  function priority
+    input Operator op;
+    input Boolean lhs;
+    output Integer priority;
+  algorithm
+    priority := match op
+      case ADD() then if lhs then 5 else 6;
+      case SUB() then 5;
+      case MUL() then 2;
+      case DIV() then 2;
+      case POW() then 1;
+      case ADD_ARR() then if lhs then 5 else 6;
+      case SUB_ARR() then 5;
+      case MUL_ARR() then if lhs then 2 else 3;
+      case DIV_ARR() then 2;
+      case MUL_ARRAY_SCALAR() then if lhs then 2 else 3;
+      case ADD_ARRAY_SCALAR() then if lhs then 5 else 6;
+      case SUB_SCALAR_ARRAY() then 5;
+      case MUL_SCALAR_PRODUCT() then if lhs then 2 else 3;
+      case MUL_MATRIX_PRODUCT() then if lhs then 2 else 3;
+      case DIV_ARRAY_SCALAR() then 2;
+      case DIV_SCALAR_ARRAY() then 2;
+      case POW_ARRAY_SCALAR() then 1;
+      case POW_SCALAR_ARRAY() then 1;
+      case POW_ARR() then 1;
+      case POW_ARR2() then 1;
+      case AND() then 8;
+      case OR() then 9;
+      else 0;
+    end match;
+  end priority;
+
+  function isAssociative
+    input Operator op;
+    output Boolean isAssociative;
+  algorithm
+    isAssociative := match op
+      case ADD() then true;
+      case ADD_ARR() then true;
+      case ADD_ARRAY_SCALAR() then true;
+      case MUL_ARR() then true;
+      case MUL_ARRAY_SCALAR() then true;
+      else false;
+    end match;
+  end isAssociative;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFOperator;

--- a/Compiler/NFFrontEnd/NFPackage.mo
+++ b/Compiler/NFFrontEnd/NFPackage.mo
@@ -49,6 +49,7 @@ protected
   import NFClass.Class;
   import Sections = NFSections;
   import ClassTree = NFClassTree;
+  import NFTyping.ExpOrigin;
 
 public
   type Constants = ConstantsSetImpl.Tree;
@@ -153,7 +154,7 @@ public
       case Expression.CREF(cref = cref as ComponentRef.CREF())
         algorithm
           if ComponentRef.isPackageConstant(cref) then
-            Typing.typeComponentBinding(cref.node);
+            Typing.typeComponentBinding(cref.node, ExpOrigin.CLASS);
             // Add the constant to the set.
             constants := Constants.add(constants, ComponentRef.stripSubscriptsAll(cref));
             // Collect constants from the constant's binding.

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -759,6 +759,10 @@ public constant Message MULTIPLE_SECTIONS_IN_FUNCTION = MESSAGE(315, TRANSLATION
   Util.gettext("Function %s has more than one algorithm section or external declaration."));
 public constant Message INVALID_EXTERNAL_LANGUAGE = MESSAGE(316, TRANSLATION(), ERROR(),
   Util.gettext("'%s' is not a valid language for an external function."));
+public constant Message SUBSCRIPT_TYPE_MISMATCH = MESSAGE(317, TRANSLATION(), ERROR(),
+  Util.gettext("Subscript '%s' has type %s, expected type %s."));
+public constant Message EXP_INVALID_IN_FUNCTION = MESSAGE(318, TRANSLATION(), ERROR(),
+  Util.gettext("%s is not allowed in a function."));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),


### PR DESCRIPTION
- Replaced EquationScope, ClassScope and ExpOrigin with new ExpOrigin
  bitfield.
- Removed Component.Attributes.DEFAULT and Class.Attributes.DEFAULT,
  constants work equally well to save memory and simplifies the code.
- Set variables with no variability prefix and discrete type to be
  discrete so e.g. pre() works correctly.
- Fixed variability of many builtin functions.
- Fixed variability of relations with regards to noEvent.
- Fixed variability of expressions in when-clauses.
- Fixed typing of noEvent.
- Added check that time, pre, edge and change isn't used in a
  function context.
- Fixed handling of size on subscripted expressions.
- Moved handling of end to typing of subscripts, since the old handling
  relied upon ExpOrigin being a uniontype with subscript information.
- Improved handling of end to generate appropriate size expressions when
  the size of the dimension is unknown.
- Adapted the parenthesization algorithm from Dump to
  NFExpression.toString to get rid of extraneous parentheses in error
  messages.