### PR TITLE
[DAEmode] Introduce evaluation stages on equation level

### DIFF
--- a/Compiler/BackEnd/BackendDAE.mo
+++ b/Compiler/BackEnd/BackendDAE.mo
@@ -303,19 +303,31 @@ public uniontype EquationKind "equation kind"
   end UNKNOWN_EQUATION_KIND;
 end EquationKind;
 
+public uniontype EvaluationStages "evaluation stages"
+  record EVALUATION_STAGES
+    Boolean dynamicEval;
+    Boolean algebraicEval;
+    Boolean zerocrossEval;
+    Boolean discreteEval;
+  end EVALUATION_STAGES;
+end EvaluationStages;
+
+public constant EvaluationStages defaultEvalStages = EVALUATION_STAGES(false,false,false,false);
+
 public uniontype EquationAttributes
   record EQUATION_ATTRIBUTES
     Boolean differentiated "true if the equation was differentiated, and should not differentiated again to avoid equal equations";
     EquationKind kind;
+    EvaluationStages evalStages;
   end EQUATION_ATTRIBUTES;
 end EquationAttributes;
 
-public constant EquationAttributes EQ_ATTR_DEFAULT_DYNAMIC = EQUATION_ATTRIBUTES(false, DYNAMIC_EQUATION());
-public constant EquationAttributes EQ_ATTR_DEFAULT_BINDING = EQUATION_ATTRIBUTES(false, BINDING_EQUATION());
-public constant EquationAttributes EQ_ATTR_DEFAULT_INITIAL = EQUATION_ATTRIBUTES(false, INITIAL_EQUATION());
-public constant EquationAttributes EQ_ATTR_DEFAULT_DISCRETE = EQUATION_ATTRIBUTES(false, DISCRETE_EQUATION());
-public constant EquationAttributes EQ_ATTR_DEFAULT_AUX = EQUATION_ATTRIBUTES(false, AUX_EQUATION());
-public constant EquationAttributes EQ_ATTR_DEFAULT_UNKNOWN = EQUATION_ATTRIBUTES(false, UNKNOWN_EQUATION_KIND());
+public constant EquationAttributes EQ_ATTR_DEFAULT_DYNAMIC = EQUATION_ATTRIBUTES(false, DYNAMIC_EQUATION(),defaultEvalStages);
+public constant EquationAttributes EQ_ATTR_DEFAULT_BINDING = EQUATION_ATTRIBUTES(false, BINDING_EQUATION(),defaultEvalStages);
+public constant EquationAttributes EQ_ATTR_DEFAULT_INITIAL = EQUATION_ATTRIBUTES(false, INITIAL_EQUATION(),defaultEvalStages);
+public constant EquationAttributes EQ_ATTR_DEFAULT_DISCRETE = EQUATION_ATTRIBUTES(false, DISCRETE_EQUATION(),defaultEvalStages);
+public constant EquationAttributes EQ_ATTR_DEFAULT_AUX = EQUATION_ATTRIBUTES(false, AUX_EQUATION(),defaultEvalStages);
+public constant EquationAttributes EQ_ATTR_DEFAULT_UNKNOWN = EQUATION_ATTRIBUTES(false, UNKNOWN_EQUATION_KIND(),defaultEvalStages);
 
 public
 uniontype Equation

--- a/Compiler/BackEnd/BackendDAECreate.mo
+++ b/Compiler/BackEnd/BackendDAECreate.mo
@@ -709,7 +709,7 @@ algorithm
         // Add the binding as an equation and remove the binding from the variable.
         outVars := lowerDynamicVar(inElement, inFunctions) :: outVars;
         e1 := Expression.crefExp(cr);
-        attr := BackendDAE.EQUATION_ATTRIBUTES(false, BackendDAE.BINDING_EQUATION());
+        attr := BackendDAE.EQ_ATTR_DEFAULT_BINDING;
         outEqns := BackendDAE.EQUATION(e1, e2, src, attr) :: outEqns;
       then
         ();
@@ -1255,14 +1255,14 @@ algorithm
     case DAE.EQUATION(e1 as DAE.TUPLE(_),e2 as DAE.CALL(),source)
       equation
         (DAE.EQUALITY_EXPS(e1_1,e2_1), source) = ExpressionSimplify.simplifyAddSymbolicOperation(DAE.EQUALITY_EXPS(e1,e2),source);
-        eqns = lowerExtendedRecordEqn(e1_1,e2_1,source,BackendDAE.DYNAMIC_EQUATION(),functionTree,inEquations);
+        eqns = lowerExtendedRecordEqn(e1_1,e2_1,source,BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC,functionTree,inEquations);
       then
         (eqns,inREquations,inIEquations);
 
     case DAE.EQUATION(e2 as DAE.CALL(),e1 as DAE.TUPLE(_),source)
       equation
         (DAE.EQUALITY_EXPS(e1_1,e2_1), source) = ExpressionSimplify.simplifyAddSymbolicOperation(DAE.EQUALITY_EXPS(e1,e2),source);
-        eqns = lowerExtendedRecordEqn(e1_1,e2_1,source,BackendDAE.DYNAMIC_EQUATION(),functionTree,inEquations);
+        eqns = lowerExtendedRecordEqn(e1_1,e2_1,source,BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC,functionTree,inEquations);
       then
         (eqns,inREquations,inIEquations);
 
@@ -1270,14 +1270,14 @@ algorithm
     case DAE.INITIALEQUATION(e1 as DAE.TUPLE(_),e2 as DAE.CALL(),source)
       equation
         (DAE.EQUALITY_EXPS(e1_1,e2_1), source) = ExpressionSimplify.simplifyAddSymbolicOperation(DAE.EQUALITY_EXPS(e1,e2),source);
-        eqns = lowerExtendedRecordEqn(e1_1,e2_1,source,BackendDAE.INITIAL_EQUATION(),functionTree,inIEquations);
+        eqns = lowerExtendedRecordEqn(e1_1,e2_1,source,BackendDAE.EQ_ATTR_DEFAULT_INITIAL,functionTree,inIEquations);
       then
         (inEquations,inREquations,eqns);
 
     case DAE.INITIALEQUATION(e2 as DAE.CALL(), e1 as DAE.TUPLE(_),source)
       equation
         (DAE.EQUALITY_EXPS(e1_1,e2_1), source) = ExpressionSimplify.simplifyAddSymbolicOperation(DAE.EQUALITY_EXPS(e1,e2),source);
-        eqns = lowerExtendedRecordEqn(e1_1,e2_1,source,BackendDAE.INITIAL_EQUATION(),functionTree,inIEquations);
+        eqns = lowerExtendedRecordEqn(e1_1,e2_1,source,BackendDAE.EQ_ATTR_DEFAULT_INITIAL,functionTree,inIEquations);
       then
         (inEquations,inREquations,eqns);
 
@@ -1297,7 +1297,7 @@ algorithm
       equation
         e1 = Expression.crefExp(cr1);
         e2 = Expression.crefExp(cr2);
-        eqns = lowerExtendedRecordEqn(e1,e2,source,BackendDAE.DYNAMIC_EQUATION(),functionTree,inEquations);
+        eqns = lowerExtendedRecordEqn(e1,e2,source,BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC,functionTree,inEquations);
       then
        (eqns,inREquations,inIEquations);
 
@@ -1319,7 +1319,7 @@ algorithm
       equation
          //TODO: remove inline
         (DAE.EQUALITY_EXPS(e1_1,e2_1), source) = Inline.simplifyAndForceInlineEquationExp(DAE.EQUALITY_EXPS(e1,e2), (SOME(functionTree), {DAE.NORM_INLINE(), DAE.DEFAULT_INLINE()}), source);
-        eqns = lowerExtendedRecordEqn(e1_1,e2_1,source,BackendDAE.DYNAMIC_EQUATION(),functionTree,inEquations);
+        eqns = lowerExtendedRecordEqn(e1_1,e2_1,source,BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC,functionTree,inEquations);
       then
         (eqns,inREquations,inIEquations);
 
