### PR TITLE
[NF] Improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFBindingOrigin.mo
+++ b/Compiler/NFFrontEnd/NFBindingOrigin.mo
@@ -31,6 +31,7 @@
 
 encapsulated uniontype NFBindingOrigin
   import NFModifier.ModifierScope;
+  import NFInstNode.InstNode;
 
 protected
   import BindingOrigin = NFBindingOrigin;
@@ -41,28 +42,23 @@ public
   record ORIGIN
     Integer level;
     ElementType ty;
+    Option<InstNode> node;
     SourceInfo info;
   end ORIGIN;
 
   function create
-    input Boolean eachPrefix;
     input Integer level;
     input ElementType ty;
     input SourceInfo info;
     output BindingOrigin origin;
   algorithm
-    origin := ORIGIN(if eachPrefix then -level else level, ty, info);
+    origin := ORIGIN(level, ty, NONE(), info);
   end create;
 
   function level
     input BindingOrigin origin;
     output Integer level = origin.level;
   end level;
-
-  function isEach
-    input BindingOrigin origin;
-    output Boolean isEach = origin.level < 0;
-  end isEach;
 
   function info
     input BindingOrigin origin;
@@ -77,6 +73,13 @@ public
   algorithm
     fromClass := ty == ElementType.CLASS;
   end isFromClass;
+
+  function setNode
+    input InstNode node;
+    input output BindingOrigin origin;
+  algorithm
+    origin.node := SOME(node);
+  end setNode;
 
   annotation(__OpenModelica_Interface="frontend");
 end NFBindingOrigin;

--- a/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -44,7 +44,7 @@ public
 import Absyn;
 import SCode;
 import Binding = NFBinding;
-import BindingOrigin = NFBindingOrigin;
+import NFBindingOrigin;
 import NFClass.Class;
 import NFClassTree.ClassTree;
 import NFComponent.Component;
@@ -175,12 +175,11 @@ constant InstNode TIME =
     Pointer.createImmutable(Component.TYPED_COMPONENT(
       REAL_NODE,
       Type.REAL(),
-      Binding.UNBOUND(),
-      Binding.UNBOUND(),
+      Binding.UNBOUND(NONE()),
+      Binding.UNBOUND(NONE()),
       NFComponent.INPUT_ATTR,
       NONE(),
       Absyn.dummyInfo)),
-    0,
     InstNode.EMPTY_NODE());
 
 constant ComponentRef TIME_CREF = ComponentRef.CREF(TIME, {}, Type.REAL(), Origin.CREF, ComponentRef.EMPTY());

--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -75,43 +75,43 @@ constant SCode.Element DUMMY_ELEMENT = SCode.CLASS(
 
 // Default Integer parameter.
 constant Component INT_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.INTEGER(), Binding.UNBOUND(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR, NONE(), Absyn.dummyInfo);
+  Type.INTEGER(), Binding.UNBOUND(NONE()), Binding.UNBOUND(NONE()), NFComponent.DEFAULT_ATTR, NONE(), Absyn.dummyInfo);
 
 constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
   Visibility.PUBLIC,
-  Pointer.createImmutable(INT_COMPONENT), 0, InstNode.EMPTY_NODE());
+  Pointer.createImmutable(INT_COMPONENT), InstNode.EMPTY_NODE());
 
 // Default Real parameter.
 constant Component REAL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.REAL(), Binding.UNBOUND(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR, NONE(), Absyn.dummyInfo);
+  Type.REAL(), Binding.UNBOUND(NONE()), Binding.UNBOUND(NONE()), NFComponent.DEFAULT_ATTR, NONE(), Absyn.dummyInfo);
 
 constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
   Visibility.PUBLIC,
-  Pointer.createImmutable(REAL_COMPONENT), 0, InstNode.EMPTY_NODE());
+  Pointer.createImmutable(REAL_COMPONENT), InstNode.EMPTY_NODE());
 
 // Default Boolean parameter.
 constant Component BOOL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.BOOLEAN(), Binding.UNBOUND(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR, NONE(), Absyn.dummyInfo);
+  Type.BOOLEAN(), Binding.UNBOUND(NONE()), Binding.UNBOUND(NONE()), NFComponent.DEFAULT_ATTR, NONE(), Absyn.dummyInfo);
 
 constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
   Visibility.PUBLIC,
-  Pointer.createImmutable(BOOL_COMPONENT), 0, InstNode.EMPTY_NODE());
+  Pointer.createImmutable(BOOL_COMPONENT), InstNode.EMPTY_NODE());
 
 // Default String parameter.
 constant Component STRING_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.STRING(), Binding.UNBOUND(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR, NONE(), Absyn.dummyInfo);
+  Type.STRING(), Binding.UNBOUND(NONE()), Binding.UNBOUND(NONE()), NFComponent.DEFAULT_ATTR, NONE(), Absyn.dummyInfo);
 
 constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
   Visibility.PUBLIC,
