### PR TITLE
[NF] Fix variability of size() properly.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -767,7 +767,7 @@ uniontype Call
         algorithm
           ptree := buildParameterTree(fnArgs, ptree);
           exp := Expression.map(dim.exp, function evaluateCallTypeDimExp(ptree = ptree));
-          exp := Ceval.evalExp(exp, ExpOrigin.FUNCTION, Ceval.EvalTarget.IGNORE_ERRORS());
+          exp := Ceval.evalExp(exp, Ceval.EvalTarget.IGNORE_ERRORS());
         then
           Dimension.fromExp(exp, dim.var);
 
@@ -1940,7 +1940,7 @@ protected
       (arg, arg_ty, arg_var) := Typing.typeExp(arg, origin, info);
 
       if arg_var <= Variability.STRUCTURAL_PARAMETER then
-        arg := Ceval.evalExp(arg, origin);
+        arg := Ceval.evalExp(arg);
         arg_ty := Expression.typeOf(arg);
       end if;
 
@@ -2203,7 +2203,7 @@ protected
     if variability > Variability.PARAMETER then
       Error.addSourceMessageAndFail(Error.NF_CAT_FIRST_ARG_EVAL, {Expression.toString(arg), Prefixes.variabilityString(variability)}, info);
     end if;
-    Expression.INTEGER(n) := Ceval.evalExp(arg, origin, Ceval.EvalTarget.GENERIC(info));
+    Expression.INTEGER(n) := Ceval.evalExp(arg, Ceval.EvalTarget.GENERIC(info));
 
     res := {};
     tys := {};

--- a/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -167,11 +167,6 @@ end evaluateExternal;
 
 protected
 
-function evalExp
-  input Expression exp;
-  output Expression outExp = Ceval.evalExp(exp, ExpOrigin.FUNCTION);
-end evalExp;
-
 function createReplacements
   input Function fn;
   input list<Expression> args;
@@ -348,14 +343,14 @@ protected
   Expression e;
 algorithm
   if listLength(outputs) == 1 then
-    exp := evalExp(ReplTree.get(repl, InstNode.name(listHead(outputs))));
+    exp := Ceval.evalExp(ReplTree.get(repl, InstNode.name(listHead(outputs))));
     assertAssignedOutput(listHead(outputs), exp);
   else
     expl := {};
     types := {};
 
     for o in outputs loop
-      e := evalExp(ReplTree.get(repl, InstNode.name(o)));
+      e := Ceval.evalExp(ReplTree.get(repl, InstNode.name(o)));
       assertAssignedOutput(o, e);
       expl := e :: expl;
     end for;
@@ -427,7 +422,7 @@ function evaluateAssignment
   input Expression rhsExp;
   output FlowControl ctrl = FlowControl.NEXT;
 algorithm
-  assignVariable(lhsExp, evalExp(rhsExp));
+  assignVariable(lhsExp, Ceval.evalExp(rhsExp));
 end evaluateAssignment;
 
 function assignVariable
@@ -545,7 +540,7 @@ protected
   list<Statement> body = forBody;
   Integer i = 0, limit = Flags.getConfigInt(Flags.EVAL_LOOP_LIMIT);
 algorithm
-  range_exp := evalExp(Util.getOption(range));
+  range_exp := Ceval.evalExp(Util.getOption(range));
   range_iter := RangeIterator.fromExp(range_exp);
 
   if RangeIterator.hasNext(range_iter) then
@@ -593,7 +588,7 @@ algorithm
   for branch in branches loop
     (cond, body) := branch;
 
-    if Expression.isTrue(evalExp(cond)) then
+    if Expression.isTrue(Ceval.evalExp(cond)) then
       ctrl := evaluateStatements(body);
       return;
     end if;
@@ -610,10 +605,10 @@ protected
   Expression msg, lvl;
   DAE.ElementSource source;
 algorithm
-  if Expression.isFalse(evalExp(condition)) then
+  if Expression.isFalse(Ceval.evalExp(condition)) then
     Statement.ASSERT(message = msg, level = lvl, source = source) := assertStmt;
