### PR TITLE
[NF] Implemented basic function inlining.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -67,6 +67,7 @@ import NFFunction.MatchedFunction;
 import Ceval = NFCeval;
 import SimplifyExp = NFSimplifyExp;
 import Subscript = NFSubscript;
+import Inline = NFInline;
 
 public
 uniontype CallAttributes
@@ -453,6 +454,7 @@ uniontype Call
               outExp := toRecordExpression(call, ty);
             else
               outExp := Expression.CALL(call);
+              outExp := Inline.inlineCallExp(outExp);
             end if;
           end if;
         then
@@ -2676,6 +2678,17 @@ protected
         then Expression.RECORD(Absyn.stripLast(Function.name(call.fn)), ty, call.arguments);
     end match;
   end toRecordExpression;
+
+  function inlineType
+    input Call call;
+    output DAE.InlineType inlineTy;
+  algorithm
+    inlineTy := match call
+      case TYPED_CALL(attributes = CallAttributes.CALL_ATTR(inlineType = inlineTy))
+        then inlineTy;
+      else DAE.InlineType.NO_INLINE();
+    end match;
+  end inlineType;
 end Call;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -1139,7 +1139,7 @@ algorithm
         else
           evalNormalCall(call.fn, args, call);
 
-    case Call.UNTYPED_MAP_CALL()
+    case Call.TYPED_MAP_CALL()
       algorithm
         Error.addInternalError(getInstanceName() + ": unimplemented case for mapcall", sourceInfo());
       then
@@ -1173,7 +1173,6 @@ algorithm
     case "ceil" then evalBuiltinCeil(listHead(args));
     case "cosh" then evalBuiltinCosh(listHead(args));
     case "cos" then evalBuiltinCos(listHead(args));
-    case "cross" then evalBuiltinCross(args);
     case "der" then evalBuiltinDer(listHead(args));
     // TODO: Fix typing of diagonal so the argument isn't boxed.
     case "diagonal" then evalBuiltinDiagonal(Expression.unbox(listHead(args)));
@@ -1417,27 +1416,6 @@ algorithm
     else algorithm printWrongArgsError(getInstanceName(), {arg}, sourceInfo()); then fail();
   end match;
 end evalBuiltinCos;
-
-function evalBuiltinCross
-  input list<Expression> args;
-  output Expression result;
-protected
-  Real x1, x2, x3, y1, y2, y3;
-  Expression z1, z2, z3;
-algorithm
-  result := match args
-    case {Expression.ARRAY(elements = {Expression.REAL(x1), Expression.REAL(x2), Expression.REAL(x3)}),
-          Expression.ARRAY(elements = {Expression.REAL(y1), Expression.REAL(y2), Expression.REAL(y3)})}
-      algorithm
-        z1 := Expression.REAL(x2 * y3 - x3 * y2);
-        z2 := Expression.REAL(x3 * y1 - x1 * y3);
-        z3 := Expression.REAL(x1 * y2 - x2 * y1);
-      then
-        Expression.ARRAY(Type.ARRAY(Type.REAL(), {Dimension.fromInteger(3)}), {z1, z2, z3});
-
-    else algorithm printWrongArgsError(getInstanceName(), args, sourceInfo()); then fail();
-  end match;
-end evalBuiltinCross;
 
 function evalBuiltinDer
   input Expression arg;

--- a/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -119,7 +119,7 @@ algorithm
   Pointer.update(call_counter, call_count);
 
   try
-    fn_body := getFunctionBody(fn.node);
+    fn_body := Function.getBody(fn);
     repl := createReplacements(fn, args);
     // TODO: Also apply replacements to the replacements themselves, i.e. the
     //       bindings of the function parameters. But the probably need to be
@@ -164,32 +164,6 @@ algorithm
 end evaluateExternal;
 
 protected
-
-function getFunctionBody
-  input InstNode node;
-  output list<Statement> body;
-protected
-  Class cls = InstNode.getClass(node);
-algorithm
-  body := match cls
-    case Class.INSTANCED_CLASS(sections = Sections.SECTIONS(algorithms = {body})) then body;
-
-    case Class.INSTANCED_CLASS(sections = Sections.SECTIONS(algorithms = _ :: _))
-      algorithm
-        Error.assertion(false, getInstanceName() + " got function with multiple algorithm sections", sourceInfo());
-      then
-        fail();
-
-    case Class.TYPED_DERIVED() then getFunctionBody(cls.baseClass);
-
-    else
-      algorithm
-        Error.assertion(false, getInstanceName() + " got unknown function", sourceInfo());
-      then
-        fail();
-
-  end match;
-end getFunctionBody;
 
 function createReplacements
   input Function fn;

