### PR TITLE
Improve reporting memory usage

### DIFF
--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -1021,7 +1021,7 @@ public constant Message UNIONTYPE_MISSING_TYPEVARS = MESSAGE(5044, TRANSLATION()
 public constant Message UNIONTYPE_WRONG_NUM_TYPEVARS = MESSAGE(5045, TRANSLATION(), ERROR(),
   Util.gettext("Uniontype %s has %s type variables, but got %s."));
 public constant Message SERIALIZED_SIZE = MESSAGE(5046, TRANSLATION(), NOTIFICATION(),
-  Util.gettext("%s has serialized size %s."));
+  Util.gettext("%s uses %s of memory."));
 
 public constant Message COMPILER_ERROR = MESSAGE(5999, TRANSLATION(), ERROR(),
   Util.notrans("%s"));

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -526,6 +526,8 @@ constant DebugFlag SUSAN_MATCHCONTINUE_DEBUG = DEBUG_FLAG(175, "susanDebug", fal
   Util.gettext("Makes Susan generate code using try/else to better debug which function broke the expected match semantics."));
 constant DebugFlag OLD_FE_UNITCHECK = DEBUG_FLAG(176, "oldFrontEndUnitCheck", false,
   Util.gettext("Checks the consistency of units in equation (for the old front-end)."));
+constant DebugFlag EXEC_STAT_EXTRA_GC = DEBUG_FLAG(177, "execstatGCcollect", false,
+  Util.gettext("When running execstat, also perform an extra full garbage collection."));
 
 // This is a list of all debug flags, to keep track of which flags are used. A
 // flag can not be used unless it's in this list, and the list is checked at
@@ -708,7 +710,8 @@ constant list<DebugFlag> allDebugFlags = {
   IGNORE_CYCLES,
   ALIAS_CONFLICTS,
   SUSAN_MATCHCONTINUE_DEBUG,
-  OLD_FE_UNITCHECK
+  OLD_FE_UNITCHECK,
+  EXEC_STAT_EXTRA_GC
 };
 
 public

--- a/Compiler/Util/Serializer.mo
+++ b/Compiler/Util/Serializer.mo
@@ -41,6 +41,7 @@ encapsulated package Serializer
  This package provides functions to serialize MetaModelica data.
  The external C implementation is in TOP/Compiler/runtime/Serializer.c"
 
+// Note: Reading back the data does not work as of 2018-02-19
 
 public function outputFile<T> "
 Prints the structure of the object."

