### PR TITLE
Add default top alignment for table rows

### DIFF
--- a/Examples/GenerateDoc.mos
+++ b/Examples/GenerateDoc.mos
@@ -425,6 +425,7 @@ table td,th
     border-style: solid;
     margin: 0;
     padding: 4px;
+    vertical-align: top;
 }
 
 pre


### PR DESCRIPTION
During a documentation clean up of the MSL for 3.2.3 release the
style settings for vertical alignment were removed (https://github.com/modelica/ModelicaStandardLibrary/pull/2517)
Other tools (e.g., SimulationX and Dymola) have their own default settings
that actually match top alignment. OMEdit is probably going to have
the same. This PR adds this for the documentation generation.
