### PR TITLE
Improve report of used size of MM datatypes

### DIFF
--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -202,7 +202,7 @@ algorithm
           ExecStat.execStat("FrontEnd - scodeFlatten");
         end if;
         (cache,env) = Builtin.initialGraph(cache);
-        env_1 = FGraphBuildEnv.mkProgramGraph(cdecls, FCore.USERDEFINED(), env);
+        env = FGraphBuildEnv.mkProgramGraph(cdecls, FCore.USERDEFINED(), env);
 
         // set the source of this element
         source = ElementSource.addElementSourcePartOfOpt(DAE.emptyElementSource, FGraph.getScopePath(env));
@@ -212,7 +212,7 @@ algorithm
         end if;
         ExecStat.execStat("FrontEnd - mkProgramGraph");
 
-        (cache,env_2,ih,dae2) = instClassInProgram(cache, env_1, ih, cdecls, path, source);
+        (cache,env,ih,dae2) = instClassInProgram(cache, env, ih, cdecls, path, source);
         // check the models for balancing
         //Debug.fcall2(Flags.CHECK_MODEL_BALANCE, checkModelBalancing, SOME(path), dae1);
         //Debug.fcall2(Flags.CHECK_MODEL_BALANCE, checkModelBalancing, SOME(path), dae2);
@@ -220,7 +220,7 @@ algorithm
         // let the GC collect these as they are used only by Inst!
         releaseInstHashTable();
       then
-        (cache,env_2,ih,dae2);
+        (cache,env,ih,dae2);
 
     // class in package
     case (cache,ih,(cdecls as (_ :: _)),(path as Absyn.QUALIFIED()))
@@ -240,13 +240,13 @@ algorithm
 
         //System.startTimer();
         //print("\nInstClassDecls");
-        env_1 = FGraphBuildEnv.mkProgramGraph(cdecls, FCore.USERDEFINED(), env);
+        env = FGraphBuildEnv.mkProgramGraph(cdecls, FCore.USERDEFINED(), env);
         //System.stopTimer();
         //print("\nInstClassDecls: " + realString(System.getTimerIntervalTime()));
 
         //System.startTimer();
         //print("\nLookupClass");
-        (cache,(cdef as SCode.CLASS(name = n)),env_2) = Lookup.lookupClass(cache, env_1, path, SOME(Absyn.dummyInfo));
+        (cache,(cdef as SCode.CLASS(name = n)),env) = Lookup.lookupClass(cache, env, path, SOME(Absyn.dummyInfo));
 
         //System.stopTimer();
         //print("\nLookupClass: " + realString(System.getTimerIntervalTime()));
@@ -258,8 +258,8 @@ algorithm
         end if;
         ExecStat.execStat("FrontEnd - mkProgramGraph");
 
-        (cache,env_2,ih,_,dae,_,_,_,_,_) = instClass(cache,env_2,ih,
-          UnitAbsynBuilder.emptyInstStore(),DAE.NOMOD(), makeTopComponentPrefix(env_2, n), cdef,
+        (cache,env,ih,_,dae,_,_,_,_,_) = instClass(cache,env,ih,
+          UnitAbsynBuilder.emptyInstStore(),DAE.NOMOD(), makeTopComponentPrefix(env, n), cdef,
           {}, false, InstTypes.TOP_CALL(), ConnectionGraph.EMPTY, Connect.emptySet) "impl";
         //System.stopTimer();
         //print("\nInstClass: " + realString(System.getTimerIntervalTime()));
@@ -267,7 +267,7 @@ algorithm
         //System.startTimer();
         //print("\nReEvaluateIf");
         //print(" ********************** backpatch 1 **********************\n");
-        dae = InstUtil.reEvaluateInitialIfEqns(cache,env_2,dae,true);
+        dae = InstUtil.reEvaluateInitialIfEqns(cache,env,dae,true);
         //System.stopTimer();
         //print("\nReEvaluateIf: " + realString(System.getTimerIntervalTime()));
 
@@ -287,7 +287,7 @@ algorithm
         // let the GC collect these as they are used only by Inst!
         releaseInstHashTable();
       then
-        (cache, env_2, ih, dae);
+        (cache, env, ih, dae);
 
   end match;
 end instantiateClass_dispatch;

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -1021,7 +1021,7 @@ public constant Message UNIONTYPE_MISSING_TYPEVARS = MESSAGE(5044, TRANSLATION()
 public constant Message UNIONTYPE_WRONG_NUM_TYPEVARS = MESSAGE(5045, TRANSLATION(), ERROR(),
   Util.gettext("Uniontype %s has %s type variables, but got %s."));
 public constant Message SERIALIZED_SIZE = MESSAGE(5046, TRANSLATION(), NOTIFICATION(),
-  Util.gettext("%s uses %s of memory."));
+  Util.gettext("%s uses %s of memory (%s without GC overhead)."));
 
 public constant Message COMPILER_ERROR = MESSAGE(5999, TRANSLATION(), ERROR(),
   Util.notrans("%s"));

--- a/Compiler/Util/System.mo
+++ b/Compiler/Util/System.mo
@@ -1310,7 +1310,8 @@ end updateUriMapping;
 function getSizeOfData<T>
   input T data;
   output Real sz;
-external "C" sz=SystemImpl__getSizeOfData(data) annotation(Library = {"omcruntime"}, Documentation(info="<html>
+  output Real raw_sz "The size without granule overhead";
+external "C" sz=SystemImpl__getSizeOfData(data, raw_sz) annotation(Library = {"omcruntime"}, Documentation(info="<html>
 Counts the number of bytes that were allocated to hold the given data structure.
 Includes constant data and handles cycles.
 </html>"));


### PR DESCRIPTION
We now collect both how many bytes we want to allocate and how much
memory libGC will consume and report this when reportSerializedSize
is used.

Also fixed a bug where the incorrect size was calculated for the GC
overhead: GC uses 1 byte internally so a 15-byte allocation allocates
a single 16-byte granule whereas a 16-byte allocation allocates 2 16-
byte granules. This accounts for a 20% overhead that was not accounted
for previously.