### PR TITLE
[NF] Use Error.assertion() instead of assert()

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -142,7 +142,7 @@ uniontype Call
       case Absyn.FOR_ITER_FARG() then instIteratorCall(functionName, functionArgs, scope, info);
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown call type");
+          Error.assertion(false, getInstanceName() + " got unknown call type", sourceInfo());
         then
           fail();
     end match;
@@ -194,7 +194,7 @@ uniontype Call
 
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown function args");
+          Error.assertion(false, getInstanceName() + " got unknown function args", sourceInfo());
         then
           fail();
     end match;
@@ -356,7 +356,7 @@ uniontype Call
       case "zeros" then typeZerosOnesCall(call, origin, info);
       else
         algorithm
-          assert(false, getInstanceName() + " got unhandled builtin function");
+          Error.assertion(false, getInstanceName() + " got unhandled builtin function", sourceInfo());
         then
           fail();
     end match;
@@ -412,7 +412,7 @@ uniontype Call
       case UNTYPED_MAP_CALL(ref = ComponentRef.CREF(node = fn_node))  algorithm
         // Fetch the cached function(s).
         fnl := typeCachedFunctions(call.ref);
-        assert(listLength(fnl) == 1, getInstanceName() + " overloaded functions in mapping functions not handled yet.");
+        Error.assertion(listLength(fnl) == 1, getInstanceName() + " overloaded functions in mapping functions not handled yet.", sourceInfo());
         fn := listHead(fnl);
 
         for iter in call.iters loop
@@ -431,7 +431,7 @@ uniontype Call
         (TYPED_MAP_CALL(fn, ty, arg, call.iters), ty, variability);
 
       else algorithm
-        assert(false, getInstanceName() + " got invalid function call expression");
+        Error.assertion(false, getInstanceName() + " got invalid function call expression", sourceInfo());
       then
         fail();
     end match;
@@ -462,7 +462,7 @@ uniontype Call
         typeArgs(call, origin, info);
 
       else algorithm
-        assert(false, getInstanceName() + " got invalid function call expression");
+        Error.assertion(false, getInstanceName() + " got invalid function call expression", sourceInfo());
       then
         fail();
     end match;
@@ -494,7 +494,7 @@ uniontype Call
 
       else
         algorithm
-          assert(false, getInstanceName() + " got invalid function call reference");
+          Error.assertion(false, getInstanceName() + " got invalid function call reference", sourceInfo());
         then
           fail();
     end match;
@@ -537,7 +537,7 @@ uniontype Call
         (TYPED_CALL(fn, ty, args, ca), ty, variability);
 
       else algorithm
-        assert(false, getInstanceName() + " got invalid function call expression");
+        Error.assertion(false, getInstanceName() + " got invalid function call expression", sourceInfo());
       then
         fail();
     end match;
@@ -758,7 +758,7 @@ protected
 
       else
         algorithm
-          assert(false, getInstanceName() + " got untyped call");
+          Error.assertion(false, getInstanceName() + " got untyped call", sourceInfo());
         then
           fail();
     end match;
@@ -839,7 +839,7 @@ protected
       case TYPED_MAP_CALL() then call.fn;
       else
         algorithm
-          assert(false, getInstanceName() + " got untyped function");
+          Error.assertion(false, getInstanceName() + " got untyped function", sourceInfo());
         then
           fail();
     end match;

--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -126,7 +126,7 @@ algorithm
 
     case Expression.RECORD()
       algorithm
-        assert(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName());
+        Error.assertion(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName(), sourceInfo());
       then fail();
 
     case Expression.CALL(call = call as Call.TYPED_CALL())
@@ -226,7 +226,7 @@ algorithm
         originExp;
     else
       algorithm
-        assert(false, getInstanceName() + " failed on untyped binding");
+        Error.assertion(false, getInstanceName() + " failed on untyped binding", sourceInfo());
       then
         fail();
   end match;
@@ -280,7 +280,7 @@ algorithm
 
       else
         algorithm
