### PR TITLE
[NF] Cleaning and various optimizations.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -46,7 +46,7 @@ import SCode;
 import Binding = NFBinding;
 import BindingOrigin = NFBindingOrigin;
 import NFClass.Class;
-import NFClassTree;
+import NFClassTree.ClassTree;
 import NFComponent.Component;
 import Expression = NFExpression;
 import NFInstNode.InstNode;
@@ -61,6 +61,10 @@ import ComponentRef = NFComponentRef;
 import NFComponentRef.Origin;
 import Restriction = NFRestriction;
 
+protected
+import MetaModelica.Dangerous.*;
+
+public
 encapsulated package Elements
   import SCode;
   import Absyn;
@@ -100,224 +104,61 @@ encapsulated package Elements
     SCode.PARTS({}, {}, {}, {}, {}, {}, {}, NONE()),
     SCode.noComment, Absyn.dummyInfo);
 
-  constant SCode.Element STATESELECT = SCode.CLASS("StateSelect",
-    SCode.defaultPrefixes, SCode.NOT_ENCAPSULATED(), SCode.NOT_PARTIAL(), SCode.R_TYPE(),
-    SCode.ENUMERATION({
-      SCode.ENUM("never",   SCode.noComment),
-      SCode.ENUM("avoid",   SCode.noComment),
-      SCode.ENUM("default", SCode.noComment),
-      SCode.ENUM("prefer",  SCode.noComment),
-      SCode.ENUM("always",  SCode.noComment)
-    }),
-    SCode.noComment, Absyn.dummyInfo);
-
-  constant SCode.Element EXTERNALOBJECT = SCode.CLASS("ExternalObject",
-    SCode.defaultPrefixes, SCode.NOT_ENCAPSULATED(), SCode.PARTIAL(), SCode.R_CLASS(),
-    SCode.PARTS({}, {}, {}, {}, {}, {}, {}, NONE()), SCode.noComment, Absyn.dummyInfo);
-
 end Elements;
+
+// An empty InstNode cache for the builtin types. This should really be an empty
+// array to make sure all attempts at using the cache fails, since trying to
+// update the cache of a constant literal would cause a segfault. Creating a
+// completely empty array here doesn't work due to compiler bugs though
+// (generates invalid C code), but this is probably close enough.
+constant array<NFInstNode.CachedData> EMPTY_NODE_CACHE = listArrayLiteral({
+  NFInstNode.CachedData.FUNCTION({}, true, true)
+});
 
 // InstNodes for the builtin types. These have empty class trees to prevent
 // access to the attributes via dot notation (which is not needed for
 // modifiers and illegal in other cases).
 constant InstNode POLYMORPHIC_NODE = InstNode.CLASS_NODE("polymorphic",
   Elements.ANY, Visibility.PUBLIC,
-  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.POLYMORPHIC(""), NFClassTree.EMPTY,
+  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.POLYMORPHIC(""), ClassTree.EMPTY_TREE(),
     Modifier.NOMOD(), Restriction.TYPE())),
