### PR TITLE
Move initialization of symboltable

### DIFF
--- a/Compiler/Main/Main.mo
+++ b/Compiler/Main/Main.mo
@@ -776,6 +776,7 @@ algorithm
   args_1 := Flags.new(args);
   System.gettextInit(if Config.getRunningTestsuite() then "C" else Flags.getConfigString(Flags.LOCALE_FLAG));
   setDefaultCC();
+  SymbolTable.reset();
 end init;
 
 public function main
@@ -848,8 +849,6 @@ algorithm
 
   try
     Settings.getInstallationDirectoryPath();
-
-    SymbolTable.reset();
 
     readSettings(args);
     if Flags.isSet(Flags.INTERACTIVE_TCP) then


### PR DESCRIPTION
The interactive clients all call Main.init, so init the symbol table
in this call as well.