### PR TITLE
Evaluate parameters with non-literal bindings

### DIFF
--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -344,7 +344,7 @@ algorithm
       DAE.Exp e;
 
     case (BackendDAE.VAR(bindExp=SOME(e)))
-    then not Expression.isConst(e);
+    then not Expression.isConstValue(e) /* Do not use isConst here; we need to evaluate non-literals at runtime */;
 
     else not varHasConstantStartExp(v);
   end match;
@@ -359,7 +359,7 @@ protected
 algorithm
   try
     e := varStartValueFail(v);
-    out := Expression.isConst(e);
+    out := Expression.isConstValue(e) /* Do not use isConst here; we need to evaluate non-literals at runtime */;
   else
     out := true;
   end try;


### PR DESCRIPTION
Previously, constant non-literal bindings such as `p=f(0)` were
ignored. This is because Expression.isConst was used while it should
have used isConstValue.