### PR TITLE
Improved instantiateModel

### DIFF
--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -1702,10 +1702,17 @@ algorithm
 
     case (cache,env,"instantiateModel",{Values.CODE(Absyn.C_TYPENAME(className))},_)
       equation
-        (cache,env,odae) = runFrontEnd(cache,env,className,true);
         ExecStat.execStatReset();
-        str = if isNone(odae) then "" else DAEDump.dumpStr(Util.getOption(odae),FCore.getFunctionTree(cache));
-        ExecStat.execStat("DAEDump.dumpStr(" + Absyn.pathString(className) + ")");
+        (cache,env,odae) = runFrontEnd(cache,env,className,true);
+        ExecStat.execStat("runFrontEnd");
+        if isNone(odae) then
+          str = "";
+        elseif Config.silent() then
+          str = "model " + Absyn.pathString(className) + "\n  /* Silent mode */\nend" + Absyn.pathString(className) + ";\n"; // Not the empty string, so we can
+        else
+          str = DAEDump.dumpStr(Util.getOption(odae),FCore.getFunctionTree(cache));
+          ExecStat.execStat("DAEDump.dumpStr");
+        end if;
       then
         (cache,Values.STRING(str));
 

--- a/Compiler/Script/Interactive.mo
+++ b/Compiler/Script/Interactive.mo
@@ -178,41 +178,23 @@ public function evaluateToStdOut
   The resulting string after evaluation is printed.
   If an error has occurred, this string will be empty.
   The error messages can be retrieved by calling print_messages_str() in Error.mo."
-  input GlobalScript.Statements inStatements;
-  input Boolean inBoolean;
+  input GlobalScript.Statements statements;
+  input Boolean verbose;
+protected
+  GlobalScript.Statement x;
+  list<GlobalScript.Statement> xs;
+  Boolean semicolon;
+  String res;
 algorithm
-  _ := match (inStatements,inBoolean)
-    local
-      String res,res_1;
-      Boolean echo,semicolon,verbose;
-      GlobalScript.Statement x;
-      GlobalScript.Statements new;
-      list<GlobalScript.Statement> xs;
-
-    case (GlobalScript.ISTMTS(interactiveStmtLst = {x},semicolon = semicolon),verbose)
-      equation
-        showStatement(x, semicolon, true);
-        new = GlobalScript.ISTMTS({x},verbose);
-        res = evaluate2(new);
-        echo = getEcho();
-        res_1 = selectResultstr(res, semicolon, verbose, echo);
-        print(res_1);
-        showStatement(x, semicolon, false);
-      then ();
-
-    case (GlobalScript.ISTMTS(interactiveStmtLst = (x :: xs),semicolon = semicolon),verbose)
-      equation
-        showStatement(x, semicolon, true);
-        new = GlobalScript.ISTMTS({x},semicolon);
-        res = evaluate2(new);
-        echo = getEcho();
-        res_1 = selectResultstr(res, semicolon, verbose, echo);
-        print(res_1);
-        showStatement(x, semicolon, false);
-
-        evaluateToStdOut(GlobalScript.ISTMTS(xs,semicolon), verbose);
-      then ();
-  end match;
+  xs := statements.interactiveStmtLst;
+  semicolon := statements.semicolon;
+  while not listEmpty(xs) loop
+    x::xs := xs;
+    showStatement(x, semicolon, true);
+    res := evaluate2(GlobalScript.ISTMTS({x},if listEmpty(xs) then verbose else semicolon));
+    print(selectResultstr(res, semicolon, verbose, getEcho()));
+    showStatement(x, semicolon, false);
+  end while;
 end evaluateToStdOut;
 
 public function evaluateFork


### PR DESCRIPTION
- Report execStat for the frontend
- Support the silent flag `-q` for the instantiateModel API, avoiding
  calling the dumping routine if the result is not desired (the output
  is still non-empty to allow checking for empty string to signify
  success)