-  Pointer.createImmutable(STRING_COMPONENT), 0, InstNode.EMPTY_NODE());
+  Pointer.createImmutable(STRING_COMPONENT), InstNode.EMPTY_NODE());
 
 // Default enumeration(:) parameter.
 constant Component ENUM_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.ENUMERATION_ANY(), Binding.UNBOUND(), Binding.UNBOUND(), NFComponent.DEFAULT_ATTR, NONE(), Absyn.dummyInfo);
+  Type.ENUMERATION_ANY(), Binding.UNBOUND(NONE()), Binding.UNBOUND(NONE()), NFComponent.DEFAULT_ATTR, NONE(), Absyn.dummyInfo);
 
 constant InstNode ENUM_PARAM = InstNode.COMPONENT_NODE("e",
   Visibility.PUBLIC,
-  Pointer.createImmutable(ENUM_COMPONENT), 0, InstNode.EMPTY_NODE());
+  Pointer.createImmutable(ENUM_COMPONENT), InstNode.EMPTY_NODE());
 
 // Integer(e)
 constant array<NFInstNode.CachedData> EMPTY_NODE_CACHE = listArrayLiteral({

--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -668,8 +668,8 @@ uniontype Call
           // Create a range binding on which we will iterate to vectorize.
           ty := Type.ARRAY(Type.INTEGER(), {dim});
           exp := Expression.RANGE(ty, Expression.INTEGER(1), NONE(), Expression.INTEGER(Dimension.size(dim)));
-          origin := BindingOrigin.create(false, 0, NFBindingOrigin.ElementType.COMPONENT, info);
-          bind := Binding.TYPED_BINDING(exp, ty, Variability.CONSTANT, origin);
+          origin := BindingOrigin.create(0, NFBindingOrigin.ElementType.COMPONENT, info);
+          bind := Binding.TYPED_BINDING(exp, ty, Variability.CONSTANT, origin, false);
 
           // Add an iterator to the call scope.
           (iter_scope, iter) := Inst.addIteratorToScope("$i" + intString(i), bind, iter_scope, Type.INTEGER());

--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -418,7 +418,10 @@ uniontype Class
     output Type ty;
   algorithm
     ty := match cls
-      case DERIVED_CLASS() then getType(InstNode.getClass(cls.baseClass), clsNode);
+      case DERIVED_CLASS()
+        then Type.liftArrayLeftList(
+               getType(InstNode.getClass(cls.baseClass), clsNode),
+               cls.dims);
       case INSTANCED_CLASS() then cls.ty;
       case PARTIAL_BUILTIN() then cls.ty;
       case INSTANCED_BUILTIN()

--- a/Compiler/NFFrontEnd/NFExpressionIterator.mo
+++ b/Compiler/NFFrontEnd/NFExpressionIterator.mo
@@ -109,7 +109,7 @@ public
   algorithm
     iterator := match binding
       case Binding.TYPED_BINDING()
-        then if BindingOrigin.isEach(binding.origin) or BindingOrigin.isFromClass(binding.origin) then
+        then if Binding.isEach(binding) or BindingOrigin.isFromClass(binding.origin) then
           EACH_ITERATOR(binding.bindingExp) else fromExp(binding.bindingExp);
 
       case Binding.FLAT_BINDING()

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -295,10 +295,10 @@ algorithm
     eq := Equation.ARRAY_EQUALITY(Expression.CREF(ty, name), Binding.getTypedExp(binding), ty,
       ElementSource.createElementSource(info));
     sections := Sections.prependEquation(eq, sections);
-    binding := Binding.UNBOUND();
+    binding := Binding.UNBOUND(NONE());
   end if;
 
-  ty_attrs := list(flattenTypeAttribute(m, prefix, node) for m in typeAttrs);
+  ty_attrs := list(flattenTypeAttribute(m, name, node) for m in typeAttrs);
   vars := Variable.VARIABLE(name, ty, binding, visibility, comp_attr, ty_attrs, cmt, info) :: vars;
 end flattenSimpleComponent;
 
@@ -364,7 +364,7 @@ algorithm
       eq := Equation.EQUALITY(Expression.CREF(ty, name),  binding_exp, ty,
         ElementSource.createElementSource(InstNode.info(node)));
       sections := Sections.prependEquation(eq, sections);
-      opt_binding := SOME(Binding.UNBOUND());
+      opt_binding := SOME(Binding.UNBOUND(NONE()));
     else
       opt_binding := SOME(flattenBinding(binding, prefix, node));
     end if;
@@ -427,8 +427,8 @@ algorithm
       algorithm
         binding_level := BindingOrigin.level(binding.origin);
 
-        if binding_level > 0 then
-          subs := List.flatten(ComponentRef.subscriptsN(prefix, InstNode.level(component) - binding_level));
+        if not binding.isEach and binding_level > 0 then
+          subs := List.flatten(ComponentRef.subscriptsN(prefix, binding_level));
           binding.bindingExp := Expression.applySubscripts(subs, binding.bindingExp);
         end if;
       then

--- a/Compiler/NFFrontEnd/NFRecord.mo
+++ b/Compiler/NFFrontEnd/NFRecord.mo
@@ -128,8 +128,8 @@ algorithm
   def_ctor_node := InstNode.replaceClass(Class.NOT_INSTANTIATED(), node);
 
   // Create the output record element, using the node created above as parent.
-  out_comp := Component.UNTYPED_COMPONENT(node, listArray({}), Binding.UNBOUND(),
-    Binding.UNBOUND(), NFComponent.OUTPUT_ATTR, NONE(), Absyn.dummyInfo);
+  out_comp := Component.UNTYPED_COMPONENT(node, listArray({}), Binding.UNBOUND(NONE()),
+    Binding.UNBOUND(NONE()), NFComponent.OUTPUT_ATTR, NONE(), Absyn.dummyInfo);
   out_rec := InstNode.fromComponent("$out" + InstNode.name(node), out_comp, def_ctor_node);
 
   // Make a record constructor class and update the node with it.

--- a/Compiler/NFFrontEnd/NFRestriction.mo
+++ b/Compiler/NFFrontEnd/NFRestriction.mo
@@ -118,5 +118,32 @@ public
     end match;
   end isFunction;
 
+  function isType
+    input Restriction res;
+    output Boolean isType;
+  algorithm
+    isType := match res
+      case TYPE() then true;
+      else false;
+    end match;
+  end isType;
+
+  function toString
+    input Restriction res;
+    output String str;
+  algorithm
+    str := match res
+      case CLASS() then "class";
+      case ENUMERATION() then "enumeration";
+      case EXTERNAL_OBJECT() then "ExternalObject";
+      case FUNCTION() then "function";
+      case MODEL() then "model";
+      case OPERATOR() then "operator";
+      case RECORD() then "record";
+      case TYPE() then "type";
+      else "unknown";
+    end match;
+  end toString;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFRestriction;

--- a/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/Compiler/NFFrontEnd/NFScalarize.mo
@@ -106,7 +106,7 @@ algorithm
     ty := Type.arrayElementType(ty);
     (ty_attr_names, ty_attr_iters) := scalarizeTypeAttributes(ty_attr);
 
-    if Binding.isBound(binding) and not Binding.isEach(binding) then
+    if Binding.isBound(binding) then
       binding_iter := ExpressionIterator.fromExp(Binding.getTypedExp(binding));
 
       for cr in crefs loop

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -368,6 +368,16 @@ public
     end match;
   end isTuple;
 
+  function isUnknown
+    input Type ty;
+    output Boolean isUnknown;
+  algorithm
+    isUnknown := match ty
+      case UNKNOWN() then true;
+      else false;
+    end match;
+  end isUnknown;
+
   function firstTupleType
     input Type ty;
     output Type outTy;

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -710,7 +710,7 @@ public constant Message EXT_FN_SINGLE_RETURN_ARRAY = MESSAGE(290, TRANSLATION(),
   Util.gettext("An external declaration with a single output without explicit mapping is defined as having the output as the lhs, but language %s does not support this for array variables. OpenModelica will put the output as an input (as is done when there is more than 1 output), but this is not according to the Modelica Specification. Use an explicit mapping instead of the implicit one to suppress this warning."));
 public constant Message RHS_TUPLE_EXPRESSION = MESSAGE(291, TRANSLATION(), ERROR(),
   Util.gettext("Tuple expressions may only occur on the left side of an assignment or equation with a single function call on the right side. Got the following expression: %s."));
-public constant Message EACH_ON_NON_ARRAY = MESSAGE(292, TRANSLATION(), ERROR(),
+public constant Message EACH_ON_NON_ARRAY = MESSAGE(292, TRANSLATION(), WARNING(),
   Util.gettext("'each' used when modifying non-array element %s."));
 public constant Message BUILTIN_EXTENDS_INVALID_ELEMENTS = MESSAGE(293, TRANSLATION(), ERROR(),
   Util.gettext("A class extending from builtin type %s may not have other elements."));
@@ -783,6 +783,8 @@ public constant Message REDECLARE_MISMATCHED_PREFIX = MESSAGE(327, TRANSLATION()
   Util.gettext("Invalid redeclaration '%s %s', original element is declared '%s'."));
 public constant Message EXTERNAL_ARG_NONCONSTANT_SIZE_INDEX = MESSAGE(328, TRANSLATION(), ERROR(),
   Util.gettext("Invalid external argument '%s', the dimension index must be a constant expression."));
+public constant Message NON_TYPE_DIMENSIONS = MESSAGE(329, TRANSLATION(), ERROR(),
+  Util.gettext("Invalid dimensions on ‘%s %s‘, only types may have dimensions."));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),


### PR DESCRIPTION
- Simplified the type checking of bindings, and made it work for
  binding on array types too.
- Added check that non-type classes shouldn't have dimensions.
- Fixed the check for 'each' being used correctly, and made it into
  a varning instead of an error.
- Fixed the typing of crefs so that it doesn't cause typing cycles.