### PR TITLE
Handle indexed assignment of string arrays

### DIFF
--- a/SimulationRuntime/c/util/base_array.c
+++ b/SimulationRuntime/c/util/base_array.c
@@ -375,3 +375,67 @@ void clone_reverse_base_array_spec(const base_array_t* source, base_array_t* des
         dest->dim_size[i] = source->dim_size[dest->ndims - 1 - i];
     }
 }
+
+void index_alloc_base_array_size(const real_array_t * source,
+                                 const index_spec_t* source_spec,
+                                 base_array_t* dest)
+{
+    int i;
+    int j;
+
+    omc_assert_macro(base_array_ok(source));
+    omc_assert_macro(index_spec_ok(source_spec));
+    omc_assert_macro(index_spec_fit_base_array(source_spec, source));
+
+    for(i = 0, j = 0; i < source_spec->ndims; ++i) {
+         if(source_spec->dim_size[i] != 0) { /* is 'W' or 'A' */
+           ++j;
+         }
+    }
+    dest->ndims = j;
+    dest->dim_size = size_alloc(dest->ndims);
+
+    for(i = 0, j = 0; i < source_spec->ndims; ++i) {
+        if(source_spec->dim_size[i] != 0) { /* is 'W' or 'A' */
+            if(source_spec->index[i] != NULL) { /* is 'A' */
+                dest->dim_size[j] = source_spec->dim_size[i];
+            } else { /* is 'W' */
+                dest->dim_size[j] = source->dim_size[i];
+            }
+
+            ++j;
+        }
+    }
+}
+
+void indexed_assign_base_array_size_alloc(const base_array_t *source, base_array_t *dest, const index_spec_t *dest_spec, _index_t** _idx_vec1, _index_t** _idx_size)
+{
+    _index_t* idx_vec1;
+    _index_t* idx_size;
+    int i, j;
+    omc_assert_macro(base_array_ok(source));
+    omc_assert_macro(base_array_ok(dest));
+    omc_assert_macro(index_spec_ok(dest_spec));
+    omc_assert_macro(index_spec_fit_base_array(dest_spec, dest));
+    for(i = 0,j = 0; i < dest_spec->ndims; ++i) {
+        if(dest_spec->dim_size[i] != 0) {
+            ++j;
+        }
+    }
+    omc_assert_macro(j == source->ndims);
+
+    idx_vec1 = size_alloc(dest->ndims);
+    idx_size = size_alloc(dest_spec->ndims);
+
+    for(i = 0; i < dest_spec->ndims; ++i) {
+        idx_vec1[i] = 0;
+
+        if(dest_spec->index[i] != NULL) { /* is 'S' or 'A' */
+            idx_size[i] = imax(dest_spec->dim_size[i],1);
+        } else { /* is 'W' */
+            idx_size[i] = dest->dim_size[i];
+        }
+    }
+    *_idx_vec1 = idx_vec1;
+    *_idx_size = idx_size;
+}

--- a/SimulationRuntime/c/util/base_array.h
+++ b/SimulationRuntime/c/util/base_array.h
@@ -104,4 +104,9 @@ size_t calc_base_index_dims_subs(int ndims,...);
 
 int index_spec_fit_base_array(const index_spec_t *s, const base_array_t *a);
 
+/* Helper function for index_alloc_TYPE_array; allocates the ndims and dim_size */
+void index_alloc_base_array_size(const base_array_t * source, const index_spec_t* source_spec, base_array_t* dest);
+/* Helper function for indexed_assign_TYPE_array; allocates the ndims and dim_size */
+void indexed_assign_base_array_size_alloc(const base_array_t *source, base_array_t *dest, const index_spec_t *dest_spec, _index_t** _idx_vec1, _index_t** _idx_size);
+
 #endif /* BASE_ARRAY_H_ */

--- a/SimulationRuntime/c/util/boolean_array.c
+++ b/SimulationRuntime/c/util/boolean_array.c
@@ -31,6 +31,7 @@
 
 #include "boolean_array.h"
 #include "gc/omc_gc.h"
