### PR TITLE
Only perform logging of delay for LOG_EVENTS_V

### DIFF
--- a/SimulationRuntime/c/simulation/solver/delay.c
+++ b/SimulationRuntime/c/simulation/solver/delay.c
@@ -65,18 +65,18 @@ static int findTime(double time, RINGBUFFER *delayStruct)
   double t;
 
 
-  infoStreamPrint(LOG_EVENTS, 0, "findTime %e", time);
+  infoStreamPrint(LOG_EVENTS_V, 0, "findTime %e", time);
   do
   {
     int i = (start + end) / 2;
     t = ((TIME_AND_VALUE*)getRingData(delayStruct, i))->t;
-    infoStreamPrint(LOG_EVENTS, 0, "time(%d, %d)[%d] = %e", start, end, i, t);
+    infoStreamPrint(LOG_EVENTS_V, 0, "time(%d, %d)[%d] = %e", start, end, i, t);
     if(t > time)
       end = i;
     else
       start = i;
   }while(t != time && end > start + 1);
-  infoStreamPrint(LOG_EVENTS, 0, "return time[%d, %d] = %e", start, end, t);
+  infoStreamPrint(LOG_EVENTS_V, 0, "return time[%d, %d] = %e", start, end, t);
   return (start);
 }
 
@@ -93,13 +93,13 @@ void storeDelayedExpression(DATA* data, threadData_t *threadData, int exprNumber
   tpl.t = time;
   tpl.value = exprValue;
   appendRingData(data->simulationInfo->delayStructure[exprNumber], &tpl);
-  infoStreamPrint(LOG_EVENTS, 0, "storeDelayed[%d] %g:%g position=%d", exprNumber, time, exprValue,ringBufferLength(data->simulationInfo->delayStructure[exprNumber]));
+  infoStreamPrint(LOG_EVENTS_V, 0, "storeDelayed[%d] %g:%g position=%d", exprNumber, time, exprValue,ringBufferLength(data->simulationInfo->delayStructure[exprNumber]));
 
   /* dequeue not longer needed values */
   i = findTime(time-delayMax+DBL_EPSILON,data->simulationInfo->delayStructure[exprNumber]);
   if(i > 0){
     dequeueNFirstRingDatas(data->simulationInfo->delayStructure[exprNumber], i-1);
-    infoStreamPrint(LOG_EVENTS, 0, "delayImpl: dequeueNFirstRingDatas[%d] %g = %g", i, time-delayMax+DBL_EPSILON, delayTime);
+    infoStreamPrint(LOG_EVENTS_V, 0, "delayImpl: dequeueNFirstRingDatas[%d] %g = %g", i, time-delayMax+DBL_EPSILON, delayTime);
   }
 }
 