@@ -1337,7 +1337,7 @@ algorithm
         (DAE.EQUALITY_EXPS(e1_1,e2_1), source) = ExpressionSimplify.simplifyAddSymbolicOperation(DAE.EQUALITY_EXPS(e1,e2),source);
         b1 = stringEq(Absyn.pathLastIdent(path),"equalityConstraint");
         eqns = if b1 then inREquations else inEquations;
-        eqns = lowerArrayEqn(dims,e1_1, e2_1,source,BackendDAE.DYNAMIC_EQUATION(),eqns);
+        eqns = lowerArrayEqn(dims,e1_1, e2_1,source,BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC,eqns);
         ((eqns,_)) = if b1 then (inEquations,eqns) else (eqns,inREquations);
       then
         (eqns,inREquations,inIEquations);
@@ -1345,14 +1345,14 @@ algorithm
     case DAE.ARRAY_EQUATION(dimension=dims,exp = e1,array = e2,source = source)
       equation
         (DAE.EQUALITY_EXPS(e1_1,e2_1), source) = ExpressionSimplify.simplifyAddSymbolicOperation(DAE.EQUALITY_EXPS(e1,e2),source);
-        eqns = lowerArrayEqn(dims,e1_1,e2_1,source,BackendDAE.DYNAMIC_EQUATION(),inEquations);
+        eqns = lowerArrayEqn(dims,e1_1,e2_1,source,BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC,inEquations);
       then
         (eqns,inREquations,inIEquations);
 
     case DAE.INITIAL_ARRAY_EQUATION(dimension=dims,exp = e1,array = e2,source = source)
       equation
         (DAE.EQUALITY_EXPS(e1_1,e2_1), source) = ExpressionSimplify.simplifyAddSymbolicOperation(DAE.EQUALITY_EXPS(e1,e2),source);
-        eqns = lowerArrayEqn(dims,e1_1,e2_1,source,BackendDAE.DYNAMIC_EQUATION(),inIEquations);
+        eqns = lowerArrayEqn(dims,e1_1,e2_1,source,BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC,inIEquations);
       then
         (inEquations,inREquations,eqns);
 
@@ -1680,12 +1680,12 @@ protected function lowerExtendedRecordEqns "author: Frenkel TUD 2012-06"
   input list<DAE.Exp> explst1;
   input list<DAE.Exp> explst2;
   input DAE.ElementSource source;
-  input BackendDAE.EquationKind inEqKind;
+  input BackendDAE.EquationAttributes inEqAttributes;
   input DAE.FunctionTree functionTree;
   input list<BackendDAE.Equation> inEqns;
   output list<BackendDAE.Equation> outEqns;
 algorithm
-  outEqns := match(explst1, explst2, source, inEqKind, functionTree, inEqns)
+  outEqns := match(explst1, explst2, source, inEqAttributes, functionTree, inEqns)
     local
       DAE.Exp e1, e2;
       list<DAE.Exp> elst1, elst2;
@@ -1693,9 +1693,9 @@ algorithm
     case({}, {}, _, _, _, _) then inEqns;
     case(e1::elst1, e2::elst2, _, _, _, _)
       equation
-        eqns = lowerExtendedRecordEqn(e1, e2, source, inEqKind, functionTree, inEqns);
+        eqns = lowerExtendedRecordEqn(e1, e2, source, inEqAttributes, functionTree, inEqns);
       then
-        lowerExtendedRecordEqns(elst1, elst2, source, inEqKind, functionTree, eqns);
+        lowerExtendedRecordEqns(elst1, elst2, source, inEqAttributes, functionTree, eqns);
   end match;
 end lowerExtendedRecordEqns;
 
@@ -1703,12 +1703,12 @@ protected function lowerExtendedRecordEqn "author: Frenkel TUD 2012-06"
   input DAE.Exp inExp1;
   input DAE.Exp inExp2;
   input DAE.ElementSource source;
-  input BackendDAE.EquationKind inEqKind;
+  input BackendDAE.EquationAttributes inEqAttributes;
   input DAE.FunctionTree functionTree;
   input list<BackendDAE.Equation> inEqns;
   output list<BackendDAE.Equation> outEqns;
 algorithm
-  outEqns := matchcontinue(inExp1, inExp2, source, inEqKind, functionTree, inEqns)
+  outEqns := matchcontinue(inExp1, inExp2, source, inEqAttributes, functionTree, inEqns)
     local
       DAE.Type tp;
       Integer size;
@@ -1723,7 +1723,7 @@ algorithm
         explst1 = Expression.splitRecord(inExp1, Expression.typeof(inExp1));
         explst2 = Expression.splitRecord(inExp2, Expression.typeof(inExp2));
       then
-        lowerExtendedRecordEqns(explst1, explst2, source, inEqKind, functionTree, inEqns);
+        lowerExtendedRecordEqns(explst1, explst2, source, inEqAttributes, functionTree, inEqns);
 
     // complex types to complex equations
     case (_, _, _, _, _, _)
@@ -1732,7 +1732,7 @@ algorithm
         true = DAEUtil.expTypeComplex(tp);
         size = Expression.sizeOf(tp);
       then
-        BackendDAE.COMPLEX_EQUATION(size, inExp1, inExp2, source, BackendDAE.EQUATION_ATTRIBUTES(false, inEqKind))::inEqns;
+        BackendDAE.COMPLEX_EQUATION(size, inExp1, inExp2, source, inEqAttributes)::inEqns;
 
     // array types to array equations
     case (_, _, _, _, _, _)
@@ -1741,7 +1741,7 @@ algorithm
         true = DAEUtil.expTypeArray(tp);
         dims = Expression.arrayDimension(tp);
       then
-        lowerArrayEqn(dims, inExp1, inExp2, source, inEqKind, inEqns);
+        lowerArrayEqn(dims, inExp1, inExp2, source, inEqAttributes, inEqns);
 
     // tuple types to complex equations
     case (_, _, _, _, _, _)
@@ -1750,7 +1750,7 @@ algorithm
         true = Types.isTuple(tp);
         size = Expression.sizeOf(tp);
       then
-        BackendDAE.COMPLEX_EQUATION(size, inExp1, inExp2, source, BackendDAE.EQUATION_ATTRIBUTES(false, inEqKind))::inEqns;
+        BackendDAE.COMPLEX_EQUATION(size, inExp1, inExp2, source, inEqAttributes)::inEqns;
 
     // other types
     case (_, _, _, _, _, _)
@@ -1762,7 +1762,7 @@ algorithm
         false = b1 or b2 or b3;
         //Error.assertionOrAddSourceMessage(not b1, Error.INTERNAL_ERROR, {str}, Absyn.dummyInfo);
       then
-        BackendDAE.EQUATION(inExp1, inExp2, source, BackendDAE.EQUATION_ATTRIBUTES(false, inEqKind))::inEqns;
+        BackendDAE.EQUATION(inExp1, inExp2, source, inEqAttributes)::inEqns;
     else
       equation
         // show only on failtrace!
@@ -1778,11 +1778,11 @@ protected function lowerArrayEqn "author: Frenkel TUD 2012-06"
   input DAE.Exp e1;
   input DAE.Exp e2;
   input DAE.ElementSource source;
-  input BackendDAE.EquationKind inEqKind;
+  input BackendDAE.EquationAttributes inEqAttributes;
   input list<BackendDAE.Equation> iAcc;
   output list<BackendDAE.Equation> outEqsLst;
 algorithm
-  outEqsLst := matchcontinue (dims, e1, e2, source, inEqKind, iAcc)
+  outEqsLst := matchcontinue (dims, e1, e2, source, inEqAttributes, iAcc)
     local
       list<DAE.Exp> ea1, ea2;
       list<Integer> ds;
@@ -1795,7 +1795,7 @@ algorithm
         true = Expression.isArray(e2) or Expression.isMatrix(e2);
         ea1 = Expression.flattenArrayExpToList(e1);
         ea2 = Expression.flattenArrayExpToList(e2);
-      then generateEquations(ea1, ea2, source, inEqKind, iAcc);
+      then generateEquations(ea1, ea2, source, inEqAttributes, iAcc);
 
     // array type with record
     case (_, _, _, _, _, _)
@@ -1808,12 +1808,12 @@ algorithm
         ds = List.map1(ds, intMul, i);
         //For COMPLEX_EQUATION
         //i = List.fold(ds, intMul, 1);