--- a/Compiler/Util/System.mo
+++ b/Compiler/Util/System.mo
@@ -1301,5 +1301,14 @@ external "C" OpenModelica_updateUriMapping(OpenModelica.threadData(), namesAndDi
 </html>"));
 end updateUriMapping;
 
+function getSizeOfData<T>
+  input T data;
+  output Real sz;
+external "C" sz=SystemImpl__getSizeOfData(data) annotation(Library = {"omcruntime"}, Documentation(info="<html>
+Counts the number of bytes that were allocated to hold the given data structure.
+Includes constant data and handles cycles.
+</html>"));
+end getSizeOfData;
+
 annotation(__OpenModelica_Interface="util");
 end System;

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -395,7 +395,6 @@ if true then /* Suppress output */
     "../Util/HashTableStringToUnit.mo",
     "../Util/HashTableUnitToString.mo",
     "../Util/PriorityQueue.mo",
-    "../Util/Serializer.mo",
     "../Util/SimulationResults.mo",
     "../Util/TaskGraphResults.mo"
   };

--- a/Compiler/runtime/Makefile.common
+++ b/Compiler/runtime/Makefile.common
@@ -31,10 +31,11 @@ OMC_OBJ_STUBS = corbaimpl_stub_omc.o
 
 OMC_OBJ_BOOT = $(OMC_OBJ_SHARED) $(OMC_OBJ_STUBS)
 
-OMC_OBJ = $(OMC_OBJ_SHARED) serializer.o \
+OMC_OBJ = $(OMC_OBJ_SHARED) \
   ptolemyio_omc.o SimulationResults_omc.o \
   $(OMCCORBASRC)
 
+# serializer.o # Disabled 2018-02-19; doesn't work to read back data
 # Database_omc.o
 
 all: install

--- a/Compiler/runtime/systemimplmisc.cpp
+++ b/Compiler/runtime/systemimplmisc.cpp
@@ -3,6 +3,8 @@
 
 
 #include <string>
+#include <unordered_set>
+#include <stack>
 
 using namespace std;
 
@@ -42,6 +44,61 @@ extern "C" {
     return res;
   }
 
+#define GC_GRANULE_BYTES (2*sizeof(void*))
+
+static inline size_t actualByteSize(size_t sz)
+{
+  /* GC uses 2 words as the minimum allocation unit: a granule */
+  size_t res = GC_GRANULE_BYTES*((sz+GC_GRANULE_BYTES-1) / GC_GRANULE_BYTES);
+  return res;
+}
+#include <stdio.h>
+double SystemImpl__getSizeOfData(void *data)
+{
+  size_t sz=0;
+  std::unordered_set<void*> handled;
+  std::stack<void*> work;
+  work.push(data);
+  while (!work.empty()) {
+    void *item = work.top();
+    work.pop();
+    if (handled.find(item) != handled.end()) {
+      continue;
+    }
+    handled.insert(item);
+    if (MMC_IS_IMMEDIATE(item)) {
+      /* Uses up zero space */
+      continue;
+    }
+    mmc_uint_t hdr = MMC_GETHDR(item);
+    if (MMC_HDR_IS_FORWARD(hdr) || hdr==MMC_NILHDR || hdr==MMC_NONEHDR) {
+      /* Uses up zero space */
+      continue;
+    }
+    if (hdr==MMC_REALHDR) {
+      sz += actualByteSize(sizeof(void*)+sizeof(double));
+      continue;
+    }
+    if (MMC_HDRISSTRING(hdr)) {
+      sz += actualByteSize(sizeof(void*)+MMC_STRLEN(item)+1);
+      continue;
+    }
+    if (MMC_HDRISSTRUCT(hdr)) {
+      mmc_uint_t slots = MMC_HDRSLOTS(hdr);
+      mmc_uint_t ctor  = MMC_HDRCTOR(hdr);
+      sz += actualByteSize(sizeof(void*)*(slots+1));
+      // Push the sub-objects to the stack
+      for (int i = (ctor>=3 && ctor != MMC_ARRAY_TAG) ? 2 /* MM record description */ : 1; i <= slots; i++) {
+        void *ptr = (MMC_FETCH(MMC_OFFSET(MMC_UNTAGPTR(item), i)));
+        work.push(ptr);
+      }
+      continue;
+    }
+fprintf(stderr, "abort... bytes=%d num items=%d\n", sz, handled.size());
+printAny(item);
+    abort();
+  }
+  return sz;
 }
 
-
+}

--- a/Compiler/runtime/systemimplmisc.h
+++ b/Compiler/runtime/systemimplmisc.h
@@ -5,6 +5,8 @@ extern "C" {
 
   char* _replace(const char* source_str, const char* search_str, const char* replace_str);
 
+  int SystemImpl__getSizeOfData(void *data);
+
 }
 
 #endif


### PR DESCRIPTION
Disabled Serializer.mo and wrote a dedicated memory usage counter. It
also tries to account for GC overhead (allocating 24 bytes actually
results in 32 bytes being allocated).

Added -d=execstatGCcollect, which adds a GC.gcollect() and an extra
notification for each execstat event so we can track how much memory is
in use for each phase. This has a roughly 3x performance penalty as full
GC is expensive. -d=reportSerializedSize is even slower though, and
together they cause a 10x hit to performance.