+#include "omc_error.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -306,44 +307,20 @@ void simple_indexed_assign_boolean_array2(const boolean_array_t* source,
 void indexed_assign_boolean_array(const boolean_array_t source, boolean_array_t* dest,
                                   const index_spec_t* dest_spec)
 {
-    _index_t* idx_vec1;
-    _index_t* idx_size;
-    int i,j;
-
-    assert(base_array_ok(&source));
-    assert(base_array_ok(dest));
-    assert(index_spec_ok(dest_spec));
-    assert(index_spec_fit_base_array(dest_spec, dest));
-    for(i = 0,j = 0; i < dest_spec->ndims; ++i) {
-        if(dest_spec->dim_size[i] != 0) {
-            ++j;
-        }
-    }
-    assert(j == source.ndims);
-
-    idx_vec1 = size_alloc(dest->ndims);
-    idx_size = size_alloc(dest_spec->ndims);
-
-    for(i = 0; i < dest_spec->ndims; ++i) {
-        idx_vec1[i] = 0;
-
-        if(dest_spec->index[i] != NULL) { /* is 'S' or 'A' */
-            idx_size[i] = imax(dest_spec->dim_size[i],1);
-        } else { /* is 'W' */
-            idx_size[i] = dest->dim_size[i];
-        }
-    }
+    _index_t* idx_vec1, idx_size;
+    int j;
+    indexed_assign_base_array_size_alloc(&source, dest, dest_spec, &idx_vec1, &idx_size);
 
     j = 0;
     do {
         boolean_set(dest,
-                    calc_base_index_spec(dest->ndims, idx_vec1, dest, dest_spec),
-                    boolean_get(source, j));
+                 calc_base_index_spec(dest->ndims, idx_vec1, dest, dest_spec),
+                 boolean_get(source, j));
         j++;
 
     } while(0 == next_index(dest_spec->ndims, idx_vec1, idx_size));
 
-    assert(j == base_array_nr_of_elements(source));
+    omc_assert_macro(j == base_array_nr_of_elements(source));
 }
 
 /*
@@ -428,33 +405,7 @@ void index_alloc_boolean_array(const boolean_array_t* source,
                                const index_spec_t* source_spec,
                                boolean_array_t* dest)
 {
-    int i;
-    int j;
-
-    assert(base_array_ok(source));
-    assert(index_spec_ok(source_spec));
-    assert(index_spec_fit_base_array(source_spec, source));
-
-    for(i = 0, j = 0; i < source_spec->ndims; ++i) {
-         if(source_spec->dim_size[i] != 0) { /* is 'W' or 'A' */
-           ++j;
-         }
-    }
-    dest->ndims = j;
-    dest->dim_size = size_alloc(dest->ndims);
-
-    for(i = 0, j = 0; i < source_spec->ndims; ++i) {
-        if(source_spec->dim_size[i] != 0) { /* is 'W' or 'A' */
-            if(source_spec->index[i] != NULL) { /* is 'A' */
-                dest->dim_size[j] = source_spec->dim_size[i];
-            } else { /* is 'W' */
-                dest->dim_size[j] = source->dim_size[i];
-            }
-
-            ++j;
-        }
-    }
-
+    index_alloc_base_array_size(source, source_spec, dest);
     alloc_boolean_array_data(dest);
     index_boolean_array(source, source_spec, dest);
 }