-      then BackendDAE.ARRAY_EQUATION(ds, e1, e2, source, BackendDAE.EQUATION_ATTRIBUTES(false, inEqKind))::iAcc;
+      then BackendDAE.ARRAY_EQUATION(ds, e1, e2, source, inEqAttributes)::iAcc;
 
     case (_, _, _, _, _, _)
       equation
         ds = Expression.dimensionsSizes(dims);
-      then BackendDAE.ARRAY_EQUATION(ds, e1, e2, source, BackendDAE.EQUATION_ATTRIBUTES(false, inEqKind))::iAcc;
+      then BackendDAE.ARRAY_EQUATION(ds, e1, e2, source, inEqAttributes)::iAcc;
   end matchcontinue;
 end lowerArrayEqn;
 
@@ -1821,17 +1821,17 @@ protected function generateEquations "author: Frenkel TUD 2012-06"
   input list<DAE.Exp> iE1lst;
   input list<DAE.Exp> iE2lst;
   input DAE.ElementSource source;
-  input BackendDAE.EquationKind inEqKind;
+  input BackendDAE.EquationAttributes inEqAttributes;
   input list<BackendDAE.Equation> iAcc;
   output list<BackendDAE.Equation> oEqns;
 algorithm
-  oEqns := match(iE1lst, iE2lst, source, inEqKind, iAcc)
+  oEqns := match(iE1lst, iE2lst, source, inEqAttributes, iAcc)
     local
       DAE.Exp e1, e2;
       list<DAE.Exp> e1lst, e2lst;
     case ({}, {}, _, _, _) then iAcc;
     case (e1::e1lst, e2::e2lst, _, _, _)
-      then generateEquations(e1lst, e2lst, source, inEqKind, BackendDAE.EQUATION(e1, e2, source, BackendDAE.EQUATION_ATTRIBUTES(false, inEqKind))::iAcc);
+      then generateEquations(e1lst, e2lst, source, inEqAttributes, BackendDAE.EQUATION(e1, e2, source, inEqAttributes)::iAcc);
   end match;
 end generateEquations;
 
@@ -1861,7 +1861,7 @@ algorithm
   outEqs := BackendDAE.EQUATION( exp = DAE.CREF(componentRef = cr, ty = DAE.T_CLOCK_DEFAULT),
                                 scalar = e,  source = DAE.emptyElementSource,
                                 attr = BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC ) :: inEqs;
-  outEqAttrs := BackendDAE.EQUATION_ATTRIBUTES(false, BackendDAE.CLOCKED_EQUATION(whenClkCnt));
+  outEqAttrs := BackendEquation.defaultClockedEqAttr(whenClkCnt);
 end createWhenClock;
 
 
@@ -2527,7 +2527,7 @@ algorithm
     case (target::rest_targets, source::rest_sources, _, _, _)
       equation
         (DAE.EQUALITY_EXPS(target,source), eq_source) = ExpressionSimplify.simplifyAddSymbolicOperation(DAE.EQUALITY_EXPS(target,source),inEq_source);
-        eqns = lowerExtendedRecordEqn(target, source, inEq_source, BackendDAE.UNKNOWN_EQUATION_KIND(), funcs, iEqns);
+        eqns = lowerExtendedRecordEqn(target, source, inEq_source, BackendDAE.EQ_ATTR_DEFAULT_UNKNOWN, funcs, iEqns);
       then
         lowerTupleAssignment(rest_targets, rest_sources, eq_source, funcs, eqns);
   end match;

--- a/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1488,6 +1488,148 @@ algorithm
   end matchcontinue;
 end varsInEqn;
 
+protected type TraverseIndicesTuple = tuple<list<Integer>, list<Integer>, list<Integer>>;
+
+public function setEvaluationStage
+  input BackendDAE.BackendDAE inBackendDAE;
+  output BackendDAE.BackendDAE outBackendDAE;
+protected
+  //BackendDAE.SparsePattern sp;
+  list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> spCrefs, spCrefsT;
+  BackendDAE.Variables vars;
+  list<BackendDAE.Var> varLst;
+  BackendDAE.EquationArray eqns;
+  BackendDAE.Matching matching;
+  list<Integer> indicesDynamic, indicesDiscrete, indicesAlgebraic, indicesZC;
+  list<DAE.ComponentRef> eqnCrefs;
+  TraverseIndicesTuple traverseArgs;
+  array<Integer> assigndEqn, assigndVar, markedEqns;
+  BackendDAE.EqSystems newEqs = {};
+  array<Integer> zceqnsmarks;
+
+  BackendDAE.IncidenceMatrix adjMatrix, adjMatrixT;
+
+  BackendDAE.ZeroCrossingSet zeroCrossingsSet;
+  list<BackendDAE.ZeroCrossing> zeroCrossings;
+
+  constant Boolean debug = false;
+algorithm
+
+  // get zeroCrossings
+  zeroCrossings := ZeroCrossings.toList(inBackendDAE.shared.eventInfo.zeroCrossings);
+
+  // walk once through all comps and get of dependends of dynamic, algebraic, zeroCrossings,
+  for eqSystem in inBackendDAE.eqs loop
+    if debug then
+      BackendDump.printEqSystem(eqSystem);
+    end if;
+
+    vars := eqSystem.orderedVars;
+    eqns := eqSystem.orderedEqs;
+
+    try
+      (matching as BackendDAE.MATCHING(ass2=assigndEqn,ass1=assigndVar)) := eqSystem.matching;
+      (eqSystem, adjMatrix, adjMatrixT) := getIncidenceMatrixfromOption(eqSystem, BackendDAE.ABSOLUTE(), SOME(inBackendDAE.shared.functionTree));
+
+      // collect all dynamic, discrete, algebraic equations
+      traverseArgs := ({}, {}, {});
+      traverseArgs := BackendDAEUtil.traverseEqSystemStrongComponents(eqSystem, collectEqnsIndexByKind, traverseArgs);
+      ((indicesDynamic, indicesDiscrete, indicesAlgebraic)) := traverseArgs;
+
+      if debug then
+        print("Dynamic equation indicies:\n");
+        print(stringDelimitList(list(intString(i) for i in indicesDynamic), ", "));
+        print("\n");
+      end if;
+
+      markedEqns := arrayCreate(BackendEquation.getNumberOfEquations(eqns), 0);
+      markedEqns := markStateEquationsWork(indicesDynamic, adjMatrix, assigndVar, markedEqns);
+      eqns := setMarkedEqnsEvalStage(eqns, markedEqns, BackendEquation.setEvalStageDynamic);
+
+      markedEqns := arrayCreate(BackendEquation.getNumberOfEquations(eqns), 0);
+      markedEqns := markZeroCrossingEquations(eqSystem, zeroCrossings, markedEqns, assigndVar);
+      eqns := setMarkedEqnsEvalStage(eqns, markedEqns, BackendEquation.setEvalStageZeroCross);
+
+      markedEqns := arrayCreate(BackendEquation.getNumberOfEquations(eqns), 0);
+      markedEqns := markStateEquationsWork(indicesAlgebraic, adjMatrix, assigndVar, markedEqns);
+      eqns := setMarkedEqnsEvalStage(eqns, markedEqns, BackendEquation.setEvalStageAlgebraic);
+
+      markedEqns := arrayCreate(BackendEquation.getNumberOfEquations(eqns), 0);
+      markedEqns := markStateEquationsWork(indicesDiscrete, adjMatrix, assigndVar, markedEqns);
+      markedEqns := markStateEquationsWork(indicesDiscrete, adjMatrixT, assigndVar, markedEqns);
+      eqns := setMarkedEqnsEvalStage(eqns, markedEqns, BackendEquation.setEvalStageDiscrete);
+    else
+      /* in case something goes wrong above mark all equation to be evaluated always */
+      markedEqns := arrayCreate(BackendEquation.getNumberOfEquations(eqns), 1);
+      eqns := setMarkedEqnsEvalStage(eqns, markedEqns, BackendEquation.setEvalStageAll);
+    end try;
+
+    if debug then
+      BackendDump.dumpEquationArray(eqns, "Updated equations");
+    end if;
+
+    // update EvaluationState in EquationArray
+    newEqs := eqSystem::newEqs;
+  end for;
+
+  // update BackendDAE.DAE
+  outBackendDAE := BackendDAE.DAE(newEqs, inBackendDAE.shared);
+
+end setEvaluationStage;
+
+protected function setMarkedEqnsEvalStage
+  input output BackendDAE.EquationArray eqns;
+  input array<Integer> markEqns;
+  input setEvalStage func;
+  partial function setEvalStage
+    input output BackendDAE.EvaluationStages evalStage;
+  end setEvalStage;
+protected
+  BackendDAE.Equation eqn;
+  Integer eqnIndex;
+algorithm
+  for i in 1:arrayLength(markEqns) loop
+    if markEqns[i]>0 then
+      eqn := BackendEquation.get(eqns, i);
+      eqn := BackendEquation.setEquationEvalStage(eqn, func);
+      eqns := BackendEquation.setAtIndex(eqns, i, eqn);
+    end if;
+  end for;
+end setMarkedEqnsEvalStage;
+
+protected function collectEqnsIndexByKind
+"This function collects equation indices by kind.
+ "
+  input list<BackendDAE.Equation> inEqns;
+  input list<BackendDAE.Var> inVars;
+  input list<Integer> varIdxs;
+  input list<Integer> eqnIdxs;
+  input output TraverseIndicesTuple traverserArgs;
+protected
+  list<Integer> indicesDynamic, indicesDiscrete, indicesAlgebraic;
+algorithm
+  (indicesDynamic, indicesDiscrete, indicesAlgebraic) := traverserArgs;
+  for v in inVars loop
+    // discrete equations are detected by the corresponding variables
+    if BackendVariable.isVarDiscrete(v) then
+      indicesDiscrete := listAppend(eqnIdxs, indicesDiscrete);
+    end if;
+  end for;
+
+  for eq in inEqns loop
+    // dynamic
+    if BackendEquation.isDynamicEquation(eq) then
+      indicesDynamic := listAppend(eqnIdxs, indicesDynamic);
+    end if;
+    // select also continuos equation
+    if BackendEquation.isAuxEquation(eq) then
+      indicesAlgebraic := listAppend(eqnIdxs, indicesAlgebraic);
+    end if;
+  end for;
+
+  traverserArgs := (indicesDynamic, indicesDiscrete, indicesAlgebraic);
+end collectEqnsIndexByKind;
+
 public function subscript2dCombinations
 "This function takes two lists of list of subscripts and combines them in
   all possible combinations. This is used when finding all indexes of a 2d
