### PR TITLE
[NF] Implement proper handling of subscripts.

### DIFF
--- a/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -198,7 +198,7 @@ algorithm
   source := ElementSource.mergeSources(lhsSource, rhsSource);
   //source := ElementSource.addElementSourceConnect(source, (lhsCref, rhsCref));
 
-  ty := ComponentRef.getType(lhsCref);
+  ty := ComponentRef.getComponentType(lhsCref);
   lhs_exp := Expression.fromCref(lhsCref);
   rhs_exp := Expression.fromCref(rhsCref);
 

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -2081,13 +2081,15 @@ public
     input output list<list<list<Subscript>>> subs = {};
   protected
     list<list<Subscript>> cr_subs = {};
+    list<Dimension> dims;
+
+    import NFComponentRef.Origin;
   algorithm
     subs := match cref
-      case ComponentRef.CREF()
+      case ComponentRef.CREF(origin = Origin.CREF)
         algorithm
-          for dim in listReverse(Type.arrayDims(cref.ty)) loop
-            cr_subs := RangeIterator.map(RangeIterator.fromDim(dim), Subscript.makeIndex) :: cr_subs;
-          end for;
+          dims := Type.arrayDims(cref.ty);
+          cr_subs := Subscript.expandList(cref.subscripts, dims);
         then
           expandCref2(cref.restCref, cr_subs :: subs);
 
@@ -2103,7 +2105,7 @@ public
     output Expression arrayExp;
   algorithm
     arrayExp := match subs
-      case {} then CREF(crefType, ComponentRef.fillSubscripts(accum, cref));
+      case {} then CREF(crefType, ComponentRef.setSubscriptsList(accum, cref));
       else expandCref4(listHead(subs), {}, accum, listRest(subs), cref, crefType);
     end match;
   end expandCref3;
@@ -2555,7 +2557,7 @@ public
     input ComponentRef cref;
     output Expression exp;
   algorithm
-    exp := Expression.CREF(ComponentRef.getType(cref), cref);
+    exp := Expression.CREF(ComponentRef.getSubscriptedType(cref), cref);
   end fromCref;
 
   function toCref

--- a/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/Compiler/NFFrontEnd/NFScalarize.mo
@@ -65,7 +65,8 @@ algorithm
   end for;
 
   for eq in flatModel.equations loop
-    eql := scalarizeEquation(eq, eql); end for;
+    eql := scalarizeEquation(eq, eql);
+  end for;
 
   for eq in flatModel.initialEquations loop
     ieql := scalarizeEquation(eq, ieql);

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -511,14 +511,34 @@ public
   end toDAE;
 
   function subscript
+    "Reduces a type's dimensions based on the given list of subscripts."
     input output Type ty;
     input list<Subscript> subs;
+  protected
+    Dimension dim;
+    list<Dimension> dims, subbed_dims = {};
   algorithm
+    if listEmpty(subs) then
+      return;
+    end if;
+
+    dims := arrayDims(ty);
+
     for sub in subs loop
-      if Subscript.isIndex(sub) then
-        ty := unliftArray(ty);
-      end if;
+      dim :: dims := dims;
+
+      subbed_dims := match sub
+        case Subscript.INDEX() then subbed_dims;
+        case Subscript.SLICE() then Subscript.toDimension(sub) :: subbed_dims;
+        case Subscript.WHOLE() then dim :: subbed_dims;
+      end match;
     end for;
+
+    ty := arrayElementType(ty);
+
+    if not (listEmpty(subbed_dims) and listEmpty(dims)) then
+      ty := ARRAY(ty, listAppend(listReverse(subbed_dims), dims));
+    end if;
   end subscript;
 
   function isEqual

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -1380,12 +1380,19 @@ function matchDimensions
   input Dimension dim2;
   input Boolean allowUnknown;
   output Dimension compatibleDim;
-  output Boolean compatible = true;
+  output Boolean compatible;
+protected
+  Boolean known1, known2;
 algorithm
-  if Dimension.isEqualKnown(dim1, dim2) then
+  known1 := Dimension.isKnown(dim1);
+  known2 := Dimension.isKnown(dim2);
+
+  if known1 and known2 then
     compatibleDim := dim1;
+    compatible := Dimension.isEqual(dim1, dim2);
   elseif allowUnknown then
-    compatibleDim := if Dimension.isKnown(dim1) then dim1 else dim2;
+    compatibleDim := if known1 then dim1 else dim2;
+    compatible := true;
   else
     compatibleDim := dim1;
     compatible := false;
@@ -1673,7 +1680,7 @@ algorithm
           parent := component;
 
           for i in 1:InstNode.level(component) - binding_level loop
-            parent := InstNode.parent(component);
+            parent := InstNode.parent(parent);
             dims := Type.arrayDims(InstNode.getType(parent));
             comp_ty := Type.liftArrayLeftList(comp_ty, dims);
           end for;

--- a/Compiler/NFFrontEnd/NFVariable.mo
+++ b/Compiler/NFFrontEnd/NFVariable.mo
@@ -68,7 +68,7 @@ public
   algorithm
     node := ComponentRef.node(cref);
     comp := InstNode.component(node);
-    ty := ComponentRef.getType(cref);
+    ty := ComponentRef.getSubscriptedType(cref);
     binding := Component.getBinding(comp);
     vis := InstNode.visibility(node);
     attr := Component.getAttributes(comp);


### PR DESCRIPTION
- Change typing of crefs so that subscripts aren't taken into account
  when typing each part, only for the whole cref expression.
- Implement/fix expansion of subscript slices.
- Fix type checking of array dimensions so that it actually gives an
  error message and fails on mismatched dimensions.