### PR TITLE
[NF] Add support for array concatenation

### DIFF
--- a/Compiler/FrontEnd/Ceval.mo
+++ b/Compiler/FrontEnd/Ceval.mo
@@ -1819,12 +1819,13 @@ algorithm
       Boolean impl;
       Absyn.Msg msg;
       FCore.Cache cache;
+      list<Integer> dims;
 
     case (cache,env,{arr,dim},impl,msg,_)
       equation
-        (cache,arr_val) = ceval(cache,env, arr, impl, msg,numIter+1);
+        (cache,arr_val as Values.ARRAY(dimLst=dims)) = ceval(cache,env, arr, impl, msg,numIter+1);
         (cache,Values.INTEGER(dim_val)) = ceval(cache,env, dim, impl, msg,numIter+1);
-        res = cevalBuiltinPromote2(arr_val, dim_val);
+        res = cevalBuiltinPromote2(arr_val, dim_val - listLength(dims));
       then
         (cache,res);
   end match;
@@ -1847,8 +1848,13 @@ algorithm
       equation
         n_1 = n - 1;
         (vs_1 as (Values.ARRAY(dimLst = il)::_)) = List.map1(vs, cevalBuiltinPromote2, n_1);
-      then
-        Values.ARRAY(vs_1,i::il);
+      then Values.ARRAY(vs_1,i::il);
+    case (v,n)
+      equation
+        failure(Values.ARRAY() = v);
+        n_1 = n - 1;
+        (v as Values.ARRAY(dimLst = il)) = cevalBuiltinPromote2(v, n_1);
+      then Values.ARRAY({v},1::il);
     else
       equation
         true = Flags.isSet(Flags.FAILTRACE);

--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -10778,7 +10778,7 @@ algorithm
 
         // Use the constructed types to promote the expression.
         is_array_ty = Types.isArray(inType);
-        exp = promoteExp2(inExp, is_array_ty, dims_to_add, tys);
+        exp = promoteExp2(inExp, is_array_ty, inDims, tys);
       then
         (exp, res_ty);
 

--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -2823,7 +2823,7 @@ protected
   DAE.Properties prop;
   list<DAE.Properties> rest_props;
   DAE.Type ty, sty;
-  DAE.Dimension dim2;
+  DAE.Dimension dim1, dim2;
 algorithm
   try
     exp :: rest_expl := inExpl;
@@ -2839,7 +2839,10 @@ algorithm
 
       (exp, prop as DAE.PROP(type_ = ty)) := promoteExp(exp, prop, inDims);
       accum_expl := exp :: accum_expl;
-      _ :: dim2 :: _ := Types.getDimensions(ty);
+      dim1 :: dim2 :: _ := Types.getDimensions(ty);
+      if not Expression.dimensionsEqual(dim1, outDim1) then
+        Error.addSourceMessageAndFail(Error.COMMA_OPERATOR_DIFFERENT_SIZES, {ExpressionDump.printExpStr(listHead(inExpl)), ExpressionDump.dimensionString(outDim1), ExpressionDump.printExpStr(exp), ExpressionDump.dimensionString(dim1)}, inInfo);
+      end if;
       // Comma between matrices => concatenation along second dimension.
       outDim2 := Expression.dimensionsAdd(dim2, outDim2);
       outProperties := Types.matchWithPromote(prop, outProperties, inHaveReal);

