### PR TITLE
Improve MSVC compilation on Wine

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -140,8 +140,10 @@ checkMSVCwine:
 	test ! -z "$(WINE)"
 	test ! -z "$(OMDEV)"
 	test ! -z "$(VS140COMNTOOLS)"
-	"$(WINE)" cl.exe
-	"$(WINE)" cmd /c "if not exist $(OMDEV_CMAKE) (exit 1)"
+	$(WINE) cl.exe
+	$(WINE) cmd /c "if not exist $(OMDEV_CMAKE) (exit 1)"
+	# Remove wine-mono
+	$(WINE) uninstaller --remove '{E45D8920-A758-4088-B6C6-31DBB276992E}'
 
 wine_fmil_msvc: .wine_fmil_msvc
 .wine_fmil_msvc: checkMSVCwine
@@ -150,7 +152,7 @@ wine_fmil_msvc: .wine_fmil_msvc
 	# Goto build msvc directory
 	test -d 3rdParty/FMIL
 
-	(test -f $@ && test -d 3rdParty/FMIL/build_msvc && test -d 3rdParty/FMIL/install_msvc) || (rm -rf 3rdParty/FMIL/build_msvc && rm -rf 3rdParty/FMIL/install_msvc && mkdir -p 3rdParty/FMIL/build_msvc && cd 3rdParty/FMIL/build_msvc && "$(WINE)" "$(OMDEV_CMAKE)" -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DFMILIB_BUILD_TESTS=OFF -DFMILIB_BUILD_STATIC_LIB=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DFMILIB_INSTALL_PREFIX=../install_msvc ../ -G  "NMake Makefiles" && $(WINE) nmake /f Makefile install)
+	(test -f $@ && test -d 3rdParty/FMIL/build_msvc && test -d 3rdParty/FMIL/install_msvc) || (rm -rf 3rdParty/FMIL/build_msvc && rm -rf 3rdParty/FMIL/install_msvc && mkdir -p 3rdParty/FMIL/build_msvc && cd 3rdParty/FMIL/build_msvc && $(WINE) "$(OMDEV_CMAKE)" -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DFMILIB_BUILD_TESTS=OFF -DFMILIB_BUILD_STATIC_LIB=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DFMILIB_INSTALL_PREFIX=../install_msvc ../ -G  "NMake Makefiles" && $(WINE) nmake /f Makefile install)
 
 	(cp -puf 3rdParty/FMIL/install_msvc/lib/fmilib_shared.dll $(OMBUILDDIR)/lib/omc/msvc/fmilib.dll)
 	(cp -puf 3rdParty/FMIL/install_msvc/lib/fmilib_shared.lib $(OMBUILDDIR)/lib/omc/msvc/fmilib.lib)
@@ -166,7 +168,7 @@ wine_sundials_msvc: .wine_sundials_msvc
 	# Goto build msvc directory
 	test -d 3rdParty/sundials
 
