### PR TITLE
[NF] Various fixes.

### DIFF
--- a/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -1636,7 +1636,7 @@ algorithm
   true := dim >= 1;
   false := listEmpty(exps);
   if 1 == dim then
-    outExps := listAppend(getArrayContents(e) for e in exps);
+    outExps := listAppend(getArrayContents(e) for e in listReverse(exps));
     outDims := {listLength(outExps)};
     return;
   end if;

--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -467,6 +467,18 @@ uniontype Class
     output Boolean isFunction = Restriction.isFunction(restriction(cls));
   end isFunction;
 
+  function isExternalFunction
+    input Class cls;
+    output Boolean isExtFunc;
+  algorithm
+    isExtFunc := match cls
+      case EXPANDED_DERIVED() then isExternalFunction(InstNode.getClass(cls.baseClass));
+      case INSTANCED_CLASS(sections = Sections.EXTERNAL()) then true;
+      case TYPED_DERIVED() then isExternalFunction(InstNode.getClass(cls.baseClass));
+      else false;
+    end match;
+  end isExternalFunction;
+
   function getPrefixes
     input Class cls;
     output Prefixes prefs;

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -1079,6 +1079,11 @@ uniontype Function
     output Boolean isPointer = fn.attributes.isFunctionPointer;
   end isFunctionPointer;
 
+  function isExternal
+    input Function fn;
+    output Boolean isExternal = Class.isExternalFunction(InstNode.getClass(fn.node));
+  end isExternal;
+
   function inlineBuiltin
     input Function fn;
     output DAE.InlineType inlineType;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -409,7 +409,7 @@ algorithm
   () := match c
     case Component.ITERATOR(binding = Binding.UNTYPED_BINDING(), info = info)
       algorithm
-        binding := typeBinding(c.binding, intBitOr(origin, ExpOrigin.ITERATION_RANGE));
+        binding := typeBinding(c.binding, intBitOr(origin, ExpOrigin.ITERATION_RANGE), replaceConstants = false);
 
         // If the iteration range is structural, it must be a parameter expression.
         if structural then
@@ -761,6 +761,7 @@ end typeComponentBinding;
 function typeBinding
   input output Binding binding;
   input ExpOrigin.Type origin;
+  input Boolean replaceConstants = true;
 algorithm
   binding := match binding
     local
@@ -772,7 +773,7 @@ algorithm
     case Binding.UNTYPED_BINDING(bindingExp = exp)
       algorithm
         info := Binding.getInfo(binding);
-        (exp, ty, var) := typeExp(exp, origin, info);
+        (exp, ty, var) := typeExp(exp, origin, info, replaceConstants);
       then
         Binding.TYPED_BINDING(exp, ty, var, binding.origin, binding.isEach);
 


### PR DESCRIPTION
- Fix ExpressionSimplify.evalCat so that it doesn't reverse the
  arguments when dim == 1.
- Disabled constant evaluation of function call arguments during typing.
- Added constant evaluation of ranges.