@@ -7550,7 +7692,8 @@ public function allPostOptimizationModules
     (BackendDAETransform.collapseArrayExpressions, "collapseArrayExpressions"),
     // DAEmode modules
     (DAEMode.createDAEmodeBDAE, "createDAEmodeBDAE"),
-    (SymbolicJacobian.detectSparsePatternDAE, "detectDAEmodeSparsePattern")
+    (SymbolicJacobian.detectSparsePatternDAE, "detectDAEmodeSparsePattern"),
+    (BackendDAEUtil.setEvaluationStage, "setEvaluationStage")
   };
 end allPostOptimizationModules;
 

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -2766,10 +2766,10 @@ protected function equationAttrString
   output String outString;
 protected
   BackendDAE.EquationKind kind;
+  BackendDAE.EvaluationStages evalStages;
 algorithm
-  BackendDAE.EQUATION_ATTRIBUTES(kind=kind) := inEqAttr;
-  outString := "[" + equationKindString(kind);
-  outString := outString + "]";
+  BackendDAE.EQUATION_ATTRIBUTES(kind=kind,evalStages=evalStages) := inEqAttr;
+  outString := "[" + equationKindString(kind) +  " " + equationEvaluationStageString(evalStages) + "]";
 end equationAttrString;
 
 protected function equationKindString
@@ -2796,6 +2796,16 @@ algorithm
       then fail();
   end match;
 end equationKindString;
+
+protected function equationEvaluationStageString
+  input BackendDAE.EvaluationStages inEqEvalStage;
+  output String outString = "|";
+algorithm
+  outString := outString + (if inEqEvalStage.dynamicEval then   "1|" else "0|");
+  outString := outString + (if inEqEvalStage.algebraicEval then "1|" else "0|");
+  outString := outString + (if inEqEvalStage.zerocrossEval then "1|" else "0|");
+  outString := outString + (if inEqEvalStage.discreteEval then  "1|" else "0|");
+end equationEvaluationStageString;
 
 protected function optExpressionString
 "Helper function to dump."

--- a/Compiler/BackEnd/Differentiate.mo
+++ b/Compiler/BackEnd/Differentiate.mo
@@ -280,10 +280,10 @@ try
       list<DAE.Statement> statementLst;
       DAE.Expand expand;
       BackendDAE.WhenEquation whenEqn;
-      BackendDAE.EquationKind eqKind;
+      BackendDAE.EquationAttributes eqAttr;
 
     // equations
-    case BackendDAE.EQUATION(exp=e1, scalar=e2, source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(kind=eqKind))
+    case BackendDAE.EQUATION(exp=e1, scalar=e2, source=source, attr=eqAttr)
       equation
         (e1_1, funcs) = differentiateExp(e1, inDiffwrtCref, inInputData, inDiffType, inFunctionTree, defaultMaxIter);
         (e1_1, _) = ExpressionSimplify.simplify(e1_1);
@@ -294,11 +294,12 @@ try
         op1 = DAE.OP_DIFFERENTIATE(inDiffwrtCref, e1, e1_1);
         op2 = DAE.OP_DIFFERENTIATE(inDiffwrtCref, e2, e2_1);
         source = List.foldr({op1, op2}, ElementSource.addSymbolicTransformation, source);
+
       then
-        (BackendDAE.EQUATION(e1_1, e2_1, source, BackendDAE.EQUATION_ATTRIBUTES(false, eqKind)), funcs);
+        (BackendDAE.EQUATION(e1_1, e2_1, source, eqAttr), funcs);
 
     // solved equations
-    case BackendDAE.SOLVED_EQUATION(componentRef=cref, exp=e2, source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(kind=eqKind))
+    case BackendDAE.SOLVED_EQUATION(componentRef=cref, exp=e2, source=source, attr=eqAttr)
       equation
         e1 = Expression.crefExp(cref);
 
@@ -311,11 +312,12 @@ try
         op1 = DAE.OP_DIFFERENTIATE(inDiffwrtCref, e1, e1_1);
         op2 = DAE.OP_DIFFERENTIATE(inDiffwrtCref, e2, e2_1);
         source = List.foldr({op1, op2}, ElementSource.addSymbolicTransformation, source);
+
       then
-        (BackendDAE.EQUATION(e1_1, e2_1, source, BackendDAE.EQUATION_ATTRIBUTES(false, eqKind)), funcs);
+        (BackendDAE.EQUATION(e1_1, e2_1, source, eqAttr), funcs);
 
     // RESIDUAL_EQUATION
-    case BackendDAE.RESIDUAL_EQUATION(exp=e1, source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(kind=eqKind))
+    case BackendDAE.RESIDUAL_EQUATION(exp=e1, source=source, attr=eqAttr)
       equation
 
         (e1_1, funcs) = differentiateExp(e1, inDiffwrtCref, inInputData, inDiffType, inFunctionTree, defaultMaxIter);
@@ -325,10 +327,10 @@ try
         source = List.foldr({op1}, ElementSource.addSymbolicTransformation, source);
 
       then
-        (BackendDAE.RESIDUAL_EQUATION(e1_1, source, BackendDAE.EQUATION_ATTRIBUTES(false, eqKind)), funcs);
+        (BackendDAE.RESIDUAL_EQUATION(e1_1, source, eqAttr), funcs);
 
     // complex equations
-    case BackendDAE.COMPLEX_EQUATION(size=size, left=e1, right=e2, source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(kind=eqKind))
+    case BackendDAE.COMPLEX_EQUATION(size=size, left=e1, right=e2, source=source, attr=eqAttr)
       equation
         (e1_1, funcs) = differentiateExp(e1, inDiffwrtCref, inInputData, inDiffType, inFunctionTree, defaultMaxIter);
         (e1_1, _) = ExpressionSimplify.simplify(e1_1);
