### PR TITLE
Catch out of memory errors

### DIFF
--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -3136,7 +3136,7 @@ algorithm
     (outCache, outEnv, outIH, outStore, DAE.DAE(outDae), outSets, outState, outVars, outGraph, outFieldDomOpt) :=
       instElement(outCache, outEnv, outIH, outStore, inMod, inPrefix, outState, elt, inInstDims,
         inImplicit, inCallingScope, outGraph, inSets);
-    Error.updateCurrentComponent(Prefix.NOPRE(), "", Absyn.dummyInfo, PrefixUtil.identAndPrefixToPath);
+    Error.clearCurrentComponent();
     ErrorExt.delCheckpoint("instElement2");
   else // Instantiation failed, fail or skip the element depending on inStopOnError.
     if inStopOnError then

--- a/Compiler/FrontEnd/InstVar.mo
+++ b/Compiler/FrontEnd/InstVar.mo
@@ -604,9 +604,9 @@ algorithm
     outCache := InstFunction.addRecordConstructorFunction(outCache, inEnv,
       Types.arrayElementType(outType), SCode.elementInfo(inClass));
 
-    Error.updateCurrentComponent(Prefix.NOPRE(), "", Absyn.dummyInfo, PrefixUtil.identAndPrefixToPath);
+    Error.clearCurrentComponent();
   else
-    Error.updateCurrentComponent(Prefix.NOPRE(), "", Absyn.dummyInfo, PrefixUtil.identAndPrefixToPath);
+    Error.clearCurrentComponent();
     fail();
   end try;
 end instVar_dispatch;

--- a/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -3869,6 +3869,16 @@ annotation(
 </html>"));
 end GC_expand_hp;
 
+function GC_set_max_heap_size
+  input Integer size;
+  output Boolean success;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+<p>Forces the GC to limit the maximum heap size.</p>
+</html>"));
+end GC_set_max_heap_size;
+
 function checkInterfaceOfPackages
   input TypeName cl;
   input String dependencyMatrix[:,:];

--- a/Compiler/Script/CevalScript.mo
+++ b/Compiler/Script/CevalScript.mo
@@ -677,6 +677,11 @@ algorithm
         b = GC.expandHeap(i);
       then (cache,Values.BOOL(b));
 
+    case (cache,_,"GC_set_max_heap_size",{Values.INTEGER(i)},_)
+      equation
+        GC.setMaxHeapSize(i);
+      then (cache,Values.BOOL(true));
+
     case (cache,_,"clear",{},_)
       algorithm
         SymbolTable.reset();

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -933,6 +933,8 @@ public constant Message MOVING_PARAMETER_BINDING_TO_INITIAL_EQ_SECTION = MESSAGE
   Util.gettext("Moving binding to initial equation section and setting fixed attribute of %s to false."));
 public constant Message MIXED_DETERMINED = MESSAGE(583, SYMBOLIC(), ERROR(),
   Util.gettext("The given system is mixed-determined.   [index > %s]\nPlease checkout the option \"--maxMixedDeterminedIndex\"."));
+public constant Message STACK_OVERFLOW_DETAILED = MESSAGE(584, SCRIPTING(), ERROR(),
+  Util.gettext("Stack overflow occurred while evaluating %s:\n%s"));
 
 public constant Message MATCH_SHADOWING = MESSAGE(5001, TRANSLATION(), ERROR(),
   Util.gettext("Local variable '%s' shadows another variable."));
