### PR TITLE
loadFile(".../package.mo") ignores MODELICAPATH

### DIFF
--- a/Compiler/Main/Main.mo
+++ b/Compiler/Main/Main.mo
@@ -441,7 +441,7 @@ algorithm
         path = Absyn.stringPath(inLib);
         mp = Settings.getModelicaPath(Config.getRunningTestsuite());
         p = GlobalScriptUtil.getSymbolTableAST(inSymTab);
-        (pnew, true) = CevalScript.loadModel({(path, {"default"})}, mp, p, true, true, true, false);
+        (pnew, true) = CevalScript.loadModel({(path, {"default"}, false)}, mp, p, true, true, true, false);
         newst = GlobalScriptUtil.setSymbolTableAST(inSymTab, pnew);
       then
         newst;

--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -735,7 +735,7 @@ algorithm
       GlobalScript.SimulationOptions defaulSimOpt;
       SimCode.SimulationSettings simSettings;
       Boolean dumpExtractionSteps, requireExactVersion;
-      list<tuple<Absyn.Path,list<String>>> uses;
+      list<tuple<Absyn.Path,list<String>,Boolean>> uses;
       Config.LanguageStandard oldLanguageStd;
       SCode.Element cl;
       list<SCode.Element> cls, elts;
@@ -1418,11 +1418,11 @@ algorithm
 
         case (cache,env,"buildLabel",vals,st,_)
       equation
-	  Flags.setConfigBool(Flags.GENERATE_LABELED_SIMCODE, true);
-	  //Flags.set(Flags.WRITE_TO_BUFFER,true);
-	  List.map_0(ClockIndexes.buildModelClocks,System.realtimeClear);
+    Flags.setConfigBool(Flags.GENERATE_LABELED_SIMCODE, true);
+    //Flags.set(Flags.WRITE_TO_BUFFER,true);
+    List.map_0(ClockIndexes.buildModelClocks,System.realtimeClear);
         System.realtimeTick(ClockIndexes.RT_CLOCK_SIMULATE_TOTAL);
-	  (cache,st,compileDir,executable,_,_,initfilename,_,_) = buildModel(cache,env, vals, st, msg);
+    (cache,st,compileDir,executable,_,_,initfilename,_,_) = buildModel(cache,env, vals, st, msg);
       then
         (cache,ValuesUtil.makeArray({Values.STRING(executable),Values.STRING(initfilename)}),st);
 
@@ -1430,12 +1430,12 @@ algorithm
       equation
       Flags.setConfigBool(Flags.REDUCE_TERMS, true);
      // Flags.setConfigBool(Flags.DISABLE_EXTRA_LABELING, true);
-	  Flags.setConfigBool(Flags.GENERATE_LABELED_SIMCODE, false);
-	  _=Flags.disableDebug(Flags.WRITE_TO_BUFFER);
-	  List.map_0(ClockIndexes.buildModelClocks,System.realtimeClear);
+    Flags.setConfigBool(Flags.GENERATE_LABELED_SIMCODE, false);
+    _=Flags.disableDebug(Flags.WRITE_TO_BUFFER);
+    List.map_0(ClockIndexes.buildModelClocks,System.realtimeClear);
         System.realtimeTick(ClockIndexes.RT_CLOCK_SIMULATE_TOTAL);
 
-	  (cache,st,compileDir,executable,_,_,initfilename,_,_) = buildLabeledModel(cache,env, vals, st, msg);
+    (cache,st,compileDir,executable,_,_,initfilename,_,_) = buildLabeledModel(cache,env, vals, st, msg);
       then
         (cache,ValuesUtil.makeArray({Values.STRING(executable),Values.STRING(initfilename)}),st);
     case(cache,env,"buildOpenTURNSInterface",vals,st,_)
@@ -2960,7 +2960,7 @@ algorithm
     case (_, GlobalScript.SYMBOLTABLE(p,fp,ic,iv,cf,lf))
       equation
         str = Absyn.pathFirstIdent(className);
-        (p,b) = CevalScript.loadModel({(Absyn.IDENT(str),{"default"})},Settings.getModelicaPath(Config.getRunningTestsuite()),p,true,true,true,false);
+        (p,b) = CevalScript.loadModel({(Absyn.IDENT(str),{"default"},false)},Settings.getModelicaPath(Config.getRunningTestsuite()),p,true,true,true,false);
         Error.assertionOrAddSourceMessage(not b,Error.NOTIFY_NOT_LOADED,{str,"default"},Absyn.dummyInfo);
         // print(stringDelimitList(list(Absyn.pathString(path) for path in Interactive.getTopClassnames(p)), ",") + "\n");
       then GlobalScript.SYMBOLTABLE(p,fp,ic,iv,cf,lf);
