### PR TITLE
[NF] Improve subscripting of expressions.

### DIFF
--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -658,38 +658,10 @@ algorithm
   while RangeIterator.hasNext(range_iter) loop
     (range_iter, val) := RangeIterator.next(range_iter);
     unrolled_body := list(Equation.mapExp(eq,
-      function replaceForIterator(iteratorName = iter_name, iteratorValue = val)) for eq in body);
+      function Expression.replaceIterator(iteratorName = iter_name, iteratorValue = val)) for eq in body);
     equations := listAppend(unrolled_body, equations);
   end while;
 end unrollForLoop;
-
-function replaceForIterator
-  input output Expression exp;
-  input String iteratorName;
-  input Expression iteratorValue;
-algorithm
-  exp := Expression.map(exp,
-    function replaceForIterator2(iteratorName = iteratorName, iteratorValue = iteratorValue));
-end replaceForIterator;
-
-function replaceForIterator2
-  input output Expression exp;
-  input String iteratorName;
-  input Expression iteratorValue;
-
-  import Origin = NFComponentRef.Origin;
-algorithm
-  exp := match exp
-    local
-      String name;
-
-    case Expression.CREF(cref = ComponentRef.CREF(
-        node = InstNode.COMPONENT_NODE(name = name), origin = Origin.ITERATOR))
-      then if name == iteratorName then iteratorValue else exp;
-
-    else exp;
-  end match;
-end replaceForIterator2;
 
 function flattenAlgorithms
   input output list<list<Statement>> algorithms;

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -485,6 +485,17 @@ public
     end match;
   end dimensionCount;
 
+  function nthEnumLiteral
+    input Type ty;
+    input Integer index;
+    output String literal;
+  protected
+    list<String> literals;
+  algorithm
+    ENUMERATION(literals = literals) := ty;
+    literal := listGet(literals, index);
+  end nthEnumLiteral;
+
   function toString
     input Type ty;
     output String str;

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -2034,8 +2034,8 @@ algorithm
 
     case (Expression.BOOLEAN(), Expression.BOOLEAN())
       algorithm
-        sz := if startExp.value == startExp.value then 1
-              elseif startExp.value < startExp.value then 2
+        sz := if startExp.value == stopExp.value then 1
+              elseif startExp.value < stopExp.value then 2
               else 0;
       then
         Dimension.fromInteger(sz);

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -439,6 +439,9 @@ algorithm
       then
         ();
 
+    case Component.ITERATOR(binding = Binding.TYPED_BINDING())
+      then ();
+
     case Component.ITERATOR(binding = Binding.UNBOUND())
       algorithm
         Error.assertion(false, getInstanceName() + ": Implicit iteration ranges not yet implement", sourceInfo());


### PR DESCRIPTION
- Handle typenames, ranges and reductions in
  Expression.applySubscriptIndex.
- Use Expression.applySubscriptIndex in Expression.expandGeneric,
  instead of just creating a subscripted expression.
- Fixed mistake in typing of Boolean ranges that resulted in them
  always getting a size of 1.
- Added case to Typing.typeIterator for when the iterator has already
  been typed (which can happen e.g. if the iterator is needed to
  determine the size of a dimension).