-          assert(false, getInstanceName() + " got invalid typename");
+          Error.assertion(false, getInstanceName() + " got invalid typename", sourceInfo());
         then
           fail();
 

--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -281,7 +281,7 @@ uniontype Class
           ();
       else
         algorithm
-          assert(false, getInstanceName() + " got non-modifiable class");
+          Error.assertion(false, getInstanceName() + " got non-modifiable class", sourceInfo());
         then
           fail();
     end match;

--- a/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/Compiler/NFFrontEnd/NFClassTree.mo
@@ -400,7 +400,7 @@ public
 
           else
             algorithm
-              assert(false, getInstanceName() + " got invalid component");
+              Error.assertion(false, getInstanceName() + " got invalid component", sourceInfo());
             then
               fail();
         end match;
@@ -556,8 +556,8 @@ public
             end for;
 
             // Sanity check.
-            assert(comp_idx == compCount + 1, getInstanceName() + " miscounted components in " + InstNode.name(clsNode));
-            assert(cls_idx == classCount + 1, getInstanceName() + " miscounted classes in " + InstNode.name(clsNode));
+            Error.assertion(comp_idx == compCount + 1, getInstanceName() + " miscounted components in " + InstNode.name(clsNode), sourceInfo());
+            Error.assertion(cls_idx == classCount + 1, getInstanceName() + " miscounted classes in " + InstNode.name(clsNode), sourceInfo());
 
             // Create a new class tree and update the class in the node.
             cls.elements := INSTANTIATED_TREE(ltree, clss, comps, local_comps, exts, imps, dups);
@@ -573,7 +573,7 @@ public
 
         else
           algorithm
-            assert(false, getInstanceName() + " got invalid class");
+            Error.assertion(false, getInstanceName() + " got invalid class", sourceInfo());
           then
             fail();
 
@@ -945,7 +945,7 @@ public
           node := resolveEntry(entry.entry, tree);
         end if;
       else
-        assert(false, getInstanceName() + " failed on " + name);
+        Error.assertion(false, getInstanceName() + " failed on " + name, sourceInfo());
       end try;
     end getRedeclaredNode;
 
@@ -1137,13 +1137,13 @@ public
             end for;
 
             // Make extra sure that we actually found the component.
-            assert(i == entry.index, getInstanceName() + " got invalid entry index");
+            Error.assertion(i == entry.index, getInstanceName() + " got invalid entry index", sourceInfo());
           then
             node;
 
         else
           algorithm
-            assert(false, getInstanceName() + " got invalid entry");
+            Error.assertion(false, getInstanceName() + " got invalid entry", sourceInfo());
           then
             fail();
 

--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -345,7 +345,7 @@ public
 
       else
         algorithm
-          assert(false, getInstanceName() + " failed");
+          Error.assertion(false, getInstanceName() + " failed", sourceInfo());
         then
           fail();
     end match;

--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -255,8 +255,7 @@ algorithm
       // unknown attributes here.
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown type attribute " +
-            Modifier.name(m));
+          Error.assertion(false, getInstanceName() + " got unknown type attribute " + Modifier.name(m), sourceInfo());
         then
           fail();
     end match;
@@ -286,8 +285,7 @@ algorithm
       // unknown attributes here.
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown type attribute " +
-            Modifier.name(m));
+          Error.assertion(false, getInstanceName() + " got unknown type attribute " + Modifier.name(m), sourceInfo());
         then
           fail();
     end match;
@@ -314,8 +312,7 @@ algorithm
       // unknown attributes here.
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown type attribute " +
-            Modifier.name(m));
+          Error.assertion(false, getInstanceName() + " got unknown type attribute " + Modifier.name(m), sourceInfo());
         then
           fail();
     end match;
@@ -342,8 +339,7 @@ algorithm
       // unknown attributes here.
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown type attribute " +
-            Modifier.name(m));
+          Error.assertion(false, getInstanceName() + " got unknown type attribute " + Modifier.name(m), sourceInfo());
         then
           fail();
     end match;