@@ -1069,7 +1071,19 @@ public constant Message CONFLICTING_ALIAS_SET = MESSAGE(7017, SYMBOLIC(), WARNIN
 public constant Message ENCRYPTION_NOT_SUPPORTED = MESSAGE(7018, SCRIPTING(), ERROR(),
   Util.gettext("File not Found: %s. Compile OpenModelica with Encryption support."));
 
-protected import ErrorExt;
+protected
+
+import ErrorExt;
+constant SourceInfo dummyInfo = SOURCEINFO("",false,0,0,0,0,0.0);
+
+public function clearCurrentComponent
+protected function dummy
+  input output String str;
+  input Integer i;
+end dummy;
+algorithm
+  updateCurrentComponent(0, "", dummyInfo, dummy);
+end clearCurrentComponent;
 
 public function updateCurrentComponent<T> "Function: updateCurrentComponent
 This function takes a String and set the global var to

--- a/Compiler/Util/GC.mo
+++ b/Compiler/Util/GC.mo
@@ -90,6 +90,11 @@ function setForceUnmapOnGcollect
   external "C" GC_set_force_unmap_on_gcollect(forceUnmap) annotation(Library = {"omcgc"});
 end setForceUnmapOnGcollect;
 
+function setMaxHeapSize
+  input Real sz "To avoid the 32-bit signed limit on sizes";
+external "C" GC_set_max_heap_size_dbl(sz) annotation(Include="#define GC_set_max_heap_size_dbl(sz) omc_GC_set_max_heap_size((size_t)sz)",Library = {"omcgc"});
+end setMaxHeapSize;
+
 uniontype ProfStats "TODO: Support regular records in the bootstrapped compiler to avoid allocation to return the stats in the GC..."
   record PROFSTATS
     Integer heapsize_full, free_bytes_full, unmapped_bytes, bytes_allocd_since_gc, allocd_bytes_before_gc, non_gc_bytes, gc_no, markers_m1, bytes_reclaimed_since_gc, reclaimed_bytes_before_gc;

--- a/Compiler/Util/StackOverflow.mo
+++ b/Compiler/Util/StackOverflow.mo
@@ -93,8 +93,15 @@ function generateReadableMessage
   output String str;
 algorithm
   StackOverflow.setStacktraceMessages(numSkip, numFrames);
-  str := stringDelimitList(StackOverflow.readableStacktraceMessages(),delimiter);
+  str := getReadableMessage(delimiter=delimiter);
 end generateReadableMessage;
+
+function getReadableMessage
+  input String delimiter="\n";
+  output String str;
+algorithm
+  str := stringDelimitList(StackOverflow.readableStacktraceMessages(),delimiter);
+end getReadableMessage;
 
 function readableStacktraceMessages
   output list<String> symbols = {};

--- a/Compiler/runtime/Error_omc.cpp
+++ b/Compiler/runtime/Error_omc.cpp
@@ -109,7 +109,7 @@ void Error_setShowErrorMessages(threadData_t *threadData,int show)
 static void omc_assert_compiler_common(threadData_t *threadData,ErrorLevel severity, FILE_INFO info, const char *msg, va_list args)
 {
   ErrorMessage::TokenList tokens;
-  char *str;
+  const char *str;
   GC_vasprintf(&str, msg, args);
   add_source_message(threadData, 0, ErrorType_runtime, severity, str, tokens, info.lineStart, info.colStart, info.lineEnd, info.colEnd, info.readonly, info.filename);
 }

--- a/Compiler/runtime/SimulationResults.c
+++ b/Compiler/runtime/SimulationResults.c
@@ -624,10 +624,10 @@ int SimulationResults_filterSimulationResults(const char *inFile, const char *ou
         }
       }
       msg[4] = inFile;
-      GC_asprintf((char**)msg+3, "%d", simresglob.matReader.nrows);
-      GC_asprintf((char**)msg+2, "%d", numberOfIntervals);
-      GC_asprintf((char**)msg+1, "%d", nevents);
-      GC_asprintf((char**)msg+0, "%d", neventpoints);
+      GC_asprintf(msg+3, "%d", simresglob.matReader.nrows);
+      GC_asprintf(msg+2, "%d", numberOfIntervals);
+      GC_asprintf(msg+1, "%d", nevents);
+      GC_asprintf(msg+0, "%d", neventpoints);
       c_add_message(NULL,-1, ErrorType_scripting, ErrorLevel_notification, gettext("Resampling %s from %s points to %s points, removing %s events stored in %s points.\n"), msg, 5);
     }
 
