### PR TITLE
Introduce aliasing of SimCode equations

### DIFF
--- a/Compiler/BackEnd/HpcOmTaskGraph.mo
+++ b/Compiler/BackEnd/HpcOmTaskGraph.mo
@@ -6898,7 +6898,11 @@ algorithm
     case(SimCode.SES_NONLINEAR(SimCode.NONLINEARSYSTEM(index=index), SOME(SimCode.NONLINEARSYSTEM(index=index2)))) then (index,index2);
     case(SimCode.SES_MIXED(index=index)) then (index,0);
     case(SimCode.SES_WHEN(index=index)) then (index,0);
-    else fail();
+    case(SimCode.SES_ALIAS(aliasOf=index)) then (index,0);
+    else
+      algorithm
+        Error.addInternalError(getInstanceName()+" failed", sourceInfo());
+      then fail();
   end match;
 end getIndexBySimCodeEq;
 

--- a/Compiler/SimCode/SerializeModelInfo.mo
+++ b/Compiler/SimCode/SerializeModelInfo.mo
@@ -1020,6 +1020,16 @@ algorithm
       File.write(file, "}");
     then true;
 
+    case SimCode.SES_ALIAS() equation
+      File.write(file, "\n{\"eqIndex\":");
+      File.writeInt(file, eq.index);
+      File.write(file, ",\"tag\":\"alias\",\"equation\":[");
+      File.writeInt(file, eq.aliasOf);
+      File.write(file, "],\"section\":\"");
+      File.write(file, section);
+      File.write(file, "\"}");
+    then true;
+
     else equation
       Error.addInternalError("serializeEquation failed: " + anyString(eq), sourceInfo());
     then fail();

--- a/Compiler/SimCode/SimCode.mo
+++ b/Compiler/SimCode/SimCode.mo
@@ -389,6 +389,11 @@ uniontype SimEqSystem
     BackendDAE.EquationAttributes eqAttr;
   end SES_FOR_LOOP;
 
+  record SES_ALIAS
+    Integer index;
+    Integer aliasOf;
+  end SES_ALIAS;
+
 end SimEqSystem;
 
 public

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -563,19 +563,26 @@ algorithm
 
     (crefToClockIndexHT, _) := List.fold(listReverse(inBackendDAE.eqs), collectClockedVars, (HashTable.emptyHashTable(), 1));
 
+    execStat("simCode: some other stuff during SimCode phase");
+
     reasonableSize := Util.nextPrime(10+2*listLength(allEquations));
     eqCache := HashTableSimCodeEqCache.emptyHashTableSized(reasonableSize);
 
