### PR TITLE
Do not elaborate using scripting functions in models

### DIFF
--- a/Compiler/FrontEnd/BackendInterface.mo
+++ b/Compiler/FrontEnd/BackendInterface.mo
@@ -71,7 +71,7 @@ algorithm
   (outCache, outValue) := CevalScript.cevalCallFunction(inCache, inEnv, inExp, inValues, inImplInst, inMsg, inNumIter);
 end cevalCallFunction;
 
-public function elabCallInteractive
+public function elabCallInteractive "Note: elabCall_InteractiveFunction is set in the error buffer; the called function should pop it"
   input FCore.Cache inCache;
   input FCore.Graph inEnv;
   input Absyn.ComponentRef inCref;

--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -6737,24 +6737,10 @@ algorithm
       then
         fail();
 
-    case () /* impl LS: Check if a builtin function call, e.g. size() and calculate if so */
+    case ()
+      /* Handle the scripting interface */
       algorithm
-        /* Remove errors relating to elabCallArgs, keeping only elabCallInteractive messages.
-         * Push these messages back if BackendInterface fails.
-         * This order is necessary if getErrorString() is called in the Backend (runScript, etc)
-         */
-        handles := ErrorExt.popCheckPoint("elabCall_InteractiveFunction");
-        try
-          /* An extra try-block to avoid the assignment to handles being optimized away */
-          ErrorExt.setCheckpoint("elabCall_InteractiveFunction1");
-          (cache,e,prop) := BackendInterface.elabCallInteractive(cache, env, fn, args, nargs, impl, pre, info) "Elaborate interactive function calls, such as simulate(), plot() etc." ;
-          ErrorExt.delCheckpoint("elabCall_InteractiveFunction1");
-        else
-          ErrorExt.rollBack("elabCall_InteractiveFunction1");
-          ErrorExt.pushMessages(handles);
-          fail();
-        end try;
-        ErrorExt.freeMessages(handles);
+        (cache,e,prop) := BackendInterface.elabCallInteractive(cache, env, fn, args, nargs, impl, pre, info) "Elaborate interactive function calls, such as simulate(), plot() etc." ;
       then (cache,e,prop);
 
   end matchcontinue;


### PR DESCRIPTION
For example, looking in OpenModelica.Scripting.xxx should not succeed
in models when performing model translation. It should only be performed
in the scripting context.