### PR TITLE
[NF] Ceval fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -356,7 +356,7 @@ function evalBuiltinCall
   input EvalTarget target;
   output Expression result;
 protected
-  Absyn.Path fn_path = Function.name(fn);
+  Absyn.Path fn_path = Function.nameConsiderBuiltin(fn);
 algorithm
   result := match Absyn.pathFirstIdent(fn_path)
     case "abs" then evalBuiltinAbs(listHead(args));
@@ -450,7 +450,7 @@ algorithm
   result := match arg
     case Expression.REAL(value = x)
       algorithm
-        if x <= -1.0 or x >= 1.0 then
+        if x < -1.0 or x > 1.0 then
           if EvalTarget.hasInfo(target) then
             Error.addSourceMessage(Error.ARGUMENT_OUT_OF_RANGE,
               {String(x), "acos", "-1 <= x <= 1"}, EvalTarget.getInfo(target));
@@ -486,7 +486,7 @@ algorithm
   result := match arg
     case Expression.REAL(value = x)
       algorithm
-        if x <= -1.0 or x >= 1.0 then
+        if x < -1.0 or x > 1.0 then
           if EvalTarget.hasInfo(target) then
             Error.addSourceMessage(Error.ARGUMENT_OUT_OF_RANGE,
               {String(x), "asin", "-1 <= x <= 1"}, EvalTarget.getInfo(target));

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -609,7 +609,13 @@ algorithm
 
           // Evaluate the binding if the component is a constant.
           if comp_var == Variability.CONSTANT then
-            binding := evalBinding(binding);
+            // TODO: Allow this to fail for now. Once constant evaluation has
+            // been improved we should print an error when a constant binding
+            // couldn't be evaluated instead.
+            try
+              binding := evalBinding(binding);
+            else
+            end try;
           end if;
 
           c.binding := binding;


### PR DESCRIPTION
- Allow ceval of constant binding to fail for now, since ceval
  isn't complete.
- Handle Modelica.Math builtins.
- Fix bad interval check for asin/acos.