@@ -650,8 +650,8 @@ int SimulationResults_filterSimulationResults(const char *inFile, const char *ou
           var.index=indexesToOutput[i];
           if (omc_matlab4_val(vals+j, &simresglob.matReader, &var, t)) {
             msg[2] = inFile;
-            GC_asprintf((char**)msg+1, "%d", indexesToOutput[i]);
-            GC_asprintf((char**)msg+0, "%.15g", t);
+            GC_asprintf(msg+1, "%d", indexesToOutput[i]);
+            GC_asprintf(msg+0, "%.15g", t);
             c_add_message(NULL,-1, ErrorType_scripting, ErrorLevel_error, gettext("Resampling %s failed to get variable %s at time %s.\n"), msg, 3);
             return 0;
           }

--- a/Compiler/runtime/errorext.cpp
+++ b/Compiler/runtime/errorext.cpp
@@ -568,10 +568,9 @@ extern "C" {
 
 void OpenModelica_ErrorModule_ModelicaVFormatError(const char *fmt, va_list ap)
 {
-  char *str;
+  const char *str;
   GC_vasprintf(&str, fmt, ap);
   c_add_message(NULL,0,ErrorType_runtime,ErrorLevel_error,str,NULL,0);
-  GC_free(str);
   MMC_THROW();
 }
 

--- a/SimulationRuntime/c/Makefile.objs
+++ b/SimulationRuntime/c/Makefile.objs
@@ -15,10 +15,10 @@ meta_modelica.h \
 meta_modelica_mk_box.h
 
 #Files for gc folder
-GC_OBJS_MINIMAL = memory_pool$(OBJ_EXT)
+GC_OBJS_MINIMAL = memory_pool$(OBJ_EXT) omc_gc$(OBJ_EXT)
 GC_HFILES_MINIMAL = memory_pool.h
 
-GC_OBJS = omc_gc$(OBJ_EXT) $(GC_OBJS_MINIMAL)
+GC_OBJS = $(GC_OBJS_MINIMAL)
 GC_HFILES = omc_gc.h $(GC_HFILES_MINIMAL)
 
 # Files for util functions
@@ -173,7 +173,7 @@ FMI_ME_OBJS = $(GCOBJSPATH_MINIMAL) $(UTILOBJSPATH) $(MATHOBJSPATH) $(SIMOBJSPAT
   $(CMINPACK_OBJS:%=./external_solvers/%$(OBJ_EXT)) \
   $(LAPACK_OBJS:%=./external_solvers/%$(OBJ_EXT)) \
   $(BLAS_OBJS:%=./external_solvers/%$(OBJ_EXT)) \
-  $(LIBF2C_OBJS:%=./external_solvers/%$(OBJ_EXT)) \
+  $(LIBF2C_OBJS:%=./external_solvers/%$(OBJ_EXT))
 
 ALL_HEADERS = $(METAHFILESPATH) $(GCFILESPATH) $(UTILHFILESPATH) $(MATHHFILESPATH) $(SOLVERHFILESPATH) $(INITIALIZATIONHFILESPATH) $(OPTIMIZATIONHFILESPATH) $(RESULTSHFILESPATH) $(SIMHFILESPATH)
 ALL_PATHS = $(METAPATH) $(FMIPATH) $(GCPATH) $(UTILPATH) $(MATHPATH) $(SOLVERPATH) $(INITIALIZATIONPATH) $(OPTIMIZATIONPATH) $(RESULTSPATH) $(SIMPATH) linearization/

--- a/SimulationRuntime/c/meta/meta_modelica.c
+++ b/SimulationRuntime/c/meta/meta_modelica.c
@@ -813,7 +813,8 @@ modelica_integer mmc_gdb_arrayLength(modelica_metatype arr)
  */
 char* getMetaTypeElement(modelica_metatype arr, modelica_integer i, metaType mt) {
   void *name;
-  char *displayName = NULL, *ty = NULL, *formatString = NULL, *formattedString = NULL;
+  char *displayName = NULL, *ty = NULL, *formatString = NULL;
+  const char *formattedString = NULL;
   int n, n1;
 
   /* get the pointer to the element from the array/list */
@@ -873,7 +874,6 @@ char* getMetaTypeElement(modelica_metatype arr, modelica_integer i, metaType mt)
   }
 
   /* free the memory */
-  GC_free(formattedString);
   if (mt == record_metaType) {
     free(displayName);
   }

--- a/SimulationRuntime/c/simulation/modelinfo.c
+++ b/SimulationRuntime/c/simulation/modelinfo.c
@@ -68,7 +68,7 @@ static void indent(FILE *fout, int n) {
 static void convertProfileData(const char *outputPath, const char *prefix, int numFnsAndBlocks)
 {
   const char* fullFileName;
-  if (0 > GC_asprintf((char**)&fullFileName, "%s%s", outputPath, prefix)) {
+  if (0 > GC_asprintf(&fullFileName, "%s%s", outputPath, prefix)) {
     throwStreamPrint(NULL, "modelinfo.c: Error: can not allocate memory.");
   }
   size_t len = strlen(fullFileName);
@@ -320,7 +320,7 @@ int printModelInfo(DATA *data, threadData_t *threadData, const char *outputPath,
 {
   static char buf[256];
   const char* fullFileName;
-  if (0 > GC_asprintf((char**)&fullFileName, "%s%s", outputPath, filename)) {
+  if (0 > GC_asprintf(&fullFileName, "%s%s", outputPath, filename)) {
     throwStreamPrint(NULL, "modelinfo.c: Error: can not allocate memory.");
   }
   FILE *fout = fopen(fullFileName, "w");
@@ -329,7 +329,7 @@ int printModelInfo(DATA *data, threadData_t *threadData, const char *outputPath,
   int i;
 #if defined(__MINGW32__) || defined(_MSC_VER) || defined(NO_PIPE)
   const char* fullPlotFile;
-  if (0 > GC_asprintf((char**)&fullPlotFile, "%s%s", outputPath, plotfile)) {
+  if (0 > GC_asprintf(&fullPlotFile, "%s%s", outputPath, plotfile)) {
     throwStreamPrint(NULL, "modelinfo.c: Error: can not allocate memory.");
   }
   plotCommands = fopen(fullPlotFile, "w");
@@ -563,7 +563,7 @@ int printModelInfoJSON(DATA *data, threadData_t *threadData, const char *outputP
 {
   char buf[256];
   const char* fullFileName;
-  if (0 > GC_asprintf((char**)&fullFileName, "%s%s", outputPath, filename)) {
+  if (0 > GC_asprintf(&fullFileName, "%s%s", outputPath, filename)) {
     throwStreamPrint(NULL, "modelinfo.c: Error: can not allocate memory.");
   }
   FILE *fout = fopen(fullFileName, "wb");

--- a/SimulationRuntime/c/simulation/simulation_info_json.c
+++ b/SimulationRuntime/c/simulation/simulation_info_json.c
@@ -380,7 +380,7 @@ void modelInfoInit(MODEL_DATA_XML* xml)
   if (!xml->infoXMLData) {
     const char *filename;
     if (omc_flag[FLAG_INPUT_PATH]) { /* read the input path from the command line (if any) */
-      if (0 > GC_asprintf((char**)&filename, "%s/%s", omc_flagValue[FLAG_INPUT_PATH], xml->fileName)) {
+      if (0 > GC_asprintf(&filename, "%s/%s", omc_flagValue[FLAG_INPUT_PATH], xml->fileName)) {
         throwStreamPrint(NULL, "simulation_info_json.c: Error: can not allocate memory.");
       }
       mmap_reader = omc_mmap_open_read(filename);

--- a/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -444,13 +444,13 @@ void read_input_xml(MODEL_DATA* modelData,
     if (omc_flag[FLAG_F]) {
       filename = omc_flagValue[FLAG_F];
     } else if (omc_flag[FLAG_INPUT_PATH]) { /* read the input path from the command line (if any) */
-      if (0 > GC_asprintf((char**)&filename, "%s/%s_init.xml", omc_flagValue[FLAG_INPUT_PATH], modelData->modelFilePrefix)) {
+      if (0 > GC_asprintf(&filename, "%s/%s_init.xml", omc_flagValue[FLAG_INPUT_PATH], modelData->modelFilePrefix)) {
         throwStreamPrint(NULL, "simulation_input_xml.c: Error: can not allocate memory.");
       }
     } else {
       /* no file given on the command line? use the default
        * model_name defined in generated code for model.*/
-      if (0 > GC_asprintf((char**)&filename, "%s_init.xml", modelData->modelFilePrefix)) {
+      if (0 > GC_asprintf(&filename, "%s_init.xml", modelData->modelFilePrefix)) {
         throwStreamPrint(NULL, "simulation_input_xml.c: Error: can not allocate memory.");
       }
     }

--- a/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -460,7 +460,7 @@ int startNonInteractiveSimulation(int argc, char**argv, DATA* data, threadData_t
   if (result_file) {
     data->modelData->resultFileName = GC_strdup(result_file);
   } else if (omc_flag[FLAG_OUTPUT_PATH]) { /* read the output path from the command line (if any) */
-    if (0 > GC_asprintf((char**)&result_file, "%s/%s_res.%s", omc_flagValue[FLAG_OUTPUT_PATH], data->modelData->modelFilePrefix, data->simulationInfo->outputFormat)) {
+    if (0 > GC_asprintf(&result_file, "%s/%s_res.%s", omc_flagValue[FLAG_OUTPUT_PATH], data->modelData->modelFilePrefix, data->simulationInfo->outputFormat)) {
       throwStreamPrint(NULL, "simulation_runtime.c: Error: can not allocate memory.");
     }
     data->modelData->resultFileName = GC_strdup(result_file);

--- a/SimulationRuntime/c/util/modelica_string.c
+++ b/SimulationRuntime/c/util/modelica_string.c
@@ -306,17 +306,24 @@ extern char* omc__escapedString(const char* str, int nl)
   return res;
 }
 
-int GC_vasprintf(char **strp, const char *fmt, va_list ap) {
+int GC_vasprintf(const char **strp, const char *fmt, va_list ap) {
   int len;
+  char *tmp;
+  if (0==strstr(fmt, "%")) {
+    /* A no-op; we don't actually create a copy of the string which might be unexpected... */
+    *strp = fmt;
+    return strlen(fmt);
+  }
   va_list ap2;
   va_copy(ap2, ap);
   len = vsnprintf(NULL, 0, fmt, ap);
-  *strp = omc_alloc_interface.malloc_atomic(len+1);
-  len = vsnprintf(*strp, len+1, fmt, ap2);
+  tmp = mmc_check_out_of_memory(omc_alloc_interface.malloc_atomic(len+1));
+  len = vsnprintf(tmp, len+1, fmt, ap2);
+  *strp = tmp;
   return len;
 }
 
-int GC_asprintf(char **strp, const char *fmt, ...) {
+int GC_asprintf(const char **strp, const char *fmt, ...) {
   int len;
   va_list ap;
   va_start(ap, fmt);

--- a/SimulationRuntime/c/util/modelica_string.h
+++ b/SimulationRuntime/c/util/modelica_string.h
@@ -68,8 +68,8 @@ extern modelica_string enum_to_modelica_string(modelica_integer nr, const char *
 int omc__escapedStringLength(const char* str, int nl, int *hasEscape);
 extern char* omc__escapedString(const char* str, int nl);
 
-int GC_vasprintf(char **strp, const char *fmt, va_list ap);
-int GC_asprintf(char **strp, const char *fmt, ...);
+int GC_vasprintf(const char **strp, const char *fmt, va_list ap);
+int GC_asprintf(const char **strp, const char *fmt, ...);
 
 static inline void* mmc_alloc_scon(size_t nbytes)
 {
@@ -78,7 +78,7 @@ static inline void* mmc_alloc_scon(size_t nbytes)
     struct mmc_string *p;
     void *res;
     if (nbytes == 0) return mmc_emptystring;
-    p = (struct mmc_string *) omc_alloc_interface.malloc_atomic(nwords*sizeof(void*));
+    p = (struct mmc_string *) mmc_check_out_of_memory(omc_alloc_interface.malloc_atomic(nwords*sizeof(void*)));
     p->header = header;
     p->data[0] = 0;
     res = MMC_TAGPTR(p);
@@ -94,7 +94,7 @@ static inline void* mmc_mk_scon_len(mmc_uint_t nbytes)
     mmc_uint_t nwords = MMC_HDRSLOTS(header) + 1;
     struct mmc_string *p;
     void *res;
-    p = (struct mmc_string *) omc_alloc_interface.malloc_atomic(nwords*sizeof(void*));
+    p = (struct mmc_string *) mmc_check_out_of_memory(omc_alloc_interface.malloc_atomic(nwords*sizeof(void*)));
     p->header = header;
     res = MMC_TAGPTR(p);
     return res;
@@ -112,7 +112,7 @@ static inline void* mmc_mk_scon(const char *s)
       unsigned char c = *s;
       return mmc_strings_len1[(unsigned int)c];
     }
-    p = (struct mmc_string *) omc_alloc_interface.malloc_atomic(nwords*sizeof(void*));
+    p = (struct mmc_string *) mmc_check_out_of_memory(omc_alloc_interface.malloc_atomic(nwords*sizeof(void*)));
     p->header = header;
     memcpy(p->data, s, nbytes+1);  /* including terminating '\0' */
     res = MMC_TAGPTR(p);
@@ -135,7 +135,7 @@ static inline void* mmc_mk_scon_persist(const char *s)
       unsigned char c = *s;
       return mmc_strings_len1[(unsigned int)c];
     }
-    p = (struct mmc_string *) omc_alloc_interface.malloc_string_persist(nwords*sizeof(void*));
+    p = (struct mmc_string *) mmc_check_out_of_memory(omc_alloc_interface.malloc_string_persist(nwords*sizeof(void*)));
     p->header = header;
     memcpy(p->data, s, nbytes+1);  /* including terminating '\0' */
     res = MMC_TAGPTR(p);


### PR DESCRIPTION
Also added an API call to limit the maximum GC heap. This is useful
when you are using a ulimit on vmem since the OS simply kills the
process instead of making malloc calls return NULL.

The eval loop will now catch out of memory and stack overflow and
continue with the next command. This is annoying for mos-scripts but
is necessary to make OMPython not simply crash (we want to get the
error-message through getErrorString(), and hopefully there is enough
memory to get the string after collecting some garbage).