@@ -372,8 +368,7 @@ algorithm
       // unknown attributes here.
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown type attribute " +
-            Modifier.name(m));
+          Error.assertion(false, getInstanceName() + " got unknown type attribute " + Modifier.name(m), sourceInfo());
         then
           fail();
     end match;
@@ -396,7 +391,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got untyped binding");
+        Error.assertion(false, getInstanceName() + " got untyped binding", sourceInfo());
       then
         fail();
 
@@ -427,13 +422,13 @@ algorithm
 
     case Modifier.MODIFIER(binding = Binding.TYPED_BINDING())
       algorithm
-        assert(false, getInstanceName() + " got non StateSelect value");
+        Error.assertion(false, getInstanceName() + " got non StateSelect value", sourceInfo());
       then
         fail();
 
     else
       algorithm
-        assert(false, getInstanceName() + " got untyped binding");
+        Error.assertion(false, getInstanceName() + " got untyped binding", sourceInfo());
       then
         fail();
 
@@ -452,7 +447,7 @@ algorithm
     case "always" then DAE.StateSelect.ALWAYS();
     else
       algorithm
-        assert(false, getInstanceName() + " got unknown StateSelect literal " + name);
+        Error.assertion(false, getInstanceName() + " got unknown StateSelect literal " + name, sourceInfo());
       then
         fail();
   end match;
@@ -506,7 +501,7 @@ algorithm
     // For equations should have been unrolled here.
     case Equation.FOR()
       algorithm
-        assert(false, getInstanceName() + " got a for equation");
+        Error.assertion(false, getInstanceName() + " got a for equation", sourceInfo());
       then
         fail();
 
@@ -645,7 +640,7 @@ algorithm
     // For equations should have been unrolled here.
     case Equation.FOR()
       algorithm
-        assert(false, getInstanceName() + " got a for equation");
+        Error.assertion(false, getInstanceName() + " got a for equation", sourceInfo());
       then
         fail();
 
@@ -941,7 +936,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got unknown function");
+        Error.assertion(false, getInstanceName() + " got unknown function", sourceInfo());
       then
         fail();
 
@@ -985,7 +980,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got untyped component.");
+        Error.assertion(false, getInstanceName() + " got untyped component.", sourceInfo());
       then
         fail();
 

--- a/Compiler/NFFrontEnd/NFDimension.mo
+++ b/Compiler/NFFrontEnd/NFDimension.mo
@@ -91,7 +91,7 @@ public
             case Type.ENUMERATION() then ENUM(ty);
             else
               algorithm
-                assert(false, getInstanceName() + " got invalid typename");
+                Error.assertion(false, getInstanceName() + " got invalid typename", sourceInfo());
               then
                 fail();
           end match;

--- a/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -39,7 +39,7 @@ encapsulated package NFEvalFunction
   TODO:
     * Implement evaluation of MetaModelica statements.
     * Enable NORETCALL (see comment in evaluateStatement).
-    * Implement terminate and assert(false, ...).
+    * Implement terminate and Error.assertion(false, ..., sourceInfo()).
     * Arrays of records probably doesn't work yet.
 "
 

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -433,7 +433,7 @@ public
 
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown expression.");
+          Error.assertion(false, getInstanceName() + " got unknown expression.", sourceInfo());
         then
           fail();
 
@@ -573,7 +573,7 @@ public
 
         else
           algorithm
-            assert(false, getInstanceName() + " got unknown subscript " + anyString(sub));
+            Error.assertion(false, getInstanceName() + " got unknown subscript " + anyString(sub), sourceInfo());
           then
             fail();
 
@@ -627,14 +627,14 @@ public
     list<list<Expression>> partexps;
     Integer dimsize;
   algorithm
