### PR TITLE
Fix handling of element redeclare condition.

### DIFF
--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -3175,6 +3175,12 @@ algorithm
     (el, _) := element;
     (el_name, info) := InstUtil.extractCurrentName(el);
 
+    // An element redeclare may not have a condition.
+    if SCode.isElementRedeclare(el) then
+      Error.addSourceMessage(Error.REDECLARE_CONDITION, {el_name}, info);
+      fail();
+    end if;
+
     (cond_val_opt, cache) :=
       InstUtil.instElementCondExp(cache, env, el, prefix, info);
 

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -775,6 +775,8 @@ public constant Message AMBIGUOUS_MATCHING_FUNCTIONS_NFINST = MESSAGE(323, TRANS
   Util.gettext("Ambiguous matching functions found for %s.\nCandidates are:\n  %s"));
 public constant Message AMBIGUOUS_MATCHING_OPERATOR_FUNCTIONS_NFINST = MESSAGE(324, TRANSLATION(), ERROR(),
   Util.gettext("Ambiguous matching overloaded operator functions found for %s.\nCandidates are:\n  %s"));
+public constant Message REDECLARE_CONDITION = MESSAGE(325, TRANSLATION(), ERROR(),
+  Util.gettext("Invalid redeclaration of %s, a redeclare may not have a condition attribute."));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),

--- a/Compiler/runtime/ErrorMessage.cpp
+++ b/Compiler/runtime/ErrorMessage.cpp
@@ -107,7 +107,7 @@ std::string ErrorMessage::getMessage_(int warningsAsErrors)
       message_.replace(str_pos, 2, *tok);
       str_pos += tok->size();
       *tok++;
-    } else if(index_symbol >= '0' || index_symbol <= '9') {
+    } else if(index_symbol >= '0' && index_symbol <= '9') {
       index = index_symbol - '0' - 1;
 
       if(index >= tokens_.size() || index < 0) {
@@ -119,6 +119,8 @@ std::string ErrorMessage::getMessage_(int warningsAsErrors)
 
       message_.replace(str_pos, 2, tokens_[index]);
       str_pos += tokens_[index].size();
+    } else {
+      ++str_pos;
     }
   }
   veryshort_msg = message_;


### PR DESCRIPTION
- Add error message when an element redeclare includes a condition.
- Fix the sanity check for positional argument indices in the error
  message handling code.