### PR TITLE
Revert partially "Handle indexed assignment of string arrays"

### DIFF
--- a/SimulationRuntime/c/util/boolean_array.c
+++ b/SimulationRuntime/c/util/boolean_array.c
@@ -307,7 +307,7 @@ void simple_indexed_assign_boolean_array2(const boolean_array_t* source,
 void indexed_assign_boolean_array(const boolean_array_t source, boolean_array_t* dest,
                                   const index_spec_t* dest_spec)
 {
-    _index_t* idx_vec1, idx_size;
+    _index_t *idx_vec1, *idx_size;
     int j;
     indexed_assign_base_array_size_alloc(&source, dest, dest_spec, &idx_vec1, &idx_size);
 

--- a/SimulationRuntime/c/util/integer_array.c
+++ b/SimulationRuntime/c/util/integer_array.c
@@ -302,7 +302,7 @@ void simple_indexed_assign_integer_array2(const integer_array_t * source,
 void indexed_assign_integer_array(const integer_array_t source, integer_array_t* dest,
                                   const index_spec_t* dest_spec)
 {
-    _index_t* idx_vec1, idx_size;
+    _index_t *idx_vec1, *idx_size;
     int j;
     indexed_assign_base_array_size_alloc(&source, dest, dest_spec, &idx_vec1, &idx_size);
 

--- a/SimulationRuntime/c/util/real_array.c
+++ b/SimulationRuntime/c/util/real_array.c
@@ -279,7 +279,7 @@ void simple_indexed_assign_real_array2(const real_array_t * source,
 void indexed_assign_real_array(const real_array_t source, real_array_t* dest,
                                const index_spec_t* dest_spec)
 {
-    _index_t* idx_vec1, idx_size;
+    _index_t *idx_vec1, *idx_size;
     int j;
     indexed_assign_base_array_size_alloc(&source, dest, dest_spec, &idx_vec1, &idx_size);
 

--- a/SimulationRuntime/c/util/string_array.c
+++ b/SimulationRuntime/c/util/string_array.c
@@ -248,7 +248,7 @@ void indexed_assign_string_array(const string_array_t source,
                                  string_array_t* dest,
                                  const index_spec_t* dest_spec)
 {
-    _index_t* idx_vec1, idx_size;
+    _index_t *idx_vec1, *idx_size;
     int j;
     indexed_assign_base_array_size_alloc(&source, dest, dest_spec, &idx_vec1, &idx_size);
 


### PR DESCRIPTION
This fixes the PNlib on Windows, but I have no idea why. @sjoelund Any idea?