### PR TITLE
[NF] Initial function evaluation implementation.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -128,7 +128,7 @@ constant InstNode INTEGER_DUMMY_NODE = NFInstNode.CLASS_NODE("Integer",
 constant Function INTEGER_FUNCTION = Function.FUNCTION(Path.IDENT("Integer"),
   INTEGER_DUMMY_NODE, {ENUM_PARAM}, {}, {}, {
     Slot.SLOT("e", SlotType.POSITIONAL, NONE(), NONE())
-  }, Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+  }, Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 constant InstNode INTEGER_NODE = InstNode.CLASS_NODE("IntegerFunc",
   DUMMY_ELEMENT, Visibility.PUBLIC,
@@ -153,14 +153,16 @@ constant Function STRING_REAL = Function.FUNCTION(Path.IDENT("String"),
     Slot.SLOT("significantDigits", SlotType.NAMED, SOME(Expression.INTEGER(6)), NONE()),
     Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE()),
     Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE())
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+  Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 // String(r, format="-0.6g")
 constant Function STRING_REAL_FORMAT = Function.FUNCTION(Path.IDENT("String"),
   STRING_DUMMY_NODE, {REAL_PARAM, STRING_PARAM}, {STRING_PARAM}, {}, {
     Slot.SLOT("r", SlotType.POSITIONAL, NONE(), NONE()),
     Slot.SLOT("format", SlotType.NAMED, NONE(), NONE())
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+  Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 // String(i, minimumLength=0, leftJustified=true)
 constant Function STRING_INT = Function.FUNCTION(Path.IDENT("String"),
@@ -168,7 +170,8 @@ constant Function STRING_INT = Function.FUNCTION(Path.IDENT("String"),
     Slot.SLOT("i", SlotType.POSITIONAL, NONE(), NONE()),
     Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE()),
     Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE())
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+  Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 // String(b, minimumLength=0, leftJustified=true)
 constant Function STRING_BOOL = Function.FUNCTION(Path.IDENT("String"),
@@ -176,7 +179,8 @@ constant Function STRING_BOOL = Function.FUNCTION(Path.IDENT("String"),
     Slot.SLOT("b", SlotType.POSITIONAL, NONE(), NONE()),
     Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE()),
     Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE())
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+  Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 // String(e, minimumLength=0, leftJustified=true)
 constant Function STRING_ENUM = Function.FUNCTION(Path.IDENT("String"),
@@ -184,7 +188,8 @@ constant Function STRING_ENUM = Function.FUNCTION(Path.IDENT("String"),
     Slot.SLOT("e", SlotType.POSITIONAL, NONE(), NONE()),
     Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE()),
     Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE())
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+  Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 constant InstNode STRING_NODE = InstNode.CLASS_NODE("String",
   DUMMY_ELEMENT, Visibility.PUBLIC,
@@ -208,35 +213,43 @@ constant ComponentRef STRING_CREF =
 
 constant Function ABS_REAL = Function.FUNCTION(Path.IDENT("abs"),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 constant Function MAX_REAL = Function.FUNCTION(Path.IDENT("max"),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 constant Function POSITIVE_MAX_REAL = Function.FUNCTION(Path.IDENT("$OMC$PositiveMax"),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 constant Function IN_STREAM = Function.FUNCTION(Path.IDENT("inStream"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 constant Function PROMOTE = Function.FUNCTION(Path.IDENT("promote"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 constant Function CAT = Function.FUNCTION(Path.IDENT("cat"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 constant Function ARRAY_FUNC = Function.FUNCTION(Path.IDENT("array"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 constant Function FILL_FUNC = Function.FUNCTION(Path.IDENT("fill"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, Pointer.createImmutable(true));
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 annotation(__OpenModelica_Interface="frontend");
 end NFBuiltinFuncs;

--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -49,6 +49,7 @@ import NFPrefixes.Variability;
 
 protected
 import NFFunction.Function;
+import EvalFunction = NFEvalFunction;
 import List;
 import System;
 
@@ -117,7 +118,7 @@ end EvalTarget;
 
 function evalExp
   input output Expression exp;
-  input EvalTarget target;
+  input EvalTarget target = EvalTarget.IGNORE_ERRORS();
 algorithm
   exp := match exp
     local
@@ -221,6 +222,12 @@ algorithm
       algorithm
         exp1 := evalExp(exp.exp, target);
       then Expression.UNBOX(exp1, exp.ty);
+
+    case Expression.MUTABLE()
+      algorithm
+        exp1 := evalExp(Mutable.access(exp.exp), target);
+      then
+        exp1;
 
     else exp;
   end match;
@@ -1248,10 +1255,7 @@ function evalNormalCall
   input Function fn;
   input list<Expression> args;
   input Call call;
-  output Expression result;
-algorithm
-  Error.addInternalError(getInstanceName() + ": IMPLEMENT ME: " + Call.toString(call), sourceInfo());
-  fail();
+  output Expression result = EvalFunction.evaluate(fn, args);
 end evalNormalCall;
 
 function printWrongArgsError

--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -181,7 +181,6 @@ uniontype Component
 
   record ITERATOR
     Type ty;
-    Binding binding;
     Variability variability;
     SourceInfo info;
   end ITERATOR;
@@ -426,7 +425,6 @@ uniontype Component
     b := match component
       case UNTYPED_COMPONENT() then component.binding;
       case TYPED_COMPONENT() then component.binding;
-      case ITERATOR() then component.binding;
     end match;
   end getBinding;
 
@@ -447,11 +445,6 @@ uniontype Component
         then
           ();
 
-      case ITERATOR()
-        algorithm
-          component.binding := binding;
-        then
-          ();
     end match;
   end setBinding;
 

--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -787,17 +787,14 @@ function convertForStatement
 protected
   InstNode iterator;
   Type ty;
-  Binding binding;
   Expression range;
   list<Statement> body;
   list<DAE.Statement> dbody;
   DAE.ElementSource source;
 algorithm
-  Statement.FOR(iterator = iterator, body = body, source = source) := forStmt;
+  Statement.FOR(iterator = iterator, range = SOME(range), body = body, source = source) := forStmt;
   dbody := convertStatements(body);
-
-  Component.ITERATOR(ty = ty, binding = binding) := InstNode.component(iterator);
-  SOME(range) := Binding.typedExp(binding);
+  Component.ITERATOR(ty = ty) := InstNode.component(iterator);
 
   forDAE := DAE.Statement.STMT_FOR(Type.toDAE(ty), Type.isArray(ty),
     InstNode.name(iterator), 0, Expression.toDAE(range), dbody, source);

--- a/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -30,46 +30,464 @@
  */
 
 encapsulated package NFEvalFunction
-" file:         NFEvalFunction.mo
-  package:      NFEvalFunction
-  description:  This module constant evaluates NFInstTypes.Function objects, i.e.
-                modelica functions defined by the user.
 
+import Expression = NFExpression;
+import NFClass.Class;
+import NFFunction.Function;
+import NFInstNode.InstNode;
+import Sections = NFSections;
+import Statement = NFStatement;
+import ComponentRef = NFComponentRef;
+import Binding = NFBinding;
+import NFComponent.Component;
+import Type = NFType;
 
-  TODO:
-    * Implement evaluation of MetaModelica statements.
-    * Enable NORETCALL (see comment in evaluateStatement).
-    * Implement terminate and Error.assertion(false, ..., sourceInfo()).
-    * Arrays of records probably doesn't work yet.
-"
+protected
+import Ceval = NFCeval;
+import MetaModelica.Dangerous.*;
+import RangeIterator = NFRangeIterator;
+import ElementSource;
 
-// Jump table for CevalFunction:
-// [TYPE]  Types.
-// [EVAL]  Constant evaluation functions.
-// [EENV]  Environment extension functions (add variables).
-// [MENV]  Environment manipulation functions (set and get variables).
-// [DEPS]  Function variable dependency handling.
-// [EOPT]  Expression optimization functions.
+encapsulated package ReplTree
+  import BaseAvlTree;
+  import Expression = NFExpression;
 
-// public imports
+  extends BaseAvlTree(redeclare type Key = String,
+                      redeclare type Value = Expression);
 
-// protected imports
+  redeclare function extends keyStr
+  algorithm
+    outString := inKey;
+  end keyStr;
 
-// [TYPE]  Types
+  redeclare function extends valueStr
+  algorithm
+    outString := Expression.toString(inValue);
+  end valueStr;
 
-// LoopControl is used to control the functions behaviour in different
-// situations. All evaluation functions returns a LoopControl variable that
-// tells the caller whether it should continue evaluating or not.
-protected uniontype LoopControl
-  record NEXT "Continue to the next statement." end NEXT;
-  record BREAK "Exit the current loop." end BREAK;
-  record RETURN "Exit the function." end RETURN;
-end LoopControl;
+  redeclare function extends keyCompare
+  algorithm
+    outResult := stringCompare(inKey1, inKey2);
+  end keyCompare;
 
-// [EVAL]  Constant evaluation functions.
+  annotation(__OpenModelica_Interface="util");
+end ReplTree;
 
-public function evaluate
+type FlowControl = enumeration(NEXT, CONTINUE, BREAK, RETURN, FAIL);
+
+public
+function evaluate
+  input Function fn;
+  input list<Expression> args;
+  output Expression result;
+protected
+  list<Statement> fn_body;
+  list<Binding> bindings;
+  ReplTree.Tree repl;
+  Integer call_count, limit;
+  Pointer<Integer> call_counter = fn.callCounter;
+  FlowControl ctrl;
+algorithm
+  // Functions contain a mutable call counter that's increased by one at the
+  // start of each evaluation, and decreased by one when the evalution is
+  // finished. This is used to limit the number of recursive functions calls.
+  call_count := Pointer.access(call_counter) + 1;
+  limit := Flags.getConfigInt(Flags.EVAL_RECURSION_LIMIT);
+
+  if call_count > limit then
+    Pointer.update(call_counter, 0);
+    Error.addSourceMessage(Error.EVAL_RECURSION_LIMIT_REACHED,
+      {String(limit), Absyn.pathString(Function.name(fn))}, InstNode.info(fn.node));
+    fail();
+  end if;
+
+  Pointer.update(call_counter, call_count);
+
+  try
+    fn_body := getFunctionBody(fn.node);
+    repl := createReplacements(fn, args);
+    // TODO: Also apply replacements to the replacements themselves, i.e. the
+    //       bindings of the function parameters. But the probably need to be
+    //       sorted by dependencies first.
+    fn_body := applyReplacements(repl, fn_body);
+    ctrl := evaluateStatements(fn_body);
+    result := createResult(repl, fn.outputs);
+  else
+    // Make sure we always decrease the call counter even if the evaluation fails.
+    Pointer.update(call_counter, call_count - 1);
+    fail();
+  end try;
+
+  Pointer.update(call_counter, call_count - 1);
 end evaluate;
+
+protected
+
+function getFunctionBody
+  input InstNode node;
+  output list<Statement> body;
+protected
+  Class cls = InstNode.getClass(node);
+algorithm
+  body := match cls
+    case Class.INSTANCED_CLASS(sections = Sections.SECTIONS(algorithms = {body})) then body;
+
+    case Class.INSTANCED_CLASS(sections = Sections.SECTIONS(algorithms = _ :: _))
+      algorithm
+        Error.assertion(false, getInstanceName() + " got function with multiple algorithm sections", sourceInfo());
+      then
+        fail();
+
+    case Class.TYPED_DERIVED() then getFunctionBody(cls.baseClass);
+
+    else
+      algorithm
+        Error.assertion(false, getInstanceName() + " got unknown function", sourceInfo());
+      then
+        fail();
+
+  end match;
+end getFunctionBody;
+
+function createReplacements
+  input Function fn;
+  input list<Expression> args;
+  output ReplTree.Tree repl;
+protected
+  Expression arg;
+  list<Expression> rest_args = args;
+algorithm
+  repl := ReplTree.new();
+
+  for i in fn.inputs loop
+    arg :: rest_args := rest_args;
+    repl := addInputReplacement(i, "", arg, repl);
+  end for;
+
+  repl := List.fold(fn.outputs, function addMutableReplacement(prefix = ""), repl);
+  repl := List.fold(fn.locals, function addMutableReplacement(prefix = ""), repl);
+end createReplacements;
+
+function addMutableReplacement
+  input InstNode node;
+  input String prefix = "";
+  input output ReplTree.Tree repl;
+protected
+  Binding binding;
+  Expression repl_exp;
+algorithm
+  binding := Component.getBinding(InstNode.component(node));
+
+  // TODO: Handle records.
+  if Binding.isBound(binding) then
+    repl_exp := Binding.getExp(binding);
+  else
+    // TODO: Replace with something more suitable, Expression.EMPTY?
+    repl_exp := Expression.INTEGER(0);
+  end if;
+
+  repl_exp := Expression.makeMutable(repl_exp);
+  repl := ReplTree.add(repl, prefix + InstNode.name(node), repl_exp);
+end addMutableReplacement;
+
+function addInputReplacement
+  input InstNode node;
+  input String prefix = "";
+  input Expression argument;
+  input output ReplTree.Tree repl;
+algorithm
+  repl := ReplTree.add(repl, prefix + InstNode.name(node), argument);
+end addInputReplacement;
+
+function applyReplacements
+  input ReplTree.Tree repl;
+  input output list<Statement> fnBody;
+algorithm
+  fnBody := Statement.mapExpList(fnBody,
+    function Expression.map(func = function applyReplacements2(repl = repl)));
+end applyReplacements;
+
+function applyReplacements2
+  input ReplTree.Tree repl;
+  input output Expression exp;
+algorithm
+  exp := match exp
+    local
+      Option<Expression> repl_exp;
+
+    case Expression.CREF(cref = ComponentRef.CREF(subscripts = _ :: _))
+      algorithm
+        Error.assertion(false, getInstanceName() + ": missing handling of subscripts", sourceInfo());
+      then
+        fail();
+
+    case Expression.CREF() guard not ComponentRef.isIterator(exp.cref)
+      algorithm
+        // TODO: Handle subscripting.
+        repl_exp := ReplTree.getOpt(repl, ComponentRef.toString(exp.cref));
+      then
+        if isSome(repl_exp) then Util.getOption(repl_exp) else exp;
+
+    else exp;
+  end match;
+end applyReplacements2;
+
+function createResult
+  input ReplTree.Tree repl;
+  input list<InstNode> outputs;
+  output Expression exp;
+protected
+  list<Expression> expl;
+  list<Type> types;
+algorithm
+  if listLength(outputs) == 1 then
+    exp := Expression.makeImmutable(ReplTree.get(repl, InstNode.name(listHead(outputs))));
+  else
+    expl := {};
+    types := {};
+
+    for o in outputs loop
+      expl := Expression.makeImmutable(ReplTree.get(repl, InstNode.name(o))) :: expl;
+    end for;
+
+    expl := listReverseInPlace(expl);
+    types := list(Expression.typeOf(e) for e in expl);
+    exp := Expression.TUPLE(Type.TUPLE(types, NONE()), expl);
+  end if;
+end createResult;
+
+function evaluateStatements
+  input list<Statement> stmts;
+  output FlowControl ctrl = FlowControl.NEXT;
+algorithm
+  for s in stmts loop
+    ctrl := evaluateStatement(s);
+
+    if ctrl <> FlowControl.NEXT then
+      if ctrl == FlowControl.CONTINUE then
+        ctrl := FlowControl.NEXT;
+      end if;
+
+      break;
+    end if;
+  end for;
+end evaluateStatements;
+
+function evaluateStatement
+  input Statement stmt;
+  output FlowControl ctrl;
+algorithm
+  ctrl := match stmt
+    case Statement.ASSIGNMENT() then evaluateAssignment(stmt.lhs, stmt.rhs);
+    case Statement.FOR()        then evaluateFor(stmt.iterator, stmt.range, stmt.body, stmt.source);
+    case Statement.IF()         then evaluateIf(stmt.branches);
+    case Statement.ASSERT()     then evaluateAssert(stmt.condition, stmt);
+    case Statement.TERMINATE()  then evaluateTerminate(stmt.message, stmt.source);
+    case Statement.NORETCALL()  then evaluateNoRetCall(stmt.exp);
+    case Statement.WHILE()      then evaluateWhile(stmt.condition, stmt.body, stmt.source);
+    case Statement.RETURN()     then FlowControl.RETURN;
+    case Statement.BREAK()      then FlowControl.BREAK;
+    else
+      algorithm
+        Error.assertion(false, getInstanceName() + " failed on " + anyString(stmt) + "\n", sourceInfo());
+      then
+        fail();
+
+  end match;
+end evaluateStatement;
+
+function evaluateAssignment
+  input Expression lhsExp;
+  input Expression rhsExp;
+  output FlowControl ctrl = FlowControl.NEXT;
+protected
+  Expression rhs;
+algorithm
+  rhs := Ceval.evalExp(rhsExp);
+
+  () := match lhsExp
+    case Expression.MUTABLE()
+      algorithm
+        Mutable.update(lhsExp.exp, rhs);
+      then
+        ();
+
+    else
+      algorithm
+        Error.assertion(false, getInstanceName() + " failed on " +
+          Expression.toString(lhsExp) + " := " + Expression.toString(rhsExp), sourceInfo());
+      then
+        fail();
+
+  end match;
+end evaluateAssignment;
+
+function evaluateFor
+  input InstNode iterator;
+  input Option<Expression> range;
+  input list<Statement> forBody;
+  input DAE.ElementSource source;
+  output FlowControl ctrl;
+protected
+  RangeIterator range_iter;
+  Mutable<Expression> iter_exp;
+  Expression range_exp, value;
+  list<Statement> body = forBody;
+  Integer i = 0, limit = Flags.getConfigInt(Flags.EVAL_LOOP_LIMIT);
+algorithm
+  range_exp := Ceval.evalExp(Util.getOption(range));
+  range_iter := RangeIterator.fromExp(range_exp);
+
+  if RangeIterator.hasNext(range_iter) then
+    // Replace the iterator with a mutable expression.
+    // TODO: If each iterator contained a mutable binding that we could update
+    //       this wouldn't be necessary, but the handling of for loops needs to
+    //       be fixed so we don't try to evaluate iterators when we shouldn't.
+    iter_exp := Mutable.create(Expression.INTEGER(0));
+    value := Expression.MUTABLE(iter_exp);
+    body := Statement.mapExpList(forBody,
+      function Expression.replaceIterator(iterator = iterator, iteratorValue = value));
+
+    // Loop through each value in the iteration range.
+    while RangeIterator.hasNext(range_iter) loop
+      (range_iter, value) := RangeIterator.next(range_iter);
+      // Update the mutable expression with the iteration value and evaluate the statement.
+      Mutable.update(iter_exp, value);
+      ctrl := evaluateStatements(body);
+
+      if ctrl <> FlowControl.NEXT then
+        if ctrl == FlowControl.BREAK then
+          ctrl := FlowControl.NEXT;
+        end if;
+
+        break;
+      end if;
+
+      i := i + 1;
+      if i > limit then
+        Error.addSourceMessage(Error.EVAL_LOOP_LIMIT_REACHED, {String(limit)},
+          ElementSource.getInfo(source));
+        fail();
+      end if;
+    end while;
+  end if;
+end evaluateFor;
+
+function evaluateIf
+  input list<tuple<Expression, list<Statement>>> branches;
+  output FlowControl ctrl;
+protected
+  Expression cond;
+  list<Statement> body;
+algorithm
+  for branch in branches loop
+    (cond, body) := branch;
+
+    if Expression.isTrue(Ceval.evalExp(cond)) then
+      ctrl := evaluateStatements(body);
+      return;
+    end if;
+  end for;
+
+  ctrl := FlowControl.NEXT;
+end evaluateIf;
+
+function evaluateAssert
+  input Expression condition;
+  input Statement assertStmt;
+  output FlowControl ctrl = FlowControl.NEXT;
+protected
+  Expression msg, lvl;
+  DAE.ElementSource source;
+algorithm
+  if Expression.isFalse(Ceval.evalExp(condition)) then
+    Statement.ASSERT(message = msg, level = lvl, source = source) := assertStmt;
+    msg := Ceval.evalExp(msg);
+    lvl := Ceval.evalExp(lvl);
+
+    () := match (msg, lvl)
+      case (Expression.STRING(), Expression.ENUM_LITERAL(name = "warning"))
+        algorithm
+          Error.addSourceMessage(Error.ASSERT_TRIGGERED_WARNING, {msg.value}, ElementSource.getInfo(source));
+        then
+          ();
+
+      case (Expression.STRING(), Expression.ENUM_LITERAL(name = "error"))
+        algorithm
+          Error.addSourceMessage(Error.ASSERT_TRIGGERED_ERROR, {msg.value}, ElementSource.getInfo(source));
+        then
+          fail();
+
+      else
+        algorithm
+          Error.assertion(false, getInstanceName() + " failed to evaluate assert(false, " +
+            Expression.toString(msg) + ", " + Expression.toString(lvl) + ")", sourceInfo());
+        then
+          fail();
+    end match;
+  end if;
+end evaluateAssert;
+
+function evaluateTerminate
+  input Expression message;
+  input DAE.ElementSource source;
+  output FlowControl dummy = FlowControl.NEXT;
+protected
+  Expression msg;
+algorithm
+  msg := Ceval.evalExp(message);
+
+  _ := match msg
+    case Expression.STRING()
+      algorithm
+        Error.addSourceMessage(Error.TERMINATE_TRIGGERED, {msg.value}, ElementSource.getInfo(source));
+      then
+        fail();
+
+    else
+      algorithm
+        Error.assertion(false, getInstanceName() + " failed to evaluate terminate(" +
+          Expression.toString(msg) + ")", sourceInfo());
+      then
+        fail();
+
+  end match;
+end evaluateTerminate;
+
+function evaluateNoRetCall
+  input Expression callExp;
+  output FlowControl ctrl = FlowControl.NEXT;
+algorithm
+  Ceval.evalExp(callExp);
+end evaluateNoRetCall;
+
+function evaluateWhile
+  input Expression condition;
+  input list<Statement> body;
+  input DAE.ElementSource source;
+  output FlowControl ctrl = FlowControl.NEXT;
+protected
+  Integer i = 0, limit = Flags.getConfigInt(Flags.EVAL_LOOP_LIMIT);
+algorithm
+  while Expression.isTrue(Ceval.evalExp(condition)) loop
+    ctrl := evaluateStatements(body);
+
+    if ctrl <> FlowControl.NEXT then
+      if ctrl == FlowControl.BREAK then
+        ctrl := FlowControl.NEXT;
+      end if;
+
+      break;
+    end if;
+
+    i := i + 1;
+    if i > limit then
+      Error.addSourceMessage(Error.EVAL_LOOP_LIMIT_REACHED, {String(limit)},
+        ElementSource.getInfo(source));
+      fail();
+    end if;
+  end while;
+end evaluateWhile;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFEvalFunction;

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -637,22 +637,15 @@ function unrollForLoop
   input output list<Equation> equations;
 protected
   InstNode iter;
-  String iter_name;
   list<Equation> body, unrolled_body;
-  Binding binding;
   Expression range;
   RangeIterator range_iter;
   Expression val;
 algorithm
-  Equation.FOR(iterator = iter, body = body) := forLoop;
-
-  // Get the range to iterate over.
-  Component.ITERATOR(binding = binding) := InstNode.component(iter);
-  iter_name := InstNode.name(iter);
-  SOME(range) := Binding.typedExp(binding);
-  range_iter := RangeIterator.fromExp(range);
+  Equation.FOR(iterator = iter, range = SOME(range), body = body) := forLoop;
 
   // Unroll the loop by replacing the iterator with each of its values in the for loop body.
+  range_iter := RangeIterator.fromExp(range);
   while RangeIterator.hasNext(range_iter) loop
     (range_iter, val) := RangeIterator.next(range_iter);
     unrolled_body := list(Equation.mapExp(eq,

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -206,6 +206,7 @@ uniontype Function
     Type returnType;
     DAE.FunctionAttributes attributes;
     Pointer<Boolean> collected "Whether this function has already been added to the function tree or not.";
+    Pointer<Integer> callCounter "Used during function evaluation to avoid infinite loops.";
   end FUNCTION;
 
   function new
@@ -223,7 +224,8 @@ uniontype Function
     attr := makeAttributes(node, inputs, outputs);
     // Make sure builtin functions aren't added to the function tree.
     collected := Pointer.create(isBuiltinAttr(attr));
-    fn := FUNCTION(path, node, inputs, outputs, locals, {}, Type.UNKNOWN(), attr, collected);
+    fn := FUNCTION(path, node, inputs, outputs, locals, {}, Type.UNKNOWN(),
+      attr, collected, Pointer.create(0));
   end new;
 
   function lookupFunctionSimple

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -2315,7 +2315,6 @@ algorithm
       list<Equation> eql;
       list<tuple<Expression, list<Equation>>> branches;
       SourceInfo info;
-      Binding binding;
       InstNode for_scope, iter;
       ComponentRef lhs_cr, rhs_cr;
 
@@ -2347,13 +2346,11 @@ algorithm
 
     case SCode.EEquation.EQ_FOR(info = info)
       algorithm
-        binding := Binding.fromAbsyn(scodeEq.range, false, 0, scope, info);
-        binding := instBinding(binding);
-
-        (for_scope, iter) := addIteratorToScope(scodeEq.index, binding, scope, scodeEq.info);
+        oexp := instExpOpt(scodeEq.range, scope, info);
+        (for_scope, iter) := addIteratorToScope(scodeEq.index, scope, scodeEq.info);
         eql := instEEquations(scodeEq.eEquationLst, for_scope, eqScope);
       then
-        Equation.FOR(iter, eql, makeSource(scodeEq.comment, info));
+        Equation.FOR(iter, oexp, eql, makeSource(scodeEq.comment, info));
 
     case SCode.EEquation.EQ_IF(info = info)
       algorithm
@@ -2482,7 +2479,6 @@ algorithm
       list<Statement> stmtl;
       list<tuple<Expression, list<Statement>>> branches;
       SourceInfo info;
-      Binding binding;
       InstNode for_scope, iter;
 
     case SCode.Statement.ALG_ASSIGN(info = info)
@@ -2494,13 +2490,11 @@ algorithm
 
     case SCode.Statement.ALG_FOR(info = info)
       algorithm
-        binding := Binding.fromAbsyn(scodeStmt.range, false, 0, scope, info);
-        binding := instBinding(binding);
-
-        (for_scope, iter) := addIteratorToScope(scodeStmt.index, binding, scope, info);
+        oexp := instExpOpt(scodeStmt.range, scope, info);
+        (for_scope, iter) := addIteratorToScope(scodeStmt.index, scope, info);
         stmtl := instStatements(scodeStmt.forBody, for_scope);
       then
-        Statement.FOR(iter, stmtl, makeSource(scodeStmt.comment, info));
+        Statement.FOR(iter, oexp, stmtl, makeSource(scodeStmt.comment, info));
 
     case SCode.Statement.ALG_IF(info = info)
       algorithm
@@ -2585,7 +2579,6 @@ end instStatement;
 
 function addIteratorToScope
   input String name;
-  input Binding binding;
   input output InstNode scope;
   input SourceInfo info;
   input Type iter_type = Type.UNKNOWN();
@@ -2594,7 +2587,7 @@ protected
   Component iter_comp;
 algorithm
   scope := InstNode.openImplicitScope(scope);
-  iter_comp := Component.ITERATOR(iter_type, binding, Variability.CONTINUOUS, info);
+  iter_comp := Component.ITERATOR(iter_type, Variability.CONTINUOUS, info);
   iterator := InstNode.fromComponent(name, iter_comp, scope);
   scope := InstNode.addIterator(iterator, scope);
 end addIteratorToScope;

--- a/Compiler/NFFrontEnd/NFRecord.mo
+++ b/Compiler/NFFrontEnd/NFRecord.mo
@@ -136,7 +136,8 @@ algorithm
   def_ctor_cls := Class.makeRecordConstructor(inputs, locals, out_rec);
   def_ctor_node := InstNode.updateClass(def_ctor_cls, def_ctor_node);
 
-  InstNode.cacheAddFunc(node, Function.FUNCTION(con_path, def_ctor_node, inputs, {out_rec}, locals, {}, Type.UNKNOWN(), attr, collected), false);
+  InstNode.cacheAddFunc(node, Function.FUNCTION(con_path, def_ctor_node, inputs,
+    {out_rec}, locals, {}, Type.UNKNOWN(), attr, collected, Pointer.create(0)), false);
 end instConstructors;
 
 

--- a/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/Compiler/NFFrontEnd/NFScalarize.mo
@@ -288,7 +288,7 @@ function scalarizeStatement
 algorithm
   statements := match stmt
     case Statement.FOR()
-      then Statement.FOR(stmt.iterator, scalarizeAlgorithm(stmt.body), stmt.source) :: statements;
+      then Statement.FOR(stmt.iterator, stmt.range, scalarizeAlgorithm(stmt.body), stmt.source) :: statements;
 
     case Statement.IF()
       then scalarizeIfStatement(stmt.branches, stmt.source, statements);

--- a/Compiler/NFFrontEnd/NFStatement.mo
+++ b/Compiler/NFFrontEnd/NFStatement.mo
@@ -39,6 +39,7 @@ encapsulated uniontype NFStatement
 protected
   import Statement = NFStatement;
   import ElementSource;
+  import Util;
 
 public
   record ASSIGNMENT
@@ -55,6 +56,7 @@ public
 
   record FOR
     InstNode iterator;
+    Option<Expression> range;
     list<Statement> body "The body of the for loop.";
     DAE.ElementSource source;
   end FOR;
@@ -177,6 +179,7 @@ public
       case FOR()
         algorithm
           stmt.body := mapExpList(stmt.body, func);
+          stmt.range := Util.applyOption(stmt.range, func);
         then
           stmt;
 
@@ -273,6 +276,10 @@ public
       case Statement.FOR()
         algorithm
           arg := foldExpList(stmt.body, func, arg);
+
+          if isSome(stmt.range) then
+            arg := func(Util.getOption(stmt.range), arg);
+          end if;
         then
           ();
 

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -338,8 +338,8 @@ public constant Message ILLEGAL_SUBSCRIPT = MESSAGE(104, TRANSLATION(), ERROR(),
   Util.gettext("Illegal subscript %s for dimensions %s in component %s."));
 public constant Message ILLEGAL_EQUATION_TYPE = MESSAGE(105, TRANSLATION(), ERROR(),
   Util.gettext("Illegal type in equation %s, only builtin types (Real, String, Integer, Boolean or enumeration) or record type allowed in equation."));
-public constant Message ASSERT_FAILED = MESSAGE(106, TRANSLATION(), ERROR(),
-  Util.gettext("Assertion failed in function, message: %s"));
+public constant Message EVAL_LOOP_LIMIT_REACHED = MESSAGE(106, TRANSLATION(), ERROR(),
+  Util.gettext("The loop iteration limit (--evalLoopLimit=%s) was exceeded during evaluation."));
 public constant Message LOOKUP_IN_PARTIAL_CLASS = MESSAGE(107, TRANSLATION(), ERROR(),
   Util.gettext("%s is partial, name lookup is not allowed in partial classes."));
 public constant Message MISSING_INNER_PREFIX = MESSAGE(108, TRANSLATION(), WARNING(),
@@ -787,6 +787,14 @@ public constant Message NON_TYPE_DIMENSIONS = MESSAGE(329, TRANSLATION(), ERROR(
   Util.gettext("Invalid dimensions on ‘%s %s‘, only types may have dimensions."));
 public constant Message MISSING_TYPE_BASETYPE = MESSAGE(330, TRANSLATION(), ERROR(),
   Util.gettext("Type ‘%s‘ does not extend a basic type."));
+public constant Message ASSERT_TRIGGERED_WARNING = MESSAGE(331, TRANSLATION(), WARNING(),
+  Util.gettext("assert triggered: %s"));
+public constant Message ASSERT_TRIGGERED_ERROR = MESSAGE(332, TRANSLATION(), ERROR(),
+  Util.gettext("assert triggered: %s"));
+public constant Message TERMINATE_TRIGGERED = MESSAGE(333, TRANSLATION(), ERROR(),
+  Util.gettext("terminate triggered: %s"));
+public constant Message EVAL_RECURSION_LIMIT_REACHED = MESSAGE(334, TRANSLATION(), ERROR(),
+  Util.gettext("The recursion limit (--evalRecursionLimit=%s) was exceeded during evaluation of %s."));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -1452,6 +1452,15 @@ constant ConfigFlag IGNORE_REPLACEABLE = CONFIG_FLAG(117, "ignoreReplaceable",
     }),NONE(),
     Util.gettext("Sets the optimization modules for the DAEmode in the back end. See --help=optmodules for more info."));
 
+  constant ConfigFlag EVAL_LOOP_LIMIT = CONFIG_FLAG(125,
+    "evalLoopLimit", NONE(), EXTERNAL(), INT_FLAG(100000), NONE(),
+    Util.gettext("The loop iteration limit used when evaluating constant function calls."));
+
+  constant ConfigFlag EVAL_RECURSION_LIMIT = CONFIG_FLAG(126,
+    "evalRecursionLimit", NONE(), EXTERNAL(), INT_FLAG(256), NONE(),
+    Util.gettext("The recursion limit used when evaluating constant function calls."));
+
+
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
 // in this list, and the list is checked at initialization so that all flags are
@@ -1580,7 +1589,9 @@ constant list<ConfigFlag> allConfigFlags = {
   Load_PACKAGE_FILE,
   BUILDING_FMU,
   BUILDING_MODEL,
-  POST_OPT_MODULES_DAE
+  POST_OPT_MODULES_DAE,
+  EVAL_LOOP_LIMIT,
+  EVAL_RECURSION_LIMIT
 };
 
 public function new

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -305,7 +305,7 @@ if true then /* Suppress output */
     "../NFFrontEnd/NFConnector.mo",
     "../NFFrontEnd/NFDimension.mo",
     "../NFFrontEnd/NFEquation.mo",
-    //"../NFFrontEnd/NFEvalFunction.mo",
+    "../NFFrontEnd/NFEvalFunction.mo",
     "../NFFrontEnd/NFExpression.mo",
     "../NFFrontEnd/NFExpressionIterator.mo",
     "../NFFrontEnd/NFExpOrigin.mo",


### PR DESCRIPTION
- Implemented basic function evaluation that supports all control
  structures and scalar assignments, but not e.g. arrays or records.
- Moved storage of iteration ranges from the mutable iterators to the
  loop or reductions themselves, so they can safely be modified.
- Added new mutable Expression for use by the function evaluation to
  avoid having to do name lookup.
- Added flags --evalLoopLimit and --evalRecursionLimit to let users
  set the limits used to avoid infinite evaluation or stack overflows.