### PR TITLE
[NF] Minor fixes for type attributes.

### DIFF
--- a/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/Compiler/NFFrontEnd/NFClassTree.mo
@@ -613,9 +613,11 @@ public
           then
             ();
 
-        case Class.EXPANDED_DERIVED()
+        case Class.EXPANDED_DERIVED(baseClass = node)
           algorithm
-            (node, _, classCount, compCount) := instantiate(cls.baseClass);
+            node := InstNode.setNodeType(
+              InstNodeType.BASE_CLASS(clsNode, InstNode.definition(node)), node);
+            (node, _, classCount, compCount) := instantiate(node);
             cls.baseClass := node;
           then
             ();

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -2733,6 +2733,30 @@ public
     Expression.ARRAY(elements = elements) := array;
   end arrayElements;
 
+  function arrayScalarElements
+    input Expression exp;
+    output list<Expression> elements;
+  algorithm
+    elements := listReverseInPlace(arrayScalarElements_impl(exp, {}));
+  end arrayScalarElements;
+
+  function arrayScalarElements_impl
+    input Expression exp;
+    input output list<Expression> elements;
+  algorithm
+    elements := match exp
+      case ARRAY()
+        algorithm
+          for e in exp.elements loop
+            elements := arrayScalarElements_impl(e, elements);
+          end for;
+        then
+          elements;
+
+      else exp :: elements;
+    end match;
+  end arrayScalarElements_impl;
+
   function hasArrayCall
     "Returns true if the given expression contains a function call that returns
      an array, otherwise false."

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -862,7 +862,7 @@ algorithm
         if isSome(binding_origin.node) then
           SOME(mod_parent) := binding_origin.node;
         else
-          mod_parent := component;
+          mod_parent := InstNode.getDerivedNode(component);
         end if;
 
         // Type and type check the attribute.
@@ -1347,6 +1347,12 @@ algorithm
   typedSubs := {};
   next_origin := intBitOr(origin, ExpOrigin.SUBSCRIPT);
   i := 1;
+
+  if listLength(subscripts) > listLength(dims) then
+    Error.addSourceMessage(Error.WRONG_NUMBER_OF_SUBSCRIPTS,
+      {ComponentRef.toString(cref), String(listLength(subscripts)), String(listLength(dims))}, info);
+    fail();
+  end if;
 
   for s in subscripts loop
     dim :: dims := dims;


### PR DESCRIPTION
- Set correct basetype in ClassTree.instantiate for derived classes.
- Fixed scalarization of non-each class modifiers on array components.
- Moved subscript count check from the instantiation to the typing,
  since dimensions from types aren't added to components until then.
- Use correct parent node when type checking type attributes.