### PR TITLE
Some work-arounds for Ceval of zero-size arrays

### DIFF
--- a/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -1300,6 +1300,10 @@ algorithm
         e = Expression.makeImpureBuiltinCall("delay",{e,e3,e4},tp);
       then DAE.UNARY(op,e);
 
+    // The sum of an empty array is simply the sum of its elements
+    case DAE.CALL(path=Absyn.IDENT("sum"),expLst={DAE.ARRAY(array={})}, attr=DAE.CALL_ATTR(ty=tp1))
+      then Expression.makeConstZero(tp1);
+
     // To calculate sums, first try matrix concatenation
     case DAE.CALL(path=Absyn.IDENT("sum"),expLst={DAE.MATRIX(ty=tp1,matrix=mexpl)},attr=DAE.CALL_ATTR(ty=tp2))
       equation

--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -8462,10 +8462,8 @@ algorithm
     // checkModel this should succeed anyway, since we might be checking a function
     // that takes a vector of unknown size. So pretend that the dimension is 1.
     case (e, (DAE.DIM_UNKNOWN() :: ad), prop)
-      algorithm
-        true := Flags.getConfigBool(Flags.CHECK_MODEL);
-      then
-        vectorizeCall(e, DAE.DIM_INTEGER(1) :: ad, inSlots, prop, info);
+      guard Flags.getConfigBool(Flags.CHECK_MODEL)
+      then vectorizeCall(e, DAE.DIM_INTEGER(1) :: ad, inSlots, prop, info);
 
     /* Scalar expression, i.e function call */
     case (e as DAE.CALL(),(dim :: ad),DAE.PROP(tp,c))
@@ -8474,8 +8472,7 @@ algorithm
         exp_type := Types.simplifyType(Types.liftArray(tp, dim)) "pass type of vectorized result expr";
         vect_exp := vectorizeCallScalar(e, exp_type, int_dim, inSlots);
         tp := Types.liftArray(tp, dim);
-      then
-        vectorizeCall(vect_exp, ad, inSlots, DAE.PROP(tp,c),info);
+      then vectorizeCall(vect_exp, ad, inSlots, DAE.PROP(tp,c),info);
 
     /* array expression of function calls */
     case (DAE.ARRAY(),(dim :: ad),DAE.PROP(tp,c))
@@ -8484,8 +8481,7 @@ algorithm
         // _ = Types.simplifyType(Types.liftArray(tp, dim));
         vect_exp := vectorizeCallArray(inExp, int_dim, inSlots);
         tp := Types.liftArrayRight(tp, dim);
-      then
-        vectorizeCall(vect_exp, ad, inSlots, DAE.PROP(tp,c),info);
+      then vectorizeCall(vect_exp, ad, inSlots, DAE.PROP(tp,c),info);
 
     /* Multiple dimensions are possible to change to a reduction, like:
      * f(arr1,arr2) => array(f(x,y) thread for x in arr1, y in arr2)

--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -3241,7 +3241,7 @@ algorithm
       FCore.Cache cache;
       Prefix.Prefix pre;
       DAE.Type ety;
-      DAE.Dimensions dims;
+      DAE.Dimensions dims, dims1, dims2;
 
     case (cache, env, {arraycr, dim}, impl, pre)
       equation
@@ -3250,11 +3250,12 @@ algorithm
         (cache, arraycrefe, prop, _) =
           elabExpInExpression(cache, env, arraycr, impl, NONE(), false, pre, info);
         ety = Expression.typeof(arraycrefe);
-        dims = Expression.arrayDimension(ety);
+        dims1 = Expression.arrayDimension(ety);
+        (,dims2) = Types.flattenArrayType(Types.getPropType(prop));
+        dims = if listLength(dims1) >= listLength(dims2) then dims1 else dims2 "In case there is a zero-size array somewhere...";
         // sent in the props of the arraycrefe as if the array is constant then the size(x, 1) is constant!
         // see Modelica.Media.Incompressible.Examples.Glycol47 and Modelica.Media.Incompressible.TableBased (hasDensity)
-        (SOME(exp), SOME(prop)) =
-          elabBuiltinSizeIndex(arraycrefe, prop, ety, dimp, dims, env, info);
+        (SOME(exp), SOME(prop)) = elabBuiltinSizeIndex(arraycrefe, prop, ety, dimp, dims, env, info);
       then
         (cache, exp, prop);
 

--- a/Compiler/FrontEnd/ValuesUtil.mo
+++ b/Compiler/FrontEnd/ValuesUtil.mo
@@ -2346,5 +2346,16 @@ algorithm
   end match;
 end typeConvertRecord;
 
+public function fixZeroSizeArray "Work-around for Values.ARRAY({}) becoming T_UNKNOWN in ValuesUtil.valueExp"
+  input output DAE.Exp e;
+  input DAE.Type ty;
+algorithm
+  e := match e
+    case DAE.ARRAY(ty=DAE.T_ARRAY(ty=DAE.T_UNKNOWN()), scalar=false, array={})
+      then DAE.ARRAY(ty, not Types.isArray(Types.unliftArray(ty)), {});
+    else e;
+  end match;
+end fixZeroSizeArray;
+
 annotation(__OpenModelica_Interface="frontend");
 end ValuesUtil;


### PR DESCRIPTION
The Values.mo structure does not store the type of the array which means
that `Values.ARRAY({})` becomes `{} /* T_UNKNOWN[0] */` instead of
containing the actual type. We now have some work-arounds for this case:
- cevalIfConstant will not try to evaluate literal values
- If an empty array is returned in cevalIfConstant, we backpatch the
  array type to the expected type (but this only works for the top-level
  expression; hopefully this is enough to not propagate unknown
  dimensions too far though).