@@ -339,11 +341,12 @@ try
         op1 = DAE.OP_DIFFERENTIATE(inDiffwrtCref, e1, e1_1);
         op2 = DAE.OP_DIFFERENTIATE(inDiffwrtCref, e2, e2_1);
         source = List.foldr({op1, op2}, ElementSource.addSymbolicTransformation, source);
+
       then
-        (BackendDAE.COMPLEX_EQUATION(size, e1_1, e2_1, source, BackendDAE.EQUATION_ATTRIBUTES(false, eqKind)), funcs);
+        (BackendDAE.COMPLEX_EQUATION(size, e1_1, e2_1, source, eqAttr), funcs);
 
     // Array Equations
-    case BackendDAE.ARRAY_EQUATION(dimSize=dimSize, left=e1, right=e2, source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(kind=eqKind))
+    case BackendDAE.ARRAY_EQUATION(dimSize=dimSize, left=e1, right=e2, source=source, attr=eqAttr)
       equation
         (e1_1, funcs) = differentiateExp(e1, inDiffwrtCref, inInputData, inDiffType, inFunctionTree, defaultMaxIter);
         (e1_1, _) = ExpressionSimplify.simplify(e1_1);
@@ -354,11 +357,12 @@ try
         op1 = DAE.OP_DIFFERENTIATE(inDiffwrtCref, e1, e1_1);
         op2 = DAE.OP_DIFFERENTIATE(inDiffwrtCref, e2, e2_1);
         source = List.foldr({op1, op2}, ElementSource.addSymbolicTransformation, source);
+
       then
-        (BackendDAE.ARRAY_EQUATION(dimSize, e1_1, e2_1, source, BackendDAE.EQUATION_ATTRIBUTES(false, eqKind)), funcs);
+        (BackendDAE.ARRAY_EQUATION(dimSize, e1_1, e2_1, source, eqAttr), funcs);
 
     // differentiate algorithm
-    case BackendDAE.ALGORITHM(size=size, alg=DAE.ALGORITHM_STMTS(statementLst=statementLst), source=source, expand=expand, attr=BackendDAE.EQUATION_ATTRIBUTES(kind=eqKind))
+    case BackendDAE.ALGORITHM(size=size, alg=DAE.ALGORITHM_STMTS(statementLst=statementLst), source=source, expand=expand, attr=eqAttr)
       equation
         // get Allgorithm
         (statementLst, funcs) = differentiateStatements(statementLst, inDiffwrtCref, inInputData, inDiffType, {}, inFunctionTree, defaultMaxIter);
@@ -367,22 +371,25 @@ try
         //op1 = DAE.OP_DIFFERENTIATE(cr, before, after)
         //op1 = DAE.OP_DIFFERENTIATE(inDiffwrtCref, e1, e2);
         //source = ElementSource.addSymbolicTransformation(source, op1);
+
        then
-        (BackendDAE.ALGORITHM(size, alg, source, expand, BackendDAE.EQUATION_ATTRIBUTES(false, eqKind)), funcs);
+        (BackendDAE.ALGORITHM(size, alg, source, expand, eqAttr), funcs);
 
     // if-equations
-    case BackendDAE.IF_EQUATION(conditions=expExpLst, eqnstrue=eqnslst, eqnsfalse=eqns, source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(kind=eqKind))
+    case BackendDAE.IF_EQUATION(conditions=expExpLst, eqnstrue=eqnslst, eqnsfalse=eqns, source=source, attr=eqAttr)
       equation
         (eqnslst, funcs) = differentiateEquationsLst(eqnslst, inDiffwrtCref, inInputData, inDiffType, {}, inFunctionTree);
         (eqns, funcs) = differentiateEquations(eqns, inDiffwrtCref, inInputData, inDiffType, {}, funcs);
-      then
-        (BackendDAE.IF_EQUATION(expExpLst, eqnslst, eqns, source, BackendDAE.EQUATION_ATTRIBUTES(false, eqKind)), funcs);
 
-    case BackendDAE.WHEN_EQUATION(size=size, whenEquation=whenEqn, source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(kind=eqKind))
+      then
+        (BackendDAE.IF_EQUATION(expExpLst, eqnslst, eqns, source, eqAttr), funcs);
+
+    case BackendDAE.WHEN_EQUATION(size=size, whenEquation=whenEqn, source=source, attr=eqAttr)
       equation
         (whenEqn, funcs) = differentiateWhenEquations(whenEqn, inDiffwrtCref, inInputData, inDiffType, inFunctionTree);
+
       then
-        (BackendDAE.WHEN_EQUATION(size, whenEqn, source, BackendDAE.EQUATION_ATTRIBUTES(false, eqKind)), funcs);
+        (BackendDAE.WHEN_EQUATION(size, whenEqn, source, eqAttr), funcs);
     else equation
       Error.addSourceMessage(Error.NON_EXISTING_DERIVATIVE, {BackendDump.equationString(inEquation), ComponentReference.crefStr(inDiffwrtCref)}, sourceInfo());
      then fail();

--- a/Compiler/BackEnd/DynamicOptimization.mo
+++ b/Compiler/BackEnd/DynamicOptimization.mo
@@ -228,7 +228,7 @@ algorithm
   (cr, v) := makeVar(name);
   annoObj := findObj(varlst);
   annoObj := mergeObjectVars(annoObj, optimicaExp);
-  e := BackendEquation.generateSolvedEqnsfromOption(cr, annoObj, DAE.emptyElementSource, BackendDAE.UNKNOWN_EQUATION_KIND());
+  e := BackendEquation.generateSolvedEqnsfromOption(cr, annoObj, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_UNKNOWN);
   outTpl := (v, e, annoObj);
 end makeObject;
 

--- a/Compiler/BackEnd/HpcOmEqSystems.mo
+++ b/Compiler/BackEnd/HpcOmEqSystems.mo
@@ -1913,7 +1913,7 @@ algorithm
       varExp = List.map(arrayList(vectorX),BackendVariable.varExp);
       detLst = List.map1(detLst,function Expression.makeBinaryExp(inOp = DAE.DIV(ty=DAE.T_ANYTYPE_DEFAULT)),detA);
       (detLst,_) = List.map_2(detLst,ExpressionSimplify.simplify);
-      eqLst = List.threadMap2(varExp, detLst, BackendEquation.generateEQUATION, DAE.emptyElementSource, BackendDAE.UNKNOWN_EQUATION_KIND());
+      eqLst = List.threadMap2(varExp, detLst, BackendEquation.generateEquation, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_UNKNOWN);
           //BackendDump.dumpEquationList(eqLst,"new residual eqs");
     then (eqLst,{},{});
   case(LINSYS(dim=dim,matrixA=matrixA, vectorX=vectorX))
@@ -1929,7 +1929,7 @@ algorithm
       varExp = List.map(arrayList(vectorX),BackendVariable.varExp);
       detLst = List.map1(detLst,function Expression.makeBinaryExp(inOp = DAE.DIV(ty=DAE.T_ANYTYPE_DEFAULT)),detA);
       (detLst,_) = List.map_2(detLst,ExpressionSimplify.simplify);
-      eqLst = List.threadMap2(varExp, detLst, BackendEquation.generateEQUATION, DAE.emptyElementSource, BackendDAE.UNKNOWN_EQUATION_KIND());
+      eqLst = List.threadMap2(varExp, detLst, BackendEquation.generateEquation, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_UNKNOWN);
           //BackendDump.dumpEquationList(eqLst,"new residual eqs");
     then (eqLst,{},{});
   case(LINSYS(dim=dim))

--- a/Compiler/BackEnd/InlineArrayEquations.mo
+++ b/Compiler/BackEnd/InlineArrayEquations.mo
@@ -140,43 +140,42 @@ algorithm
       DAE.Exp lhs, rhs, e1_1, e2_1;
       list<DAE.Exp> ea1, ea2;
       list<BackendDAE.Equation> eqns;
-      Boolean differentiated;
-      BackendDAE.EquationKind eqKind;
+      BackendDAE.EquationAttributes eqAttr;
 