-  arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
-  InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
+  EMPTY_NODE_CACHE, InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
 
 constant InstNode REAL_NODE = InstNode.CLASS_NODE("Real",
   Elements.REAL, Visibility.PUBLIC,
-  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.REAL(), NFClassTree.EMPTY,
-    Modifier.NOMOD(), Restriction.TYPE())),
-  arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
-  InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
+  Pointer.createImmutable(
+    Class.PARTIAL_BUILTIN(Type.REAL(), ClassTree.EMPTY_TREE(), Modifier.NOMOD(), Restriction.TYPE())),
+  EMPTY_NODE_CACHE, InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
 
 constant InstNode INTEGER_NODE = InstNode.CLASS_NODE("Integer",
   Elements.INTEGER, Visibility.PUBLIC,
-  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.INTEGER(), NFClassTree.EMPTY,
-    Modifier.NOMOD(), Restriction.TYPE())),
-  listArray({NFInstNode.CachedData.FUNCTION({NFBuiltinFuncs.INTEGER}, true, false), NFInstNode.CachedData.NO_CACHE(), NFInstNode.CachedData.NO_CACHE()}),
-  InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
-
-constant ComponentRef INTEGER_CREF =
-  ComponentRef.CREF(INTEGER_NODE, {}, Type.INTEGER(), Origin.CREF, ComponentRef.EMPTY());
+  Pointer.createImmutable(
+    Class.PARTIAL_BUILTIN(Type.INTEGER(), ClassTree.EMPTY_TREE(), Modifier.NOMOD(), Restriction.TYPE())),
+  EMPTY_NODE_CACHE, InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
 
 constant InstNode BOOLEAN_NODE = InstNode.CLASS_NODE("Boolean",
   Elements.BOOLEAN, Visibility.PUBLIC,
-  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.BOOLEAN(), NFClassTree.EMPTY,
-    Modifier.NOMOD(), Restriction.TYPE())),
-  arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
-  InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
+  Pointer.createImmutable(
+    Class.PARTIAL_BUILTIN(Type.BOOLEAN(), ClassTree.EMPTY_TREE(), Modifier.NOMOD(), Restriction.TYPE())),
+  EMPTY_NODE_CACHE, InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
 
 constant ComponentRef BOOLEAN_CREF =
   ComponentRef.CREF(BOOLEAN_NODE, {}, Type.INTEGER(), Origin.CREF, ComponentRef.EMPTY());
 
 constant InstNode STRING_NODE = InstNode.CLASS_NODE("String",
   Elements.STRING, Visibility.PUBLIC,
-  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.STRING(), NFClassTree.EMPTY,
-    Modifier.NOMOD(), Restriction.TYPE())),
-  listArray({ NFInstNode.CachedData.FUNCTION({
-                                                  NFBuiltinFuncs.STRING_ENUM, NFBuiltinFuncs.STRING_INT,
-                                                  NFBuiltinFuncs.STRING_BOOL, NFBuiltinFuncs.STRING_REAL,
-                                                  NFBuiltinFuncs.STRING_REAL_FORMAT
-                                              },
-                                              true, true),
-              NFInstNode.CachedData.NO_CACHE(),
-              NFInstNode.CachedData.NO_CACHE()}
-            ),
-  InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
-
-constant ComponentRef STRING_CREF =
-  ComponentRef.CREF(STRING_NODE, {}, Type.INTEGER(), Origin.CREF, ComponentRef.EMPTY());
+  Pointer.createImmutable(
+    Class.PARTIAL_BUILTIN(Type.STRING(), ClassTree.EMPTY_TREE(), Modifier.NOMOD(), Restriction.TYPE())),
+  EMPTY_NODE_CACHE, InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
 
 constant InstNode ENUM_NODE = InstNode.CLASS_NODE("enumeration",
   Elements.ENUMERATION, Visibility.PUBLIC,
-  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.ENUMERATION_ANY(), NFClassTree.EMPTY,
+  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.ENUMERATION_ANY(), ClassTree.EMPTY_TREE(),
     Modifier.NOMOD(), Restriction.ENUMERATION())),
-  arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
-  InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
+  EMPTY_NODE_CACHE, InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
 
 constant Type STATESELECT_TYPE = Type.ENUMERATION(
   Absyn.IDENT("StateSelect"), {"never", "avoid", "default", "prefer", "always"});
