### PR TITLE
filterSimulationResults option to remove descriptions

### DIFF
--- a/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -2869,11 +2869,18 @@ public function filterSimulationResults
   input String outFile;
   input String[:] vars;
   input Integer numberOfIntervals = 0 "0=Do not resample";
+  input Boolean removeDescription = false;
   output Boolean success;
 external "builtin";
 annotation(Documentation(info="<html>
 <p>Takes one simulation result and filters out the selected variables only, producing the output file.</p>
 <p>If numberOfIntervals<>0, re-sample to that number of intervals, ignoring event points (might be changed in the future).</p>
+<p>if removeDescription=true, the description matrix will contain 0-length strings, making the file smaller.</p>
+</html>",revisions="<html>
+<table>
+<tr><th>Revision</th><th>Author</th><th>Comment</th></tr>
+<tr><td>1.13.0</td><td>sjoelund.se</td><td>Introduced removeDescription.</td></tr>
+</table>
 </html>"),preferredView="text");
 end filterSimulationResults;
 

--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -2272,10 +2272,10 @@ algorithm
     case (cache,_,"compareSimulationResults",_,_)
       then (cache,Values.STRING("Error in compareSimulationResults"));
 
-    case (cache,_,"filterSimulationResults",{Values.STRING(filename),Values.STRING(filename_1),Values.ARRAY(valueLst=cvars),Values.INTEGER(numberOfIntervals)},_)
+    case (cache,_,"filterSimulationResults",{Values.STRING(filename),Values.STRING(filename_1),Values.ARRAY(valueLst=cvars),Values.INTEGER(numberOfIntervals),Values.BOOL(b)},_)
       equation
         vars_1 = List.map(cvars, ValuesUtil.extractValueString);
-        b = SimulationResults.filterSimulationResults(filename,filename_1,vars_1,numberOfIntervals);
+        b = SimulationResults.filterSimulationResults(filename,filename_1,vars_1,numberOfIntervals,b);
       then
         (cache,Values.BOOL(b));
 

--- a/Compiler/Util/SimulationResults.mo
+++ b/Compiler/Util/SimulationResults.mo
@@ -149,8 +149,9 @@ public function filterSimulationResults
   input String outFile;
   input list<String> vars;
   input Integer numberOfIntervals=0;
+  input Boolean removeDescription;
   output Boolean result;
-  external "C" result=SimulationResults_filterSimulationResults(inFile,outFile,vars,numberOfIntervals) annotation(Library = "omcruntime");
+  external "C" result=SimulationResults_filterSimulationResults(inFile,outFile,vars,numberOfIntervals,removeDescription) annotation(Library = "omcruntime");
 end filterSimulationResults;
 
 annotation(__OpenModelica_Interface="frontend");


### PR DESCRIPTION
The string comments on variables take up a lot of space in the result-
file. This option allows filtering them all away.