-    assert(not listEmpty(inDims), "Empty dimension list given in arrayFromList.");
+    Error.assertion(not listEmpty(inDims), "Empty dimension list given in arrayFromList.", sourceInfo());
 
     ldim::restdims := inDims;
     dimsize := Dimension.size(ldim);
     ty := Type.liftArrayLeft(elemTy, ldim);
 
     if List.hasOneElement(inDims) then
-      assert(dimsize == listLength(inExps), "Length mismatch in arrayFromList.");
+      Error.assertion(dimsize == listLength(inExps), "Length mismatch in arrayFromList.", sourceInfo());
       outExp := ARRAY(ty,inExps);
       return;
     end if;
@@ -880,7 +880,7 @@ public
 
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown expression '" + toString(exp) + "'");
+          Error.assertion(false, getInstanceName() + " got unknown expression '" + toString(exp) + "'", sourceInfo());
         then
           fail();
 

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -176,7 +176,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got non-instantiated component " + ComponentRef.toString(prefix) + "\n");
+        Error.assertion(false, getInstanceName() + " got non-instantiated component " + ComponentRef.toString(prefix) + "\n", sourceInfo());
       then
         ();
 
@@ -262,7 +262,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got unknown component");
+        Error.assertion(false, getInstanceName() + " got unknown component", sourceInfo());
       then
         fail();
 
@@ -321,7 +321,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got untyped binding.");
+        Error.assertion(false, getInstanceName() + " got untyped binding.", sourceInfo());
       then
         fail();
 

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -879,7 +879,7 @@ protected
     array<Mutable<InstNode>> comps;
     InstNode n;
   algorithm
-    assert(InstNode.isClass(node), getInstanceName() + " got non-class node");
+    Error.assertion(InstNode.isClass(node), getInstanceName() + " got non-class node", sourceInfo());
     cls := InstNode.getClass(node);
 
     () := match cls
@@ -906,7 +906,7 @@ protected
 
       else
         algorithm
-          assert(false, getInstanceName() + " got non-instantiated function");
+          Error.assertion(false, getInstanceName() + " got non-instantiated function", sourceInfo());
         then
           fail();
     end match;
@@ -981,7 +981,7 @@ protected
 
       slot := SLOT(InstNode.name(component), SlotType.GENERIC, default, NONE());
     else
-      assert(false, getInstanceName() + " got invalid component");
+      Error.assertion(false, getInstanceName() + " got invalid component", sourceInfo());
     end try;
   end makeSlot;
 
@@ -1024,8 +1024,7 @@ protected
     def := InstNode.definition(node);
     res := SCode.getClassRestriction(def);
 
-    assert(SCode.isFunctionRestriction(res),
-      getInstanceName() + " got non-function restriction");
+    Error.assertion(SCode.isFunctionRestriction(res), getInstanceName() + " got non-function restriction", sourceInfo());
 
     SCode.Restriction.R_FUNCTION(functionRestriction = fres) := res;
 

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -220,7 +220,7 @@ protected
   SCode.ClassDef cdef, ce_cdef;
   Type ty;
 algorithm
-  assert(SCode.elementIsClass(definition), getInstanceName() + " got non-class element");
+  Error.assertion(SCode.elementIsClass(definition), getInstanceName() + " got non-class element", sourceInfo());
   SCode.CLASS(classDef = cdef) := definition;
 
   cls := match cdef
@@ -378,7 +378,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got unknown class");
+        Error.assertion(false, getInstanceName() + " got unknown class", sourceInfo());
       then
         fail();
 
@@ -786,7 +786,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got unknown class.");
+        Error.assertion(false, getInstanceName() + " got unknown class.", sourceInfo());
       then
         ();
 
@@ -853,7 +853,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got invalid instance cache");
+        Error.assertion(false, getInstanceName() + " got invalid instance cache", sourceInfo());
       then
         fail();
 
@@ -900,7 +900,7 @@ algorithm
 
           else
             algorithm
-              assert(false, getInstanceName() + " got invalid class tree");
+              Error.assertion(false, getInstanceName() + " got invalid class tree", sourceInfo());
             then
               ();
         end match;