-
-constant InstNode STATESELECT_NODE = InstNode.CLASS_NODE("StateSelect",
-  Elements.STATESELECT, Visibility.PUBLIC,
-  Pointer.createImmutable(Class.PARTIAL_BUILTIN(STATESELECT_TYPE, NFClassTree.EMPTY,
-    Modifier.NOMOD(), Restriction.ENUMERATION())),
-  arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
-  InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
-
-constant ComponentRef STATESELECT_CREF =
-  ComponentRef.CREF(STATESELECT_NODE, {}, STATESELECT_TYPE, Origin.CREF, ComponentRef.EMPTY());
-
-constant Binding STATESELECT_NEVER_BINDING =
-  Binding.TYPED_BINDING(
-    Expression.ENUM_LITERAL(STATESELECT_TYPE, "never", 1),
-    STATESELECT_TYPE,
-    Variability.CONSTANT,
-    BindingOrigin.ORIGIN(-1, NFBindingOrigin.ElementType.CLASS, Absyn.dummyInfo));
-
-constant Binding STATESELECT_AVOID_BINDING =
-  Binding.TYPED_BINDING(
-    Expression.ENUM_LITERAL(STATESELECT_TYPE, "avoid", 2),
-    STATESELECT_TYPE,
-    Variability.CONSTANT,
-    BindingOrigin.ORIGIN(-1, NFBindingOrigin.ElementType.CLASS, Absyn.dummyInfo));
-
-constant Binding STATESELECT_DEFAULT_BINDING =
-  Binding.TYPED_BINDING(
-    Expression.ENUM_LITERAL(STATESELECT_TYPE, "default", 3),
-    STATESELECT_TYPE,
-    Variability,
-    BindingOrigin.ORIGIN(-1, NFBindingOrigin.ElementType.CLASS, Absyn.dummyInfo));
-
-constant Binding STATESELECT_PREFER_BINDING =
-  Binding.TYPED_BINDING(
-    Expression.ENUM_LITERAL(STATESELECT_TYPE, "prefer", 4),
-    STATESELECT_TYPE,
-    Variability.CONSTANT,
-    BindingOrigin.ORIGIN(-1, NFBindingOrigin.ElementType.CLASS, Absyn.dummyInfo));
-
-constant Binding STATESELECT_ALWAYS_BINDING =
-  Binding.TYPED_BINDING(
-    Expression.ENUM_LITERAL(STATESELECT_TYPE, "always", 5),
-    STATESELECT_TYPE,
-    Variability.CONSTANT,
-    BindingOrigin.ORIGIN(-1, NFBindingOrigin.ElementType.CLASS, Absyn.dummyInfo));
-
-constant InstNode STATESELECT_NEVER =
-  InstNode.COMPONENT_NODE("never",
-    Visibility.PUBLIC,
-    Pointer.createImmutable(Component.TYPED_COMPONENT(
-      InstNode.EMPTY_NODE(),
-      STATESELECT_TYPE,
-      STATESELECT_NEVER_BINDING,
-      Binding.UNBOUND(),
-      NFComponent.CONSTANT_ATTR,
-      NONE(),
-      Absyn.dummyInfo)),
-    0,
-    STATESELECT_NODE);
-
-constant ComponentRef STATESELECT_NEVER_CREF =
-  ComponentRef.CREF(STATESELECT_NEVER, {}, STATESELECT_TYPE, Origin.CREF, STATESELECT_CREF);
-
-constant InstNode STATESELECT_AVOID =
-  InstNode.COMPONENT_NODE("avoid",
-    Visibility.PUBLIC,
-    Pointer.createImmutable(Component.TYPED_COMPONENT(
-      InstNode.EMPTY_NODE(),
-      STATESELECT_TYPE,
-      STATESELECT_AVOID_BINDING,
-      Binding.UNBOUND(),
-      NFComponent.CONSTANT_ATTR,
-      NONE(),
-      Absyn.dummyInfo)),
-    0,
-    STATESELECT_NODE);
-
-constant ComponentRef STATESELECT_AVOID_CREF =
-  ComponentRef.CREF(STATESELECT_AVOID, {}, STATESELECT_TYPE, Origin.CREF, STATESELECT_CREF);
-
-constant InstNode STATESELECT_DEFAULT =
-  InstNode.COMPONENT_NODE("default",
-    Visibility.PUBLIC,
-    Pointer.createImmutable(Component.TYPED_COMPONENT(
-      InstNode.EMPTY_NODE(),
-      STATESELECT_TYPE,
-      STATESELECT_DEFAULT_BINDING,
-      Binding.UNBOUND(),
-      NFComponent.CONSTANT_ATTR,
-      NONE(),
-      Absyn.dummyInfo)),
-    0,
-    STATESELECT_NODE);
-
-constant ComponentRef STATESELECT_DEFAULT_CREF =
-  ComponentRef.CREF(STATESELECT_DEFAULT, {}, STATESELECT_TYPE, Origin.CREF, STATESELECT_CREF);
-
-constant InstNode STATESELECT_PREFER =
-  InstNode.COMPONENT_NODE("prefer",
-    Visibility.PUBLIC,
-    Pointer.createImmutable(Component.TYPED_COMPONENT(
-      InstNode.EMPTY_NODE(),
-      STATESELECT_TYPE,
-      STATESELECT_PREFER_BINDING,
-      Binding.UNBOUND(),
-      NFComponent.CONSTANT_ATTR,
-      NONE(),
-      Absyn.dummyInfo)),
-    0,
-    STATESELECT_NODE);
-
-constant ComponentRef STATESELECT_PREFER_CREF =
-  ComponentRef.CREF(STATESELECT_PREFER, {}, STATESELECT_TYPE, Origin.CREF, STATESELECT_CREF);
-
-constant InstNode STATESELECT_ALWAYS =
-  InstNode.COMPONENT_NODE("always",
-    Visibility.PUBLIC,
-    Pointer.createImmutable(Component.TYPED_COMPONENT(
-      InstNode.EMPTY_NODE(),
-      STATESELECT_TYPE,
-      STATESELECT_ALWAYS_BINDING,
-      Binding.UNBOUND(),
-      NFComponent.CONSTANT_ATTR,
-      NONE(),
-      Absyn.dummyInfo)),
-    0,
-    STATESELECT_NODE);
-
-constant ComponentRef STATESELECT_ALWAYS_CREF =
-  ComponentRef.CREF(STATESELECT_ALWAYS, {}, STATESELECT_TYPE, Origin.CREF, STATESELECT_CREF);
-
-constant InstNode EXTERNALOBJECT_NODE = InstNode.CLASS_NODE("ExternalObject",
-  Elements.EXTERNALOBJECT, Visibility.PUBLIC,
-  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.UNKNOWN(), NFClassTree.EMPTY,
-    Modifier.NOMOD(), Restriction.CLASS())),
-  arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
-  InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
 
 constant Type ASSERTIONLEVEL_TYPE = Type.ENUMERATION(
   Absyn.IDENT("AssertionLevel"), {"error", "warning"});