-    case (BackendDAE.ARRAY_EQUATION(left=lhs, right=rhs, source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(differentiated=differentiated, kind=eqKind)), _) equation
+    case (BackendDAE.ARRAY_EQUATION(left=lhs, right=rhs, source=source, attr=eqAttr), _) equation
       true = Expression.isArray(lhs) or Expression.isMatrix(lhs);
       true = Expression.isArray(rhs) or Expression.isMatrix(rhs);
       ea1 = Expression.flattenArrayExpToList(lhs);
       ea2 = Expression.flattenArrayExpToList(rhs);
-      ((_, eqns)) = List.threadFold4(ea1, ea2, generateScalarArrayEqns2, source, differentiated, eqKind, DAE.EQUALITY_EXPS(lhs, rhs), (1, inAccEqnLst));
+      ((_, eqns)) = List.threadFold3(ea1, ea2, generateScalarArrayEqns2, source, eqAttr, DAE.EQUALITY_EXPS(lhs, rhs), (1, inAccEqnLst));
     then (eqns, true);
 
-    case (BackendDAE.ARRAY_EQUATION(left=(lhs as DAE.CREF()), right=rhs, source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(differentiated=differentiated, kind=eqKind)), _) equation
+    case (BackendDAE.ARRAY_EQUATION(left=(lhs as DAE.CREF()), right=rhs, source=source, attr=eqAttr), _) equation
       // the lhs array is expressed as a cref
       true = Expression.isArray(rhs) or Expression.isMatrix(rhs);
       (e1_1, _) = Expression.extendArrExp(lhs, false);
       ea1 = Expression.flattenArrayExpToList(e1_1);
       ea2 = Expression.flattenArrayExpToList(rhs);
-      ((_, eqns)) = List.threadFold4(ea1, ea2, generateScalarArrayEqns2, source, differentiated, eqKind, DAE.EQUALITY_EXPS(lhs, rhs), (1, inAccEqnLst));
+      ((_, eqns)) = List.threadFold3(ea1, ea2, generateScalarArrayEqns2, source, eqAttr, DAE.EQUALITY_EXPS(lhs, rhs), (1, inAccEqnLst));
     then (eqns, true);
 
-    case (BackendDAE.ARRAY_EQUATION(left=lhs, right=rhs as DAE.CREF(), source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(differentiated=differentiated, kind=eqKind)), _) equation
+    case (BackendDAE.ARRAY_EQUATION(left=lhs, right=rhs as DAE.CREF(), source=source, attr=eqAttr), _) equation
       true = Expression.isArray(lhs) or Expression.isMatrix(lhs);
       (e2_1, _) = Expression.extendArrExp(rhs,false);
       ea1 = Expression.flattenArrayExpToList(lhs);
       ea2 = Expression.flattenArrayExpToList(e2_1);
-      ((_, eqns)) = List.threadFold4(ea1, ea2, generateScalarArrayEqns2, source, differentiated, eqKind, DAE.EQUALITY_EXPS(lhs, rhs), (1, inAccEqnLst));
+      ((_, eqns)) = List.threadFold3(ea1, ea2, generateScalarArrayEqns2, source, eqAttr, DAE.EQUALITY_EXPS(lhs, rhs), (1, inAccEqnLst));
     then (eqns,true);
 
-    case (BackendDAE.ARRAY_EQUATION(left=lhs as DAE.CREF(),right=rhs as DAE.CREF(), source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(differentiated=differentiated, kind=eqKind)), _) equation
+    case (BackendDAE.ARRAY_EQUATION(left=lhs as DAE.CREF(),right=rhs as DAE.CREF(), source=source, attr=eqAttr), _) equation
       (e1_1, _) = Expression.extendArrExp(lhs, false);
       (e2_1, _) = Expression.extendArrExp(rhs, false);
       ea1 = Expression.flattenArrayExpToList(e1_1);
       ea2 = Expression.flattenArrayExpToList(e2_1);
-      ((_, eqns)) = List.threadFold4(ea1, ea2, generateScalarArrayEqns2, source, differentiated, eqKind, DAE.EQUALITY_EXPS(lhs, rhs), (1, inAccEqnLst));
+      ((_, eqns)) = List.threadFold3(ea1, ea2, generateScalarArrayEqns2, source, eqAttr, DAE.EQUALITY_EXPS(lhs, rhs), (1, inAccEqnLst));
     then (eqns, true);
 
-    case (BackendDAE.ARRAY_EQUATION(left=lhs,right=rhs, source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(differentiated=differentiated, kind=eqKind)), _) equation
+    case (BackendDAE.ARRAY_EQUATION(left=lhs,right=rhs, source=source, attr=eqAttr), _) equation
       (e1_1, _) = Expression.extendArrExp(lhs, false);
       (e2_1, _) = Expression.extendArrExp(rhs, false);
       (e1_1,_) = ExpressionSimplify.simplify(e1_1);
@@ -185,13 +184,13 @@ algorithm
       true = Expression.isArray(e2_1) or Expression.isMatrix(e2_1);
       ea1 = Expression.flattenArrayExpToList(e1_1);
       ea2 = Expression.flattenArrayExpToList(e2_1);
-      ((_, eqns)) = List.threadFold4(ea1, ea2, generateScalarArrayEqns2, source, differentiated, eqKind, DAE.EQUALITY_EXPS(lhs, rhs), (1, inAccEqnLst));
+      ((_, eqns)) = List.threadFold3(ea1, ea2, generateScalarArrayEqns2, source, eqAttr, DAE.EQUALITY_EXPS(lhs, rhs), (1, inAccEqnLst));
     then (eqns, true);
 
-    case (BackendDAE.COMPLEX_EQUATION(left=lhs, right=rhs, source=source, attr=BackendDAE.EQUATION_ATTRIBUTES(differentiated=differentiated, kind=eqKind)), _) equation
+    case (BackendDAE.COMPLEX_EQUATION(left=lhs, right=rhs, source=source, attr=eqAttr), _) equation
       ea1 = Expression.splitRecord(lhs,Expression.typeof(lhs));
       ea2 = Expression.splitRecord(rhs,Expression.typeof(rhs));
-      ((_, eqns)) = List.threadFold4(ea1, ea2, generateScalarArrayEqns2, source, differentiated, eqKind, DAE.EQUALITY_EXPS(lhs, rhs), (1, inAccEqnLst));
+      ((_, eqns)) = List.threadFold3(ea1, ea2, generateScalarArrayEqns2, source, eqAttr, DAE.EQUALITY_EXPS(lhs, rhs), (1, inAccEqnLst));
     then (eqns, true);
 
     case (_, _)
@@ -203,13 +202,12 @@ protected function generateScalarArrayEqns2
   input DAE.Exp inExp1;
   input DAE.Exp inExp2;
   input DAE.ElementSource inSource;
-  input Boolean inDiffed;
-  input BackendDAE.EquationKind inEqKind;
+  input BackendDAE.EquationAttributes eqAttr;
   input DAE.EquationExp eqExp "original expressions; for the symbolic trace";
   input tuple<Integer /* current index; for the symbolic trace */, list<BackendDAE.Equation>> iEqns;
   output tuple<Integer, list<BackendDAE.Equation>> oEqns;
 algorithm
-  oEqns := matchcontinue(inExp1, inExp2, inSource, inDiffed, inEqKind, eqExp, iEqns)
+  oEqns := matchcontinue(inExp1, inExp2, inSource, eqAttr, eqExp, iEqns)
     local
       DAE.Type tp;
       Integer size, i;
@@ -220,30 +218,30 @@ algorithm
       DAE.ElementSource source;
 
     // complex types to complex equations
-    case (_, _, _, _, _, _, (i, eqns)) equation
+    case (_, _, _, _, _, (i, eqns)) equation
       tp = Expression.typeof(inExp1);
       true = DAEUtil.expTypeComplex(tp);
       size = Expression.sizeOf(tp);
       source = ElementSource.addSymbolicTransformation(inSource, DAE.OP_SCALARIZE(eqExp, i, DAE.EQUALITY_EXPS(inExp1, inExp2)));
