### PR TITLE
[NF] Fix ConnectEquations.makePositiveMaxCall.

### DIFF
--- a/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -453,7 +453,7 @@ protected
   Expression stream_exp, flow_exp;
 algorithm
   (stream_exp, flow_exp) := streamFlowExp(element);
-  exp := Expression.BINARY(makePositiveMaxCall(flow_exp, flowThreshold),
+  exp := Expression.BINARY(makePositiveMaxCall(flow_exp, element, flowThreshold),
     Operator.makeMul(Type.REAL()), makeInStreamCall(stream_exp));
 end sumOutside1;
 
@@ -469,7 +469,7 @@ protected
 algorithm
   (stream_exp, flow_exp) := streamFlowExp(element);
   flow_exp := Expression.UNARY(Operator.makeUMinus(Type.REAL()), flow_exp);
-  exp := Expression.BINARY(makePositiveMaxCall(flow_exp, flowThreshold),
+  exp := Expression.BINARY(makePositiveMaxCall(flow_exp, element, flowThreshold),
     Operator.makeMul(Type.REAL()), stream_exp);
 end sumInside1;
 
@@ -484,7 +484,7 @@ protected
   Expression flow_exp;
 algorithm
   flow_exp := flowExp(element);
-  exp := makePositiveMaxCall(flow_exp, flowThreshold);
+  exp := makePositiveMaxCall(flow_exp, element, flowThreshold);
 end sumOutside2;
 
 function sumInside2
@@ -499,7 +499,7 @@ protected
 algorithm
   flow_exp := flowExp(element);
   flow_exp := Expression.UNARY(Operator.makeUMinus(Type.REAL()), flow_exp);
-  exp := makePositiveMaxCall(flow_exp, flowThreshold);
+  exp := makePositiveMaxCall(flow_exp, element, flowThreshold);
 end sumInside2;
 
 function makeInStreamCall
@@ -514,6 +514,7 @@ end makeInStreamCall;
 function makePositiveMaxCall
   "Generates a max(flow_exp, eps) call."
   input Expression flowExp;
+  input Connector element;
   input Expression flowThreshold;
   output Expression positiveMaxCall;
 protected
@@ -521,7 +522,7 @@ protected
   Option<Expression> nominal_oexp;
   Expression nominal_exp, flow_threshold;
 algorithm
-  flow_node := ComponentRef.node(Expression.toCref(flowExp));
+  flow_node := ComponentRef.node(Connector.flowCref(element));
   nominal_oexp := Class.lookupAttributeValue("nominal", InstNode.getClass(flow_node));
 
   if isSome(nominal_oexp) then

--- a/Compiler/NFFrontEnd/NFConnector.mo
+++ b/Compiler/NFFrontEnd/NFConnector.mo
@@ -171,6 +171,13 @@ public
     connl := splitImpl(conn.name, conn.ty, conn.face, conn.source, conn.cty);
   end split;
 
+  function flowCref
+    input Connector conn;
+    output ComponentRef cref;
+  algorithm
+    SOME(cref) := conn.associatedFlow;
+  end flowCref;
+
 protected
   function crefFace
     "Determines whether a cref refers to an inside or outside connector, where

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -804,77 +804,10 @@ function evaluateEquationsConnOp
   input ConnectionSets.Sets sets;
   input array<list<Connector>> setsArray;
 algorithm
-  equations := list(evaluateEquationConnOp(eq, sets, setsArray) for eq in equations);
+  equations := list(
+      Equation.mapExp(eq, function ConnectEquations.evaluateOperators(sets = sets, setsArray = setsArray))
+    for eq in equations);
 end evaluateEquationsConnOp;
-
-function evaluateEquationConnOp
-  input output Equation eq;
-  input ConnectionSets.Sets sets;
-  input array<list<Connector>> setsArray;
-algorithm
-  eq := match eq
-    local
-      Expression e1, e2;
-
-    case Equation.EQUALITY()
-      algorithm
-        e1 := ConnectEquations.evaluateOperators(eq.lhs, sets, setsArray);
-        e2 := ConnectEquations.evaluateOperators(eq.rhs, sets, setsArray);
-      then
-        Equation.EQUALITY(e1, e2, eq.ty, eq.source);
-
-    case Equation.ARRAY_EQUALITY()
-      algorithm
-        eq.rhs := ConnectEquations.evaluateOperators(eq.rhs, sets, setsArray);
-      then
-        eq;
-
-    case Equation.FOR()
-      algorithm
-        eq.body := evaluateEquationsConnOp(eq.body, sets, setsArray);
-      then
-        eq;
-
-    case Equation.IF()
-      algorithm
-        eq.branches := list(evaluateEqBranchConnOp(b, sets, setsArray) for b in eq.branches);
-      then
-        eq;
-
-    case Equation.WHEN()
-      algorithm
-        eq.branches := list(evaluateEqBranchConnOp(b, sets, setsArray) for b in eq.branches);
-      then
-        eq;
-
-    case Equation.REINIT()
-      algorithm
-        eq.reinitExp := ConnectEquations.evaluateOperators(eq.reinitExp, sets, setsArray);
-      then
-        eq;
-
-    case Equation.NORETCALL()
-      algorithm
-        eq.exp := ConnectEquations.evaluateOperators(eq.exp, sets, setsArray);
-      then
-        eq;
-
-    else eq;
-  end match;
-end evaluateEquationConnOp;
-
-function evaluateEqBranchConnOp
-  input output tuple<Expression, list<Equation>> branch;
-  input ConnectionSets.Sets sets;
-  input array<list<Connector>> setsArray;
-protected
-  Expression exp;
-  list<Equation> eql;
-algorithm
-  (exp, eql) := branch;
-  eql := evaluateEquationsConnOp(eql, sets, setsArray);
-  branch := (exp, eql);
-end evaluateEqBranchConnOp;
 
 function flattenFunctions
   input FlatModel flatModel;


### PR DESCRIPTION
- Fetch the instance node from the flow cref instead of assuming that
  the flow expression is always a cref expressions, which is often
  not the case.