--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -161,5 +161,13 @@ constant Function IN_STREAM = Function.FUNCTION(Path.IDENT("inStream"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
 
+constant Function PROMOTE = Function.FUNCTION(Path.IDENT("promote"),
+  InstNode.EMPTY_NODE(), {}, {}, {}, {},
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+
+constant Function CAT = Function.FUNCTION(Path.IDENT("cat"),
+  InstNode.EMPTY_NODE(), {}, {}, {}, {},
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+
 annotation(__OpenModelica_Interface="frontend");
 end NFBuiltinFuncs;

--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -370,6 +370,7 @@ uniontype Call
     (callExp, ty, variability) := match ComponentRef.firstName(cref)
       case "String" then typeStringCall(call, origin, info);
       case "cardinality" then typeCardinalityCall(call, origin, info);
+      case "cat" then typeCatCall(call, origin, info);
       case "change" then typeChangeCall(call, origin, info);
       case "der" then typeDerCall(call, origin, info);
       case "diagonal" then typeDiagonalCall(call, origin, info);
@@ -394,7 +395,7 @@ uniontype Call
       case "zeros" then typeZerosOnesCall(call, origin, info);
       else
         algorithm
-          Error.assertion(false, getInstanceName() + " got unhandled builtin function", sourceInfo());
+          Error.assertion(false, getInstanceName() + " got unhandled builtin function: " + Call.toString(call), sourceInfo());
         then
           fail();
     end match;
@@ -434,6 +435,10 @@ uniontype Call
           variability := call.var;
         then
           ();
+      else
+        algorithm
+          Error.assertion(false, getInstanceName() + ": " + Expression.toString(callExp), sourceInfo());
+        then fail();
     end match;
   end typeCall;
 
@@ -520,6 +525,7 @@ uniontype Call
   protected
     InstNode fn_node;
     Boolean typed, special;
+    String name;
   algorithm
     functions := match functionRef
       case ComponentRef.CREF(node = fn_node)
@@ -833,6 +839,138 @@ uniontype Call
     end match;
   end setType;
 
+  function makeBuiltinCat
+    input Integer n;
+    input list<Expression> args;
+    input list<Type> tys;
+    input SourceInfo info;
+    output Expression callExp;
+    output Type ty;
+  protected
+    Expression arg2;
+    list<Expression> args2 = {}, res = {};
+    list<Type> tys2 = tys, tys3;
+    list<list<Dimension>> dimsLst = {};
+    list<Dimension> dims;
+    Type resTy = Type.UNKNOWN(), ty1, ty2, resTyToMatch;
+    TypeCheck.MatchKind mk;
+    Integer maxn, pos;
+    Dimension sumDim;
+  algorithm
+    Error.assertion(listLength(args)==listLength(tys) and listLength(args)>=1, getInstanceName() + " got wrong input sizes", sourceInfo());
+
+    // First: Get the number of dimensions and the element type
+
+    for arg in args loop
+      ty::tys2 := tys2;
+      dimsLst := Type.arrayDims(ty) :: dimsLst;
+      if Type.isEqual(resTy, Type.UNKNOWN()) then
+        resTy := Type.arrayElementType(ty);
+      else
+        (,, ty1, mk) := TypeCheck.matchExpressions(Expression.INTEGER(0), Type.arrayElementType(ty), Expression.INTEGER(0), resTy);
+        if TypeCheck.isCompatibleMatch(mk) then
+          resTy := ty1;
+        end if;
+      end if;
+    end for;
+
+    maxn := max(listLength(d) for d in dimsLst);
+    if maxn <> min(listLength(d) for d in dimsLst) then
+      Error.addSourceMessageAndFail(Error.NF_DIFFERENT_NUM_DIM_IN_ARGUMENTS, {stringDelimitList(list(String(listLength(d)) for d in dimsLst), ", "), "cat"}, info);
+    end if;
+    if n < 1 or n > maxn then
+      Error.addSourceMessageAndFail(Error.NF_CAT_WRONG_DIMENSION, {String(maxn), String(n)}, info);
+    end if;
+
+    tys2 := tys;
+    tys3 := {};
+    args2 := {};
+    pos := listLength(args)+2;
+
+    // Second: Try to match the element type of all the arguments
+
+    for arg in args loop
+      ty::tys2 := tys2;
+      pos := pos-1;
+      ty2 := Type.setArrayElementType(ty, resTy);
+      (arg2, ty1, mk) := TypeCheck.matchTypes(ty, ty2, arg);
+      if TypeCheck.isIncompatibleMatch(mk) then
+        Error.addSourceMessageAndFail(Error.ARG_TYPE_MISMATCH, {String(pos), "cat", "arg", Expression.toString(arg), Type.toString(ty), Type.toString(ty2)}, info);
+      end if;
+      args2 := arg2 :: args2;
+      tys3 := ty1 :: tys3;
+    end for;
+
+    // Third: We now have matched the element types of all arguments
+    //        Try to match the dimensions as well
+
+    resTy := Type.UNKNOWN();
+    tys2 := tys3;
+
+    for arg in args2 loop
+      ty::tys2 := tys2;
+
+      if Type.isEqual(resTy, Type.UNKNOWN()) then
+        resTy := ty;
+      else
+        (,, ty1, mk) := TypeCheck.matchExpressions(Expression.INTEGER(0), ty, Expression.INTEGER(0), resTy);
+        if TypeCheck.isCompatibleMatch(mk) then
+          resTy := ty1;
+        end if;
+      end if;
+    end for;
+
+    // Got the supertype of the dimensions; trying to match all arguments
+    // with the concatenated dimension set to unknown.
+
+    dims := Type.arrayDims(resTy);
+    resTyToMatch := Type.ARRAY(Type.arrayElementType(resTy), List.set(dims, n, Dimension.UNKNOWN()));
+    dims := list(listGet(lst, n) for lst in dimsLst);
+    sumDim := Dimension.INTEGER(0);
+    for d in dims loop
+      // Create the concatenated dimension
+      sumDim := Dimension.add(sumDim, d);
+    end for;
+    resTy := Type.ARRAY(Type.arrayElementType(resTy), List.set(Type.arrayDims(resTy), n, sumDim));
+    tys2 := tys3;
+    tys3 := {};
+    res := {};
+    pos := listLength(args)+2;
+
+    for arg in args2 loop
+      ty::tys2 := tys2;
+      pos := pos-1;
+      (arg2, ty1, mk) := TypeCheck.matchTypes(ty, resTyToMatch, arg, allowUnknown=true);
+      if TypeCheck.isIncompatibleMatch(mk) then
+        Error.addSourceMessageAndFail(Error.ARG_TYPE_MISMATCH, {String(pos), "cat", "arg", Expression.toString(arg), Type.toString(ty), Type.toString(resTyToMatch)}, info);
+      end if;
+      res := arg2 :: res;
+      tys3 := ty1 :: tys3;
+    end for;
+
+    // We have all except dimension n having equal sizes; with matching types
+
+    ty := resTy;
+    callExp := Expression.CALL(makeBuiltinCall2(NFBuiltinFuncs.CAT, Expression.INTEGER(n)::res, resTy));
+  end makeBuiltinCat;
+
+protected
+  function matchFunction
+    input Function func;
+    input list<TypedArg> args;
+    input list<TypedNamedArg> named_args;
+    input SourceInfo info;
+    output list<TypedArg> out_args;
+    output Boolean matched;
+    output FunctionMatchKind matchKind;
+  algorithm
+    (out_args, matched) := Function.fillArgs(args, named_args, func, info);
+    if matched then
+      (out_args, matched, matchKind) := Function.matchArgs(func, out_args, info);
+    end if;
+  end matchFunction;
+
+  public
   function arguments
     input Call call;
     output list<Expression> arguments;
@@ -1082,7 +1220,6 @@ uniontype Call
         DAE.NO_INLINE(), DAE.NO_TAIL()));
   end makeBuiltinCall;
 
-protected
   function makeBuiltinCall2
     "Creates a call to a builtin function, given a Function, list of
      argument expressions and a return type. Used for builtin functions defined with no return type."
@@ -1173,6 +1310,7 @@ protected
     callExp := Expression.CALL(argtycall);
   end typeStringCall;
 
+protected
   function typeDiscreteCall
     "Types a function call that can be typed normally, but which always has
      discrete variability regardless of the variability of the arguments."
@@ -1807,6 +1945,61 @@ protected
     {fn} := typeCachedFunctions(fn_ref);
     callExp := Expression.CALL(makeBuiltinCall2(fn, {arg}, ty, variability));
   end typeMatrixCall;
+
+  function typeCatCall
+    input Call call;
+    input ExpOrigin.Type origin;
+    input SourceInfo info;
+    output Expression callExp;
+    output Type ty;
+    output Variability variability;
+  protected
+    ComponentRef fn_ref;
+    list<Expression> args, res;
+    list<NamedArg> named_args;
+    list<Type> tys;
+    Expression arg;
+    Variability var;
+    TypeCheck.MatchKind mk;
+    Function fn;
+    Integer n;
+  algorithm
+    UNTYPED_CALL(ref = fn_ref, arguments = args, named_args = named_args) := call;
+
+    if not listEmpty(named_args) then
+      Error.addSourceMessageAndFail(Error.NO_SUCH_PARAMETER,
+        {ComponentRef.toString(fn_ref), Util.tuple21(listHead(named_args))}, info);
+    end if;
+
+    if listLength(args) < 2 then
+      Error.addSourceMessageAndFail(Error.NO_MATCHING_FUNCTION_FOUND_NFINST,
+        {toString(call), "cat(Integer, Any[:,:], ...) => Any[:]"}, info);
+    end if;
+
+    arg::args := args;
+
+    (arg, ty, variability) := Typing.typeExp(arg, origin, info);
+    (arg, ty, mk) := TypeCheck.matchTypes(ty, Type.INTEGER(), arg);
+
+    if variability > Variability.PARAMETER then
+      Error.addSourceMessageAndFail(Error.NF_CAT_FIRST_ARG_EVAL, {Expression.toString(arg), Prefixes.variabilityString(variability)}, info);
+    end if;
+    arg := Ceval.evalExp(arg, Ceval.EvalTarget.GENERIC(info));
+    Expression.INTEGER(n) := SimplifyExp.simplifyExp(arg);
+
+    res := {};
+    tys := {};
+
+    for a in args loop
+      (arg, ty, var) := Typing.typeExp(a, origin, info);
+      variability := Prefixes.variabilityMax(var, variability);
+      res := arg :: res;
+      tys := ty :: tys;
+    end for;
+
+    (callExp, ty) := makeBuiltinCat(n, listReverse(res), listReverse(tys), info);
+
+  end typeCatCall;
 
   function typeSymmetricCall
     input Call call;

--- a/Compiler/NFFrontEnd/NFDimension.mo
+++ b/Compiler/NFFrontEnd/NFDimension.mo
@@ -32,6 +32,8 @@
 encapsulated uniontype NFDimension
 protected
   import Dimension = NFDimension;
+  import Operator = NFOperator;
+  import Prefixes = NFPrefixes;
 
 public
   import Absyn.{Exp, Path, Subscript};
@@ -121,6 +123,21 @@ public
       case UNKNOWN() then DAE.DIM_UNKNOWN();
     end match;
   end toDAE;
+
+  function add
+    input Dimension a, b;
+    output Dimension c;
+  algorithm
+    c := match (a, b)
+      case (UNKNOWN(),_) then UNKNOWN();
+      case (_,UNKNOWN()) then UNKNOWN();
+      case (INTEGER(),INTEGER()) then INTEGER(a.size+b.size);
+      case (INTEGER(),EXP()) then EXP(Expression.BINARY(b.exp, Operator.OPERATOR(Type.INTEGER(), NFOperator.Op.ADD), Expression.INTEGER(a.size)), b.var);
+      case (EXP(),INTEGER()) then EXP(Expression.BINARY(a.exp, Operator.OPERATOR(Type.INTEGER(), NFOperator.Op.ADD), Expression.INTEGER(b.size)), a.var);
+      case (EXP(),EXP()) then EXP(Expression.BINARY(a.exp, Operator.OPERATOR(Type.INTEGER(), NFOperator.Op.ADD), b.exp), Prefixes.variabilityMax(a.var, b.var));
+      else UNKNOWN();
+    end match;
+  end add;
 
   function size
     input Dimension dim;

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -832,6 +832,7 @@ uniontype Function
           // Can have variable number of arguments.
           case "array" then true;
           case "cardinality" then true;
+          case "cat" then true;
           // Function should not be used in function context.
           // argument should be a cref?
           case "change" then true;

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -1499,6 +1499,7 @@ algorithm
       Option<Expression> oe;
       Operator op;
       list<Expression> expl;
+      list<list<Expression>> expll;
 
     case Absyn.Exp.INTEGER() then Expression.INTEGER(absynExp.value);
     case Absyn.Exp.REAL() then Expression.REAL(stringReal(absynExp.value));
@@ -1516,11 +1517,9 @@ algorithm
 
     case Absyn.Exp.MATRIX()
       algorithm
-        expl := list(Expression.ARRAY(
-            Type.UNKNOWN(), list(instExp(e, scope, info) for e in el))
-          for el in absynExp.matrix);
+        expll := list(list(instExp(e, scope, info) for e in el) for el in absynExp.matrix);
       then
-        Expression.ARRAY(Type.UNKNOWN(), expl);
+        Expression.MATRIX(expll);
 
     case Absyn.Exp.RANGE()
       algorithm

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -369,7 +369,7 @@ uniontype InstNode
       case INNER_OUTER_NODE() then name(node.innerNode);
       // For bug catching, these names should never be used.
       case REF_NODE() then "$REF[" + String(node.index) + "]";
-      case NAME_NODE() then "$NAME[" + node.name + "]";
+      case NAME_NODE() then node.name;
       case IMPLICIT_SCOPE() then "$IMPLICIT";
       case EMPTY_NODE() then "$EMPTY";
     end match;

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -135,6 +135,22 @@ public
     end match;
   end liftArrayLeftList;
 
+  function liftArrayRightList
+    "Adds array dimensions to a type on the left side, e.g.
+       listArrayLeft(Real[2, 3], [4, 5]) => Real[2, 3, 4, 5]."
+    input output Type ty;
+    input list<Dimension> dims;
+  algorithm
+    if listEmpty(dims) then
+      return;
+    end if;
+
+    ty := match ty
+      case ARRAY() then ARRAY(ty.elementType, listAppend(ty.dimensions, dims));
+      else ARRAY(ty, dims);
+    end match;
+  end liftArrayRightList;
+
   function unliftArray
     input output Type ty;
   protected

--- a/Compiler/Template/CodegenCFunctions.tpl
+++ b/Compiler/Template/CodegenCFunctions.tpl
@@ -5790,7 +5790,8 @@ simple_alloc_1d_base_array(&<%tvar%>, <%nElts%>, <%tvardata%>);
     let var2 = daeExp(n, context, &preExp, &varDecls, &auxFunction)
     let arr_tp_str = '<%expTypeFromExpArray(A)%>'
     let tvar = tempDecl(arr_tp_str, &varDecls)
-    let &preExp += 'promote_alloc_<%arr_tp_str%>(&<%var1%>, <%var2%>, &<%tvar%>);<%\n%>'
+    /* Runtime gets number of dimensions to promote; Modelica has the total number of dimensions that the promoted result should have */
+    let &preExp += 'promote_alloc_<%arr_tp_str%>(&<%var1%>, <%var2%> - ndims_base_array(&<%var1%>), &<%tvar%>);<%\n%>'
     tvar
 
   case CALL(path=IDENT(name="transpose"), expLst={A}) then

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -945,6 +945,14 @@ public constant Message NF_VECTOR_INVALID_DIMENSIONS = MESSAGE(585, TRANSLATION(
   Util.gettext("Invalid dimensions %s in %s, no more than one dimension may have size > 1."));
 public constant Message NF_ARRAY_TYPE_MISMATCH = MESSAGE(586, TRANSLATION(), ERROR(),
   Util.gettext("Array types mismatch. Argument %s (%s) has type %s whereas previous arguments have type %s."));
+public constant Message NF_DIFFERENT_NUM_DIM_IN_ARGUMENTS = MESSAGE(587, TRANSLATION(), ERROR(),
+  Util.gettext("Different number of dimensions (%s) in arguments to %s."));
+public constant Message NF_CAT_WRONG_DIMENSION = MESSAGE(588, TRANSLATION(), ERROR(),
+  Util.gettext("The first argument of cat characterizes an existing dimension in the other arguments (1..%s), but got dimension %s."));
+public constant Message NF_CAT_FIRST_ARG_EVAL = MESSAGE(589, TRANSLATION(), ERROR(),
+  Util.gettext("The first argument of cat must be possible to evaluate during compile-time. Expression %s has variability %s."));
+public constant Message COMMA_OPERATOR_DIFFERENT_SIZES = MESSAGE(590, TRANSLATION(), ERROR(),
+  Util.gettext("Arguments of concatenation comma operator have different sizes for the first dimension: %s has dimension %s and %s has dimension %s."));
 
 public constant Message MATCH_SHADOWING = MESSAGE(5001, TRANSLATION(), ERROR(),
   Util.gettext("Local variable '%s' shadows another variable."));


### PR DESCRIPTION
- `cat(k, A, ..., C)` now works
- `[A,B ; C,D]` is now implemented

Previously, support for `cat` did not exist and `[A,B ; C,D]` pretended
it was the array constructor. This fixes ticket:4778.