@@ -1368,7 +1368,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got invalid class");
+        Error.assertion(false, getInstanceName() + " got invalid class", sourceInfo());
       then
         fail();
 
@@ -1448,7 +1448,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got invalid component");
+        Error.assertion(false, getInstanceName() + " got invalid component", sourceInfo());
       then
         fail();
 
@@ -1597,7 +1597,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got unknown expression");
+        Error.assertion(false, getInstanceName() + " got unknown expression", sourceInfo());
       then
         fail();
 
@@ -1661,7 +1661,7 @@ algorithm
               algorithm
                 // This should be caught by lookupComponent, only type name classes
                 // are allowed to be used where a component is expected.
-                assert(false, getInstanceName() + " got unknown class node");
+                Error.assertion(false, getInstanceName() + " got unknown class node", sourceInfo());
               then
                 fail();
           end match;
@@ -1999,7 +1999,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got unknown equation");
+        Error.assertion(false, getInstanceName() + " got unknown equation", sourceInfo());
       then
         fail();
 
@@ -2131,7 +2131,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got unknown statement");
+        Error.assertion(false, getInstanceName() + " got unknown statement", sourceInfo());
       then
         fail();
 

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -136,7 +136,7 @@ uniontype CachedData
                                     func_cache.specialBuiltin or specialBuiltin);
       else
         algorithm
-          assert(false, getInstanceName() + ": Invalid cache for function");
+          Error.assertion(false, getInstanceName() + ": Invalid cache for function", sourceInfo());
         then
           fail();
     end match;
@@ -870,7 +870,7 @@ uniontype InstNode
   algorithm
     () := match node
       case CLASS_NODE() algorithm CachedData.addFunc(fn, specialBuiltin, node.caches); then ();
-      else algorithm assert(false, getInstanceName() + " got node without cache"); then fail();
+      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end cacheAddFunc;
 
@@ -880,7 +880,7 @@ uniontype InstNode
   algorithm
     func_cache := match inNode
       case CLASS_NODE() then CachedData.getFuncCache(inNode.caches);
-      else algorithm assert(false, getInstanceName() + " got node without cache"); then fail();
+      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end getFuncCache;
 
@@ -890,7 +890,7 @@ uniontype InstNode
   algorithm
     () := match node
       case CLASS_NODE() algorithm CachedData.setFuncCache(node.caches, in_func_cache); then ();
-      else algorithm assert(false, getInstanceName() + " got node without cache"); then fail();
+      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end setFuncCache;
 
@@ -900,7 +900,7 @@ uniontype InstNode
   algorithm
     pack_cache := match inNode
       case CLASS_NODE() then CachedData.getPackageCache(inNode.caches);
-      else algorithm assert(false, getInstanceName() + " got node without cache"); then fail();
+      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end getPackageCache;
 
@@ -910,7 +910,7 @@ uniontype InstNode
   algorithm
     () := match node
       case CLASS_NODE() algorithm CachedData.setPackageCache(node.caches, in_pack_cache); then ();
-      else algorithm assert(false, getInstanceName() + " got node without cache"); then fail();
+      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end setPackageCache;
 
@@ -919,7 +919,7 @@ uniontype InstNode
   algorithm
     () := match node
       case CLASS_NODE() algorithm CachedData.clearPackageCache(node.caches); then ();
-      else algorithm assert(false, getInstanceName() + " got node without cache"); then fail();
+      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end clearPackageCache;
 
@@ -929,7 +929,7 @@ uniontype InstNode
   algorithm
     pack_cache := match inNode
       case CLASS_NODE() then CachedData.getInnerOuterCache(inNode.caches);
-      else algorithm assert(false, getInstanceName() + " got node without cache"); then fail();
+      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end getInnerOuterCache;
 
@@ -939,7 +939,7 @@ uniontype InstNode
   algorithm
     () := match node
       case CLASS_NODE() algorithm CachedData.setInnerOuterCache(node.caches, in_out_cache); then ();