-    then ((i+1, BackendDAE.COMPLEX_EQUATION(size, inExp1, inExp2, source, BackendDAE.EQUATION_ATTRIBUTES(inDiffed, inEqKind))::eqns));
+    then ((i+1, BackendDAE.COMPLEX_EQUATION(size, inExp1, inExp2, source, eqAttr)::eqns));
 
     // array types to array equations
-    case (_, _, _, _, _, _, (i, eqns)) equation
+    case (_, _, _, _, _, (i, eqns)) equation
       tp = Expression.typeof(inExp1);
       true = DAEUtil.expTypeArray(tp);
       dims = Expression.arrayDimension(tp);
       ds = Expression.dimensionsSizes(dims);
       source = ElementSource.addSymbolicTransformation(inSource, DAE.OP_SCALARIZE(eqExp, i, DAE.EQUALITY_EXPS(inExp1, inExp2)));
-    then ((i+1, BackendDAE.ARRAY_EQUATION(ds, inExp1, inExp2, source, BackendDAE.EQUATION_ATTRIBUTES(inDiffed, inEqKind))::eqns));
+    then ((i+1, BackendDAE.ARRAY_EQUATION(ds, inExp1, inExp2, source, eqAttr)::eqns));
 
     // other types
-    case (_, _, _, _, _, _, (i, eqns)) equation
+    case (_, _, _, _, _, (i, eqns)) equation
       tp = Expression.typeof(inExp1);
       b1 = DAEUtil.expTypeComplex(tp);
       b2 = DAEUtil.expTypeArray(tp);
       false = b1 or b2;
       source = ElementSource.addSymbolicTransformation(inSource, DAE.OP_SCALARIZE(eqExp, i, DAE.EQUALITY_EXPS(inExp1, inExp2)));
-    then ((i+1, BackendDAE.EQUATION(inExp1, inExp2, source, BackendDAE.EQUATION_ATTRIBUTES(inDiffed, inEqKind))::eqns));
+    then ((i+1, BackendDAE.EQUATION(inExp1, inExp2, source, eqAttr)::eqns));
 
     else equation
       // show only on failtrace!

--- a/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/Compiler/BackEnd/SynchronousFeatures.mo
@@ -1329,7 +1329,7 @@ algorithm
         (e1,(newEqs, newVars, suffixIdx)) := Expression.traverseExpTopDown(e1, replaceSampledClocks2, (newEqs, newVars, suffixIdx0));
         (e2,(newEqs, newVars, suffixIdx)) := Expression.traverseExpTopDown(e2, replaceSampledClocks2, (newEqs, newVars, suffixIdx));
         if intEq(suffixIdx-suffixIdx0, 1) then
-          attr := BackendDAE.EQUATION_ATTRIBUTES(false, BackendDAE.CLOCKED_EQUATION(suffixIdx0));
+          attr := BackendEquation.defaultClockedEqAttr(suffixIdx0);
         else
           attr := BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC;
         end if;
@@ -2217,15 +2217,15 @@ algorithm
       eqAttr := match eqAttr
         local
           Integer whenIdx;
-          Boolean diff;
           list<Integer> partitionsWhenClocksLst;
-        case BackendDAE.EQUATION_ATTRIBUTES(diff, BackendDAE.CLOCKED_EQUATION(whenIdx))
+        case BackendDAE.EQUATION_ATTRIBUTES(kind=BackendDAE.CLOCKED_EQUATION(whenIdx))
           algorithm
             partitionsWhenClocksLst := partitionsWhenClocks[partitionIdx];
             if whenIdx <> 0 and List.notMember(whenIdx, partitionsWhenClocksLst) then
               arrayUpdate(partitionsWhenClocks, partitionIdx, whenIdx::partitionsWhenClocksLst);
             end if;
-          then BackendDAE.EQUATION_ATTRIBUTES(diff, BackendDAE.DYNAMIC_EQUATION());
+            eqAttr.kind := BackendDAE.DYNAMIC_EQUATION();
+          then eqAttr;
         else eqAttr;
       end match;
       eq := BackendEquation.setEquationAttributes(eq, eqAttr);

--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -897,6 +897,7 @@ template simulationFile_dae(SimCode simCode)
      <<
      /* DAE residuals */
      <%simulationFileHeader(fileNamePrefix)%>
