### PR TITLE
Use set instead of unordered_set

### DIFF
--- a/Compiler/runtime/systemimplmisc.cpp
+++ b/Compiler/runtime/systemimplmisc.cpp
@@ -3,7 +3,7 @@
 
 
 #include <string>
-#include <unordered_set>
+#include <set>
 #include <stack>
 
 using namespace std;
@@ -56,7 +56,7 @@ static inline size_t actualByteSize(size_t sz)
 double SystemImpl__getSizeOfData(void *data)
 {
   size_t sz=0;
-  std::unordered_set<void*> handled;
+  std::set<void*> handled;
   std::stack<void*> work;
   work.push(data);
   while (!work.empty()) {


### PR DESCRIPTION
OSX has some difficulty using unordered_set so use set instead.
Performance is not important here since this is only used for debugging.