-      else algorithm assert(false, getInstanceName() + " got node without cache"); then fail();
+      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end setInnerOuterCache;
 

--- a/Compiler/NFFrontEnd/NFLookup.mo
+++ b/Compiler/NFFrontEnd/NFLookup.mo
@@ -582,7 +582,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " was called with an invalid path.");
+        Error.assertion(false, getInstanceName() + " was called with an invalid path.", sourceInfo());
       then
         fail();
   end match;
@@ -631,7 +631,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " was called with an invalid path.");
+        Error.assertion(false, getInstanceName() + " was called with an invalid path.", sourceInfo());
       then
         fail();
   end match;
@@ -844,7 +844,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got top node with missing cache");
+        Error.assertion(false, getInstanceName() + " got top node with missing cache", sourceInfo());
       then
         fail();
 
@@ -885,7 +885,7 @@ algorithm
 
             else
               algorithm
-                assert(false, getInstanceName() + " got unknown component");
+                Error.assertion(false, getInstanceName() + " got unknown component", sourceInfo());
               then
                 fail();
           end match;
@@ -894,7 +894,7 @@ algorithm
 
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown node");
+          Error.assertion(false, getInstanceName() + " got unknown node", sourceInfo());
         then
           fail();
   end match;

--- a/Compiler/NFFrontEnd/NFLookupState.mo
+++ b/Compiler/NFFrontEnd/NFLookupState.mo
@@ -372,7 +372,7 @@ uniontype LookupState
       case SCode.CLASS() then CLASS();
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown element.");
+          Error.assertion(false, getInstanceName() + " got unknown element.", sourceInfo());
         then
           fail();
     end match;
@@ -457,8 +457,7 @@ uniontype LookupState
 
       else
         algorithm
-          assert(false, getInstanceName() + " failed on unknown transition for element "
-            + InstNode.name(node));
+          Error.assertion(false, getInstanceName() + " failed on unknown transition for element " + InstNode.name(node), sourceInfo());
         then
           fail();
 

--- a/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -298,7 +298,7 @@ function linspace "Real vector with equally spaced elements"
   input Integer n "number";
   output Real v[n];
 algorithm