-	(test -f $@ && test -d 3rdParty/sundials/build_msvc) || (rm -rf 3rdParty/sundials/build_msvc && mkdir -p 3rdParty/sundials/build_msvc && cd 3rdParty/sundials/build_msvc && "$(WINE)" "$(OMDEV_CMAKE)" -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DBUILD_STATIC_LIBS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=. ../ -G  "NMake Makefiles" && $(WINE) nmake /f Makefile install)
+	(test -f $@ && test -d 3rdParty/sundials/build_msvc) || (rm -rf 3rdParty/sundials/build_msvc && mkdir -p 3rdParty/sundials/build_msvc && cd 3rdParty/sundials/build_msvc && $(WINE) "$(OMDEV_CMAKE)" -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DBUILD_STATIC_LIBS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=. ../ -G  "NMake Makefiles" && $(WINE) nmake /f Makefile install)
 	mkdir -p $(OMBUILDDIR)/include/omc/msvc/sundials
 	(cp -pufr 3rdParty/sundials/build_msvc/include/* $(OMBUILDDIR)/include/omc/msvc/sundials)
 	(cp -puf 3rdParty/sundials/build_msvc/lib/* $(OMBUILDDIR)/lib/omc/msvc/)
@@ -178,7 +180,7 @@ wine_runc_msvc_release: .wine_runc_msvc_release
 	mkdir -p $(OMBUILDDIR)/lib/omc/msvc/release
 	echo 'Build the MSVC RELEASE'
 
-	(test -f $@ && test -d SimulationRuntime/c/build_msvc/) || (rm -rf SimulationRuntime/c/build_msvc && mkdir -p SimulationRuntime/c/build_msvc && cd SimulationRuntime/c/build_msvc && "$(WINE)" "$(OMDEV_CMAKE)" -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:String=$(OMBUILDDIR) ../ -G "NMake Makefiles" && "$(WINE)" nmake /f Makefile)
+	(test -f $@ && test -d SimulationRuntime/c/build_msvc/) || (rm -rf SimulationRuntime/c/build_msvc && mkdir -p SimulationRuntime/c/build_msvc && cd SimulationRuntime/c/build_msvc && $(WINE) "$(OMDEV_CMAKE)" -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:String=$(OMBUILDDIR) ../ -G "NMake Makefiles" && $(WINE) nmake /f Makefile)
 	@echo 'Copy the .lib files (needed for compilation) and .pdb files (needed for debugging) to $(OMBUILDDIR)/lib/omc'
 	(cd SimulationRuntime/c/build_msvc && find . -type f -path "*.lib" -exec cp {} $(OMBUILDDIR)/lib/omc/msvc/release/. \;)
 	(cd SimulationRuntime/c/build_msvc && find . -type f -path "*.pdb" -exec cp {} $(OMBUILDDIR)/lib/omc/msvc/release/. \;)
@@ -190,7 +192,7 @@ wine_runc_msvc_debug: .wine_runc_msvc_debug
 	mkdir -p $(OMBUILDDIR)/lib/omc/msvc/debug
 	echo 'Build the MSVC DEBUG'
 
-	(test -f $@ && test -d SimulationRuntime/c/build_msvc_debug/) || (rm -rf SimulationRuntime/c/build_msvc_debug && mkdir -p SimulationRuntime/c/build_msvc_debug && cd SimulationRuntime/c/build_msvc && "$(WINE)" "$(OMDEV_CMAKE)" -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:String=$(OMBUILDDIR) ../ -G "NMake Makefiles" && "$(WINE)" nmake /f Makefile)
+	(test -f $@ && test -d SimulationRuntime/c/build_msvc_debug/) || (rm -rf SimulationRuntime/c/build_msvc_debug && mkdir -p SimulationRuntime/c/build_msvc_debug && cd SimulationRuntime/c/build_msvc && $(WINE) "$(OMDEV_CMAKE)" -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:String=$(OMBUILDDIR) ../ -G "NMake Makefiles" && $(WINE) nmake /f Makefile)
 	@echo 'Copy the .lib files (needed for compilation) and .pdb files (needed for debugging) to $(OMBUILDDIR)/lib/omc'
 	(cd SimulationRuntime/c/build_msvc_debug && find . -type f -path "*.lib" -exec cp {} $(OMBUILDDIR)/lib/omc/msvc/debug/. \;)
 	(cd SimulationRuntime/c/build_msvc_debug && find . -type f -path "*.pdb" -exec cp {} $(OMBUILDDIR)/lib/omc/msvc/debug/. \;)
@@ -201,7 +203,7 @@ wine_runc_msvc_gc: .wine_runc_msvc_gc
 	# build gc as well, as it is needed for the msvc c runtime
 	@echo 'Build gc (RelWithDebInfo)'
 
-	(test -f $@ && test -d 3rdParty/gc/build_msvc/) || (rm -rf 3rdParty/gc/build_msvc/ && mkdir -p 3rdParty/gc/build_msvc && cd 3rdParty/gc/build_msvc && "$(WINE)" "$(OMDEV_CMAKE)" -DCMAKE_BUILD_TYPE=RelWithDebInfo ../ -G "NMake Makefiles" && "$(WINE)" nmake /f Makefile)
+	(test -f $@ && test -d 3rdParty/gc/build_msvc/) || (rm -rf 3rdParty/gc/build_msvc/ && mkdir -p 3rdParty/gc/build_msvc && cd 3rdParty/gc/build_msvc && $(WINE) "$(OMDEV_CMAKE)" -DCMAKE_BUILD_TYPE=RelWithDebInfo ../ -G "NMake Makefiles" && $(WINE) nmake /f Makefile)
 	@echo 'Copy the .lib files (needed for compilation) and .pdb files (needed for debugging) to $(OMBUILDDIR)/lib/omc/msvc/'
 	cp -u 3rdParty/gc/build_msvc/gc-lib.* $(OMBUILDDIR)/lib/omc/msvc/
 	@touch $@
@@ -210,7 +212,7 @@ wine_run_omc_msvc: .wine_run_omc_msvc
 .wine_run_omc_msvc: checkMSVCwine
 	@echo 'Build MSVC Compiler/runtime (RelWithDebInfo)'
 
-	(test -f $@ && test -d Compiler/runtime/build_msvc/) || (rm -rf Compiler/runtime/build_msvc/ && mkdir -p Compiler/runtime/build_msvc && cd Compiler/runtime/build_msvc && "$(WINE)" "$(OMDEV_CMAKE)" -DCMAKE_BUILD_TYPE=RelWithDebInfo ../ -G "NMake Makefiles" && "$(WINE)" nmake /f Makefile)
+	(test -f $@ && test -d Compiler/runtime/build_msvc/) || (rm -rf Compiler/runtime/build_msvc/ && mkdir -p Compiler/runtime/build_msvc && cd Compiler/runtime/build_msvc && $(WINE) "$(OMDEV_CMAKE)" -DCMAKE_BUILD_TYPE=RelWithDebInfo ../ -G "NMake Makefiles" && $(WINE) nmake /f Makefile)
 	@echo 'Copy the .lib files (needed for compilation) and .pdb files (needed for debugging) to $(OMBUILDDIR)/lib/omc/msvc/'
 	# cp -u Compiler/runtime/build_msvc/gc-lib.* $(OMBUILDDIR)/lib/omc/msvc/
 	@touch $@

--- a/scripts/wine-msvc.source
+++ b/scripts/wine-msvc.source
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+# Note: Depends on WSDK and W10SDK already being set. OMDEV should
+# also be set to compile using cmake with our makefiles
+
 WINEARCH=win32
-WINE=/opt/wine-stable/bin/wine
+WINE="env -u MAKE -u MAKEFLAGS /opt/wine-stable/bin/wine"
 WINEPREFIX=${WINEPREFIX:-$HOME/.wineprefixes/vs2015}
 export WINE
 export WINEARCH


### PR DESCRIPTION
- Do not pass GNU Make MAKEFLAGS to nmake.exe
- Uninstall wine-mono to reduce the log-file