### PR TITLE
[NF] Use class scopes for function names.

### DIFF
--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -487,8 +487,7 @@ uniontype Class
         String lang;
 
       case EXPANDED_DERIVED() then isExternalFunction(InstNode.getClass(cls.baseClass));
-      case INSTANCED_CLASS(sections = Sections.EXTERNAL(language = lang))
-        guard lang <> "builtin" then true;
+      case INSTANCED_CLASS(sections = Sections.EXTERNAL(language = lang)) then lang <> "builtin";
       case TYPED_DERIVED() then isExternalFunction(InstNode.getClass(cls.baseClass));
       else false;
     end match;

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -266,7 +266,7 @@ uniontype Function
     end try;
 
     (functionRef, found_scope) := Lookup.lookupFunctionName(functionName, scope, info);
-    prefix := ComponentRef.fromNodeList(InstNode.scopeList(found_scope));
+    prefix := ComponentRef.fromNodeList(InstNode.scopeList(InstNode.classScope(found_scope)));
     functionRef := ComponentRef.append(functionRef, prefix);
   end lookupFunction;
 


### PR DESCRIPTION
- Use the enclosing scope of a function when generating it's name,
  instead of the found scope (which might be a component). This fixes
  some issues with external functions where the backend assumes the
  name is prefixed with the enclosing scope, and we don't yet generate
  unique instances for functions in components anyway.
- Use better coding style in Class.isExternalFunction.