-    msg := evalExp(msg);
-    lvl := evalExp(lvl);
+    msg := Ceval.evalExp(msg);
+    lvl := Ceval.evalExp(lvl);
 
     () := match (msg, lvl)
       case (Expression.STRING(), Expression.ENUM_LITERAL(name = "warning"))
@@ -645,7 +640,7 @@ function evaluateTerminate
 protected
   Expression msg;
 algorithm
-  msg := evalExp(message);
+  msg := Ceval.evalExp(message);
 
   _ := match msg
     case Expression.STRING()
@@ -668,7 +663,7 @@ function evaluateNoRetCall
   input Expression callExp;
   output FlowControl ctrl = FlowControl.NEXT;
 algorithm
-  evalExp(callExp);
+  Ceval.evalExp(callExp);
 end evaluateNoRetCall;
 
 function evaluateWhile
@@ -679,7 +674,7 @@ function evaluateWhile
 protected
   Integer i = 0, limit = Flags.getConfigInt(Flags.EVAL_LOOP_LIMIT);
 algorithm
-  while Expression.isTrue(evalExp(condition)) loop
+  while Expression.isTrue(Ceval.evalExp(condition)) loop
     ctrl := evaluateStatements(body);
 
     if ctrl <> FlowControl.NEXT then

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -384,7 +384,7 @@ algorithm
     binding_exp := Binding.getTypedExp(binding);
 
     if Component.variability(comp) <= Variability.PARAMETER then
-      binding_exp := Ceval.evalExp(binding_exp, ExpOrigin.CLASS);
+      binding_exp := Ceval.evalExp(binding_exp);
     end if;
 
     if not Expression.isRecord(binding_exp) then

--- a/Compiler/NFFrontEnd/NFPackage.mo
+++ b/Compiler/NFFrontEnd/NFPackage.mo
@@ -249,7 +249,7 @@ public
     exp := match exp
       case Expression.CREF(cref = cref as ComponentRef.CREF())
         then if ComponentRef.isPackageConstant(cref) then
-          Ceval.evalExp(exp, ExpOrigin.CLASS, Ceval.EvalTarget.IGNORE_ERRORS()) else exp;
+          Ceval.evalExp(exp, Ceval.EvalTarget.IGNORE_ERRORS()) else exp;
 
       else exp;
     end match;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -419,7 +419,7 @@ algorithm
             Error.addSourceMessageAndFail(Error.NON_PARAMETER_ITERATOR_RANGE,
               {Expression.toString(exp)}, info);
           else
-            exp := Ceval.evalExp(exp, origin, Ceval.EvalTarget.RANGE(info));
+            exp := Ceval.evalExp(exp, Ceval.EvalTarget.RANGE(info));
           end if;
         end if;
 
@@ -512,7 +512,7 @@ algorithm
 
         if var <= Variability.PARAMETER then
           // Evaluate the dimension if it's a parameter expression.
-          exp := Ceval.evalExp(exp, origin, Ceval.EvalTarget.DIMENSION(component, index, exp, info));
+          exp := Ceval.evalExp(exp, Ceval.EvalTarget.DIMENSION(component, index, exp, info));
         else
           // Dimensions must be parameter expressions, unless we're in a function.
           if intBitAnd(origin, ExpOrigin.FUNCTION) == 0 then
@@ -825,7 +825,7 @@ algorithm
           fail();
         end if;
 
-        exp := Ceval.evalExp(exp, origin, Ceval.EvalTarget.CONDITION(info));
+        exp := Ceval.evalExp(exp, Ceval.EvalTarget.CONDITION(info));
       then
         Binding.FLAT_BINDING(exp);
 
@@ -904,7 +904,7 @@ algorithm
 
     case Binding.TYPED_BINDING()
       algorithm
-        exp := Ceval.evalExp(binding.bindingExp, origin, Ceval.EvalTarget.ATTRIBUTE(binding));
+        exp := Ceval.evalExp(binding.bindingExp, Ceval.EvalTarget.ATTRIBUTE(binding));
       then
         Binding.TYPED_BINDING(exp, binding.bindingType, binding.variability, binding.origin, binding.isEach);
 
