### PR TITLE
[NF] Inlining fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -216,9 +216,34 @@ constant Function ABS_REAL = Function.FUNCTION(Path.IDENT("abs"),
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
     Pointer.createImmutable(true), Pointer.createImmutable(0));
 
+constant Function MAX_INT = Function.FUNCTION(Path.IDENT("max"),
+  InstNode.EMPTY_NODE(), {INT_PARAM, INT_PARAM}, {INT_PARAM}, {}, {},
+    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
+
 constant Function MAX_REAL = Function.FUNCTION(Path.IDENT("max"),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
+
+constant Function DIV_INT = Function.FUNCTION(Path.IDENT("div"),
+  InstNode.EMPTY_NODE(), {INT_PARAM, INT_PARAM}, {INT_PARAM}, {}, {},
+    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
+
+constant Function FLOOR = Function.FUNCTION(Path.IDENT("floor"),
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
+
+constant Function INTEGER_REAL = Function.FUNCTION(Path.IDENT("integer"),
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {INT_PARAM}, {}, {},
+    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
+
+constant Function INTEGER_ENUM = Function.FUNCTION(Path.IDENT("Integer"),
+  InstNode.EMPTY_NODE(), {ENUM_PARAM}, {INT_PARAM}, {}, {},
+    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN,
     Pointer.createImmutable(true), Pointer.createImmutable(0));
 
 constant Function POSITIVE_MAX_REAL = Function.FUNCTION(Path.IDENT("$OMC$PositiveMax"),

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -517,6 +517,43 @@ public
     end match;
   end dimensionCount;
 
+  function mapDims
+    input output Type ty;
+    input FuncT func;
+
+    partial function FuncT
+      input output Dimension dim;
+    end FuncT;
+  algorithm
+    () := match ty
+      case ARRAY()
+        algorithm
+          ty.dimensions := list(func(d) for d in ty.dimensions);
+        then
+          ();
+
+      case TUPLE()
+        algorithm
+          ty.types := list(mapDims(t, func) for t in ty.types);
+        then
+          ();
+
+      case FUNCTION()
+        algorithm
+          ty.resultType := mapDims(ty.resultType, func);
+        then
+          ();
+
+      case METABOXED()
+        algorithm
+          ty.ty := mapDims(ty.ty, func);
+        then
+          ();
+
+      else ();
+    end match;
+  end mapDims;
+
   function nthEnumLiteral
     input Type ty;
     input Integer index;


### PR DESCRIPTION
- Create an appropriate dimension expression for ranges of unknown size.
- Do replacements in array dimensions during inlining too.
- Fix Call.typeArgs so that only external function arguments are left
  unevaluated, and not all function arguments.