### PR TITLE
[NF] Minor fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -1911,7 +1911,7 @@ protected
       (arg, arg_ty, arg_var) := Typing.typeExp(arg, origin, info);
 
       if arg_var <= Variability.STRUCTURAL_PARAMETER then
-        arg := SimplifyExp.simplifyExp(arg);
+        arg := Ceval.evalExp(arg);
         arg_ty := Expression.typeOf(arg);
       end if;
 

--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -163,7 +163,7 @@ uniontype Class
     ClassTree tree;
   algorithm
     tree := ClassTree.fromRecordConstructor(inputs, locals, out);
-    cls := EXPANDED_CLASS(tree, Modifier.NOMOD(), DEFAULT_PREFIXES, Restriction.FUNCTION());
+    cls := INSTANCED_CLASS(Type.UNKNOWN(), tree, Sections.EMPTY(), Restriction.FUNCTION());
   end makeRecordConstructor;
 
   function initExpandedClass

--- a/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/Compiler/NFFrontEnd/NFClassTree.mo
@@ -660,28 +660,26 @@ public
     protected
       LookupTree.Tree ltree = LookupTree.new();
       Integer i = 1;
-      array<Mutable<InstNode>> comps;
+      array<InstNode> comps;
     algorithm
-      comps := arrayCreateNoInit(listLength(inputs) + listLength(locals) + 1,
-        Mutable.create(InstNode.EMPTY_NODE()));
+      comps := arrayCreateNoInit(listLength(inputs) + listLength(locals) + 1, InstNode.EMPTY_NODE());
 
       for ci in inputs loop
-        comps[i] := Mutable.create(ci);
+        comps[i] := ci;
         ltree := addLocalElement(InstNode.name(ci), LookupTree.Entry.COMPONENT(i), tree, ltree);
         i := i + 1;
       end for;
 
       for cl in locals loop
-        comps[i] := Mutable.create(cl);
+        comps[i] := cl;
         ltree := addLocalElement(InstNode.name(cl), LookupTree.Entry.COMPONENT(i), tree, ltree);
         i := i + 1;
       end for;
 
-      comps[i] := Mutable.create(out);
+      comps[i] := out;
       ltree := addLocalElement(InstNode.name(out), LookupTree.Entry.COMPONENT(i), tree, ltree);
 
-      tree := INSTANTIATED_TREE(ltree, listArray({}), comps, List.intRange(i),
-        listArray({}), listArray({}), DuplicateTree.new());
+      tree := FLAT_TREE(ltree, listArray({}), comps, listArray({}), DuplicateTree.new());
     end fromRecordConstructor;
 
     function mapRedeclareChains

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -1069,6 +1069,10 @@ algorithm
     case Class.INSTANCED_CLASS(elements = cls_tree as ClassTree.FLAT_TREE(), sections = sections)
       algorithm
         for c in cls_tree.components loop
+          if InstNode.isEmpty(c) then
+            continue;
+          end if;
+
           comp := InstNode.component(c);
           funcs := collectTypeFuncs(Component.getType(comp), funcs);
           binding := Component.getBinding(comp);

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -129,6 +129,20 @@ uniontype CachedData
     output array<CachedData> cache = arrayCreate(NUMBER_OF_CACHES, NO_CACHE());
   end empty;
 
+  function initFunc
+    input array<CachedData> caches;
+  protected
+    CachedData func_cache;
+  algorithm
+    func_cache := getFuncCache(caches);
+    func_cache := match func_cache
+      case NO_CACHE() then FUNCTION({}, false, false);
+      case FUNCTION() then func_cache;
+    end match;
+
+    setFuncCache(caches, func_cache);
+  end initFunc;
+
   function addFunc
     input Function fn;
     input Boolean specialBuiltin;
@@ -912,6 +926,15 @@ uniontype InstNode
       else node;
     end match;
   end resolveOuter;
+
+  function cacheInitFunc
+    input output InstNode node;
+  algorithm
+    () := match node
+      case CLASS_NODE() algorithm CachedData.initFunc(node.caches); then ();
+      else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
+    end match;
+  end cacheInitFunc;
 
   function cacheAddFunc
     input output InstNode node;

--- a/Compiler/NFFrontEnd/NFPackage.mo
+++ b/Compiler/NFFrontEnd/NFPackage.mo
@@ -178,8 +178,10 @@ public
                                  sections = sections)
         algorithm
           for c in comps loop
-            constants := collectBindingConstants(
-              Component.getBinding(InstNode.component(c)), constants);
+            if not InstNode.isEmpty(c) then
+              constants := collectBindingConstants(
+                Component.getBinding(InstNode.component(c)), constants);
+            end if;
           end for;
 
           () := match sections

--- a/Compiler/NFFrontEnd/NFRecord.mo
+++ b/Compiler/NFFrontEnd/NFRecord.mo
@@ -148,7 +148,7 @@ function collectRecordParams
 protected
 
   Class cls;
-  array<Mutable<InstNode>> components;
+  array<InstNode> components;
   InstNode n;
   Component comp;
 algorithm
@@ -157,10 +157,15 @@ algorithm
   cls := InstNode.getClass(recNode);
 
   () := match cls
-    case Class.EXPANDED_CLASS(elements = ClassTree.INSTANTIATED_TREE(components = components))
+    case Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE(components = components))
       algorithm
         for i in arrayLength(components):-1:1 loop
-          n := Mutable.access(components[i]);
+          n := components[i];
+
+          if InstNode.isEmpty(n) then
+            continue;
+          end if;
+
           comp := InstNode.component(n);
 
           if InstNode.isProtected(n) or
@@ -187,7 +192,7 @@ function instOperatorFunctions
   input SourceInfo info;
 protected
   Class cls;
-  array<Mutable<InstNode>> mclss;
+  array<InstNode> mclss;
   InstNode op;
   Absyn.Path path;
   list<Function> allfuncs = {}, funcs;
@@ -196,9 +201,9 @@ algorithm
   cls := InstNode.getClass(node);
 
     () := match cls
-      case Class.EXPANDED_CLASS(elements = ClassTree.INSTANTIATED_TREE(classes = mclss))  algorithm
+      case Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE(classes = mclss))  algorithm
         for i in arrayLength(mclss):-1:1 loop
-          op := Mutable.access(mclss[i]);
+          op := mclss[i];
           path := InstNode.scopePath(op);
           Function.instFunc2(path, op, info);
           funcs := Function.getCachedFuncs(op);


### PR DESCRIPTION
- Flatten the class tree of functions before creating the actual
  Function, so that duplicate elements are handled correctly.
- Use Ceval when evaluating 'fill' instead of deprecated SimplifyExp.