### PR TITLE
fix crashes in omccAPI if threadData is allocated in the heap

### DIFF
--- a/SimulationRuntime/c/meta/meta_modelica_data.h
+++ b/SimulationRuntime/c/meta/meta_modelica_data.h
@@ -250,6 +250,9 @@ void mmc_catch_dummy_fn();
 #define MMC_ELSE() } else { threadData->mmc_jumper = old_jumper;
 
 #define MMC_TRY_TOP() { threadData_t threadDataOnStack = {0}, *oldThreadData = (threadData_t*)pthread_getspecific(mmc_thread_data_key),*threadData = &threadDataOnStack; pthread_setspecific(mmc_thread_data_key,threadData); pthread_mutex_init(&threadData->parentMutex,NULL); mmc_init_stackoverflow(threadData); MMC_TRY_INTERNAL(mmc_jumper) threadData->mmc_stack_overflow_jumper = threadData->mmc_jumper; /* Let the default stack overflow handler be the top-level handler */
+
+#define MMC_TRY_TOP_SET(X) { threadData_t threadDataOnStack = *((threadData_t*)X), *oldThreadData = (threadData_t*)pthread_getspecific(mmc_thread_data_key),*threadData = &threadDataOnStack; pthread_setspecific(mmc_thread_data_key,threadData); pthread_mutex_init(&threadData->parentMutex,NULL); mmc_init_stackoverflow(threadData); MMC_TRY_INTERNAL(mmc_jumper) threadData->mmc_stack_overflow_jumper = threadData->mmc_jumper; /* Let the default stack overflow handler be the top-level handler */
+
 #define MMC_TRY_TOP_INTERNAL() { threadData_t *oldThreadData = (threadData_t*)pthread_getspecific(mmc_thread_data_key); pthread_setspecific(mmc_thread_data_key,threadData); pthread_mutex_init(&threadData->parentMutex,NULL); mmc_init_stackoverflow(threadData); MMC_TRY_INTERNAL(mmc_jumper) threadData->mmc_stack_overflow_jumper = threadData->mmc_jumper;
 #define MMC_CATCH_TOP(X) pthread_setspecific(mmc_thread_data_key,oldThreadData); } else {pthread_setspecific(mmc_thread_data_key,oldThreadData);X;}}}
 

--- a/SimulationRuntime/cpp/Core/ReduceDAE/com/ModelicaCompiler.cpp
+++ b/SimulationRuntime/cpp/Core/ReduceDAE/com/ModelicaCompiler.cpp
@@ -33,7 +33,7 @@ _model(model)
   std::cout << "Intialize OMC, use gcc" << std::endl;
 
 
