### PR TITLE
[NF] Better handling of constants.

### DIFF
--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -141,15 +141,10 @@ algorithm
   // Flatten and convert the class into a DAE.
   (flat_model, funcs) := Flatten.flatten(inst_cls, name);
 
-  // The backend doesn't handle constants well, so for now we just replace all
-  // constants in Typing.typeExp.
-  //// Replace or collect package constants depending on the
-  //// replacePackageConstants debug flag.
-  //if Flags.isSet(Flags.REPLACE_PACKAGE_CONSTS) then
-  //  (flat_model, funcs) := Package.replaceConstants(flat_model, funcs);
-  //else
-  //  flat_model := Package.collectConstants(flat_model, funcs);
-  //end if;
+  // Collect package constants that couldn't be substituted with their values
+  // (e.g. because they where used with non-constants subscripts), and add them
+  // to the model.
+  flat_model := Package.collectConstants(flat_model, funcs);
 
   flat_model := Scalarize.scalarize(flat_model, name);
   (dae, daeFuncs) := ConvertDAE.convert(flat_model, funcs, name, InstNode.info(inst_cls));

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -526,8 +526,6 @@ constant DebugFlag SUSAN_MATCHCONTINUE_DEBUG = DEBUG_FLAG(175, "susanDebug", fal
   Util.gettext("Makes Susan generate code using try/else to better debug which function broke the expected match semantics."));
 constant DebugFlag OLD_FE_UNITCHECK = DEBUG_FLAG(176, "oldFrontEndUnitCheck", false,
   Util.gettext("Checks the consistency of units in equation (for the old front-end)."));
-constant DebugFlag REPLACE_PACKAGE_CONSTS = DEBUG_FLAG(177, "replacePackageConstants", true,
-  Util.gettext("Replaces package constants with their evaluated values if set."));
 
 // This is a list of all debug flags, to keep track of which flags are used. A
 // flag can not be used unless it's in this list, and the list is checked at
@@ -710,8 +708,7 @@ constant list<DebugFlag> allDebugFlags = {
   IGNORE_CYCLES,
   ALIAS_CONFLICTS,
   SUSAN_MATCHCONTINUE_DEBUG,
-  OLD_FE_UNITCHECK,
-  REPLACE_PACKAGE_CONSTS
+  OLD_FE_UNITCHECK
 };
 
 public


### PR DESCRIPTION
- Take the subscripts into account when determining the variability
  of a cref, so we don't try to e.g. evaluate a constant with
  non-constant subscripts.
- Turn on collection of package constants again, since they might be
  used in the flat model due to the above change.