### PR TITLE
Bugfix for URI lookup in class

### DIFF
--- a/SimulationRuntime/c/util/utility.c
+++ b/SimulationRuntime/c/util/utility.c
@@ -314,7 +314,7 @@ extern modelica_string OpenModelica_uriToFilename_impl(threadData_t *threadData,
       /* Copy the old directory in there */
       strcpy(buf, MMC_STRINGDATA(dir));
       buf[MMC_STRLEN(dir)]='/';
-      if (!(0==stat(dir, &stat_buf) && S_ISDIR(stat_buf.st_mode))) {
+      if (!(0==stat(buf, &stat_buf) && S_ISDIR(stat_buf.st_mode))) {
         break;
       }
       dir = mmc_mk_scon(buf);


### PR DESCRIPTION
Classes in a package were not handled properly; the wrong directory
was used for the isDirectory check.