### PR TITLE
[NF] Function evaluation improvements for records.

### DIFF
--- a/Compiler/NFFrontEnd/NFBinding.mo
+++ b/Compiler/NFFrontEnd/NFBinding.mo
@@ -156,6 +156,12 @@ public
           binding.bindingExp := exp;
         then
           ();
+
+      case FLAT_BINDING()
+        algorithm
+          binding.bindingExp := exp;
+        then
+          ();
     end match;
   end setTypedExp;
 

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -192,6 +192,9 @@ public
     Mutable<Expression> exp;
   end MUTABLE;
 
+  record EMPTY
+  end EMPTY;
+
   function isCref
     input Expression exp;
     output Boolean isTrue;
@@ -976,6 +979,7 @@ public
       case SUBSCRIPTED_EXP() then toString(exp.exp) + "[" + stringDelimitList(list(toString(e) for e in exp.subscripts), ", ") + "]";
       case TUPLE_ELEMENT() then toString(exp.tupleExp) + "[" + intString(exp.index) + "]";
       case MUTABLE() then toString(Mutable.access(exp.exp));
+      case EMPTY() then "#EMPTY#";
 
       else anyString(exp);
     end match;

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -79,6 +79,7 @@ import NFPrefixes.Variability;
 import Variable = NFVariable;
 import BindingOrigin = NFBindingOrigin;
 import ElementSource;
+import Ceval = NFCeval;
 
 public
 type FunctionTree = FunctionTreeImpl.Tree;
@@ -378,7 +379,12 @@ algorithm
 
   // Create an equation if there's a binding on a complex component.
   if Binding.isBound(binding) then
+    binding := flattenBinding(binding, prefix, node);
     binding_exp := Binding.getTypedExp(binding);
+
+    if Component.variability(comp) <= Variability.PARAMETER then
+      binding_exp := Ceval.evalExp(binding_exp);
+    end if;
 
     if not Expression.isRecord(binding_exp) then
       eq := Equation.EQUALITY(Expression.CREF(ty, name),  binding_exp, ty,
@@ -386,7 +392,8 @@ algorithm
       sections := Sections.prependEquation(eq, sections);
       opt_binding := SOME(Binding.UNBOUND(NONE()));
     else
-      opt_binding := SOME(flattenBinding(binding, prefix, node));
+      binding := Binding.setTypedExp(binding_exp, binding);
+      opt_binding := SOME(binding);
     end if;
   else
     opt_binding := NONE();

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -795,6 +795,8 @@ public constant Message TERMINATE_TRIGGERED = MESSAGE(333, TRANSLATION(), ERROR(
   Util.gettext("terminate triggered: %s"));
 public constant Message EVAL_RECURSION_LIMIT_REACHED = MESSAGE(334, TRANSLATION(), ERROR(),
   Util.gettext("The recursion limit (--evalRecursionLimit=%s) was exceeded during evaluation of %s."));
+public constant Message UNASSIGNED_FUNCTION_OUTPUT = MESSAGE(335, TRANSLATION(), ERROR(),
+  Util.gettext("Output parameter %s was not assigned a value"));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),


### PR DESCRIPTION
- Build a record expression from the child nodes if a record output
  doesn't have an explicit binding.
- Evaluate expressions in function outputs and local variables too
  (currently in order of declaration, needs to be dependency sorted).
- Added check that the outputs are assigned a value when evaluation a
  function (by adding Expression.EMPTY() and using it as the initial
  value if an output has no binding).
- Always evaluate complex bindings on parameters, even if they aren't
  structural, since they need to be split into their component values.