-  status = InitOMC(&_omcPtr,"gcc",omhome, 1);
+  status = InitOMC(&_omcPtr,"gcc",omhome);
   if(status > 0)
   {
     std::cout << "..ok" << std::endl;
@@ -43,7 +43,7 @@ _model(model)
   {
     std::cout << "..failed" << std::endl;
     char* errorMsg = 0;
-    status = GetError(&_omcPtr, &errorMsg);
+    status = GetError(_omcPtr, &errorMsg);
     string errorMsgStr(errorMsg);
     throw std::runtime_error("error to intialize OMC: " + errorMsgStr);
   }
@@ -52,7 +52,7 @@ _model(model)
 
 ModelicaCompiler::~ModelicaCompiler(void)
 {
-
+   FreeOMC(_omcPtr);
 }
 
 void ModelicaCompiler::loadFile(bool load_file)
@@ -65,7 +65,7 @@ void ModelicaCompiler::loadFile(bool load_file)
   {
     //command="loadModel(Modelica)";
     command="loadModel(Modelica,{\"3.2.2\"})";
-    status=SendCommand(&_omcPtr,command.c_str(),&result);
+    status=SendCommand(_omcPtr,command.c_str(),&result);
     if(status>0)
       cout<<"load Modelica Library : "<< result<<std::endl;
     else
@@ -82,7 +82,7 @@ void ModelicaCompiler::loadFile(bool load_file)
   {
     //command="loadModel(Modelica)";
     command="loadModel(Modelica,{\"3.2.2\"})";
-    status=SendCommand(&_omcPtr,command.c_str(),&result);
+    status=SendCommand(_omcPtr,command.c_str(),&result);
 
     if(status>0)
       cout<<"load Modelica Library : "<< result<<std::endl;
@@ -101,7 +101,7 @@ void ModelicaCompiler::loadFile()
   char* result =0;
 
   command="loadModel(Modelica,{\"3.2.2\"})";
-  status = SendCommand(&_omcPtr, command.c_str(), &result);
+  status = SendCommand(_omcPtr, command.c_str(), &result);
 
   if(status>0)
     cout<<"load Modelica Library : "<< result<<std::endl;
@@ -131,7 +131,7 @@ void ModelicaCompiler::loadFile()
 
   cout << "PackageName : " << str << std::endl;
 
-  status=LoadFile(&_omcPtr,fileToLoad);
+  status=LoadFile(_omcPtr,fileToLoad);
   //status=LoadFile(_omcPtr,"package.mo");
 
   if(status>0)
@@ -141,7 +141,7 @@ void ModelicaCompiler::loadFile()
 
     std::cout << "failed to load "<<str << std::endl;
     char* errorMsg=0;
-    status = GetError(&_omcPtr,&errorMsg);
+    status = GetError(_omcPtr,&errorMsg);
     string errorMsgStr(errorMsg);
     throw std::runtime_error("error while loading file: " + str+" " + errorMsgStr);
   }
@@ -169,7 +169,7 @@ void ModelicaCompiler::generateLabeledSimCode(string reduction_method)
   //command.append(s);
   command.append(")");
   cout << command << std::endl;
-  int status = SendCommand(&_omcPtr, command.c_str(), &result);
+  int status = SendCommand(_omcPtr, command.c_str(), &result);
   if(status>0)
     cout<<"generated labeled simcode for: "<<_model<<" "<< result<<std::endl;
   else
@@ -177,7 +177,7 @@ void ModelicaCompiler::generateLabeledSimCode(string reduction_method)
 
     std::cout << "..failed" << std::endl;
     char* errorMsg=0;
-    status = GetError(&_omcPtr, &errorMsg);
+    status = GetError(_omcPtr, &errorMsg);
 
     throw std::runtime_error("error while executing " + command+ " with error " + errorMsg);
   }
@@ -192,7 +192,7 @@ void ModelicaCompiler::generateReferenceSolution()
   command.append(_model);
   command.append(_model);
   command.append(")");
-  int status = SendCommand(&_omcPtr, command.c_str(), &result);
+  int status = SendCommand(_omcPtr, command.c_str(), &result);
 
   if(status>0)
     cout<<"generated reference solution for: "<<_model<<" "<< result<<std::endl;
@@ -201,7 +201,7 @@ void ModelicaCompiler::generateReferenceSolution()
 
     std::cout << "..failed" << std::endl;
     char* errorMsg = 0;
-    status = GetError(&_omcPtr, &errorMsg);
+    status = GetError(_omcPtr, &errorMsg);
 
     throw std::runtime_error("error while executing  " + command+ " with error " + errorMsg);
   }
