### PR TITLE
[NF] Fix external object calls.

### DIFF
--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -395,6 +395,7 @@ uniontype Class
       case INSTANCED_CLASS()   algorithm cls.restriction := res; then ();
       case INSTANCED_BUILTIN() algorithm cls.restriction := res; then ();
       case EXPANDED_CLASS()    algorithm cls.restriction := res; then ();
+      // PARTIAL_BUILTIN is only used for predefined builtin types and not needed here.
       case DERIVED_CLASS()     algorithm cls.restriction := res; then ();
     end match;
   end setRestriction;

--- a/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/Compiler/NFFrontEnd/NFClassTree.mo
@@ -153,6 +153,8 @@ public
 
   constant ClassTree EMPTY = ClassTree.PARTIAL_TREE(LookupTree.EMPTY(),
       listArray({}), listArray({}), listArray({}), listArray({}), DuplicateTree.EMPTY());
+  constant ClassTree EMPTY_FLAT = ClassTree.FLAT_TREE(LookupTree.EMPTY(),
+      listArray({}), listArray({}), listArray({}), DuplicateTree.EMPTY());
 
   uniontype ClassTree
     record PARTIAL_TREE

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -207,7 +207,7 @@ uniontype Function
         {Dump.printComponentRefStr(functionName)}, info);
     end try;
 
-    (functionRef, found_scope) := Lookup.lookupCallableName(functionName, scope, info);
+    (functionRef, found_scope) := Lookup.lookupFunctionName(functionName, scope, info);
     prefix := ComponentRef.fromNodeList(InstNode.scopeList(found_scope));
     functionRef := ComponentRef.append(functionRef, prefix);
   end lookupFunction;
@@ -258,11 +258,8 @@ uniontype Function
     input SourceInfo info;
           output Boolean specialBuiltin;
   protected
-    SCode.Element def;
+    SCode.Element def = InstNode.definition(fnNode);
   algorithm
-
-    def := InstNode.definition(fnNode);
-
     (fnNode, specialBuiltin) := match def
       local
         SCode.ClassDef cdef;

--- a/Compiler/NFFrontEnd/NFLookupState.mo
+++ b/Compiler/NFFrontEnd/NFLookupState.mo
@@ -132,13 +132,24 @@ uniontype LookupState
 
   function isCallable
     input InstNode node;
-    output Boolean b = false;
+    output Boolean callable;
   protected
-    SCode.Element def;
+    SCode.Element def = InstNode.definition(node);
   algorithm
-    def := InstNode.definition(node);
-    b := SCode.isRecord(def) or SCode.isOperator(def);
+    callable := SCode.isRecord(def) or SCode.isOperator(def);
   end isCallable;
+
+  function isClass
+    input LookupState state;
+    output Boolean isClass;
+  algorithm
+    isClass := match state
+      case COMP_CLASS() then true;
+      case CLASS() then true;
+      case PREDEF_CLASS() then true;
+      else false;
+    end match;
+  end isClass;
 
   function assertState
     input LookupState endState;


### PR DESCRIPTION
- Change external object calls so they call the constructor instead.
- Use an empty class tree for external object so the constructor or
  destructor can't be called explicitly.
- Fix error message for when a function can't be found to say function
  instead of variable.