### PR TITLE
Handle record indexing better

### DIFF
--- a/Compiler/BackEnd/Differentiate.mo
+++ b/Compiler/BackEnd/Differentiate.mo
@@ -2119,7 +2119,7 @@ algorithm
     case (e as DAE.CALL(path=path, expLst=expl, attr=attr), _, _, _, _) guard( Expression.isRecordCall(e, inFunctionTree))
       equation
         (dexpl, functions) = List.map3Fold(expl, function differentiateExp(maxIter=maxIter), inDiffwrtCref, inInputData, inDiffType, inFunctionTree);
-    then (DAE.CALL(path, dexpl, attr), functions);
+      then (DAE.CALL(path, dexpl, attr), functions);
 
     //differentiate function partial
     case (e, _, _, _, _)
@@ -2155,8 +2155,7 @@ algorithm
          when differentiating.";
         tp = Expression.typeof(inExp);
         zero = Expression.createZeroExpression(tp);
-      then
-        (zero, inFunctionTree);
+      then (zero, inFunctionTree);
 
       else
       equation

--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -4494,10 +4494,10 @@ algorithm
     // record type
     case DAE.T_COMPLEX(varLst=varLst,complexClassType=ClassInf.RECORD(path)) equation
       cr = DAE.CREF_IDENT("$TMP", inType, {});
-      crefs = ComponentReference.expandCref(cr, true);
-      typeLst = List.mapMap(crefs, crefExp, typeof);
+      typeLst = list(v.ty for v in varLst);
       expLst = List.map(typeLst, createZeroExpression);
       varNames = List.map(varLst, varName);
+      true = listLength(varNames) == listLength(expLst);
       e = DAE.RECORD(path, expLst, varNames, inType);
     then e;
 

--- a/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -310,8 +310,19 @@ algorithm
   e := match e
     local
       DAE.ComponentRef cr;
+      Integer i;
+      list<DAE.Exp> exps;
+      list<String> comp;
+      Absyn.Path p1,p2;
+      DAE.Type ty;
+      list<DAE.Var> vars;
     case (DAE.RSUB(exp=DAE.CREF(componentRef=cr), ix=-1))
       then DAE.CREF(ComponentReference.joinCrefs(cr, ComponentReference.makeCrefIdent(e.fieldName, e.ty, {})), e.ty);
+    case (DAE.RSUB(exp=DAE.CALL(path=p1, expLst=exps, attr=DAE.CALL_ATTR(ty=DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(path=p2), varLst=vars))), ix=-1))
+      guard Absyn.pathEqual(p1,p2)
+      then listGet(exps, List.position1OnTrue(list(v.name for v in vars), stringEq, e.fieldName));
+    case (DAE.RSUB(exp=DAE.RECORD(exps=exps,comp=comp), ix=-1))
+      then listGet(exps, List.position1OnTrue(comp, stringEq, e.fieldName));
     else e;
   end match;
 end simplifyRSub;

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -13330,7 +13330,7 @@ algorithm
           case SimCodeVar.NEGATEDALIAS(varName=cref)
             algorithm
               Error.addSourceMessage(Error.INTERNAL_ERROR, {getInstanceName() + " got a negated alias variable " + ComponentReference.printComponentRefStr(inCref) + " to " + ComponentReference.printComponentRefStr(cref) + ", but before code generation these should have been removed"}, sv.source.info);
-            then fail();
+            then sv;
         end match;
       then sv;
 


### PR DESCRIPTION
Simplify record constructor calls with record indexing. Also, handle
construction of zero records better (array components were flattened
before, resulting in additional arguments to the constructor).