-    (allEquations, eqCache) := aliasSimEqs(allEquations, eqCache);
-    (odeEquations, eqCache) := aliasSimEqSystems(odeEquations, eqCache);
-    (algebraicEquations, eqCache) := aliasSimEqSystems(algebraicEquations, eqCache);
-    (initialEquations, eqCache) := aliasSimEqs(initialEquations, eqCache);
-    (initialEquations_lambda0, eqCache) := aliasSimEqs(initialEquations_lambda0, eqCache);
-    (removedEquations, eqCache) := aliasSimEqs(removedEquations, eqCache);
-    (removedInitialEquations, eqCache) := aliasSimEqs(removedInitialEquations, eqCache);
-    (algorithmAndEquationAsserts, eqCache) := aliasSimEqs(algorithmAndEquationAsserts, eqCache);
-    (jacobianEquations, eqCache) := aliasSimEqs(jacobianEquations, eqCache);
-    (parameterEquations, eqCache) := aliasSimEqs(parameterEquations, eqCache);
+    if Config.simCodeTarget() <> "Cpp" then
+      // Alias equations to other equations.
+      // The C++ codegen does things differently and will not handle this
+      (allEquations, eqCache) := aliasSimEqs(allEquations, eqCache);
+      (odeEquations, eqCache) := aliasSimEqSystems(odeEquations, eqCache);
+      (algebraicEquations, eqCache) := aliasSimEqSystems(algebraicEquations, eqCache);
+      (initialEquations, eqCache) := aliasSimEqs(initialEquations, eqCache);
+      (initialEquations_lambda0, eqCache) := aliasSimEqs(initialEquations_lambda0, eqCache);
+      (removedEquations, eqCache) := aliasSimEqs(removedEquations, eqCache);
+      (removedInitialEquations, eqCache) := aliasSimEqs(removedInitialEquations, eqCache);
+      (algorithmAndEquationAsserts, eqCache) := aliasSimEqs(algorithmAndEquationAsserts, eqCache);
+      (jacobianEquations, eqCache) := aliasSimEqs(jacobianEquations, eqCache);
+      (parameterEquations, eqCache) := aliasSimEqs(parameterEquations, eqCache);
+      execStat("simCode: alias equations");
+    end if;
 
     simCode := SimCode.SIMCODE(modelInfo,
                               {}, // Set by the traversal below...

--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -3010,7 +3010,7 @@ template functionEquationsMultiFiles(list<SimEqSystem> inEqs, Integer numEqs, In
                   <%simulationFileHeader(fileNamePrefix)%>
                   #if defined(__cplusplus)
                   extern "C" {
-                  #endif
+                  #endif<%\n%>
                   >>)) +
                   (eqs |> eq => equation_impl_options(-1, eq, contextSimulationDiscrete, modelNamePrefix, static, noOpt) ; separator="\n") +
                   <<
@@ -4839,7 +4839,7 @@ template equation_arrayFormat(SimEqSystem eq, String name, Context context, Inte
   case e as SES_MIXED(__)
     then equationMixed(e, context, &eqfuncs, modelNamePrefix)
   else
-    "NOT IMPLEMENTED EQUATION equation_"
+    error(sourceInfo(), "NOT IMPLEMENTED EQUATION equation_")
 
   let &eqArray += '<%symbolName(modelNamePrefix,"eqFunction")%>_<%ix%>, <%\n%>'
   let &varD += addRootsTempArray()
@@ -4889,7 +4889,8 @@ template equation_impl2(Integer clockIndex, SimEqSystem eq, Context context, Str
 ::=
   let OMC_NO_OPT = if noOpt then 'OMC_DISABLE_OPT<%\n%>' else (match eq case SES_LINEAR(__) then 'OMC_DISABLE_OPT<%\n%>')
   match eq
-  case e as SES_ALGORITHM(statements={})
+  case SES_ALIAS(__) then 'extern void <%symbolName(modelNamePrefix,"eqFunction")%>_<%aliasOf%>(DATA *data, threadData_t *threadData);<%\n%>'
+  case SES_ALGORITHM(statements={})
   then ""
   else
   (
@@ -4936,7 +4937,7 @@ template equation_impl2(Integer clockIndex, SimEqSystem eq, Context context, Str
   case e as SES_FOR_LOOP(__)
     then equationForLoop(e, context, &varD, &tempeqns)
   else
-    "NOT IMPLEMENTED EQUATION equation_"
+    error(sourceInfo(), "NOT IMPLEMENTED EQUATION equation_")
   let x2 = match eq
   case e as SES_LINEAR(lSystem=ls as LINEARSYSTEM(__), alternativeTearing = SOME(at as LINEARSYSTEM(__))) then
     equationLinearAlternativeTearing(e, context, &varD)

--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -9823,7 +9823,7 @@ template equationString(SimEqSystem eq, Context context, Text &varDecls, SimCode
     IF EQUATIONS ARE NOT IMPLEMENTED
     >>
   else
-    "NOT IMPLEMENTED EQUATION 2"
+    error(sourceInfo(),"NOT IMPLEMENTED EQUATION 2")
 end equationString;
 
 template equation_function_call(SimEqSystem eq, Context context, Text &varDecls, SimCode simCode ,Text& extraFuncs,Text& extraFuncsDecl,Text extraFuncsNamespace,Text method)
@@ -9879,7 +9879,7 @@ template equation_function_create_single_func(SimEqSystem eq, Context context, S
       then
         equationForLoop(e, context, &varDeclsLocal,simCode , &extraFuncs , &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     else
-      "NOT IMPLEMENTED EQUATION"
+      error(sourceInfo(),"NOT IMPLEMENTED EQUATION")
   end match
   let &measureTimeStartVar += if createMeasureTime then generateMeasureTimeStartCode("measuredProfileBlockStartValues", 'evaluate<%ix_str%>', "MEASURETIME_PROFILEBLOCKS") else ""
   let &measureTimeEndVar += if createMeasureTime then generateMeasureTimeEndCode("measuredProfileBlockStartValues", "measuredProfileBlockEndValues", '(*measureTimeProfileBlocksArray)[<%ix_str_array%>]', 'evaluate<%ix_str%>', "MEASURETIME_PROFILEBLOCKS") else ""

--- a/Compiler/Template/CodegenUtilSimulation.tpl
+++ b/Compiler/Template/CodegenUtilSimulation.tpl
@@ -84,6 +84,9 @@ template equationIndex(SimEqSystem eq)
   case SES_WHEN(__)
   case SES_FOR_LOOP(__)
     then index
+  case SES_ALIAS(__)
+    then aliasOf
+  else error(sourceInfo(), "equationIndex failed")
 end equationIndex;
 
 template equationIndexAlternativeTearing(SimEqSystem eq)

--- a/Compiler/Template/CodegenXML.tpl
+++ b/Compiler/Template/CodegenXML.tpl
@@ -722,6 +722,8 @@ template equation_Xml(SimEqSystem eq, Context context, Text &varDecls /*BUFP*/, 
     then  equationNonlinearXml(e, context, &varD /*BUFD*/)
   case e as SES_WHEN(__)
     then " "
+  case e as SES_ALIAS(__)
+    then " "
   else
     "NOT IMPLEMENTED EQUATION"
   let &eqs +=

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -512,6 +512,10 @@ package SimCode
       DAE.ElementSource source;
       BackendDAE.EquationAttributes eqAttr;
     end SES_FOR_LOOP;
+
+    record SES_ALIAS
+      Integer aliasOf;
+    end SES_ALIAS;
   end SimEqSystem;
 
   uniontype LinearSystem

--- a/Compiler/Util/HashTableSimCodeEqCache.mo
+++ b/Compiler/Util/HashTableSimCodeEqCache.mo
@@ -1,0 +1,112 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2014, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package HashTableSimCodeEqCache
+
+/* Below is the instance specific code. For each hashtable the user must define:
+
+Key       - The key used to uniquely define elements in a hashtable
+Value     - The data to associate with each key
+hashFunc   - A function that maps a key to a positive integer.
+keyEqual   - A comparison function between two keys, returns true if equal.
+*/
+
+/* HashTable instance specific code */
+
+import BaseHashTable;
+import DAE;
+import SimCode;
+
+protected
+
+import ComponentReference;
+import Expression;
+import ExpressionDump;
+import SimCodeUtil;
+
+public
+
+type Key = SimCode.SimEqSystem;
+type Value = Integer;
+
+type HashTableCrefFunctionsType = tuple<FuncHashCref,FuncCrefEqual,FuncCrefStr,FuncExpStr>;
+type HashTable = tuple<
+  array<list<tuple<Key,Integer>>>,
+  tuple<Integer,Integer,array<Option<tuple<Key,Value>>>>,
+  Integer,
+  HashTableCrefFunctionsType
+>;
+
+partial function FuncHashCref
+  input Key cr;
+  input Integer mod;
+  output Integer res;
+end FuncHashCref;
+
+partial function FuncCrefEqual
+  input Key cr1;
+  input Key cr2;
+  output Boolean res;
+end FuncCrefEqual;
+
+partial function FuncCrefStr
+  input Key cr;
+  output String res;
+end FuncCrefStr;
+
+partial function FuncExpStr
+  input Value exp;
+  output String res;
+end FuncExpStr;
+
+function emptyHashTable
+"
+  Returns an empty HashTable.
+  Using the default bucketsize..
+"
+  output HashTable hashTable;
+algorithm
+  hashTable := emptyHashTableSized(BaseHashTable.defaultBucketSize);
+end emptyHashTable;
+
+function emptyHashTableSized
+"
+  Returns an empty HashTable.
+  Using the bucketsize size.
+"
+  input Integer size;
+  output HashTable hashTable;
+algorithm
+  hashTable := BaseHashTable.emptyHashTableWork(size,(SimCodeUtil.hashEqSystemMod,SimCodeUtil.compareEqSystemsEquality,SimCodeUtil.simEqSystemString,intString));
+end emptyHashTableSized;
+
+annotation(__OpenModelica_Interface="backend");
+end HashTableSimCodeEqCache;

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -407,6 +407,7 @@ if true then /* Suppress output */
     "../Util/HashTableCrToExpSourceTpl.mo",
     "../Util/HashTableCrToCrEqLst.mo",
     "../Util/HashTableCrToUnit.mo",
+    "../Util/HashTableSimCodeEqCache.mo",
     "../Util/HashTableStringToUnit.mo",
     "../Util/HashTableUnitToString.mo",
     "../Util/PriorityQueue.mo",


### PR DESCRIPTION
Very many equations are the same in the continuous, initial, lambda0,
and parameter equation systems. This makes some of these equations
become aliases to other ones. The aliasing is performed as the last
step before code generation since this is the most conservative
approach (it might be bad for performance since the same traversals
have been performed on the different systems). Strongly connected
components, if-equations, and algorithms are not considered yet.
Roughly 1/3 of the equations seem to be removed by this aliasing which
hopefully increases performance.