### PR TITLE
[NF] ExternalObject fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -843,16 +843,7 @@ algorithm
       algorithm
         // TODO: Collect functions from the component's type attributes.
 
-        // Collect external object structors.
-        () := match ty
-          case Type.COMPLEX(complexTy = ComplexType.EXTERNAL_OBJECT())
-            algorithm
-              funcs := collectExternalObjectStructors(ty.complexTy, funcs);
-            then
-              ();
-
-          else ();
-        end match;
+        funcs := collectTypeFuncs(ty, funcs);
 
         // Collect functions used in the component's binding, if it has one.
         if Binding.isBound(binding) then
@@ -863,6 +854,22 @@ algorithm
 
   end match;
 end collectComponentFuncs;
+
+function collectTypeFuncs
+  input Type ty;
+  input output FunctionTree funcs;
+algorithm
+  () := match ty
+    // Collect external object structors.
+    case Type.COMPLEX(complexTy = ComplexType.EXTERNAL_OBJECT())
+      algorithm
+        funcs := collectExternalObjectStructors(ty.complexTy, funcs);
+      then
+        ();
+
+    else ();
+  end match;
+end collectTypeFuncs;
 
 function collectExternalObjectStructors
   input ComplexType ty;
@@ -1079,6 +1086,7 @@ algorithm
       algorithm
         for c in cls_tree.components loop
           comp := InstNode.component(c);
+          funcs := collectTypeFuncs(Component.getType(comp), funcs);
           binding := Component.getBinding(comp);
 
           if Binding.isBound(binding) then

--- a/Compiler/NFFrontEnd/NFRestriction.mo
+++ b/Compiler/NFFrontEnd/NFRestriction.mo
@@ -118,6 +118,16 @@ public
     end match;
   end isFunction;
 
+  function isRecord
+    input Restriction res;
+    output Boolean isFunction;
+  algorithm
+    isFunction := match res
+      case RECORD() then true;
+      else false;
+    end match;
+  end isRecord;
+
   function isType
     input Restriction res;
     output Boolean isType;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -215,12 +215,14 @@ algorithm
   CachedData.FUNCTION({fn}, typed, special) := InstNode.getFuncCache(constructor);
   if not typed then
     fn := Function.typeFunction(fn);
+    fn := Function.typeFunctionBody(fn);
     InstNode.setFuncCache(constructor, CachedData.FUNCTION({fn}, true, special));
   end if;
 
   CachedData.FUNCTION({fn}, typed, special) := InstNode.getFuncCache(destructor);
   if not typed then
     fn := Function.typeFunction(fn);
+    fn := Function.typeFunctionBody(fn);
     InstNode.setFuncCache(destructor, CachedData.FUNCTION({fn}, true, special));
   end if;
 end typeExternalObjectStructors;


### PR DESCRIPTION
- Added missing calls to typeFunctionBody when typing ExternalObject
  structors, so the whole function is typed and not only the inputs.
- Collect ExternalObject structors in functions too.