### PR TITLE
[NF] Fix FBuiltin.getBasicTypes for NF.

### DIFF
--- a/Compiler/FFrontEnd/FBuiltin.mo
+++ b/Compiler/FFrontEnd/FBuiltin.mo
@@ -307,11 +307,12 @@ protected constant SCode.Element objectiveVarComp =
             SCode.noComment, NONE(), Absyn.dummyInfo);
 
 protected constant list<SCode.Element> basicTypes = {clockType, rlType, intType, strType, boolType, enumType, ExternalObjectType, realType, integerType, stringType, booleanType, uncertaintyType};
+protected constant list<SCode.Element> basicTypesNF = {clockType, rlType, intType, strType, boolType, enumType, realType, integerType, stringType, booleanType, uncertaintyType};
 
 public function getBasicTypes
   output list<SCode.Element> tys;
 algorithm
-  tys := basicTypes;
+  tys := if Flags.isSet(Flags.SCODE_INST) then basicTypesNF else basicTypes;
 end getBasicTypes;
 
 public function variableIsBuiltin


### PR DESCRIPTION
- ExternalObject is defined in ModelicaBuiltin in the NF and should not
  be added by FBuiltin.getBasicTypes when -d=newInst is set.