### PR TITLE
Fix listArrayLiteral

### DIFF
--- a/Compiler/FrontEnd/Expression.mo
+++ b/Compiler/FrontEnd/Expression.mo
@@ -13190,5 +13190,34 @@ algorithm
   end match;
 end isSimpleLiteralValue;
 
+public function consToListIgnoreSharedLiteral
+  input output DAE.Exp e;
+protected
+  DAE.Exp exp;
+algorithm
+  if match e
+    case DAE.SHARED_LITERAL() then true;
+    case DAE.LIST() then true;
+    case DAE.CONS() then true;
+    else false; end match then
+    try
+      e := consToListIgnoreSharedLiteralWork(e);
+    else
+    end try;
+  end if;
+end consToListIgnoreSharedLiteral;
+
+protected function consToListIgnoreSharedLiteralWork
+  input output DAE.Exp e;
+  input list<DAE.Exp> acc={};
+algorithm
+  e := match (e,acc)
+    case (DAE.SHARED_LITERAL(),_) then consToListIgnoreSharedLiteralWork(e.exp, acc);
+    case (DAE.LIST(),{}) then e;
+    case (DAE.LIST(),_) then DAE.LIST(List.append_reverse(acc, e.valList));
+    case (DAE.CONS(),_) then consToListIgnoreSharedLiteralWork(e.cdr, e.car::acc);
+  end match;
+end consToListIgnoreSharedLiteralWork;
+
 annotation(__OpenModelica_Interface="frontend");
 end Expression;

--- a/Compiler/FrontEnd/Types.mo
+++ b/Compiler/FrontEnd/Types.mo
@@ -1184,6 +1184,17 @@ algorithm
         ts = List.mapMap(vs, typeOfValue, boxIfUnboxedType);
       then DAE.T_METATUPLE(ts);
 
+    case Values.META_ARRAY(valueLst = (v :: vs))
+      equation
+        tp = boxIfUnboxedType(typeOfValue(v));
+        tp = DAE.T_METAARRAY(tp);
+      then tp;
+
+    case Values.META_ARRAY(valueLst = {})
+      equation
+        tp = DAE.T_METAARRAY(DAE.T_UNKNOWN_DEFAULT);
+      then tp;
+
     case Values.META_BOX(v)
       equation
         tp = typeOfValue(v);

--- a/Compiler/FrontEnd/ValuesUtil.mo
+++ b/Compiler/FrontEnd/ValuesUtil.mo
@@ -926,7 +926,7 @@ algorithm
         typelist = List.map(vallist, Types.typeOfValue);
         vt = Types.boxIfUnboxedType(List.reduce(typelist,Types.superType));
         (explist,_) = Types.matchTypes(explist, typelist, vt, true);
-      then Expression.makeBuiltinCall("listArrayLiteral", explist, DAE.T_METAARRAY(vt), false);
+      then Expression.makeBuiltinCall("listArrayLiteral", {DAE.LIST(explist)}, DAE.T_METAARRAY(vt), false);
 
       /* MetaRecord */
     case (Values.RECORD(path,vallist,namelst,ix))

--- a/Compiler/Template/CodegenCFunctions.tpl
+++ b/Compiler/Template/CodegenCFunctions.tpl
@@ -3415,13 +3415,16 @@ template literalExpConst(Exp lit, Integer litindex) "These should all be declare
     %>static const MMC_DEFSTRUCTLIT(<%tmp%>,<%intAdd(1,listLength(args))%>,<%newIndex%>) {&<%underscorePath(path)%>__desc,<%args |> exp hasindex i0 => literalExpConstBoxedVal(exp,litindex+"_"+i0); separator=","%>}};
     #define <%name%> MMC_REFSTRUCTLIT(<%tmp%>)
     >>
-  case CALL(path=IDENT(name="listArrayLiteral"), expLst=args) then
+  case CALL(path=IDENT(name="listArrayLiteral"), expLst={e}) then
     /* We need to use #define's to be C-compliant. Yea, total crap :) */
+    match consToListIgnoreSharedLiteral(e)
+    case LIST(valList=args) then
     <<
     <%args |> exp hasindex i0 => literalExpConstBoxedValPreLit(exp,litindex+"_"+i0) ; empty
     %>static const MMC_DEFSTRUCTLIT(<%tmp%>,<%listLength(args)%>,MMC_ARRAY_TAG) {<%args |> exp hasindex i0 => literalExpConstBoxedVal(exp,litindex+"_"+i0); separator=","%>}};
     #define <%name%> MMC_REFSTRUCTLIT(<%tmp%>)
     >>
+    else error(sourceInfo(), 'literalExpConst failed; listArrayLiteral requires a list or cons-cells: <%ExpressionDumpTpl.dumpExp(e,"\"")%>')
   else error(sourceInfo(), 'literalExpConst failed: <%ExpressionDumpTpl.dumpExp(lit,"\"")%>')
 end literalExpConst;
 

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -3419,6 +3419,12 @@ package Expression
     input DAE.ClockKind inClk;
     output DAE.Exp outIntvl;
   end getClockInterval;
+
+  function consToListIgnoreSharedLiteral
+    input DAE.Exp e1;
+    output DAE.Exp ee;
+  end consToListIgnoreSharedLiteral;
+
 end Expression;
 
 package ExpressionDump


### PR DESCRIPTION
The functionality had some bad logic previously that caused it to give
unexpected results (such as giving an array of size 1 when size 3 as
expected). listArrayLiteral now always contains one argument of size 1
which has a List type.