### PR TITLE
[NF] Fix generation of record constructors.

### DIFF
--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -1834,7 +1834,8 @@ protected
   ComplexType cty;
 algorithm
   cty := match restriction
-    case Restriction.RECORD() then ComplexType.RECORD(node);
+    case Restriction.RECORD()
+      then ComplexType.RECORD(InstNode.classScope(InstNode.getDerivedNode(node)));
     else ComplexType.CLASS();
   end match;
 

--- a/Compiler/NFFrontEnd/NFRecord.mo
+++ b/Compiler/NFFrontEnd/NFRecord.mo
@@ -129,7 +129,7 @@ protected
 algorithm
   // The node we get is usually a record instance, with applied modifiers and so on.
   // So the first thing we do is to create a "pure" instance of the record.
-  node := Lookup.lookupLocalSimpleName(InstNode.name(node), InstNode.parentScope(node));
+  node := Lookup.lookupLocalSimpleName(InstNode.name(node), InstNode.classScope(InstNode.parent(node)));
   node := Inst.instantiate(node);
   Inst.instExpressions(node);
 
@@ -137,7 +137,7 @@ algorithm
   (inputs, locals) := collectRecordParams(node);
 
   // Create the output record element, using the instance created above as both parent and type.
-  out_comp := Component.TYPED_COMPONENT(node, Type.COMPLEX(node, ComplexType.RECORD(node)),
+  out_comp := Component.UNTYPED_COMPONENT(node, listArray({}),
                 Binding.UNBOUND(NONE()), Binding.UNBOUND(NONE()),
                 NFComponent.OUTPUT_ATTR, NONE(), Absyn.dummyInfo);
   out_rec := InstNode.fromComponent("$out" + InstNode.name(node), out_comp, node);

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -116,13 +116,8 @@ function isValidAssignmentMatch
   input MatchKind kind;
   output Boolean v = kind == MatchKind.EXACT
                      or kind == MatchKind.CAST
-                     ;
+                     or kind == MatchKind.PLUG_COMPATIBLE;
 end isValidAssignmentMatch;
-
-function isValidBindingMatch
-  input MatchKind kind;
-  output Boolean v = isValidAssignmentMatch(kind);
-end isValidBindingMatch;
 
 function isValidArgumentMatch
   input MatchKind kind;
@@ -2188,7 +2183,7 @@ algorithm
 
         (exp, ty, ty_match) := matchTypes(binding.bindingType, comp_ty, binding.bindingExp, true);
 
-        if not isValidBindingMatch(ty_match) then
+        if not isValidAssignmentMatch(ty_match) then
           Error.addSourceMessage(Error.VARIABLE_BINDING_TYPE_MISMATCH,
             {name, Binding.toString(binding), Type.toString(comp_ty),
              Type.toString(binding.bindingType)}, Binding.getInfo(binding));


### PR DESCRIPTION
- Generate record constructors from new instances of the records,
  so that they don't share child instances with the record instances
  that triggered the generation.