@@ -109,7 +109,7 @@ double delayImpl(DATA* data, threadData_t *threadData, int exprNumber, double ex
   RINGBUFFER* delayStruct = data->simulationInfo->delayStructure[exprNumber];
   int length = ringBufferLength(delayStruct);
 
-  infoStreamPrint(LOG_EVENTS, 0, "delayImpl: exprNumber = %d, exprValue = %g, time = %g, delayTime = %g", exprNumber, exprValue, time, delayTime);
+  infoStreamPrint(LOG_EVENTS_V, 0, "delayImpl: exprNumber = %d, exprValue = %g, time = %g, delayTime = %g", exprNumber, exprValue, time, delayTime);
 
   /* Check for errors */
 
@@ -118,7 +118,7 @@ double delayImpl(DATA* data, threadData_t *threadData, int exprNumber, double ex
 
   if(time <= data->simulationInfo->tStart)
   {
-    infoStreamPrint(LOG_EVENTS, 0, "delayImpl: Entered at time < starting time: %g.", exprValue);
+    infoStreamPrint(LOG_EVENTS_V, 0, "delayImpl: Entered at time < starting time: %g.", exprValue);
     return (exprValue);
   }
 
@@ -147,7 +147,7 @@ double delayImpl(DATA* data, threadData_t *threadData, int exprNumber, double ex
   if(time <= data->simulationInfo->tStart + delayTime)
   {
     double res = ((TIME_AND_VALUE*)getRingData(delayStruct, 0))->value;
-    infoStreamPrint(LOG_EVENTS, 0, "findTime: time <= tStart + delayTime: [%d] = %g",exprNumber, res);
+    infoStreamPrint(LOG_EVENTS_V, 0, "findTime: time <= tStart + delayTime: [%d] = %g",exprNumber, res);
     return res;
   }
   else
@@ -162,14 +162,14 @@ double delayImpl(DATA* data, threadData_t *threadData, int exprNumber, double ex
     /* find the row for the lower limit */
     if(timeStamp > ((TIME_AND_VALUE*)getRingData(delayStruct, length - 1))->t)
     {
-      infoStreamPrint(LOG_EVENTS, 0, "delayImpl: find the row  %g = %g", timeStamp, ((TIME_AND_VALUE*)getRingData(delayStruct, length - 1))->t);
+      infoStreamPrint(LOG_EVENTS_V, 0, "delayImpl: find the row  %g = %g", timeStamp, ((TIME_AND_VALUE*)getRingData(delayStruct, length - 1))->t);
       /* delay between the last accepted time step and the current time */
       time0 = ((TIME_AND_VALUE*)getRingData(delayStruct, length - 1))->t;
       value0 = ((TIME_AND_VALUE*)getRingData(delayStruct, length - 1))->value;
       time1 = time;
       value1 = exprValue;
-      infoStreamPrint(LOG_EVENTS, 0, "delayImpl: times %g and %g", time0, time1);
-      infoStreamPrint(LOG_EVENTS, 0, "delayImpl: values %g and  %g", value0, value1);
+      infoStreamPrint(LOG_EVENTS_V, 0, "delayImpl: times %g and %g", time0, time1);
+      infoStreamPrint(LOG_EVENTS_V, 0, "delayImpl: values %g and  %g", value0, value1);
     }
     else
     {
@@ -188,11 +188,11 @@ double delayImpl(DATA* data, threadData_t *threadData, int exprNumber, double ex
     }
     /* was it an exact match?*/
     if(time0 == timeStamp){
-      infoStreamPrint(LOG_EVENTS, 0, "delayImpl: Exact match at %g = %g", timeStamp, value0);
+      infoStreamPrint(LOG_EVENTS_V, 0, "delayImpl: Exact match at %g = %g", timeStamp, value0);
 
       return value0;
     } else if(time1 == timeStamp) {
-      infoStreamPrint(LOG_EVENTS, 0, "delayImpl: Exact match at %g = %g", timeStamp, value1);
+      infoStreamPrint(LOG_EVENTS_V, 0, "delayImpl: Exact match at %g = %g", timeStamp, value1);
 
       return value1;
     } else {
@@ -201,8 +201,8 @@ double delayImpl(DATA* data, threadData_t *threadData, int exprNumber, double ex
       double dt0 = time1 - timeStamp;
       double dt1 = timeStamp - time0;
       double retVal = (value0 * dt0 + value1 * dt1) / timedif;
-      infoStreamPrint(LOG_EVENTS, 0, "delayImpl: Linear interpolation of %g between %g and %g", timeStamp, time0, time1);
-      infoStreamPrint(LOG_EVENTS, 0, "delayImpl: Linear interpolation of %g value: %g and %g = %g", timeStamp, value0, value1, retVal);
+      infoStreamPrint(LOG_EVENTS_V, 0, "delayImpl: Linear interpolation of %g between %g and %g", timeStamp, time0, time1);
+      infoStreamPrint(LOG_EVENTS_V, 0, "delayImpl: Linear interpolation of %g value: %g and %g = %g", timeStamp, value0, value1, retVal);
       return retVal;
     }
   }


### PR DESCRIPTION
The delay logging is very verbose, causing huge logs. It is now only
enabled when verbose logging is enabled.