### PR TITLE
[NF] Implement structural parameter handling.

### DIFF
--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -96,11 +96,11 @@ constant Component.Attributes CONSTANT_ATTR =
     Replaceable.NOT_REPLACEABLE()
   );
 
-constant Component.Attributes DISCRETE_ATTR =
+constant Component.Attributes IMPL_DISCRETE_ATTR =
   Component.Attributes.ATTRIBUTES(
     ConnectorType.POTENTIAL,
     Parallelism.NON_PARALLEL,
-    Variability.DISCRETE,
+    Variability.IMPLICITLY_DISCRETE,
     Direction.NONE,
     InnerOuter.NOT_INNER_OUTER,
     false,
@@ -515,6 +515,32 @@ uniontype Component
       else Variability.CONTINUOUS;
     end match;
   end variability;
+
+  function setVariability
+    input Variability variability;
+    input output Component component;
+  algorithm
+    () := match component
+      local
+        Attributes attr;
+
+      case UNTYPED_COMPONENT(attributes = attr)
+        algorithm
+          attr.variability := variability;
+          component.attributes := attr;
+        then
+          ();
+
+      case TYPED_COMPONENT(attributes = attr)
+        algorithm
+          attr.variability := variability;
+          component.attributes := attr;
+        then
+          ();
+
+      else ();
+    end match;
+  end setVariability;
 
   function isConst
     input Component component;

--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -149,7 +149,7 @@ algorithm
       then
         DAE.VAR(
           dcref,
-          Prefixes.variabilityToDAE(attr.variability, ty),
+          Prefixes.variabilityToDAE(attr.variability),
           Prefixes.directionToDAE(dir),
           Prefixes.parallelismToDAE(attr.parallelism),
           Prefixes.visibilityToDAE(vis),

--- a/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -184,6 +184,7 @@ algorithm
         case Op.SUB then Expression.INTEGER(i1 - i2);
         case Op.MUL then Expression.INTEGER(i1 * i2);
         case Op.DIV then Expression.REAL(i1 / i2);
+        else exp;
       end match;
 
     case Expression.BINARY(exp1=Expression.REAL(value=r1), exp2=Expression.REAL(value=r2))
@@ -192,6 +193,7 @@ algorithm
         case Op.SUB then Expression.REAL(r1 - r2);
         case Op.MUL then Expression.REAL(r1 * r2);
         case Op.DIV then Expression.REAL(r1 / r2);
+        else exp;
       end match;
 
     case Expression.UNARY(operator = Operator.OPERATOR(op = Op.UMINUS))

--- a/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/Compiler/NFFrontEnd/NFSubscript.mo
@@ -44,6 +44,7 @@ public
   import Expression = NFExpression;
   import Absyn;
   import Dimension = NFDimension;
+  import NFPrefixes.Variability;
 
   record RAW_SUBSCRIPT
     Absyn.Subscript subscript;
@@ -384,6 +385,18 @@ public
 
     outSubscripts := listReverse(outSubscripts);
   end expandList;
+
+  function variability
+    input Subscript subscript;
+    output Variability var;
+  algorithm
+    var := match subscript
+      case UNTYPED() then Expression.variability(subscript.exp);
+      case INDEX() then Expression.variability(subscript.index);
+      case SLICE() then Expression.variability(subscript.slice);
+      case WHOLE() then Variability.CONSTANT;
+    end match;
+  end variability;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFSubscript;


### PR DESCRIPTION
- Added Variability.STRUCTURAL_PARAMETER used to mark structural
  parameters.
- Changed the condition for evaluating bindings to include structural
  parameters, and changed the conditions for evaluation various
  expressions to exclude non-structural parameters.
- Added Variability.IMPLICITLY_DISCRETE used for discrete-time variables
  that are not declared as such, e.g. Integer, Boolean, etc variables.