### PR TITLE
[NF] Minor fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -2167,7 +2167,7 @@ algorithm
       expl := evalReduction2(exp, el_ty, ranges_rest, iters_rest) :: expl;
     end while;
 
-    result := Expression.ARRAY(el_ty, listReverseInPlace(expl));
+    result := Expression.ARRAY(ty, listReverseInPlace(expl));
   end if;
 end evalReduction2;
 

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -1829,7 +1829,8 @@ algorithm
     fail();
   end if;
 
-  if cond_var <= Variability.STRUCTURAL_PARAMETER then
+  if cond_var <= Variability.STRUCTURAL_PARAMETER and
+    not Expression.contains(cond, isNonConstantIfCondition) then
     // If the condition is constant, always do branch selection.
     if evaluateCondition(cond, info) then
       (ifExp, ty, var) := typeExp(tb, next_origin, info);


### PR DESCRIPTION
- Fix type when evaluating reductions.
- Don't do branch selection during typing for if-expressions with
  conditions that contain non-evaluatable expressions.