--- a/Compiler/NFFrontEnd/NFInline.mo
+++ b/Compiler/NFFrontEnd/NFInline.mo
@@ -1,0 +1,155 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2014, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package NFInline
+
+import Expression = NFExpression;
+import NFCall.Call;
+import Statement = NFStatement;
+import ComponentRef = NFComponentRef;
+import DAE.InlineType;
+import NFFunction.Function;
+import NFInstNode.InstNode;
+import Subscript = NFSubscript;
+
+function inlineCallExp
+  input Expression callExp;
+  output Expression result;
+algorithm
+  result := match callExp
+    local
+      Call call;
+      Boolean shouldInline;
+
+    case Expression.CALL(call = call as Call.TYPED_CALL())
+      algorithm
+        shouldInline := match Call.inlineType(call)
+          case DAE.InlineType.BUILTIN_EARLY_INLINE() then true;
+          case DAE.InlineType.EARLY_INLINE()
+            guard Flags.isSet(Flags.INLINE_FUNCTIONS) then true;
+          else false;
+        end match;
+      then
+        if shouldInline then inlineCall(call) else callExp;
+
+    else callExp;
+  end match;
+end inlineCallExp;
+
+function inlineCall
+  input Call call;
+  output Expression exp;
+algorithm
+  exp := match call
+    local
+      Function fn;
+      Expression arg;
+      list<Expression> args;
+      list<InstNode> inputs, outputs, locals;
+      list<Statement> body;
+      Statement stmt;
+
+    case Call.TYPED_CALL(fn = fn as Function.FUNCTION(inputs = inputs, outputs = outputs, locals = locals),
+                         arguments = args)
+      algorithm
+        body := Function.getBody(fn);
+
+        // This function can so far only handle functions with exactly one
+        // statement and output and no local variables.
+        if listLength(body) <> 1 or listLength(outputs) <> 1 or listLength(locals) > 0 then
+          exp := Expression.CALL(call);
+          return;
+        end if;
+
+        Error.assertion(listLength(inputs) == listLength(args),
+          getInstanceName() + " got wrong number of arguments for " +
+          Absyn.pathString(Function.name(fn)), sourceInfo());
+
+        stmt := listHead(body);
+
+        for i in inputs loop
+          arg :: args := args;
+          stmt := Statement.mapExp(stmt,
+            function Expression.map(func = function replaceCrefNode(node = i, value = arg)));
+        end for;
+      then
+        getOutputExp(stmt, listHead(outputs), call);
+
+    else Expression.CALL(call);
+  end match;
+end inlineCall;
+
+protected
+function replaceCrefNode
+  input output Expression exp;
+  input InstNode node;
+  input Expression value;
+algorithm
+  exp := match exp
+    local
+      InstNode cr_node;
+      ComponentRef rest_cr;
+      list<Subscript> subs;
+
+    // TODO: This only works for simple crefs, for complex crefs (i.e. records)
+    //       we need to somehow replace the rest of the cref with nodes from the
+    //       record.
+    case Expression.CREF(cref = ComponentRef.CREF(node = cr_node, subscripts = subs, restCref = rest_cr))
+      guard InstNode.refEqual(node, cr_node) and not ComponentRef.isFromCref(rest_cr)
+      then Expression.applySubscripts(subs, value);
+
+    else exp;
+  end match;
+end replaceCrefNode;
+
+function getOutputExp
+  input Statement stmt;
+  input InstNode outputNode;
+  input Call call;
+  output Expression exp;
+algorithm
+  exp := match stmt
+    local
+      InstNode cr_node;
+      ComponentRef rest_cr;
+
+    case Statement.ASSIGNMENT(lhs = Expression.CREF(
+        cref = ComponentRef.CREF(node = cr_node, subscripts = {}, restCref = rest_cr)))
+      guard InstNode.refEqual(outputNode, cr_node) and not ComponentRef.isFromCref(rest_cr)
+      then stmt.rhs;
+
+    else Expression.CALL(call);
+  end match;
+end getOutputExp;
+
+annotation(__OpenModelica_Interface="frontend");
+end NFInline;
+

--- a/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -348,12 +348,9 @@ function cross "Cross product of two 3-vectors"
   input Real[3] x;
   input Real[3] y;
   output Real[3] z;
-/* Not working due to problems with non-builtin overloaded functions? Maybe it works now. Maybe it's bad to inline due to evaluating the same element many times?
 algorithm
   z := { x[2]*y[3]-x[3]*y[2] , x[3]*y[1]-x[1]*y[3] , x[1]*y[2]-x[2]*y[1] };
-*/
-external "builtin" cross(x,y,z);
-  annotation(__OpenModelica_EarlyInline = true, preferredView="text",Documentation(info="<html>
+annotation(__OpenModelica_EarlyInline = true, preferredView="text",Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'cross()'\">cross()</a>
 </html>"));
 end cross;

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -316,6 +316,7 @@ if true then /* Suppress output */
     "../NFFrontEnd/NFClass.mo",
     "../NFFrontEnd/NFClassTree.mo",
     "../NFFrontEnd/NFImport.mo",
+    "../NFFrontEnd/NFInline.mo",
     "../NFFrontEnd/NFInstNode.mo",
     "../NFFrontEnd/NFLookup.mo",
     "../NFFrontEnd/NFLookupState.mo",


### PR DESCRIPTION
- Implemented early inlining of functions with one output and one
  statement.
- Removed Ceval.evalBuiltinCross, the definition in ModelicaBuiltin
  is used instead.
- Updated Expression map and fold function to also consider reduction
  iterators.