### PR TITLE
[NF] Record binding improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFBinding.mo
+++ b/Compiler/NFFrontEnd/NFBinding.mo
@@ -156,6 +156,16 @@ public
     end match;
   end setTypedExp;
 
+  function isRecordExp
+    input Binding binding;
+    output Boolean isRecordExp;
+  algorithm
+    isRecordExp := match binding
+      case TYPED_BINDING(bindingExp = Expression.RECORD()) then true;
+      else false;
+    end match;
+  end isRecordExp;
+
   function variability
     input Binding binding;
     output Variability var;

--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -52,11 +52,16 @@ import Binding = NFBinding;
 import Pointer;
 import NFPrefixes.Visibility;
 
-// Dummy SCode component, since we usually don't need the definition for anything.
-constant SCode.Element DUMMY_ELEMENT = SCode.COMPONENT("dummy",
-  SCode.defaultPrefixes, SCode.defaultVarAttr,
-  TypeSpec.TPATH(Path.IDENT("$dummy"), NONE()), SCode.Mod.NOMOD(),
-  SCode.Comment.COMMENT(NONE(), NONE()), NONE(), Absyn.dummyInfo);
+constant SCode.Element DUMMY_ELEMENT = SCode.CLASS(
+  "$DummyFunction",
+  SCode.defaultPrefixes,
+  SCode.Encapsulated.ENCAPSULATED(),
+  SCode.Partial.NOT_PARTIAL(),
+  SCode.Restriction.R_FUNCTION(SCode.FunctionRestriction.FR_NORMAL_FUNCTION(false)),
+  SCode.ClassDef.PARTS({}, {}, {}, {}, {}, {}, {}, NONE()),
+  SCode.Comment.COMMENT(NONE(), NONE()),
+  Absyn.dummyInfo
+);
 
 // Default Integer parameter.
 constant Component INT_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
@@ -99,8 +104,13 @@ constant InstNode ENUM_PARAM = InstNode.COMPONENT_NODE("e",
   Pointer.createImmutable(ENUM_COMPONENT), 0, InstNode.EMPTY_NODE());
 
 // Integer(e)
+constant InstNode INTEGER_NODE = NFInstNode.CLASS_NODE("Integer",
+  DUMMY_ELEMENT, Visibility.PUBLIC, Pointer.createImmutable(Class.NOT_INSTANTIATED()),
+  arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
+  InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
+
 constant Function INTEGER = Function.FUNCTION(Path.IDENT("Integer"),
-  InstNode.EMPTY_NODE(), {ENUM_PARAM}, {}, {}, {
+  INTEGER_NODE, {ENUM_PARAM}, {}, {}, {
     Slot.SLOT("e", SlotType.POSITIONAL, NONE(), NONE())
   }, Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
 

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -764,6 +764,7 @@ public
                         ) + ":" + operandString(exp.stop, exp, false);
 
       case TUPLE() then "(" + stringDelimitList(list(toString(e) for e in exp.elements), ", ") + ")";
+      case RECORD() then List.toString(exp.elements, toString, Absyn.pathString(exp.path), "(", ", ", ")", true);
       case CALL() then Call.toString(exp.call);
       case SIZE() then "size(" + toString(exp.exp) +
                         (


### PR DESCRIPTION
- Evaluate record constructors to record expressions.
- Split record expressions when flattening a complex component.
- Added dummy node to the definition of the Integer function instead
  of using an empty node, so we can assume each function has a node.