### PR TITLE
[NF] Port inStream changes from #2319.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -214,6 +214,10 @@ constant Function MAX_REAL = Function.FUNCTION(Path.IDENT("max"),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
 
+constant Function POSITIVE_MAX_REAL = Function.FUNCTION(Path.IDENT("$OMC$PositiveMax"),
+  InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+
 constant Function IN_STREAM = Function.FUNCTION(Path.IDENT("inStream"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));

--- a/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -60,6 +60,7 @@ import NFInstNode.InstNode;
 import NFClass.Class;
 import Binding = NFBinding;
 import NFFunction.Function;
+import Global;
 
 constant Expression EQ_ASSERT_STR =
   Expression.STRING("Connected constants/parameters must be equal");
@@ -78,6 +79,8 @@ protected
   potFunc potfunc;
   Expression flowThreshold;
 algorithm
+  setGlobalRoot(Global.isInStream, NONE());
+
   //potfunc := if Config.orderConnections() then
   //  generatePotentialEquationsOrdered else generatePotentialEquations;
   potfunc := generatePotentialEquations;
@@ -528,8 +531,10 @@ algorithm
     flow_threshold := flowThreshold;
   end if;
 
-  positiveMaxCall := Expression.CALL(Call.makeBuiltinCall(NFBuiltinFuncs.MAX_REAL,
+  positiveMaxCall := Expression.CALL(Call.makeBuiltinCall(NFBuiltinFuncs.POSITIVE_MAX_REAL,
     {flowExp, flow_threshold}));
+
+  setGlobalRoot(Global.isInStream, SOME(true));
 end makePositiveMaxCall;
 
 function evaluateOperatorExp


### PR DESCRIPTION
- Port the changes made to inStream in the old frontend to the new,
  in particular setting the Global.isInStream global root to avoid
  the backend failing when trying to access it.