--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -32,6 +32,7 @@
 encapsulated package NFBuiltinFuncs
 
 import NFClass.Class;
+import NFClassTree.ClassTree;
 import NFFunction.Function;
 import NFFunction.Slot;
 import NFFunction.SlotType;
@@ -51,7 +52,16 @@ import Builtin = NFBuiltin;
 import Binding = NFBinding;
 import Pointer;
 import NFPrefixes.Visibility;
+import Restriction = NFRestriction;
+import ComponentRef = NFComponentRef;
+import NFComponentRef.Origin;
+import NFModifier.Modifier;
+import Sections = NFSections;
 
+protected
+import MetaModelica.Dangerous.*;
+
+public
 constant SCode.Element DUMMY_ELEMENT = SCode.CLASS(
   "$DummyFunction",
   SCode.defaultPrefixes,
@@ -104,24 +114,41 @@ constant InstNode ENUM_PARAM = InstNode.COMPONENT_NODE("e",
   Pointer.createImmutable(ENUM_COMPONENT), 0, InstNode.EMPTY_NODE());
 
 // Integer(e)
-constant InstNode INTEGER_NODE = NFInstNode.CLASS_NODE("Integer",
+constant array<NFInstNode.CachedData> EMPTY_NODE_CACHE = listArrayLiteral({
+  NFInstNode.CachedData.NO_CACHE(),
+  NFInstNode.CachedData.NO_CACHE(),
+  NFInstNode.CachedData.NO_CACHE()
+});
+
+constant InstNode INTEGER_DUMMY_NODE = NFInstNode.CLASS_NODE("Integer",
   DUMMY_ELEMENT, Visibility.PUBLIC, Pointer.createImmutable(Class.NOT_INSTANTIATED()),
-  arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
+  EMPTY_NODE_CACHE,
   InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
 
-constant Function INTEGER = Function.FUNCTION(Path.IDENT("Integer"),
-  INTEGER_NODE, {ENUM_PARAM}, {}, {}, {
+constant Function INTEGER_FUNCTION = Function.FUNCTION(Path.IDENT("Integer"),
+  INTEGER_DUMMY_NODE, {ENUM_PARAM}, {}, {}, {
     Slot.SLOT("e", SlotType.POSITIONAL, NONE(), NONE())
   }, Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
 
-// String(r, significantDigits=d, minimumLength=0, leftJustified=true)
-constant InstNode STRING_NODE = NFInstNode.CLASS_NODE("String", DUMMY_ELEMENT,
-  Visibility.PUBLIC, Pointer.createImmutable(Class.NOT_INSTANTIATED()),
-  arrayCreate(NFInstNode.NUMBER_OF_CACHES, NFInstNode.CachedData.NO_CACHE()),
-  InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
+constant InstNode INTEGER_NODE = InstNode.CLASS_NODE("IntegerFunc",
+  DUMMY_ELEMENT, Visibility.PUBLIC,
+  Pointer.createImmutable(Class.INSTANCED_CLASS(ClassTree.EMPTY_TREE(),
+    Sections.EMPTY(), Type.UNKNOWN(), Restriction.FUNCTION())),
+  listArrayLiteral({NFInstNode.CachedData.FUNCTION({INTEGER_FUNCTION}, true, false),
+                    NFInstNode.CachedData.NO_CACHE(),
+                    NFInstNode.CachedData.NO_CACHE()}),
+  InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
 
+constant ComponentRef INTEGER_CREF =
+  ComponentRef.CREF(INTEGER_NODE, {}, Type.INTEGER(), Origin.CREF, ComponentRef.EMPTY());
+
+constant InstNode STRING_DUMMY_NODE = NFInstNode.CLASS_NODE("String",
+  DUMMY_ELEMENT, Visibility.PUBLIC, Pointer.createImmutable(Class.NOT_INSTANTIATED()),
+  EMPTY_NODE_CACHE, InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
+
+// String(r, significantDigits=d, minimumLength=0, leftJustified=true)
 constant Function STRING_REAL = Function.FUNCTION(Path.IDENT("String"),
-  STRING_NODE, {REAL_PARAM, INT_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
+  STRING_DUMMY_NODE, {REAL_PARAM, INT_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
     Slot.SLOT("r", SlotType.POSITIONAL, NONE(), NONE()),
     Slot.SLOT("significantDigits", SlotType.NAMED, SOME(Expression.INTEGER(6)), NONE()),
     Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE()),
@@ -130,14 +157,14 @@ constant Function STRING_REAL = Function.FUNCTION(Path.IDENT("String"),
 
 // String(r, format="-0.6g")
 constant Function STRING_REAL_FORMAT = Function.FUNCTION(Path.IDENT("String"),
-  STRING_NODE, {REAL_PARAM, STRING_PARAM}, {STRING_PARAM}, {}, {
+  STRING_DUMMY_NODE, {REAL_PARAM, STRING_PARAM}, {STRING_PARAM}, {}, {
     Slot.SLOT("r", SlotType.POSITIONAL, NONE(), NONE()),
     Slot.SLOT("format", SlotType.NAMED, NONE(), NONE())
   }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
 
 // String(i, minimumLength=0, leftJustified=true)
 constant Function STRING_INT = Function.FUNCTION(Path.IDENT("String"),
-  STRING_NODE, {INT_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
+  STRING_DUMMY_NODE, {INT_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
     Slot.SLOT("i", SlotType.POSITIONAL, NONE(), NONE()),
     Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE()),
     Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE())
@@ -145,7 +172,7 @@ constant Function STRING_INT = Function.FUNCTION(Path.IDENT("String"),
 
 // String(b, minimumLength=0, leftJustified=true)
 constant Function STRING_BOOL = Function.FUNCTION(Path.IDENT("String"),
-  STRING_NODE, {BOOL_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
+  STRING_DUMMY_NODE, {BOOL_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
     Slot.SLOT("b", SlotType.POSITIONAL, NONE(), NONE()),
     Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE()),
     Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE())
@@ -153,11 +180,31 @@ constant Function STRING_BOOL = Function.FUNCTION(Path.IDENT("String"),
 
 // String(e, minimumLength=0, leftJustified=true)
 constant Function STRING_ENUM = Function.FUNCTION(Path.IDENT("String"),
-  STRING_NODE, {ENUM_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
+  STRING_DUMMY_NODE, {ENUM_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
     Slot.SLOT("e", SlotType.POSITIONAL, NONE(), NONE()),
     Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE()),
     Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE())
   }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+
+constant InstNode STRING_NODE = InstNode.CLASS_NODE("String",
+  DUMMY_ELEMENT, Visibility.PUBLIC,
+  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.STRING(), ClassTree.EMPTY_TREE(),
+    Modifier.NOMOD(), Restriction.TYPE())),
+  listArrayLiteral({
+    NFInstNode.CachedData.FUNCTION({
+        STRING_ENUM,
+        STRING_INT,
+        STRING_BOOL,
+        STRING_REAL,
+        STRING_REAL_FORMAT},
+      true, true),
+    NFInstNode.CachedData.NO_CACHE(),
+    NFInstNode.CachedData.NO_CACHE()}
+  ),
+  InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
+
+constant ComponentRef STRING_CREF =
+  ComponentRef.CREF(STRING_NODE, {}, Type.INTEGER(), Origin.CREF, ComponentRef.EMPTY());
 
 constant Function ABS_REAL = Function.FUNCTION(Path.IDENT("abs"),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},

--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -1414,7 +1414,7 @@ protected
       Type.COMPLEX(cls=recopnode) := argty;
 
       // This will fail if it can't find the function.
-      fn_ref := Function.lookupFunctionSilent(Absyn.CREF_IDENT("'String'",{}), recopnode);
+      fn_ref := Function.lookupFunctionSimple("'String'", recopnode);
       fn_ref := Function.instFuncRef(fn_ref, InstNode.info(recopnode));
       candidates := Call.typeCachedFunctions(fn_ref);
       for fn in candidates loop

--- a/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/Compiler/NFFrontEnd/NFClassTree.mo
@@ -202,6 +202,9 @@ public
       DuplicateTree.Tree duplicates;
     end FLAT_TREE;
 
+    record EMPTY_TREE
+    end EMPTY_TREE;
+
     function fromSCode
       "Creates a new class tree from a list of SCode elements."
       input list<SCode.Element> elements;
@@ -794,6 +797,22 @@ public
         elements := {lookupElementPtr(name, tree)};
       end try;
     end lookupElementsPtr;
+
+    function mapClasses
+      input ClassTree tree;
+      input FuncT func;
+
+      partial function FuncT
+        input output InstNode extendsNode;
+      end FuncT;
+    protected
+      array<InstNode> clss = getClasses(tree);
+    algorithm
+      for i in 1:arrayLength(clss) loop
+        arrayUpdateNoBoundsChecking(clss, i,
+          func(arrayGetNoBoundsChecking(clss, i)));
+      end for;
+    end mapClasses;
 
     function foldClasses<ArgT>
       input ClassTree tree;

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -226,21 +226,21 @@ uniontype Function
     fn := FUNCTION(path, node, inputs, outputs, locals, {}, Type.UNKNOWN(), attr, collected);
   end new;
 
-  function lookupFunctionSilent
-    input Absyn.ComponentRef ab_fn_cref;
+  function lookupFunctionSimple
+    input String functionName;
     input InstNode scope;
-    input SourceInfo info = InstNode.info(scope);
-    output ComponentRef fn_ref;
+    output ComponentRef functionRef;
+  protected
+    InstNode found_scope;
+    LookupState state;
+    Absyn.Path functionPath;
+    ComponentRef prefix;
   algorithm
-    ErrorExt.setCheckpoint("NFFunction:lookupFunctionSilent");
-    try
-      fn_ref := lookupFunction(ab_fn_cref, scope, info);
-      ErrorExt.delCheckpoint("NFFunction:lookupFunctionSilent");
-    else
-      ErrorExt.rollBack("NFFunction:lookupFunctionSilent");
-      fail();
-    end try;
-  end lookupFunctionSilent;
+    (functionRef, found_scope) :=
+      Lookup.lookupFunctionNameSilent(Absyn.CREF_IDENT(functionName, {}), scope);
+    prefix := ComponentRef.fromNodeList(InstNode.scopeList(found_scope));
+    functionRef := ComponentRef.append(functionRef, prefix);
+  end lookupFunctionSimple;
 
   function lookupFunction
     input Absyn.ComponentRef functionName;

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1244,6 +1244,15 @@ uniontype InstNode
     end match;
   end toDAEType;
 
+  function isBuiltin
+    input InstNode node;
+    output Boolean isBuiltin;
+  algorithm
+    isBuiltin := match node
+      case CLASS_NODE(nodeType = InstNodeType.BUILTIN_CLASS()) then true;
+      else false;
+    end match;
+  end isBuiltin;
 end InstNode;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/Compiler/NFFrontEnd/NFLookupState.mo
+++ b/Compiler/NFFrontEnd/NFLookupState.mo
@@ -139,6 +139,19 @@ uniontype LookupState
     callable := SCode.isRecord(def) or SCode.isOperator(def);
   end isCallable;
 
+  function isFunction
+    input LookupState state;
+    input InstNode node;
+    output Boolean isFunction;
+  algorithm
+    isFunction := match state
+      case FUNC() then true;
+      case COMP_FUNC() then true;
+      case CLASS() then isCallable(node);
+      else false;
+    end match;
+  end isFunction;
+
   function isClass
     input LookupState state;
     output Boolean isClass;

--- a/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -35,7 +35,11 @@ type StateSelect = enumeration(
   default "Use as state if appropriate, but only if variable appears differentiated.",
   prefer "Prefer it as state over those having the default value (also variables can be selected, which do not appear differentiated).",
   always "Do use it as a state."
-);
+) annotation(__OpenModelica_builtin = true);
+
+partial class ExternalObject
+  annotation(__OpenModelica_builtin=true);
+end ExternalObject;
 
 function der "Derivative of the input expression"
   input Real x(unit="'p");

--- a/Compiler/NFFrontEnd/NFRecord.mo
+++ b/Compiler/NFFrontEnd/NFRecord.mo
@@ -86,7 +86,7 @@ algorithm
 
   // See if we have overloaded costructors.
   try
-    con_ref := Function.lookupFunctionSilent(Absyn.CREF_IDENT("'constructor'",{}), node, info);
+    con_ref := Function.lookupFunctionSimple("'constructor'", node);
     ctor_defined := true;
   else
     ctor_defined := false;
@@ -102,7 +102,7 @@ algorithm
 
   // See if we have '0' costructor.
   try
-    con_ref := Function.lookupFunctionSilent(Absyn.CREF_IDENT("'0'",{}), node, info);
+    con_ref := Function.lookupFunctionSimple("'0'", node);
     ctor_defined := true;
   else
     ctor_defined := false;

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -197,7 +197,7 @@ algorithm
   if Type.isComplex(inType1) then
     Type.COMPLEX(cls=node1) := inType1;
     try
-      fn_ref := Function.lookupFunctionSilent(Absyn.CREF_IDENT(opstr,{}), node1);
+      fn_ref := Function.lookupFunctionSimple(opstr, node1);
       oper_defined := true;
     else
       oper_defined := false;
@@ -219,7 +219,7 @@ algorithm
     // operators from this one.
     if not (Type.isComplex(inType1) and InstNode.isSame(node1, node2)) then
         try
-          fn_ref := Function.lookupFunctionSilent(Absyn.CREF_IDENT(opstr,{}), node2);
+          fn_ref := Function.lookupFunctionSimple(opstr, node2);
           oper_defined := true;
         else
           oper_defined := false;
@@ -861,7 +861,7 @@ algorithm
   opstr := Operator.symbol(inOp,"'");
   Type.COMPLEX(cls=node1) := inType1;
 
-  fn_ref := Function.lookupFunctionSilent(Absyn.CREF_IDENT(opstr,{}), node1);
+  fn_ref := Function.lookupFunctionSimple(opstr, node1);
   fn_ref := Function.instFuncRef(fn_ref, InstNode.info(node1));
   candidates := Call.typeCachedFunctions(fn_ref);
   for fn in candidates loop

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -1404,14 +1404,6 @@ protected
   Variability var;
 algorithm
   dims := Type.arrayDims(crefType);
-
-  if listLength(subscripts) > listLength(dims) then
-    Error.addSourceMessage(Error.WRONG_NUMBER_OF_SUBSCRIPTS,
-      {ComponentRef.toString(cref),
-       String(listLength(subscripts)), String(listLength(dims))}, info);
-    fail();
-  end if;
-
   typedSubs := {};
   next_origin := intBitOr(origin, ExpOrigin.SUBSCRIPT);
   i := 1;


### PR DESCRIPTION
- Cleaned up the name lookup a bit, and got rid of the error spamming
  from Function.lookupFunctionSilent.
- Changed the handling of Integer and String so that e.g. the type
  Integer and the function Integer are different entities, instead of
  e.g. using the same InstNode for both.
- Optimize the constants in NFBuiltin and NFBuiltinFuncs so that they
  become actual constants in the generated code, and not created each
  time they're used.
- Remove special handling of StateSelect and ExternalObject from the
  name lookup, since Modelica 3.4 clarifies that they aren't reserved
  names, and added ExternalObject to ModelicaBuiltin instead
  (StateSelect was already defined there).
- Implemented a better check for subscripts on elements that shouldn't
  be subscripted.