### PR TITLE
[NF] Fix ExpressionIterator for arrays.

### DIFF
--- a/Compiler/NFFrontEnd/NFExpressionIterator.mo
+++ b/Compiler/NFFrontEnd/NFExpressionIterator.mo
@@ -71,7 +71,8 @@ public
 
       case Expression.ARRAY()
         algorithm
-          (arr, slice) := nextArraySlice(exp.elements);
+          Expression.ARRAY(elements = arr) := Expression.expand(exp);
+          (arr, slice) := nextArraySlice(arr);
         then
           ARRAY_ITERATOR(arr, slice);
 


### PR DESCRIPTION
- Expand the array when creating a new array iterator, since it can
  contain non-scalar elements.