--- a/SimulationRuntime/c/util/integer_array.c
+++ b/SimulationRuntime/c/util/integer_array.c
@@ -302,33 +302,9 @@ void simple_indexed_assign_integer_array2(const integer_array_t * source,
 void indexed_assign_integer_array(const integer_array_t source, integer_array_t* dest,
                                   const index_spec_t* dest_spec)
 {
-    _index_t* idx_vec1;
-    _index_t* idx_size;
-    int i,j;
-
-    omc_assert_macro(base_array_ok(&source));
-    omc_assert_macro(base_array_ok(dest));
-    omc_assert_macro(index_spec_ok(dest_spec));
-    omc_assert_macro(index_spec_fit_base_array(dest_spec, dest));
-    for(i = 0,j = 0; i < dest_spec->ndims; ++i) {
-        if(dest_spec->dim_size[i] != 0) {
-            ++j;
-        }
-    }
-    omc_assert_macro(j == source.ndims);
-
-    idx_vec1 = size_alloc(dest->ndims);
-    idx_size = size_alloc(dest_spec->ndims);
-
-    for(i = 0; i < dest_spec->ndims; ++i) {
-        idx_vec1[i] = 0;
-
-        if(dest_spec->index[i] != NULL) { /* is 'S' or 'A' */
-            idx_size[i] = imax(dest_spec->dim_size[i],1);
-        } else { /* is 'W' */
-            idx_size[i] = dest->dim_size[i];
-        }
-    }
+    _index_t* idx_vec1, idx_size;
+    int j;
+    indexed_assign_base_array_size_alloc(&source, dest, dest_spec, &idx_vec1, &idx_size);
 
     j = 0;
     do {
@@ -424,34 +400,7 @@ void index_alloc_integer_array(const integer_array_t * source,
              const index_spec_t* source_spec,
              integer_array_t* dest)
 {
-    int i;
-    int j;
-
-    omc_assert_macro(base_array_ok(source));
-    omc_assert_macro(index_spec_ok(source_spec));
-    omc_assert_macro(index_spec_fit_base_array(source_spec,source));
-
-
-    for(i = 0, j = 0; i < source_spec->ndims; ++i) {
-         if(source_spec->dim_size[i] != 0) { /* is 'W' or 'A' */
-           ++j;
-         }
-    }
-    dest->ndims = j;
-    dest->dim_size = size_alloc(dest->ndims);
-
-    for(i = 0, j = 0; i < source_spec->ndims; ++i) {
-        if(source_spec->dim_size[i] != 0) { /* is 'W' or 'A' */
-            if(source_spec->index[i] != NULL) { /* is 'A' */
-                dest->dim_size[j] = source_spec->dim_size[i];
-            } else { /* is 'W' */
-                dest->dim_size[j] = source->dim_size[i];
-            }
-
-            ++j;
-        }
-    }
-
+    index_alloc_base_array_size(source, source_spec, dest);
     alloc_integer_array_data(dest);
     index_integer_array(source, source_spec, dest);
 }

--- a/SimulationRuntime/c/util/real_array.c
+++ b/SimulationRuntime/c/util/real_array.c
@@ -279,33 +279,9 @@ void simple_indexed_assign_real_array2(const real_array_t * source,
 void indexed_assign_real_array(const real_array_t source, real_array_t* dest,
                                const index_spec_t* dest_spec)
 {
-    _index_t* idx_vec1;
-    _index_t* idx_size;
-    int i,j;
-
-    omc_assert_macro(base_array_ok(&source));
-    omc_assert_macro(base_array_ok(dest));
-    omc_assert_macro(index_spec_ok(dest_spec));
-    omc_assert_macro(index_spec_fit_base_array(dest_spec, dest));
-    for(i = 0,j = 0; i < dest_spec->ndims; ++i) {
-        if(dest_spec->dim_size[i] != 0) {
-            ++j;
-        }
-    }
-    omc_assert_macro(j == source.ndims);
-
-    idx_vec1 = size_alloc(dest->ndims);
-    idx_size = size_alloc(dest_spec->ndims);
-
-    for(i = 0; i < dest_spec->ndims; ++i) {
-        idx_vec1[i] = 0;
-
-        if(dest_spec->index[i] != NULL) { /* is 'S' or 'A' */
-            idx_size[i] = imax(dest_spec->dim_size[i],1);
-        } else { /* is 'W' */
-            idx_size[i] = dest->dim_size[i];
-        }
-    }
+    _index_t* idx_vec1, idx_size;
+    int j;
+    indexed_assign_base_array_size_alloc(&source, dest, dest_spec, &idx_vec1, &idx_size);
 
     j = 0;
     do {
@@ -413,33 +389,7 @@ void index_alloc_real_array(const real_array_t * source,
                             const index_spec_t* source_spec,
                             real_array_t* dest)
 {
-    int i;
-    int j;
-
-    omc_assert_macro(base_array_ok(source));
-    omc_assert_macro(index_spec_ok(source_spec));
-    omc_assert_macro(index_spec_fit_base_array(source_spec, source));
-
-    for(i = 0, j = 0; i < source_spec->ndims; ++i) {
-         if(source_spec->dim_size[i] != 0) { /* is 'W' or 'A' */
-           ++j;
-         }
-    }
-    dest->ndims = j;
-    dest->dim_size = size_alloc(dest->ndims);
-
-    for(i = 0, j = 0; i < source_spec->ndims; ++i) {
-        if(source_spec->dim_size[i] != 0) { /* is 'W' or 'A' */
-            if(source_spec->index[i] != NULL) { /* is 'A' */
-                dest->dim_size[j] = source_spec->dim_size[i];
-            } else { /* is 'W' */
-                dest->dim_size[j] = source->dim_size[i];
-            }
-
-            ++j;
-        }
-    }
-
+    index_alloc_base_array_size(source, source_spec, dest);
     alloc_real_array_data(dest);
     index_real_array(source, source_spec, dest);
 }

--- a/SimulationRuntime/c/util/string_array.c
+++ b/SimulationRuntime/c/util/string_array.c
@@ -33,6 +33,7 @@
 #include "gc/omc_gc.h"
 #include "index_spec.h"
 #include "modelica_string.h"
+#include "omc_error.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -243,53 +244,24 @@ void simple_indexed_assign_string_array2(const string_array_t * source,
     string_set(dest, index, string_get(*source, index));
 }
 
-void indexed_assign_string_array(const string_array_t * source,
+void indexed_assign_string_array(const string_array_t source,
                                  string_array_t* dest,
                                  const index_spec_t* dest_spec)
 {
-    _index_t* idx_vec1;
-    _index_t* idx_vec2;
-    _index_t* idx_size;
-    int i,j;
+    _index_t* idx_vec1, idx_size;
+    int j;
+    indexed_assign_base_array_size_alloc(&source, dest, dest_spec, &idx_vec1, &idx_size);
 
-    assert(base_array_ok(source));
-    assert(base_array_ok(dest));
-    assert(index_spec_ok(dest_spec));
-    assert(index_spec_fit_base_array(dest_spec, dest));
-    for(i = 0,j = 0; i < dest_spec->ndims; ++i) {
-        if(dest_spec->dim_size[i] != 0) {
-            ++j;
-        }
-    }
-    assert(j == source->ndims);
-
-    idx_vec1 = size_alloc(dest->ndims);
-    idx_vec2 = size_alloc(source->ndims);
-    idx_size = size_alloc(dest_spec->ndims);
-
-    for(i = 0; i < dest_spec->ndims; ++i) {
-        idx_vec1[i] = 0;
-
-        if(dest_spec->index[i] != NULL) {
-            idx_size[i] = imax(dest_spec->dim_size[i],1);
-        } else {
-            idx_size[i] = dest->dim_size[i];
-        }
-    }
-
+    j = 0;
     do {
-        for(i = 0, j = 0; i < dest_spec->ndims; ++i) {
-            if(dest_spec->dim_size[i] != 0) {
-                idx_vec2[j] = idx_vec1[i];
-                ++j;
-            }
-        }
-        string_set(dest, calc_base_index_spec(dest->ndims, idx_vec1,
-                                              dest, dest_spec),
-                   string_get(*source, calc_base_index(source->ndims,
-                                                      idx_vec2, source)));
+        string_set(dest,
+                 calc_base_index_spec(dest->ndims, idx_vec1, dest, dest_spec),
+                 string_get(source, j));
+        j++;
 
     } while(0 == next_index(dest_spec->ndims, idx_vec1, idx_size));
+
+    omc_assert_macro(j == base_array_nr_of_elements(source));
 }
 
 /*
@@ -374,37 +346,7 @@ void index_alloc_string_array(const string_array_t * source,
                               const index_spec_t* source_spec,
                               string_array_t* dest)
 {
-    int i;
-    int j;
-    int ndimsdiff;
-
-    assert(base_array_ok(source));
-    assert(index_spec_ok(source_spec));
-    assert(index_spec_fit_base_array(source_spec, source));
-
-    ndimsdiff = 0;
-    for(i = 0; i < source_spec->ndims; ++i) {
-        if((source_spec->index_type[i] == 'W')
-            ||
-            (source_spec->index_type[i] == 'A')) {
-            ndimsdiff--;
-        }
-    }
-
-    dest->ndims = source->ndims + ndimsdiff;
-    dest->dim_size = size_alloc(dest->ndims);
-
-    for(i = 0,j = 0; i < dest->ndims; ++i) {
-        while(source_spec->index_type[i+j] == 'S') { /* Skip scalars */
-            j++;
-        }
-        if(source_spec->index_type[i+j] == 'W') { /*take whole dimension from source*/
-            dest->dim_size[i]=source->dim_size[i+j];
-        } else if(source_spec->index_type[i+j] == 'A') { /* Take dimension size from splice*/
-            dest->dim_size[i]=source_spec->dim_size[i+j];
-        }
-    }
-
+    index_alloc_base_array_size(source, source_spec, dest);
     alloc_string_array_data(dest);
     index_string_array(source, source_spec, dest);
 }

--- a/SimulationRuntime/c/util/string_array.h
+++ b/SimulationRuntime/c/util/string_array.h
@@ -88,7 +88,7 @@ extern void print_string_array(const string_array_t * source);
  a[1:3] := b;
 
 */
-extern void indexed_assign_string_array(const string_array_t * source,
+extern void indexed_assign_string_array(const string_array_t source,
                                         string_array_t* dest,
                                         const index_spec_t* dest_spec);
 extern void simple_indexed_assign_string_array1(const string_array_t * source,


### PR DESCRIPTION
Handle the rvalue to lvalue expected by the function. Also refactor the
code shared by indexed assignment functions. This fixes ticket:4705.