@@ -7082,14 +7082,14 @@ algorithm
 end searchClassNames;
 
 protected function makeUsesArray
-  input tuple<Absyn.Path,list<String>> inTpl;
+  input tuple<Absyn.Path,list<String>,Boolean> inTpl;
   output Values.Value v;
 algorithm
   v := match inTpl
     local
       Absyn.Path p;
       String pstr,ver;
-    case ((p,{ver}))
+    case ((p,{ver},_))
       equation
         pstr = Absyn.pathString(p);
       then ValuesUtil.makeArray({Values.STRING(pstr),Values.STRING(ver)});

--- a/Compiler/Script/Interactive.mo
+++ b/Compiler/Script/Interactive.mo
@@ -8916,9 +8916,9 @@ algorithm
             /*update case*/(boolNot(intEq(l1_1, l2)) and isSome(item)) and success) then
           parts2 = replacePublicList(parts, publst2);
         else
-	        protlst = getProtectedList(parts);
-	        protlst2 = deleteOrUpdateComponentFromElementitems(name, protlst, item);
-	        parts2 = replaceProtectedList(parts, protlst2);
+          protlst = getProtectedList(parts);
+          protlst2 = deleteOrUpdateComponentFromElementitems(name, protlst, item);
+          parts2 = replaceProtectedList(parts, protlst2);
         end if;
       then
         Absyn.CLASS(i,p,f,e,r,Absyn.CLASS_EXTENDS(bcpath,mod,cmt,parts2,ann),file_info);
@@ -11516,7 +11516,7 @@ public function getUsesAnnotation
   string of values for the Documentation annotation for the class named by the
   first argument."
   input Absyn.Program p;
-  output list<tuple<Absyn.Path,list<String>>> usesStr;
+  output list<tuple<Absyn.Path,list<String>,Boolean>> usesStr;
 algorithm
   usesStr := matchcontinue (p)
     local
@@ -11538,23 +11538,23 @@ public function getUsesAnnotationOrDefault
   first argument."
   input Absyn.Program p;
   input Boolean requireExactVersion;
-  output list<tuple<Absyn.Path,list<String>>> usesStr;
+  output list<tuple<Absyn.Path,list<String>,Boolean>> usesStr;
 protected
   list<Absyn.Path> paths;
   list<list<String>> strs;
 algorithm
   usesStr := getUsesAnnotation(p);
-  paths := List.map(usesStr,Util.tuple21);
-  strs := List.map(usesStr,Util.tuple22);
+  paths := List.map(usesStr,Util.tuple31);
+  strs := List.map(usesStr,Util.tuple32);
   if not requireExactVersion then
     strs := List.map1(strs,listAppend,{"default"});
   end if;
-  usesStr := List.threadTuple(paths,strs);
+  usesStr := list((p,s,false) threaded for p in paths, s in strs);
 end getUsesAnnotationOrDefault;
 
 protected function getUsesAnnotationString
   input Option<Absyn.Modification> mod;
-  output list<tuple<Absyn.Path,list<String>>> usesStr;
+  output list<tuple<Absyn.Path,list<String>,Boolean>> usesStr;
 algorithm
   usesStr := match (mod)
     local
@@ -11568,13 +11568,13 @@ end getUsesAnnotationString;
 
 protected function getUsesAnnotationString2
   input list<Absyn.ElementArg> eltArgs;
-  output list<tuple<Absyn.Path,list<String>>> strs;
+  output list<tuple<Absyn.Path,list<String>,Boolean>> strs;
 algorithm
   strs := match eltArgs
     local
       list<Absyn.ElementArg> xs;
       String name,  version;
-      list<tuple<Absyn.Path,list<String>>> ss;
+      list<tuple<Absyn.Path,list<String>,Boolean>> ss;
       Absyn.Info info;
 
     case ({}) then {};
@@ -11585,13 +11585,13 @@ algorithm
       })))::xs)
       equation
         ss = getUsesAnnotationString2(xs);
-      then (Absyn.IDENT(name),{version})::ss;
+      then (Absyn.IDENT(name),{version},false)::ss;
 
     case (Absyn.MODIFICATION(info = info, path = Absyn.IDENT(name = name))::xs)
       equation
         Error.addSourceMessage(Error.USES_MISSING_VERSION, {name}, info);
         ss = getUsesAnnotationString2(xs);
-      then (Absyn.IDENT(name),{"default"})::ss;
+      then (Absyn.IDENT(name),{"default"},false)::ss;
 
     case (_::xs)
       equation


### PR DESCRIPTION
Note: If the same directory contains other libraries that are loaded
according to uses-annotations, the full MODELICAPATH is used for these.
This means you might end up loading only one of the packages from the
given directory.