### PR TITLE
Fix order of arguments to String.

### DIFF
--- a/Compiler/FrontEnd/Ceval.mo
+++ b/Compiler/FrontEnd/Ceval.mo
@@ -1936,7 +1936,7 @@ algorithm
       then
         (cache,Values.STRING(str));
 
-    case (cache,env,{exp, len_exp, justified_exp, sig_dig},impl,msg,_)
+    case (cache,env,{exp, sig_dig, len_exp, justified_exp},impl,msg,_)
       equation
         (cache,Values.REAL(r)) = ceval(cache,env, exp, impl, msg,numIter+1);
         (cache,Values.INTEGER(len)) = ceval(cache,env, len_exp, impl, msg,numIter+1);

--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -6066,11 +6066,14 @@ algorithm
       NONE()), false, NONE(), {}, 1, SLOT_NOT_EVALUATED);
 
     try // Try the String(val, <option>) format.
-      // Only String(Real) has the significantDigits option.
-      slots := if Types.isRealOrSubTypeReal(ty) then
-        {STRING_ARG_SIGNIFICANT_DIGITS} else {};
+      slots := {STRING_ARG_MINLENGTH, STRING_ARG_LEFTJUSTIFIED};
 
-      slots := val_slot :: STRING_ARG_MINLENGTH :: STRING_ARG_LEFTJUSTIFIED :: slots;
+      // Only String(Real) has the significantDigits option.
+      if Types.isRealOrSubTypeReal(ty) then
+        slots := STRING_ARG_SIGNIFICANT_DIGITS :: slots;
+      end if;
+
+      slots := val_slot :: slots;
 
       (outCache, args, _, consts) := elabInputArgs(outCache, inEnv, inPosArgs, inNamedArgs,
           slots, false, true, inImplicit,

--- a/Compiler/Template/CodegenAdevs.tpl
+++ b/Compiler/Template/CodegenAdevs.tpl
@@ -4291,13 +4291,13 @@ template daeExpCall(Exp call, Context context, Text &preExp /*BUFP*/,
     '<%tvar%>'
 
   case CALL(path=IDENT(name="String"),
-            expLst={s, minlen, leftjust, signdig}) then
+            expLst={s, signdig, minlen, leftjust}) then
     let tvar = tempDecl("modelica_string", &varDecls /*BUFD*/)
     let sExp = daeExp(s, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
     let minlenExp = daeExp(minlen, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
     let leftjustExp = daeExp(leftjust, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
     let signdigExp = daeExp(signdig, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
-    let &preExp += '<%tvar%> = modelica_real_to_modelica_string(<%sExp%>, <%minlenExp%>, <%leftjustExp%>, <%signdigExp%>);<%\n%>'
+    let &preExp += '<%tvar%> = modelica_real_to_modelica_string(<%sExp%>, <%signdigExp%>, <%minlenExp%>, <%leftjustExp%>);<%\n%>'
     '<%tvar%>'
 
   case CALL(path=IDENT(name="delay"),

--- a/Compiler/Template/CodegenCFunctions.tpl
+++ b/Compiler/Template/CodegenCFunctions.tpl
@@ -5891,13 +5891,13 @@ simple_alloc_1d_base_array(&<%tvar%>, <%nElts%>, <%tvardata%>);
     tvar
     end match
 
-  case CALL(path=IDENT(name="String"), expLst={s, minlen, leftjust, signdig}) then
+  case CALL(path=IDENT(name="String"), expLst={s, signdig, minlen, leftjust}) then
     let tvar = tempDecl("modelica_string", &varDecls)
     let sExp = daeExp(s, context, &preExp, &varDecls, &auxFunction)
     let minlenExp = daeExp(minlen, context, &preExp, &varDecls, &auxFunction)
     let leftjustExp = daeExp(leftjust, context, &preExp, &varDecls, &auxFunction)
     let signdigExp = daeExp(signdig, context, &preExp, &varDecls, &auxFunction)
-    let &preExp += '<%tvar%> = modelica_real_to_modelica_string(<%sExp%>, <%minlenExp%>, <%leftjustExp%>, <%signdigExp%>);<%\n%>'
+    let &preExp += '<%tvar%> = modelica_real_to_modelica_string(<%sExp%>, <%signdigExp%>, <%minlenExp%>, <%leftjustExp%>);<%\n%>'
     tvar
 
   case CALL(path=IDENT(name="delay"), expLst={ICONST(integer=index), e, d, delayMax}) then

--- a/Compiler/Template/CodegenJava.tpl
+++ b/Compiler/Template/CodegenJava.tpl
@@ -738,13 +738,13 @@ end daeExpIf;
 
   // case CALL(
             // path=IDENT(name="String"),
-            // expLst={s, minlen, leftjust, signdig}) then
+            // expLst={s, signdig, minlen, leftjust}) then
     // let tvar = tempDecl("modelica_string", &varDecls /*BUFD*/)
     // let sExp = daeExp(s, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
     // let minlenExp = daeExp(minlen, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
     // let leftjustExp = daeExp(leftjust, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
     // let signdigExp = daeExp(signdig, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
-    // let &preExp += '<%tvar%> = modelica_real_to_modelica_string(<%sExp%>, <%minlenExp%>, <%leftjustExp%>, <%signdigExp%>);<%\n%>'
+    // let &preExp += '<%tvar%> = modelica_real_to_modelica_string(<%sExp%>, <%signdigExp%>, <%minlenExp%>, <%leftjustExp%>);<%\n%>'
     // '<%tvar%>'
 
   // case CALL(

--- a/Compiler/Template/CodegenSparseFMI.tpl
+++ b/Compiler/Template/CodegenSparseFMI.tpl
@@ -3839,13 +3839,13 @@ template daeExpCall(Exp call, Context context, Text &preExp /*BUFP*/,
     '<%tvar%>'
 
   case CALL(path=IDENT(name="String"),
-            expLst={s, minlen, leftjust, signdig}) then
+            expLst={s, signdig, minlen, leftjust}) then
     let tvar = tempDecl("modelica_string", &varDecls /*BUFD*/)
     let sExp = daeExp(s, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
     let minlenExp = daeExp(minlen, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
     let leftjustExp = daeExp(leftjust, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
     let signdigExp = daeExp(signdig, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
-    let &preExp += '<%tvar%> = modelica_real_to_modelica_string(<%sExp%>, <%minlenExp%>, <%leftjustExp%>, <%signdigExp%>);<%\n%>'
+    let &preExp += '<%tvar%> = modelica_real_to_modelica_string(<%sExp%>, <%signdigExp%>, <%minlenExp%>, <%leftjustExp%>);<%\n%>'
     '<%tvar%>'
 
   case CALL(path=IDENT(name="delay"),

--- a/Compiler/Template/CodegenXML.tpl
+++ b/Compiler/Template/CodegenXML.tpl
@@ -3257,13 +3257,13 @@ template daeExpCallXml(Exp call, Context context, Text &preExp /*BUFP*/,
     let &preExp += '<%tvar%> = <%typeStr%>_to_modelica_string(<%sExp%>, <%minlenExp%>, <%leftjustExp%>);<%\n%>'
     '<%tvar%>'
 
-  case CALL(path=IDENT(name="String"), expLst={s, minlen, leftjust, signdig}) then
+  case CALL(path=IDENT(name="String"), expLst={s, signdig, minlen, leftjust}) then
     let tvar = tempDeclXml("modelica_string", &varDecls /*BUFD*/)
     let sExp = daeExpXml(s, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
     let minlenExp = daeExpXml(minlen, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
     let leftjustExp = daeExpXml(leftjust, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
     let signdigExp = daeExpXml(signdig, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
-    let &preExp += '<%tvar%> = modelica_real_to_modelica_string(<%sExp%>, <%minlenExp%>, <%leftjustExp%>, <%signdigExp%>);<%\n%>'
+    let &preExp += '<%tvar%> = modelica_real_to_modelica_string(<%sExp%>, <%signdigExp%>, <%minlenExp%>, <%leftjustExp%>);<%\n%>'
     '<%tvar%>'
 */
 

--- a/SimulationRuntime/c/util/modelica_string.c
+++ b/SimulationRuntime/c/util/modelica_string.c
@@ -218,7 +218,7 @@ modelica_string modelica_integer_to_modelica_string(modelica_integer i, modelica
 
 /* Convert a modelica_real to a modelica_string, used in String(r) */
 
-modelica_string modelica_real_to_modelica_string(modelica_real r,modelica_integer minLen,modelica_boolean leftJustified,modelica_integer signDigits)
+modelica_string modelica_real_to_modelica_string(modelica_real r, modelica_integer signDigits, modelica_integer minLen, modelica_boolean leftJustified)
 {
   size_t sz = snprintf(NULL, 0, leftJustified ? "%-*.*g" : "%*.*g", (int) minLen, (int) signDigits, r);
   void *res = alloc_modelica_string(sz);

--- a/SimulationRuntime/c/util/modelica_string.h
+++ b/SimulationRuntime/c/util/modelica_string.h
@@ -51,8 +51,8 @@ extern modelica_string modelica_real_to_modelica_string_format(modelica_real r, 
 extern modelica_string modelica_integer_to_modelica_string_format(modelica_integer i, modelica_string format);
 extern modelica_string modelica_stringo_modelica_string_format(modelica_string s, modelica_string format);
 
-extern modelica_string modelica_real_to_modelica_string(modelica_real r,modelica_integer minLen,
-                                   modelica_boolean leftJustified,modelica_integer signDigits);
+extern modelica_string modelica_real_to_modelica_string(modelica_real r, modelica_integer signDigits,
+                                   modelica_integer minLen, modelica_boolean leftJustified);
 
 extern modelica_string modelica_string_to_modelica_string(modelica_string s);
 extern modelica_string modelica_integer_to_modelica_string(modelica_integer i,


### PR DESCRIPTION
- The significantDigits parameter should come before the other options
  in String() according to the specification, but the compiler expected
  it to be last instead.