### PR TITLE
[NF] Fix default values in record constructors.

### DIFF
--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -575,6 +575,7 @@ public
     dcref := match cref
       local
         Type ty;
+        DAE.Type dty;
 
       case EMPTY() then accumCref;
       case CREF()
@@ -585,7 +586,8 @@ public
           // after the typing, but the new frontend doesn't use these types anyway.
           // So instead we just fetch the type of the node if the type is unknown.
           ty := if Type.isUnknown(cref.ty) then InstNode.getType(cref.node) else cref.ty;
-          dcref := DAE.ComponentRef.CREF_QUAL(InstNode.name(cref.node), Type.toDAE(ty),
+          dty := Type.toDAE(ty, makeTypeVars = false);
+          dcref := DAE.ComponentRef.CREF_QUAL(InstNode.name(cref.node), dty,
             list(Subscript.toDAE(s) for s in cref.subscripts), accumCref);
         then
           toDAE_impl(cref.restCref, dcref);

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -344,11 +344,13 @@ function getRecordBindings
 protected
   Expression binding_exp;
   list<Expression> expl;
+  Variability var;
 algorithm
   binding_exp := Binding.getTypedExp(binding);
+  var := Binding.variability(binding);
 
   recordBindings := match binding_exp
-    case Expression.RECORD() then list(Binding.FLAT_BINDING(e) for e in binding_exp.elements);
+    case Expression.RECORD() then list(Binding.FLAT_BINDING(e, var) for e in binding_exp.elements);
     else
       algorithm
         Error.assertion(false, getInstanceName() + " got non-record binding " +

--- a/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/Compiler/NFFrontEnd/NFScalarize.mo
@@ -48,6 +48,7 @@ import MetaModelica.Dangerous.arrayCreateNoInit;
 import Variable = NFVariable;
 import NFComponent.Component;
 import NFPrefixes.Visibility;
+import NFPrefixes.Variability;
 import List;
 import ElementSource;
 import DAE;
@@ -96,6 +97,7 @@ protected
   Variable v;
   list<String> ty_attr_names;
   array<ExpressionIterator> ty_attr_iters;
+  Variability bind_var;
 algorithm
   if Type.isArray(var.ty) then
     Variable.VARIABLE(name, ty, binding, vis, attr, ty_attr, cmt, info) := var;
@@ -110,10 +112,11 @@ algorithm
 
     if Binding.isBound(binding) then
       binding_iter := ExpressionIterator.fromExp(Binding.getTypedExp(binding));
+      bind_var := Binding.variability(binding);
 
       for cr in crefs loop
         (binding_iter, exp) := ExpressionIterator.next(binding_iter);
-        binding := Binding.FLAT_BINDING(exp);
+        binding := Binding.FLAT_BINDING(exp, bind_var);
         ty_attr := nextTypeAttributes(ty_attr_names, ty_attr_iters);
         vars := Variable.VARIABLE(cr, ty, binding, vis, attr, ty_attr, cmt, info) :: vars;
       end for;
@@ -162,7 +165,7 @@ algorithm
     (iter, exp) := ExpressionIterator.next(iters[i]);
     arrayUpdate(iters, i, iter);
     i := i + 1;
-    attrs := (name, Binding.FLAT_BINDING(exp)) :: attrs;
+    attrs := (name, Binding.FLAT_BINDING(exp, Variability.PARAMETER)) :: attrs;
   end for;
 end nextTypeAttributes;
 

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -628,6 +628,7 @@ public
 
   function toDAE
     input Type ty;
+    input Boolean makeTypeVars = true;
     output DAE.Type daeTy;
   algorithm
     daeTy := match ty
@@ -638,15 +639,16 @@ public
       case Type.ENUMERATION() then DAE.T_ENUMERATION(NONE(), ty.typePath, ty.literals, {}, {});
       case Type.CLOCK() then DAE.T_CLOCK_DEFAULT;
       case Type.ARRAY()
-        then DAE.T_ARRAY(toDAE(ty.elementType),
+        then DAE.T_ARRAY(toDAE(ty.elementType, makeTypeVars),
           list(Dimension.toDAE(d) for d in ty.dimensions));
       case Type.TUPLE()
         then DAE.T_TUPLE(list(toDAE(t) for t in ty.types), ty.names);
       case Type.FUNCTION()
-        then DAE.T_FUNCTION({} /*TODO:FIXME*/, toDAE(ty.resultType), ty.attributes, Absyn.IDENT("TODO:FIXME"));
+        then DAE.T_FUNCTION({} /*TODO:FIXME*/, toDAE(ty.resultType, makeTypeVars), ty.attributes, Absyn.IDENT("TODO:FIXME"));
       case Type.NORETCALL() then DAE.T_NORETCALL_DEFAULT;
       case Type.UNKNOWN() then DAE.T_UNKNOWN_DEFAULT;
-      case Type.COMPLEX() then InstNode.toDAEType(ty.cls);
+      case Type.COMPLEX()
+        then if makeTypeVars then InstNode.toFullDAEType(ty.cls) else InstNode.toPartialDAEType(ty.cls);
       case Type.POLYMORPHIC() then DAE.T_METAPOLYMORPHIC(ty.name);
       case Type.ANY() then DAE.T_ANYTYPE(NONE());
       else

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -830,7 +830,7 @@ algorithm
 
         exp := Ceval.evalExp(exp, Ceval.EvalTarget.CONDITION(info));
       then
-        Binding.FLAT_BINDING(exp);
+        Binding.FLAT_BINDING(exp, var);
 
   end match;
 end typeComponentCondition;


### PR DESCRIPTION
- Fix conversion of bindings for DAE.Var, since record constructors
  uses them for default values.
- Don't generate type variables when converting types of scope crefs,
  to avoid loops when converting complex types.