### PR TITLE
[NF] Disable conversion of bindings in TYPES_VAR.

### DIFF
--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -1057,8 +1057,10 @@ algorithm
         type_var := DAE.TYPES_VAR(InstNode.name(c)
                       , Component.Attributes.toDAE(Component.getAttributes(comp))
                       , Type.toDAE(Component.getType(comp))
-                      , Binding.toDAE(Component.getBinding(comp))
-                      ,NONE()
+                      // Fix recursive bindings and update this
+                      // , Binding.toDAE(Component.getBinding(comp))
+                      , DAE.UNBOUND()
+                      , NONE()
                      );
         type_vars := type_var::type_vars;
       end for;


### PR DESCRIPTION
  - When converting variables to DAE versions we need to create TYPES_VARS for complex types.
    remove conversion of bindings in this types vars for now since it causes  infinte recurssions in some cases.

  - See https://github.com/OpenModelica/OMCompiler/commit/a134d4eadcc72fc2828d9e8779cc13a131d39daa#commitcomment-28104629