### PR TITLE
[NF] Various fixes.

### DIFF
--- a/Compiler/FrontEnd/MetaModelicaBuiltin.mo
+++ b/Compiler/FrontEnd/MetaModelicaBuiltin.mo
@@ -260,7 +260,7 @@ function intBitRShift
   output Integer o;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>Bit-wise right shift (like C, i << s).</p>
+<p>Bit-wise right shift (like C, i >> s).</p>
 </html>"));
 end intBitRShift;
 

--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -352,7 +352,7 @@ uniontype Call
 
   function typeSpecialBuiltinFunction
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -400,7 +400,7 @@ uniontype Call
   public
   function typeCall
     input output Expression callExp;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
           output Type ty;
           output Variability variability;
@@ -430,7 +430,7 @@ uniontype Call
 
   function typeMapIteratorCall
     input output Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
           output Type ty;
           output Variability variability;
@@ -474,7 +474,7 @@ uniontype Call
 
   function typeMatchNormalCall
     input output Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
           output Type ty;
           output Variability variability;
@@ -487,7 +487,7 @@ uniontype Call
 
   function typeNormalCall
     input output Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
   algorithm
     call := match call
@@ -537,7 +537,7 @@ uniontype Call
 
   function matchTypedNormalCall
     input output Call argtycall;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
           output Type ty;
           output Variability variability;
@@ -684,7 +684,7 @@ uniontype Call
 
   function typeArgs
     input output Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
   algorithm
     call := match call
@@ -1122,7 +1122,7 @@ protected
     "Types a function call that can be typed normally, but which always has
      discrete variability regardless of the variability of the arguments."
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1140,7 +1140,7 @@ protected
 
   function typeNdimsCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty = Type.INTEGER();
@@ -1172,7 +1172,7 @@ protected
 
   function typePreCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1207,7 +1207,7 @@ protected
 
   function typeChangeCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1240,7 +1240,7 @@ protected
 
   function typeDerCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1292,7 +1292,7 @@ protected
 
   function typeEdgeCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1325,7 +1325,7 @@ protected
 
   function typeMinMaxCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1347,7 +1347,7 @@ protected
 
   function typeSumProductCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1373,7 +1373,7 @@ protected
 
   function typeSmoothCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1393,7 +1393,7 @@ protected
 
   function typeFillCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1432,7 +1432,7 @@ protected
     input Type fillType;
     input list<Expression> fillArgs;
     input list<Expression> dimensionArgs;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1485,7 +1485,7 @@ protected
 
   function typeZerosOnesCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1519,7 +1519,7 @@ protected
 
   function typeScalarCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1559,7 +1559,7 @@ protected
 
   function typeVectorCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1603,7 +1603,7 @@ protected
 
   function typeMatrixCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1653,7 +1653,7 @@ protected
 
   function typeSymmetricCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1678,7 +1678,7 @@ protected
 
   function typeTransposeCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1717,7 +1717,7 @@ protected
 
   function typeCardinalityCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;
@@ -1737,7 +1737,7 @@ protected
 
   function typeNoEventCall
     input Call call;
-    input Integer origin;
+    input ExpOrigin.Type origin;
     input SourceInfo info;
     output Expression callExp;
     output Type ty;

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -39,6 +39,7 @@ protected
   import Function = NFFunction;
   import RangeIterator = NFRangeIterator;
   import NFPrefixes.Variability;
+  import Prefixes = NFPrefixes;
 
 public
   import Absyn.Path;
@@ -2249,7 +2250,6 @@ public
       else false;
     end match;
   end hasArrayCall2;
-
 
 annotation(__OpenModelica_Interface="frontend");
 end NFExpression;

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -140,13 +140,15 @@ algorithm
   // Flatten and convert the class into a DAE.
   (flat_model, funcs) := Flatten.flatten(inst_cls, name);
 
-  // Replace or collect package constants depending on the
-  // replacePackageConstants debug flag.
-  if Flags.isSet(Flags.REPLACE_PACKAGE_CONSTS) then
-    (flat_model, funcs) := Package.replaceConstants(flat_model, funcs);
-  else
-    flat_model := Package.collectConstants(flat_model, funcs);
-  end if;
+  // The backend doesn't handle constants well, so for now we just replace all
+  // constants in Typing.typeExp.
+  //// Replace or collect package constants depending on the
+  //// replacePackageConstants debug flag.
+  //if Flags.isSet(Flags.REPLACE_PACKAGE_CONSTS) then
+  //  (flat_model, funcs) := Package.replaceConstants(flat_model, funcs);
+  //else
+  //  flat_model := Package.collectConstants(flat_model, funcs);
+  //end if;
 
   flat_model := Scalarize.scalarize(flat_model, name);
   (dae, daeFuncs) := ConvertDAE.convert(flat_model, funcs, name, InstNode.info(inst_cls));

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -767,6 +767,8 @@ public constant Message NO_MATCHING_FUNCTION_FOUND_NFINST = MESSAGE(319, TRANSLA
   Util.gettext("No matching function found for %s.\nCandidates are:\n  %s"));
 public constant Message ARGUMENT_OUT_OF_RANGE = MESSAGE(320, TRANSLATION(), ERROR(),
   Util.gettext("Argument %s of %s is out of range (%s)"));
+public constant Message UNBOUND_CONSTANT = MESSAGE(321, TRANSLATION(), ERROR(),
+  Util.gettext("Constant %s is used without having been given a value."));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),


### PR DESCRIPTION
- Evaluate all constants in Typing.typeExp by default, and disable
  the package constant replacing phase since it's no longer needed.
- Don't evaluate iterators in Ceval.
- Use a type alias for ExpOrigin instead of Integer, to make it
  clearer what it is.
- Add generic error for unbound constants.