### PR TITLE
[NF] QoL fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -668,7 +668,7 @@ algorithm
   (exp, eql) := branch;
   exp := flattenExp(exp, prefix);
   eql := flattenEquations(eql, prefix);
-  branch := (exp, eql);
+  branch := (exp, listReverseInPlace(eql));
 end flattenEqBranch;
 
 function unrollForLoop

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -1764,6 +1764,8 @@ algorithm
         // A type must extend a basic type.
         if arrayLength(exts) == 1 then
           ty := Type.COMPLEX(node, ComplexType.EXTENDS_TYPE(exts[1]));
+        elseif SCode.hasBooleanNamedAnnotationInClass(InstNode.definition(node), "__OpenModelica_builtinType") then
+          ty := Type.COMPLEX(node, ComplexType.CLASS());
         else
           Error.addSourceMessage(Error.MISSING_TYPE_BASETYPE,
             {InstNode.name(node)}, InstNode.info(node));

--- a/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -854,19 +854,34 @@ record SimulationResult
 end SimulationResult; */
 encapsulated package OpenModelica "OpenModelica internal defintions and scripting functions"
 
-// TODO: $Code was declared as a type in the old frontend, and the types in it were empty.
-//       That's not legal Modelica, because types must extend from a basic type.
-//       Making $Code a package and making the types extend from Integer makes the code legal,
-//       but depending on how we want to use these it might need to be changed.
-package $Code "Code quoting is not a uniontype yet because that would require enabling MetaModelica extensions in the regular compiler.
-Besides, it has special semantics."
+package $Code
+  "Code quoting is not a uniontype yet because that would require enabling MetaModelica
+   extensions in the regular compiler. Besides, it has special semantics."
 
-type Expression = Integer "An expression of some kind";
-type ExpressionOrModification = Integer "An expression or modification of some kind";
-type TypeName = Integer "A path, for example the name of a class, e.g. A.B.C or .A.B";
-type VariableName  = Integer "A variable name, e.g. a.b or a[1].b[3].c";
-type VariableNames = Integer "An array of variable names, e.g. {a.b,a[1].b[3].c}, or a single VariableName";
+  type Expression
+    "An expression of some kind"
+    annotation(__OpenModelica_builtinType=true);
+  end Expression;
 
+  type ExpressionOrModification
+    "An expression or modification of some kind"
+    annotation(__OpenModelica_builtinType=true);
+  end ExpressionOrModification;
+
+  type TypeName
+    "A path, for example the name of a class, e.g. A.B.C or .A.B"
+    annotation(__OpenModelica_builtinType=true);
+  end TypeName;
+
+  type VariableName
+    "A variable name, e.g. a.b or a[1].b[3].c"
+    annotation(__OpenModelica_builtinType=true);
+  end VariableName;
+
+  type VariableNames
+    "An array of variable names, e.g. {a.b,a[1].b[3].c}, or a single VariableName"
+    annotation(__OpenModelica_builtinType=true);
+  end VariableNames;
 end $Code;
 
 function threadData


### PR DESCRIPTION
- Fixed order of equations in when-equations.
- Added __OpenModelica_builtinType annotation to allow the $Code types
  in NFModelicaBuiltin to work in both the new and old instantiation,
  so that Interactive doesn't break if NFModelicaBuiltin is loaded at
  start (i.e. by using -d=newInst on the command line instead of
  setting it in the script).