### PR TITLE
[NF] Fix typing of calls with multiple outputs.

### DIFF
--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -368,6 +368,16 @@ public
     end match;
   end isTuple;
 
+  function firstTupleType
+    input Type ty;
+    output Type outTy;
+  algorithm
+    outTy := match ty
+      case TUPLE() then listHead(ty.types);
+      else ty;
+    end match;
+  end firstTupleType;
+
   function arrayElementType
     "Returns the common type of the elements in an array, or just the type
      itself if it's not an array type."


### PR DESCRIPTION
- Fix typing of function calls with multiple outputs so that only the
  first output is used when the call isn't alone on the rhs.
- Use correct origin in Typing.typeSubscripts.