+     #include "simulation/solver/dae_mode.h"
 
      #ifdef __cplusplus
      extern "C" {
@@ -4038,9 +4039,10 @@ template evaluateDAEResiduals(list<list<SimEqSystem>> resEquations, String model
 
   /* for residuals DAE variables */
   OMC_DISABLE_OPT
-  int <%symbolName(modelNamePrefix,"evaluateDAEResiduals")%>(DATA *data, threadData_t *threadData)
+  int <%symbolName(modelNamePrefix,"evaluateDAEResiduals")%>(DATA *data, threadData_t *threadData, int currentEvalStage)
   {
     TRACE_PUSH
+    int evalStages;
     data->simulationInfo->callStatistics.functionEvalDAE++;
 
     <%eqCalls%>
@@ -5108,11 +5110,13 @@ template equationNames_(SimEqSystem eq, Context context, String modelNamePrefixS
   else
     equationIndex(eq)
   end match
-  let simEqAttr = match context case(DAE_MODE_CONTEXT()) then '/* eqAttr: <%simEqAttr(eq)%> */'
+  let simEqAttrEval = match context case(DAE_MODE_CONTEXT()) then '<%simEqAttrEval(eq)%>'
+  let simEqAttrIsDiscreteKind = match context case(DAE_MODE_CONTEXT()) then '<%simEqAttrIsDiscreteKind(eq)%>'
   <<
-  <%simEqAttr%>
   <% if profileAll() then 'SIM_PROF_TICK_EQ(<%ix%>);' %>
-  <%symbolName(modelNamePrefixStr,"eqFunction")%>_<%ix%>(data, threadData);
+  <% match simEqAttrEval case "" then '' else '<%simEqAttrEval%>' %>
+  <% match simEqAttrEval case "" then '' else 'if ((evalStages & currentEvalStage) && !((currentEvalStage!=EVAL_DISCRETE)?(<%simEqAttrIsDiscreteKind%>):0))' %>
+    <%symbolName(modelNamePrefixStr,"eqFunction")%>_<%ix%>(data, threadData);
   <% if profileAll() then 'SIM_PROF_ACC_EQ(<%ix%>);' %>
   >>
 end equationNames_;
@@ -5835,7 +5839,7 @@ template crefM(ComponentRef cr)
   else "P" + crefToMStr(cr)
 end crefM;
 
-template simEqAttr(SimEqSystem eq)
+template simEqAttrIsDiscreteKind(SimEqSystem eq)
 ::=
   match eq
   case SES_RESIDUAL(__)
@@ -5849,27 +5853,57 @@ template simEqAttr(SimEqSystem eq)
   case SES_MIXED(__)
   case SES_WHEN(__)
   case SES_FOR_LOOP(__)
-    then eqAttributes(eqAttr)
-end simEqAttr;
+    then eqAttributeIsDiscreteKind(eqAttr)
+end simEqAttrIsDiscreteKind;
 
-template eqAttributes(EquationAttributes eqAtt)
+template eqAttributeIsDiscreteKind(EquationAttributes eqAtt)
 ::=
   match eqAtt
-  case EQUATION_ATTRIBUTES(kind=kind) then '<%eqKind(kind)%>'
+  case EQUATION_ATTRIBUTES(kind=kind) then '<%eqIsDiscreteKind(kind)%>'
   else ''
-end eqAttributes;
+end eqAttributeIsDiscreteKind;
 
-template eqKind(EquationKind eqKind)
+template eqIsDiscreteKind(EquationKind eqKind)
 ::=
   match eqKind
-  case DYNAMIC_EQUATION() then  'DYNAMIC_EQN_KIND'
-  case BINDING_EQUATION() then  'BINDING_EQN_KIND'
-  case INITIAL_EQUATION() then  'INITAL_EQN_KIND'
-  case CLOCKED_EQUATION() then  'CLOCKED_EQN_KIND'
-  case DISCRETE_EQUATION() then 'DISCRETE_EQN_KIND'
-  case AUX_EQUATION() then      'AUX_EQN_KIND'
-  case UNKNOWN_EQUATION_KIND() then 'UNKNOWN_EQN_KIND'
-end eqKind;
+  case DISCRETE_EQUATION() then '1'
+  else  '0'
+end eqIsDiscreteKind;
+
+template simEqAttrEval(SimEqSystem eq)
+::=
+  match eq
+  case SES_RESIDUAL(__)
+  case SES_SIMPLE_ASSIGN(__)
+  case SES_SIMPLE_ASSIGN_CONSTRAINTS(__)
+  case SES_ARRAY_CALL_ASSIGN(__)
+  case SES_IFEQUATION(__)
+  case SES_ALGORITHM(__)
+  case SES_LINEAR(__)
+  case SES_NONLINEAR(__)
+  case SES_MIXED(__)
+  case SES_WHEN(__)
+  case SES_FOR_LOOP(__)
+    then eqAttributesEval(eqAttr)
+end simEqAttrEval;
+
+template eqAttributesEval(EquationAttributes eqAtt)
+::=
+  match eqAtt
+  case EQUATION_ATTRIBUTES(evalStages=evalStages) then '<%eqEval(evalStages)%>'
+  else ''
+end eqAttributesEval;
+
+template eqEval(EvaluationStages eqEval)
+::=
+  match eqEval
+  case EVALUATION_STAGES(__) then
+    let dy = if dynamicEval then '+1' else ''
+    let al = if algebraicEval then '+2' else ''
+    let zc = if zerocrossEval then '+4' else ''
+    let di = if discreteEval then '+8' else ''
+  <<evalStages = 0<%dy%><%al%><%zc%><%di%>;>>
+end eqEval;
 
 /*****************************************************************************
  *         SECTION: GENERATE OPTIMIZATION IN SIMULATION FILE

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -1342,10 +1342,20 @@ package BackendDAE
     end UNKNOWN_EQUATION_KIND;
   end EquationKind;
 
+  uniontype EvaluationStages "evaluation stages"
+    record EVALUATION_STAGES
+      Boolean dynamicEval;
+      Boolean algebraicEval;
+      Boolean zerocrossEval;
+      Boolean discreteEval;
+    end EVALUATION_STAGES;
+  end EvaluationStages;
+
   uniontype EquationAttributes
     record EQUATION_ATTRIBUTES
       Boolean differentiated "true if the equation was differentiated, and should not differentiated again to avoid equal equations";
       EquationKind kind;
+      EvaluationStages evalStages;
     end EQUATION_ATTRIBUTES;
   end EquationAttributes;
 end BackendDAE;

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -1442,13 +1442,13 @@ constant ConfigFlag IGNORE_REPLACEABLE = CONFIG_FLAG(117, "ignoreReplaceable",
     //"replaceDerCalls",
     "simplifysemiLinear",
     "simplifyComplexFunction",
-    "calculateStateSetsJacobians",
     "removeConstants",
     "simplifyTimeIndepFuncCalls",
     "simplifyAllExpressions",
     "findZeroCrossings",
     "createDAEmodeBDAE",
-    "detectDAEmodeSparsePattern"
+    "detectDAEmodeSparsePattern",
+    "setEvaluationStage"
     }),NONE(),
     Util.gettext("Sets the optimization modules for the DAEmode in the back end. See --help=optmodules for more info."));
 

--- a/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -656,7 +656,6 @@ static int callSolver(DATA* simData, threadData_t *threadData, string init_initM
     if (compiledInDAEMode)
     {
       simData->callback->functionDAE = evaluateDAEResiduals_wrapperEventUpdate;
-      simData->callback->function_ZeroCrossingsEquations = simData->simulationInfo->daeModeData->evaluateDAEResiduals;
     }
   }
 

--- a/SimulationRuntime/c/simulation/solver/dae_mode.c
+++ b/SimulationRuntime/c/simulation/solver/dae_mode.c
@@ -34,6 +34,18 @@
 extern "C" {
 #endif
 
+/* EVAL_DYNAMIC = 1000 */
+const int EVAL_DYNAMIC = 1;
+/* EVAL_ALGEBRAIC = 0100 */
+const int EVAL_ALGEBRAIC = 2;
+/* EVAL_ZEROCROSS = 0010 */
+const int EVAL_ZEROCROSS = 4;
+/* EVAL_DISCRETE = 0001 */
+const int EVAL_DISCRETE = 8;
+/* EVAL_ALL = 1111 */
+const int EVAL_ALL = 15;
+
+
 /*! \fn void evaluateDAEResiduals_wrapperEventUpdate
  *
  * wrapper function of the main evaluation function for DAE mode
@@ -43,7 +55,7 @@ int evaluateDAEResiduals_wrapperEventUpdate(DATA* data, threadData_t* threadData
   int retVal;
 
   data->simulationInfo->discreteCall = 1;
-  retVal = data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData);
+  retVal = data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData, EVAL_DISCRETE);
   data->simulationInfo->discreteCall = 0;
 
   return retVal;

--- a/SimulationRuntime/c/simulation/solver/dae_mode.h
+++ b/SimulationRuntime/c/simulation/solver/dae_mode.h
@@ -33,6 +33,17 @@
 
 #include "simulation_data.h"
 
+/* EVAL_DYNAMIC = 1000 */
+extern const int EVAL_DYNAMIC;
+/* EVAL_ALGEBRAIC = 0100 */
+extern const int EVAL_ALGEBRAIC;
+/* EVAL_ZEROCROSS = 0010 */
+extern const int EVAL_ZEROCROSS;
+/* EVAL_DISCRETE = 0001 */
+extern const int EVAL_DISCRETE;
+/* EVAL_ALL = 1111 */
+extern const int EVAL_ALL;
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -1184,7 +1184,7 @@ int residualFunctionIDA(double time, N_Vector yy, N_Vector yp, N_Vector res, voi
   if (idaData->daeMode)
   {
     /* eval residual vars */
-    data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData);
+    data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData, EVAL_DYNAMIC);
     /* get residual variables */
     for(i=0; i < idaData->N; i++)
     {
@@ -1274,7 +1274,7 @@ int rootsFunctionIDA(double time, N_Vector yy, N_Vector yp, double *gout, void* 
   data->callback->input_function(data, threadData);
   /* eval needed equations*/
   if (idaData->daeMode){
-   idaData->residualFunction(time, yy, yp, idaData->newdelta, idaData);
+   data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData, EVAL_ZEROCROSS);
   }
   else
   {

--- a/SimulationRuntime/c/simulation/solver/perform_simulation.c
+++ b/SimulationRuntime/c/simulation/solver/perform_simulation.c
@@ -39,6 +39,7 @@
 #include "nonlinearSystem.h"
 #include "mixedSystem.h"
 #include "meta/meta_modelica.h"
+#include "dae_mode.h"
 
 #include "util/omc_error.h"
 #include "simulation/solver/external_input.h"
@@ -70,7 +71,7 @@ static void prefixedName_updateContinuousSystem(DATA *data, threadData_t *thread
 
   if (compiledInDAEMode) /* dae mode */
   {
-    data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData);
+    data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData, EVAL_ALGEBRAIC);
   }
   else /* ode mode */
   {

--- a/SimulationRuntime/c/simulation_data.h
+++ b/SimulationRuntime/c/simulation_data.h
@@ -435,7 +435,7 @@ typedef struct DAEMODE_DATA
   SPARSE_PATTERN* sparsePattern;
 
   /* function to evaluate dynamic equations for DAE solver*/
-  int (*evaluateDAEResiduals)(struct DATA*, threadData_t*);
+  int (*evaluateDAEResiduals)(struct DATA*, threadData_t*, int);
 
   /* function to set algebraic DAE Variable form solver*/
   int (*setAlgebraicDAEVars)(struct DATA*, threadData_t*, double*);


### PR DESCRIPTION
For the simulation it is needed to evaluate the related
equations at four different stages:
  - *dynamic* - Evaluate all dependent equations to obtain the
    residuals for the integration.
  - *algebraic* - Evaluate equations needed at the output points.
  - *zerocross* - Evaluate equations, which are needed to obtain the
    zeroCrossings expressions.
  - *discrete* - Evaluate the equations depending on the discrete equations.

Enabled for now only in DAE mode, but it's also applicable in ODE mode.