### PR TITLE
Let the CSE look into if-conditions

### DIFF
--- a/Compiler/BackEnd/CommonSubExpression.mo
+++ b/Compiler/BackEnd/CommonSubExpression.mo
@@ -852,7 +852,12 @@ algorithm
       DAE.ComponentRef cr;
 
     case DAE.IFEXP()
-    then false;
+      algorithm
+        (_, outTuple) := Expression.traverseExpTopDown(inExp.expCond, wrapFunctionCalls_analysis3, inTuple);
+        // TODO: We should also have analyzed all of the branches; if a call is present in all branches we can perform CSE. But the data structure is a hashtable and we would need to use immutable types...
+        cont := false;
+        return;
+      then fail();
 
     // TODO: split up skip cases
     case _


### PR DESCRIPTION
If-conditions always execute, so we can consider them for CSE
optimizations. This improves some Media models by a factor of 10x since
the function calls are called inside an algebraic loop (multiple times,
although this matters little relative to moving the call outside of the
loop).

This fixes an issue with performance discovered in ticket:4423.