-  // assert(n >= 2, "linspace requires n>=2 but got " + String(n));
+  // Error.assertion(n >= 2, "linspace requires n>=2 but got " + String(n), sourceInfo());
   v := {x1 + (x2-x1)*(i-1)/(n-1) for i in 1:n};
   annotation(__OpenModelica_builtin=true,__OpenModelica_EarlyInline=true,Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'linspace()'\">linspace()</a>

--- a/Compiler/NFFrontEnd/NFOperator.mo
+++ b/Compiler/NFFrontEnd/NFOperator.mo
@@ -252,7 +252,7 @@ public
       case USERDEFINED() then DAE.USERDEFINED(op.fqName);
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown type.");
+          Error.assertion(false, getInstanceName() + " got unknown type.", sourceInfo());
         then
           fail();
     end match;
@@ -297,7 +297,7 @@ public
       case USERDEFINED() then Type.UNKNOWN();
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown type.");
+          Error.assertion(false, getInstanceName() + " got unknown type.", sourceInfo());
         then
           fail();
     end match;
@@ -343,7 +343,7 @@ public
       case USERDEFINED() then op;
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown type.");
+          Error.assertion(false, getInstanceName() + " got unknown type.", sourceInfo());
         then
           fail();
     end match;
@@ -403,7 +403,7 @@ public
       case USERDEFINED()        then "Userdefined:" + Absyn.pathString(op.fqName);
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown type.");
+          Error.assertion(false, getInstanceName() + " got unknown type.", sourceInfo());
         then
           fail();
     end match;

--- a/Compiler/NFFrontEnd/NFRangeIterator.mo
+++ b/Compiler/NFFrontEnd/NFRangeIterator.mo
@@ -113,7 +113,7 @@ public
 
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown range");
+          Error.assertion(false, getInstanceName() + " got unknown range", sourceInfo());
         then
           fail();
 
@@ -141,7 +141,7 @@ public
 
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown dim");
+          Error.assertion(false, getInstanceName() + " got unknown dim", sourceInfo());
         then
           fail();
 

--- a/Compiler/NFFrontEnd/NFRecord.mo
+++ b/Compiler/NFFrontEnd/NFRecord.mo
@@ -113,7 +113,7 @@ protected
   Component comp;
 algorithm
 
-  assert(InstNode.isClass(recNode), getInstanceName() + " got non-class node");
+  Error.assertion(InstNode.isClass(recNode), getInstanceName() + " got non-class node", sourceInfo());
   cls := InstNode.getClass(recNode);
 
   () := match cls
@@ -143,7 +143,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got non-instantiated function");
+        Error.assertion(false, getInstanceName() + " got non-instantiated function", sourceInfo());
       then
         fail();
   end match;

--- a/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -90,7 +90,7 @@ algorithm
 
     case Expression.RECORD()
       algorithm
-        assert(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName());
+        Error.assertion(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName(), sourceInfo());
       then fail();
 
     case Expression.CALL(call = call as Call.TYPED_CALL())
@@ -168,12 +168,12 @@ algorithm
 
     case Expression.RECORD()
       algorithm
-        assert(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName());
+        Error.assertion(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName(), sourceInfo());
       then fail();
 
     case Expression.CALL()
       algorithm
-        assert(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName());
+        Error.assertion(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName(), sourceInfo());
       then fail();
 
     case Expression.BINARY(exp1=Expression.INTEGER(value=i1), exp2=Expression.INTEGER(value=i2))
@@ -247,12 +247,12 @@ algorithm
 
     case Expression.CAST()
       algorithm
-        assert(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName());
+        Error.assertion(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName(), sourceInfo());
       then fail();
 
     case Expression.UNBOX()
       algorithm
-        assert(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName());
+        Error.assertion(false, "Unimplemented case for " + Expression.toString(exp) + " in " + getInstanceName(), sourceInfo());
       then fail();
 
     else exp;

--- a/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/Compiler/NFFrontEnd/NFSubscript.mo
@@ -210,7 +210,7 @@ public
       case WHOLE() then DAE.WHOLEDIM();
       else
         algorithm
-          assert(false, getInstanceName() + " failed on unknown subscript");
+          Error.assertion(false, getInstanceName() + " failed on unknown subscript", sourceInfo());
         then
           fail();
     end match;

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -420,7 +420,7 @@ public
       case Type.ANY() then "$ANY$";
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown type: " + anyString(ty));
+          Error.assertion(false, getInstanceName() + " got unknown type: " + anyString(ty), sourceInfo());
         then
           fail();
     end match;
@@ -463,7 +463,7 @@ public
       case Type.ANY() then DAE.T_ANYTYPE(NONE());
       else
         algorithm
-          assert(false, getInstanceName() + " got unknown type: " + anyString(ty));
+          Error.assertion(false, getInstanceName() + " got unknown type: " + anyString(ty), sourceInfo());
         then
           fail();
     end match;

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -826,8 +826,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + ": got a binary operation that is not
-            handled yet");
+        Error.assertion(false, getInstanceName() + ": got a binary operation that is not handled yet", sourceInfo());
       then
         fail();
   end match;
@@ -1429,7 +1428,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got unknown type.");
+        Error.assertion(false, getInstanceName() + " got unknown type.", sourceInfo());
       then
         fail();
 
@@ -2083,7 +2082,7 @@ end matchTypes_cast;
 //          ixty := Expression.typeof(sub.exp);
 //          slicedims := getTypeDims(ixty);
 //          if listLength(slicedims) > 0 then
-//            assert(listLength(slicedims) == 1,
+//            Error.assertion(listLength(slicedims, sourceInfo()) == 1,
 //              getInstanceName() + " failed. Got a slice with more than one dim?");
 //            _::dims1 := dims1;
 //            {dim} := slicedims;
@@ -2459,7 +2458,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got untyped binding " + Binding.toString(binding));
+        Error.assertion(false, getInstanceName() + " got untyped binding " + Binding.toString(binding), sourceInfo());
       then
         fail();
   end match;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -183,8 +183,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got uninstantiated class " +
-          InstNode.name(cls));
+        Error.assertion(false, getInstanceName() + " got uninstantiated class " + InstNode.name(cls), sourceInfo());
       then
         fail();
 
