### PR TITLE
[DAEmode] reduce generated code for algebraic variables

### DIFF
--- a/Compiler/Template/CodegenCFunctions.tpl
+++ b/Compiler/Template/CodegenCFunctions.tpl
@@ -4134,6 +4134,16 @@ template crefToCStr(ComponentRef cr, Integer ix, Boolean isPre, Boolean isStart)
   else "CREF_NOT_IDENT_OR_QUAL"
 end crefToCStr;
 
+template crefToIndex(ComponentRef cr)
+ "Helper function to cref."
+::=
+  match cref2simvar(cr, getSimCode())
+    case SIMVAR(index=index)
+    then
+      '<%index%>'
+    else "CREF_NOT_FOUND"
+end crefToIndex;
+
 template crefToCStrDefine(ComponentRef cr)
  "Helper function to cref."
 ::=

--- a/SimulationRuntime/c/simulation/solver/dae_mode.c
+++ b/SimulationRuntime/c/simulation/solver/dae_mode.c
@@ -61,6 +61,46 @@ int evaluateDAEResiduals_wrapperEventUpdate(DATA* data, threadData_t* threadData
   return retVal;
 }
 
+/*! \fn void getAlgebraicDAEVarNominals
+ *
+ *  collects DAE mode algebraic nominal values from modelData
+ */
+void getAlgebraicDAEVarNominals(DATA* data, double *algebraicNominals)
+{
+  int i;
+
+  DAEMODE_DATA* daeModeData = data->simulationInfo->daeModeData;
+  for(i=0; i < daeModeData->nAlgebraicDAEVars; i++){
+    algebraicNominals[i] = data->modelData->realVarsData[daeModeData->algIndexes[i]].attribute.nominal;
+  }
+}
+
+/*! \fn getAlgebraicVars
+ *
+ *  function obtains algebraic variable values for DAEmode
+ */
+void getAlgebraicDAEVars(DATA *data, double* algebraic)
+{
+  int i;
+  DAEMODE_DATA* daeModeData = data->simulationInfo->daeModeData;
+  for(i=0; i < daeModeData->nAlgebraicDAEVars; i++){
+    algebraic[i] = data->localData[0]->realVars[daeModeData->algIndexes[i]];
+  }
+}
+
+/*! \fn setAlgebraicVars
+ *
+ *  function set algebraic variable values for DAEmode
+ */
+void setAlgebraicDAEVars(DATA *data, double* algebraic)
+{
+  int i;
+  DAEMODE_DATA* daeModeData = data->simulationInfo->daeModeData;
+  for(i=0; i < daeModeData->nAlgebraicDAEVars; i++){
+    data->localData[0]->realVars[daeModeData->algIndexes[i]] = algebraic[i];
+  }
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/SimulationRuntime/c/simulation/solver/dae_mode.h
+++ b/SimulationRuntime/c/simulation/solver/dae_mode.h
@@ -50,6 +50,11 @@ extern "C" {
 
 int evaluateDAEResiduals_wrapperEventUpdate(DATA* data, threadData_t* threadData);
 
+void getAlgebraicDAEVarNominals(DATA*, double*);
+void getAlgebraicDAEVars(DATA*, double*);
+void setAlgebraicDAEVars(DATA*, double*);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -174,7 +174,7 @@ ida_solver_initial(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo
 
     memcpy(idaData->states, data->localData[0]->realVars, sizeof(double)*data->modelData->nStates);
     // and  also algebraic vars
-    data->simulationInfo->daeModeData->getAlgebraicDAEVars(data, threadData, idaData->states + data->modelData->nStates);
+    getAlgebraicDAEVars(data, idaData->states + data->modelData->nStates);
     memcpy(idaData->statesDer, data->localData[0]->realVars + data->modelData->nStates, sizeof(double)*data->modelData->nStates);
 
     idaData->y = N_VMake_Serial(idaData->N, idaData->states);
@@ -230,7 +230,7 @@ ida_solver_initial(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo
   /* daeMode: set nominal values for algebraic variables */
   if (idaData->daeMode)
   {
-    data->simulationInfo->daeModeData->getAlgebraicDAEVarNominals(data, threadData, tmp + data->modelData->nStates);
+    getAlgebraicDAEVarNominals(data, tmp + data->modelData->nStates);
   }
   /* multiply by tolerance to obtain a relative tolerace */
   for(i=0; i < idaData->N; ++i)
@@ -262,7 +262,7 @@ ida_solver_initial(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo
     /* daeMode: set nominal values for algebraic variables */
     if (idaData->daeMode)
     {
-     data->simulationInfo->daeModeData->getAlgebraicDAEVarNominals(data, threadData, idaData->yScale + data->modelData->nStates);
+     getAlgebraicDAEVarNominals(data, idaData->yScale + data->modelData->nStates);
      for(i=data->modelData->nStates; i < idaData->N; ++i)
      {
        idaData->ypScale[i] = 1.0;
@@ -702,12 +702,12 @@ ida_event_update(DATA* data, threadData_t *threadData)
       data->simulationInfo->needToIterate = 0;
 
       memcpy(idaData->states, data->localData[0]->realVars, sizeof(double)*data->modelData->nStates);
-      data->simulationInfo->daeModeData->getAlgebraicDAEVars(data, threadData, idaData->states + data->modelData->nStates);
+      getAlgebraicDAEVars(data, idaData->states + data->modelData->nStates);
       memcpy(idaData->statesDer, data->localData[0]->realVars + data->modelData->nStates, sizeof(double)*data->modelData->nStates);
 
       /* update inner algebraic get new values from data */
       evaluateDAEResiduals_wrapperEventUpdate(data, threadData);
-      data->simulationInfo->daeModeData->getAlgebraicDAEVars(data, threadData, idaData->states + data->modelData->nStates);
+      getAlgebraicDAEVars(data, idaData->states + data->modelData->nStates);
 
       infoStreamPrint(LOG_SOLVER, 0, "##IDA## do event update at %.15g", data->localData[0]->timeValue);
       flag = IDAReInit(idaData->ida_mem,
@@ -754,7 +754,7 @@ ida_event_update(DATA* data, threadData_t *threadData)
 
       memcpy(data->localData[0]->realVars, idaData->states, sizeof(double)*data->modelData->nStates);
       // and  also algebraic vars
-      data->simulationInfo->daeModeData->setAlgebraicDAEVars(data, threadData, idaData->states + data->modelData->nStates);
+      setAlgebraicDAEVars(data, idaData->states + data->modelData->nStates);
       memcpy(data->localData[0]->realVars + data->modelData->nStates, idaData->statesDer, sizeof(double)*data->modelData->nStates);
 
       /* reset initial step size again to default */
@@ -809,7 +809,7 @@ ida_solver_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo)
     {
       memcpy(idaData->states, data->localData[0]->realVars, sizeof(double)*data->modelData->nStates);
       /* and  also algebraic vars */
-      data->simulationInfo->daeModeData->getAlgebraicDAEVars(data, threadData, idaData->states + data->modelData->nStates);
+      getAlgebraicDAEVars(data, idaData->states + data->modelData->nStates);
       memcpy(idaData->statesDer, data->localData[0]->realVars + data->modelData->nStates, sizeof(double)*data->modelData->nStates);
     }
 
@@ -1023,7 +1023,7 @@ ida_solver_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo)
   {
     memcpy(data->localData[0]->realVars, idaData->states, sizeof(double)*data->modelData->nStates);
     // and  also algebraic vars
-    data->simulationInfo->daeModeData->setAlgebraicDAEVars(data, threadData, idaData->states + data->modelData->nStates);
+    setAlgebraicDAEVars(data, idaData->states + data->modelData->nStates);
     memcpy(data->localData[0]->realVars + data->modelData->nStates, idaData->statesDer, sizeof(double)*data->modelData->nStates);
     sData->timeValue = solverInfo->currentTime;
   }
@@ -1164,7 +1164,7 @@ int residualFunctionIDA(double time, N_Vector yy, N_Vector yp, N_Vector res, voi
     */
     memcpy(data->localData[0]->realVars, states, sizeof(double)*data->modelData->nStates);
     memcpy(data->localData[0]->realVars + data->modelData->nStates, statesDer, sizeof(double)*data->modelData->nStates);
-    data->simulationInfo->daeModeData->setAlgebraicDAEVars(data, threadData, states + data->modelData->nStates);
+    setAlgebraicDAEVars(data, states + data->modelData->nStates);
   }
 
   /* debug */
@@ -1263,7 +1263,7 @@ int rootsFunctionIDA(double time, N_Vector yy, N_Vector yp, double *gout, void* 
   if (idaData->daeMode)
   {
     memcpy(data->localData[0]->realVars, states, sizeof(double)*data->modelData->nStates);
-    data->simulationInfo->daeModeData->setAlgebraicDAEVars(data, threadData, states + data->modelData->nStates);
+    setAlgebraicDAEVars(data, states + data->modelData->nStates);
     memcpy(data->localData[0]->realVars + data->modelData->nStates, statesDer, sizeof(double)*data->modelData->nStates);
   }
 

--- a/SimulationRuntime/c/simulation_data.h
+++ b/SimulationRuntime/c/simulation_data.h
@@ -437,14 +437,8 @@ typedef struct DAEMODE_DATA
   /* function to evaluate dynamic equations for DAE solver*/
   int (*evaluateDAEResiduals)(struct DATA*, threadData_t*, int);
 
-  /* function to set algebraic DAE Variable form solver*/
-  int (*setAlgebraicDAEVars)(struct DATA*, threadData_t*, double*);
-
-  /* function to get algebraic DAE Variable form solver*/
-  int (*getAlgebraicDAEVars)(struct DATA*, threadData_t*, double*);
-
-  /* function to get algebraic DAE nominal values*/
-  int (*getAlgebraicDAEVarNominals)(struct DATA*, threadData_t*, double*);
+  /* index of the algebraic DAE variable in original order */
+  int *algIndexes;
 
 } DAEMODE_DATA;
 


### PR DESCRIPTION
 - store algebraic variable indices in static array
 - move get/set AlgebricDAEVar functions to runtime