### PR TITLE
[DAEmode] Avoid IDA for models without states

### DIFF
--- a/SimulationRuntime/c/Makefile.common
+++ b/SimulationRuntime/c/Makefile.common
@@ -75,7 +75,8 @@ RUNTIMESIMSOLVER_HEADERS = ./simulation/solver/delay.h \
 ./simulation/solver/events.h \
 ./simulation/solver/synchronous.h \
 ./simulation/solver/external_input.h\
-./simulation/solver/solver_main.h
+./simulation/solver/solver_main.h \
+./simulation/solver/dae_mode.h
 
 RUNTIMEMETA_HEADERS = ./meta/meta_modelica_builtin_boxptr.h \
 ./meta/meta_modelica_builtin_boxvar.h \

--- a/SimulationRuntime/c/Makefile.objs
+++ b/SimulationRuntime/c/Makefile.objs
@@ -67,11 +67,11 @@ else
 SOLVER_OBJS_MINIMAL=$(SOLVER_OBJS_FMU)
 endif
 ifeq ($(OMC_MINIMAL_RUNTIME),)
-SOLVER_OBJS=$(SOLVER_OBJS_MINIMAL) kinsolSolver$(OBJ_EXT) linearSolverKlu$(OBJ_EXT) linearSolverLis$(OBJ_EXT) linearSolverUmfpack$(OBJ_EXT) dassl$(OBJ_EXT) radau$(OBJ_EXT) sym_solver_ssc$(OBJ_EXT) nonlinearSolverNewton$(OBJ_EXT) newtonIteration$(OBJ_EXT) ida_solver$(OBJ_EXT) irksco$(OBJ_EXT)
+SOLVER_OBJS=$(SOLVER_OBJS_MINIMAL) kinsolSolver$(OBJ_EXT) linearSolverKlu$(OBJ_EXT) linearSolverLis$(OBJ_EXT) linearSolverUmfpack$(OBJ_EXT) dassl$(OBJ_EXT) radau$(OBJ_EXT) sym_solver_ssc$(OBJ_EXT) nonlinearSolverNewton$(OBJ_EXT) newtonIteration$(OBJ_EXT) ida_solver$(OBJ_EXT) irksco$(OBJ_EXT) dae_mode$(OBJ_EXT)
 else
 SOLVER_OBJS=$(SOLVER_OBJS_MINIMAL)
 endif
-SOLVER_HFILES = dassl.h delay.h epsilon.h events.h external_input.h fmi_events.h ida_solver.h linearSystem.h mixedSystem.h model_help.h nonlinearSystem.h nonlinearValuesList.h radau.h sym_solver_ssc.h solver_main.h stateset.h
+SOLVER_HFILES = dassl.h dae_mode.h delay.h epsilon.h events.h external_input.h fmi_events.h ida_solver.h linearSystem.h mixedSystem.h model_help.h nonlinearSystem.h nonlinearValuesList.h radau.h sym_solver_ssc.h solver_main.h stateset.h
 
 INITIALIZATION_OBJS = initialization$(OBJ_EXT)
 INITIALIZATION_HFILES = initialization.h

--- a/SimulationRuntime/c/simulation/solver/dae_mode.c
+++ b/SimulationRuntime/c/simulation/solver/dae_mode.c
@@ -1,0 +1,54 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2018, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+#include "dae_mode.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! \fn void evaluateDAEResiduals_wrapperEventUpdate
+ *
+ * wrapper function of the main evaluation function for DAE mode
+ */
+int evaluateDAEResiduals_wrapperEventUpdate(DATA* data, threadData_t* threadData)
+{
+  int retVal;
+
+  data->simulationInfo->discreteCall = 1;
+  retVal = data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData);
+  data->simulationInfo->discreteCall = 0;
+
+  return retVal;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/SimulationRuntime/c/simulation/solver/dae_mode.h
+++ b/SimulationRuntime/c/simulation/solver/dae_mode.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2018, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+#ifndef DAE_MODE_H
+#define DAE_MODE_H
+
+#include "simulation_data.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int evaluateDAEResiduals_wrapperEventUpdate(DATA* data, threadData_t* threadData);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/SimulationRuntime/c/simulation/solver/perform_simulation.c
+++ b/SimulationRuntime/c/simulation/solver/perform_simulation.c
@@ -76,6 +76,10 @@ static void prefixedName_updateContinuousSystem(DATA *data, threadData_t *thread
     {
       data->callback->functionAlgebraics(data, threadData);
     }
+    else if (compiledInDAEMode == 3)
+    {
+      data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData);
+    }
   }
   else /* ode mode */
   {


### PR DESCRIPTION
 - when the model has no states and no residual equations
   the general simulation algorithm with event handling is used.
 - This fixes models like Modelica.Blocks.Examples.RealNetwork1 for
   the daeMode=new.