@@ -243,7 +243,7 @@ void ModelicaCompiler::reduceTerms(std::vector<unsigned int>& labels, double sta
   //command.append(")");
 
   cout<<command<<std::endl;
-  status = SendCommand(&_omcPtr, command.c_str(), &result);
+  status = SendCommand(_omcPtr, command.c_str(), &result);
   if(status>0)
     cout<<"reduceTerms for: "<<_model<<" "<< result<<std::endl;
   else
@@ -251,7 +251,7 @@ void ModelicaCompiler::reduceTerms(std::vector<unsigned int>& labels, double sta
 
     std::cout << "..failed" << std::endl;
     char* errorMsg = 0;
-    status = GetError(&_omcPtr, &errorMsg);
+    status = GetError(_omcPtr, &errorMsg);
 
     throw std::runtime_error("error while executing " + command+ " with error " + errorMsg);
   }
@@ -271,7 +271,7 @@ void ModelicaCompiler::reduceTerms(std::vector<unsigned int>& labels, double sta
   command.append(",startTime=0.0,stopTime = 20.0)");
 
   cout<<command<<std::endl;
-  status=SendCommand(&_omcPtr,command.c_str(),&result);
+  status=SendCommand(_omcPtr,command.c_str(),&result);
   if(status>0)
     cout<<"simulation for reduced model: "<<_model<<" "<< result<<std::endl;
   else
@@ -279,7 +279,7 @@ void ModelicaCompiler::reduceTerms(std::vector<unsigned int>& labels, double sta
 
     std::cout << "simulation for reduced model failed" << std::endl;
     char* errorMsg=0;
-    status = GetError(&_omcPtr, &errorMsg);
+    status = GetError(_omcPtr, &errorMsg);
 
     throw std::runtime_error("error while executing " + command+ " with error " + errorMsg);
   }

--- a/SimulationRuntime/cpp/Include/Core/ReduceDAE/com/ModelicaCompiler.h
+++ b/SimulationRuntime/cpp/Include/Core/ReduceDAE/com/ModelicaCompiler.h
@@ -17,6 +17,6 @@ private:
   string _model;
   string _model_path;
   string _file_name;
-  OMCData _omcPtr;
+  OMCData* _omcPtr;
   bool _load_package;
 };

--- a/SimulationRuntime/cpp/omcCAPI/include/OMC.h
+++ b/SimulationRuntime/cpp/omcCAPI/include/OMC.h
@@ -6,19 +6,10 @@
 
 #include "OMCAPI.h"
 
-/**
-Complete definition for OMCData
-*/
-OMC_DLL typedef struct OMCData
-{
-   OMCData(void *threadData);
-   ~OMCData();
-   void *threadData;
-} data;
-
-
 extern "C"
 {
+    OMC_DLL typedef struct OMCData data;
+
     void OMC_DLL InitMetaOMC();
     /**
     *  \brief Allocates and initializes OpenModelica compiler(omc) instance
@@ -26,7 +17,7 @@ extern "C"
     *  \param [out] omcPtr  pointer to allocated omc instance
     *  \return returns a status flag
     */
-   int OMC_DLL InitOMC(data* omcData, const char* compiler, const char* openModelicaHome, int initThreadData = 1);
+   int OMC_DLL InitOMC(data** omcDataPtr, const char* compiler, const char* openModelicaHome);
    /**
     *  \brief returns the version of the OpenModelica compiler (omc) instance
     *  \param [in] omcPtr Pointer to omc instance

--- a/SimulationRuntime/cpp/omcCAPI/src/OMC.cpp
+++ b/SimulationRuntime/cpp/omcCAPI/src/OMC.cpp
@@ -4,18 +4,31 @@
 #include <string>
 #include <iostream>
 
+/**
+Complete definition for OMCData
+*/
+OMC_DLL typedef struct OMCData
+{
+   OMCData(threadData_t *threadData);
+   ~OMCData();
+   threadData_t *threadData;
+} data;
+
+
 OMC_DLL OMCData::~OMCData()
 {
 
 
 }
 
-OMC_DLL OMCData::OMCData(void *data)
+OMC_DLL OMCData::OMCData(threadData_t *data)
   : threadData(data)
 {
 
 
 }
+
+#define CP_TD() (memcpy(omcData->threadData, threadData, sizeof(threadData_t)))
 
 extern "C" {
 
@@ -26,57 +39,43 @@ extern "C" {
     mmc_GC_init();
   }
 
-  int InitOMC(OMCData* omcData, const char* compiler, const char* openModelicaHome, int initThreadData)
+  int InitOMC(OMCData** omcDataPtr, const char* compiler, const char* openModelicaHome)
   {
-    threadData_t *threadData = 0;
-    // thread data is not initialized, do so
-    if (initThreadData)
-    {
-      MMC_ALLOC_AND_INIT_THREADDATA(threadData);
-      omcData->threadData = (void*)threadData;
-    }
-    else
-    {
-      threadData = (threadData_t *)omcData->threadData;
-    }
-    try
-    {
-      MMC_TRY_TOP_INTERNAL()
+    // alloc omcData
+    OMCData* omcData = new OMCData((threadData_t*)GC_malloc_uncollectable(sizeof(threadData_t)));
+    *omcDataPtr = omcData;
+    memset(omcData->threadData, 0, sizeof(threadData_t));
+
+    MMC_TRY_TOP_SET(omcData->threadData)
       void *args = mmc_mk_nil();
       omc_Main_init(threadData, mmc_mk_nil());
+      CP_TD();
 #ifdef WIN32
       omc_Main_setWindowsPaths(threadData, mmc_mk_scon(openModelicaHome));
+      CP_TD();
 #endif
       omc_Main_readSettings(threadData, mmc_mk_nil());
-      MMC_CATCH_TOP()
-    }
-    catch (std::exception &exception)
-    {
-      return -1;
-    }
+      CP_TD();
+    MMC_CATCH_TOP(return -1)
 
     std::string options = "+d=execstat +simCodeTarget=Cpp +target=" + std::string(compiler);
     std::cout << "options " << options << "\n";
-    if (SetCommandLineOptions(omcData, options.c_str()))
-      return 1;
-    else
+    if (SetCommandLineOptions(omcData, options.c_str()) == -1)
+    {
+      std::cout << "could not set OpenModelica options: " << options << std::endl;
       return -1;
+    }
   }
 
   int SetCommandLineOptions(data* omcData, const char* expression)
   {
     modelica_boolean result;
-    threadData_t *threadData = (threadData_t *)omcData->threadData;
-    try
-    {
-      MMC_TRY_TOP_INTERNAL()
+
+    MMC_TRY_TOP_SET(omcData->threadData)
       result = omc_OpenModelicaScriptingAPI_setCommandLineOptions(threadData, mmc_mk_scon(expression));
-      MMC_CATCH_TOP()
-    }
-    catch (std::exception &exception)
-    {
-      return -1;
-    }
+      CP_TD();
+    MMC_CATCH_TOP(return -1)
+
     if (result == true)
       return 1;
     else
@@ -85,20 +84,21 @@ extern "C" {
 
   int GetOMCVersion(OMCData* omcData, char** result)
   {
-    threadData_t *threadData = (threadData_t *)omcData->threadData;
     void *result_mm = NULL;
-    MMC_TRY_TOP_INTERNAL()
     std::string name = "OpenModelica";
-    result_mm = omc_OpenModelicaScriptingAPI_getVersion(threadData, mmc_mk_scon(name.c_str()));
-    MMC_CATCH_TOP()
-    *result = MMC_STRINGDATA(result_mm);
 
+    MMC_TRY_TOP_SET(omcData->threadData)
+      result_mm = omc_OpenModelicaScriptingAPI_getVersion(threadData, mmc_mk_scon(name.c_str()));
+      CP_TD();
+    MMC_CATCH_TOP(return -1)
+    *result = MMC_STRINGDATA(result_mm);
     return 1;
   }
 
   void FreeOMC(OMCData* omcData)
   {
-    // GC_free(omcData->threadData);
+    GC_free(omcData->threadData);
+    delete omcData;
   }
 
   int LoadModel(OMCData* omcData, const char* className)
@@ -112,16 +112,11 @@ extern "C" {
     modelica_boolean requireExactVersion = false;
     modelica_boolean result = false;
 
-    try
-    {
-      MMC_TRY_TOP_INTERNAL()
-        result = omc_OpenModelicaScriptingAPI_loadModel(threadData, mmc_mk_scon(className), priorityVersion_lst, notify, mmc_mk_scon(languageStandard.c_str()), requireExactVersion);
-      MMC_CATCH_TOP()
-    }
-    catch (std::exception &exception)
-    {
-      return -1;
-    }
+    MMC_TRY_TOP_SET(omcData->threadData)
+      result = omc_OpenModelicaScriptingAPI_loadModel(threadData, mmc_mk_scon(className), priorityVersion_lst, notify, mmc_mk_scon(languageStandard.c_str()), requireExactVersion);
+      CP_TD();
+    MMC_CATCH_TOP(return -1)
+
     if (result == true)
       return 1;
     else
@@ -130,21 +125,15 @@ extern "C" {
 
   int LoadFile(data* omcData, const char* fileName)
   {
-    threadData_t *threadData = (threadData_t *)omcData->threadData;
     modelica_boolean result;
     std::string encoding = "UTF-8";
     modelica_boolean uses = true; //Uses-annotations
 
-    try
-    {
-      MMC_TRY_TOP_INTERNAL()
-        result = omc_OpenModelicaScriptingAPI_loadFile(threadData, mmc_mk_scon(fileName), mmc_mk_scon(encoding.c_str()), uses);
-      MMC_CATCH_TOP()
-    }
-    catch (std::exception &ex)
-    {
-      return -1;
-    }
+    MMC_TRY_TOP_SET(omcData->threadData)
+      result = omc_OpenModelicaScriptingAPI_loadFile(threadData, mmc_mk_scon(fileName), mmc_mk_scon(encoding.c_str()), uses);
+      CP_TD();
+    MMC_CATCH_TOP(return -1)
+
     if (result == true)
       return 1;
     else
@@ -153,58 +142,53 @@ extern "C" {
 
   int GetError(data* omcData, char** result)
   {
-    threadData_t *threadData = (threadData_t *)omcData->threadData;
     modelica_boolean warningsAsErrors = true;
     void *result_mm = NULL;
 
-    try
-    {
-      MMC_TRY_TOP_INTERNAL()
-        result_mm = omc_OpenModelicaScriptingAPI_getErrorString(threadData, warningsAsErrors);
+    MMC_TRY_TOP_SET(omcData->threadData)
+      result_mm = omc_OpenModelicaScriptingAPI_getErrorString(threadData, warningsAsErrors);
+      CP_TD();
       (*result) = MMC_STRINGDATA(result_mm);
-      MMC_CATCH_TOP()
-    }
-    catch (std::exception &ex)
-    {
-      return -1;
-    }
+    MMC_CATCH_TOP(return -1)
+
     return 1;
   }
 
   int SetWorkingDirectory(data* omcData, const char* directory, char** result)
   {
-    threadData_t *threadData = (threadData_t *)omcData->threadData;
     void *reply_str = NULL;
-    try
-    {
-      MMC_TRY_TOP_INTERNAL()
-        reply_str = omc_OpenModelicaScriptingAPI_cd(threadData, mmc_mk_scon(directory));
-        (*result) = MMC_STRINGDATA(reply_str);
-      MMC_CATCH_TOP()
-    }
-    catch (std::exception &ex)
-    {
-      return -1;
-    }
+    MMC_TRY_TOP_SET(omcData->threadData)
+      reply_str = omc_OpenModelicaScriptingAPI_cd(threadData, mmc_mk_scon(directory));
+      CP_TD();
+      (*result) = MMC_STRINGDATA(reply_str);
+    MMC_CATCH_TOP(return -1)
 
     return 1;
   }
 
   int SendCommand(data* omcData, const char* expression, char** result)
   {
-    threadData_t *threadData = (threadData_t *)omcData->threadData;
+    int flagError = 0;
     void *reply_str = NULL;
-    MMC_TRY_TOP_INTERNAL()
+
+    MMC_TRY_TOP_SET(omcData->threadData)
     MMC_TRY_STACK()
-      if (!omc_Main_handleCommand(threadData, mmc_mk_scon(expression), &reply_str))
+      if (omc_Main_handleCommand(threadData, mmc_mk_scon(expression), &reply_str))
       {
-        return -1;
+        (*result) = MMC_STRINGDATA(reply_str);
       }
-      (*result) = MMC_STRINGDATA(reply_str);
+      else
+      {
+        flagError = 1;
+      }
+      CP_TD();
     MMC_ELSE()
       return -1;
     MMC_CATCH_STACK()
     MMC_CATCH_TOP();
+
+    if (flagError) return -1;
     return 1;
   }
 }
+

--- a/SimulationRuntime/cpp/omcCAPI/src/OMCTest.cpp
+++ b/SimulationRuntime/cpp/omcCAPI/src/OMCTest.cpp
@@ -101,42 +101,35 @@ void runTest(OMCData* omcData, std::string testfolder, std::string omhome)
 
 int main(int argc, const char* argv[])
 {
-  OMCData omcData = {0};
+  OMCData *omcData = 0;
   int status = 0;
 
   std::cout << "Test OMC C-API dll ..." << std::endl;
   InitMetaOMC();
 
-  // define the threadData on the stack as
-  // Boehm GC on Windows has issues otherwise
-  MMC_TRY_TOP();
-
-  omcData.threadData = (threadData_t*)threadData;
-
   /*----------------------------------------*/
   std::cout << "Initialize OMC, use gcc compiler" << std::endl;
   // if you send in 1 here it will crash on Windows, i need do debug more why this happens
-  status = InitOMC(&omcData, "gcc", "", 0);
+  status = InitOMC(&omcData, "gcc", "");
   if(status > 0)
     std::cout << "..ok" << std::endl;
   else
     std::cout << "..failed" << std::endl;
   /*----------------------------------------*/
 
+
   std::cout << "starting test 1" << std::endl;
   std::string dir = "./tmp1";
-  runTest(&omcData, dir, "");
+  runTest(omcData, dir, "");
   std::cout << "starting test 2" << std::endl;
   dir = "./tmp2";
-  runTest(&omcData, dir, "");
+  runTest(omcData, dir, "");
   std::cout << "starting test 3" << std::endl;
   dir = "./tmp3";
-  runTest(&omcData, dir, "");
+  runTest(omcData, dir, "");
 
   /*------------------------------------------*/
 
-  MMC_CATCH();
-
-  FreeOMC(&omcData);
+  FreeOMC(omcData);
 }
 


### PR DESCRIPTION
- hide threadData again
- set threadData and then copy it after each call