@@ -286,8 +285,7 @@ algorithm
     // Any other type of component shouldn't show up here.
     else
       algorithm
-        assert(false, getInstanceName() + " got uninstantiated component " +
-          InstNode.name(component));
+        Error.assertion(false, getInstanceName() + " got uninstantiated component " + InstNode.name(component), sourceInfo());
       then
         fail();
 
@@ -383,13 +381,13 @@ algorithm
 
     case Component.ITERATOR(binding = Binding.UNBOUND())
       algorithm
-        assert(false, getInstanceName() + ": Implicit iteration ranges not yet implement");
+        Error.assertion(false, getInstanceName() + ": Implicit iteration ranges not yet implement", sourceInfo());
       then
         fail();
 
     else
       algorithm
-        assert(false, getInstanceName() + " got non-iterator " + InstNode.name(iterator));
+        Error.assertion(false, getInstanceName() + " got non-iterator " + InstNode.name(iterator), sourceInfo());
       then
         fail();
 
@@ -557,8 +555,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got uninstantiated class " +
-          InstNode.name(cls));
+        Error.assertion(false, getInstanceName() + " got uninstantiated class " + InstNode.name(cls), sourceInfo());
       then
         fail();
 
@@ -627,7 +624,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got invalid node " + InstNode.name(node));
+        Error.assertion(false, getInstanceName() + " got invalid node " + InstNode.name(node), sourceInfo());
       then
         fail();
 
@@ -655,7 +652,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got uninstantiated binding");
+        Error.assertion(false, getInstanceName() + " got uninstantiated binding", sourceInfo());
       then
         fail();
 
@@ -805,7 +802,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " failed for " + Binding.toString(binding));
+        Error.assertion(false, getInstanceName() + " failed for " + Binding.toString(binding), sourceInfo());
       then
         fail();
   end match;
@@ -1064,7 +1061,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got unknown expression");
+        Error.assertion(false, getInstanceName() + " got unknown expression", sourceInfo());
       then
         fail();
 
@@ -1193,7 +1190,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got invalid cref.");
+        Error.assertion(false, getInstanceName() + " got invalid cref.", sourceInfo());
       then
         fail();
 
@@ -1317,7 +1314,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got unknown cref");
+        Error.assertion(false, getInstanceName() + " got unknown cref", sourceInfo());
       then
         fail();
 
@@ -1393,7 +1390,7 @@ algorithm
     case Subscript.WHOLE() then Type.UNKNOWN();
     else
       algorithm
-        assert(false, getInstanceName() + " got untyped subscript");
+        Error.assertion(false, getInstanceName() + " got untyped subscript", sourceInfo());
       then
         fail();
   end match;
@@ -1719,8 +1716,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got uninstantiated class " +
-          InstNode.name(classNode));
+        Error.assertion(false, getInstanceName() + " got uninstantiated class " + InstNode.name(classNode), sourceInfo());
       then
         fail();
   end match;
@@ -1861,8 +1857,7 @@ algorithm
 
     else
       algorithm
-        assert(false, getInstanceName() + " got uninstantiated component " +
-          InstNode.name(component));
+        Error.assertion(false, getInstanceName() + " got uninstantiated component " + InstNode.name(component), sourceInfo());
       then
         fail();
 


### PR DESCRIPTION
Error.assertion reports errors to the error buffer, which means that the
message can be access in scripting and OMPython.

This fixes ticket:4676