### PR TITLE
[NF] Fix path when creating record expressions.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -2325,7 +2325,7 @@ protected
   algorithm
     exp := match call
       case TYPED_CALL()
-        then Expression.RECORD(Function.name(call.fn), ty, call.arguments);
+        then Expression.RECORD(Absyn.stripLast(Function.name(call.fn)), ty, call.arguments);
     end match;
   end toRecordExpression;
 end Call;


### PR DESCRIPTION
- Remove the record constructor name from the path when creating
  record expressions, and only keep the name of the record itself.