### PR TITLE
[NF] Connection handling improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -328,7 +328,7 @@ public
         algorithm
           rest_cref := setSubscriptsList(rest_subs, cref.restCref);
         then
-          CREF(cref.node, subs, Type.arrayElementType(cref.ty), cref.origin, rest_cref);
+          CREF(cref.node, subs, cref.ty, cref.origin, rest_cref);
 
       case ({}, _) then cref;
     end match;

--- a/Compiler/NFFrontEnd/NFConnections.mo
+++ b/Compiler/NFFrontEnd/NFConnections.mo
@@ -76,9 +76,9 @@ public
     Component comp;
     ComponentRef cr, lhs, rhs;
     Connector c1, c2;
-    Type ty1, ty2;
     DAE.ElementSource source;
     list<Equation> eql = {};
+    list<Connector> cl1, cl2;
   algorithm
     // Collect all flow variables.
     for var in flatModel.variables loop
@@ -94,13 +94,17 @@ public
     // Collect all connects.
     for eq in flatModel.equations loop
       eql := match eq
-        case Equation.CONNECT(lhs = Expression.CREF(cref = lhs, ty = ty1),
-                              rhs = Expression.CREF(cref = rhs, ty = ty2), source = source)
+        case Equation.CONNECT(lhs = Expression.CREF(cref = lhs),
+                              rhs = Expression.CREF(cref = rhs), source = source)
           algorithm
             if not (ComponentRef.isDeleted(lhs) or ComponentRef.isDeleted(rhs)) then
-              c1 := Connector.fromCref(lhs, ty1, source);
-              c2 := Connector.fromCref(rhs, ty2, source);
-              conns := addConnection(Connection.CONNECTION(c1, c2), conns);
+              cl1 := Connector.fromExp(Expression.expand(eq.lhs), source);
+              cl2 := Connector.fromExp(Expression.expand(eq.rhs), source);
+
+              for c1 in cl1 loop
+                c2 :: cl2 := cl2;
+                conns := addConnection(Connection.CONNECTION(c1, c2), conns);
+              end for;
             end if;
           then
             eql;

--- a/Compiler/NFFrontEnd/NFConnector.mo
+++ b/Compiler/NFFrontEnd/NFConnector.mo
@@ -81,6 +81,31 @@ public
       Component.connectorType(InstNode.component(node)), NONE(), source);
   end fromFacedCref;
 
+  function fromExp
+    "Constructs a list of Connectors from a cref or an array of crefs."
+    input Expression exp;
+    input DAE.ElementSource source;
+    input output list<Connector> conns = {};
+  algorithm
+    conns := match exp
+      case Expression.CREF() then fromCref(exp.cref, exp.ty, source) :: conns;
+      case Expression.ARRAY()
+        algorithm
+          for e in listReverse(exp.elements) loop
+            conns := fromExp(e, source, conns);
+          end for;
+        then
+          conns;
+
+      else
+        algorithm
+          Error.assertion(false, getInstanceName() + " got unknown expression " +
+            Expression.toString(exp), sourceInfo());
+        then
+          fail();
+    end match;
+  end fromExp;
+
   function getType
     input Connector conn;
     output Type ty = conn.ty;

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -2136,7 +2136,8 @@ public
           dims := Type.arrayDims(cref.ty);
           cr_subs := Subscript.expandList(cref.subscripts, dims);
         then
-          if listEmpty(cr_subs) then {} else expandCref2(cref.restCref, cr_subs :: subs);
+          if listEmpty(cr_subs) and not listEmpty(dims) then
+            {} else expandCref2(cref.restCref, cr_subs :: subs);
 
       else subs;
     end match;


### PR DESCRIPTION
- Fixed typing error in ComponentRef.setSubscriptsList, the crefs
  type shouldn't take subscripts into account.
- Expand connector expressions before creating connectors from them.
- Fixed error in Expression.expandCref2 that caused some array crefs
  to be erroneously expanded into an empty array.