@@ -953,7 +953,7 @@ algorithm
         e1 := Expression.CREF(ty, cref);
 
         if replaceConstants and variability <= Variability.STRUCTURAL_PARAMETER then
-          e1 := Ceval.evalExp(e1, origin, Ceval.EvalTarget.GENERIC(info));
+          e1 := Ceval.evalExp(e1, Ceval.EvalTarget.GENERIC(info));
         end if;
       then
         (e1, ty, variability);
@@ -1604,9 +1604,9 @@ algorithm
   end if;
 
   if variability <= Variability.STRUCTURAL_PARAMETER then
-    start_exp := Ceval.evalExp(start_exp, origin, Ceval.EvalTarget.IGNORE_ERRORS());
-    ostep_exp := Ceval.evalExpOpt(ostep_exp, origin, Ceval.EvalTarget.IGNORE_ERRORS());
-    stop_exp := Ceval.evalExp(stop_exp, origin, Ceval.EvalTarget.IGNORE_ERRORS());
+    start_exp := Ceval.evalExp(start_exp, Ceval.EvalTarget.IGNORE_ERRORS());
+    ostep_exp := Ceval.evalExpOpt(ostep_exp, Ceval.EvalTarget.IGNORE_ERRORS());
+    stop_exp := Ceval.evalExp(stop_exp, Ceval.EvalTarget.IGNORE_ERRORS());
   end if;
 
   rangeType := TypeCheck.getRangeType(start_exp, ostep_exp, stop_exp, rangeType, info);
@@ -1689,7 +1689,7 @@ algorithm
 
         if variability <= Variability.STRUCTURAL_PARAMETER then
           // Evaluate the index if it's a constant.
-          index := Ceval.evalExp(index, origin, Ceval.EvalTarget.IGNORE_ERRORS());
+          index := Ceval.evalExp(index, Ceval.EvalTarget.IGNORE_ERRORS());
 
           // TODO: Print an error if the index couldn't be evaluated to an int.
           Expression.INTEGER(iindex) := index;
@@ -1880,7 +1880,7 @@ function evaluateCondition
 protected
   Expression cond_exp;
 algorithm
-  cond_exp := Ceval.evalExp(condExp, origin, Ceval.EvalTarget.GENERIC(info));
+  cond_exp := Ceval.evalExp(condExp, Ceval.EvalTarget.GENERIC(info));
 
   condBool := match cond_exp
     case Expression.BOOLEAN() then cond_exp.value;
@@ -2061,7 +2061,7 @@ algorithm
             algorithm
               // The only other kind of expression that's allowed is scalar constants.
               if Type.isScalarBuiltin(ty) and var == Variability.CONSTANT then
-                outArg := Ceval.evalExp(outArg, ExpOrigin.FUNCTION, Ceval.EvalTarget.GENERIC(info));
+                outArg := Ceval.evalExp(outArg, Ceval.EvalTarget.GENERIC(info));
               else
                 Error.addSourceMessage(Error.EXTERNAL_ARG_WRONG_EXP,
                   {Expression.toString(outArg)}, info);
@@ -2575,7 +2575,7 @@ algorithm
       not Expression.contains(cond, isNonConstantIfCondition) then
       // If the condition is a parameter expression, evaluate it so we can do
       // branch selection later on.
-      cond := Ceval.evalExp(cond, origin, Ceval.EvalTarget.IGNORE_ERRORS());
+      cond := Ceval.evalExp(cond, Ceval.EvalTarget.IGNORE_ERRORS());
     else
       // Otherwise, set the non-expandable bit in the origin, so we can check
       // that e.g. connect isn't used in any branches from here on.


### PR DESCRIPTION
- Partially revert previous commit that propagated origin to
  Ceval.evalExp, and deduce the origin based on where a component is
  declared instead. Package constants should be typed like they're
  class variables, even when used in a function.