### PR TITLE
[NF] Record fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -163,7 +163,7 @@ uniontype Class
     ClassTree tree;
   algorithm
     tree := ClassTree.fromRecordConstructor(inputs, locals, out);
-    cls := INSTANCED_CLASS(Type.UNKNOWN(), tree, Sections.EMPTY(), Restriction.FUNCTION());
+    cls := INSTANCED_CLASS(Type.UNKNOWN(), tree, Sections.EMPTY(), Restriction.RECORD_CONSTRUCTOR());
   end makeRecordConstructor;
 
   function initExpandedClass

--- a/Compiler/NFFrontEnd/NFComplexType.mo
+++ b/Compiler/NFFrontEnd/NFComplexType.mo
@@ -53,6 +53,10 @@ public
     Boolean isExpandable;
   end CONNECTOR;
 
+  record RECORD
+    InstNode constructor;
+  end RECORD;
+
   record EXTERNAL_OBJECT
     InstNode constructor;
     InstNode destructor;

--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -38,6 +38,7 @@ import FlatModel = NFFlatModel;
 import NFFlatten.FunctionTree;
 import NFInstNode.InstNode;
 import Statement = NFStatement;
+import Restriction = NFRestriction;
 
 protected
 import ExecStat.execStat;
@@ -911,7 +912,7 @@ algorithm
   cls := InstNode.getClass(Function.instance(func));
 
   dfunc := match cls
-    case Class.INSTANCED_CLASS(sections = sections)
+    case Class.INSTANCED_CLASS(sections = sections, restriction = Restriction.FUNCTION())
       algorithm
         elems := convertFunctionParams(func.inputs, {});
         elems := convertFunctionParams(func.outputs, elems);
@@ -934,6 +935,11 @@ algorithm
         end match;
       then
         Function.toDAE(func, {def});
+
+    case Class.INSTANCED_CLASS(restriction = Restriction.RECORD_CONSTRUCTOR())
+      then DAE.Function.RECORD_CONSTRUCTOR(Function.name(func),
+                                           Function.makeDAEType(func),
+                                           DAE.emptyElementSource);
 
     else
       algorithm

--- a/Compiler/NFFrontEnd/NFRestriction.mo
+++ b/Compiler/NFFrontEnd/NFRestriction.mo
@@ -49,6 +49,7 @@ public
   record MODEL end MODEL;
   record OPERATOR end OPERATOR;
   record RECORD end RECORD;
+  record RECORD_CONSTRUCTOR end RECORD_CONSTRUCTOR;
   record TYPE end TYPE;
   record UNKNOWN end UNKNOWN;
 


### PR DESCRIPTION
- Generate default record constructors even when they aren't
  explicitly called, since calls might be generated by the backend.
- Remove the 'constructor'.$default suffix that was previously added
  to generated record constructors, since the rest of the compiler
  assumes constructors have the same name as the record itself.
- Use DAE.Function.RECORD_CONSTRUCTOR for record constructors instead
  of DAE.Function.FUNCTION.