### PR TITLE
Fix Inst.releaseInstHashTable.

### DIFF
--- a/Compiler/FrontEnd/Inst.mo
+++ b/Compiler/FrontEnd/Inst.mo
@@ -5513,7 +5513,7 @@ end initInstHashTable;
 
 public function releaseInstHashTable
 algorithm
-  setGlobalRoot(Global.instHashIndex, emptyInstHashTableSized(1));
+  setGlobalRoot(Global.instHashIndex, emptyInstHashTable());
   OperatorOverloading.initCache();
 end releaseInstHashTable;
 


### PR DESCRIPTION
-  Create a new hash table of appropriate size, instead of one with
  size 1, since it will be reused by subsequent instantiations.