### PR TITLE
[NF] Fix call attributes for operator overloading.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -609,7 +609,6 @@ uniontype Call
   protected
     Function func;
     list<Expression> args;
-    CallAttributes ca;
     list<TypedArg> typed_args;
     MatchedFunction matchedFunc;
     InstNode scope;
@@ -643,13 +642,7 @@ uniontype Call
       ty := evaluateCallType(ty, func, args);
     end if;
 
-    ca := CallAttributes.CALL_ATTR(
-            ty, Type.isTuple(ty), Function.isBuiltin(func)
-            , Function.isImpure(func), Function.isFunctionPointer(func)
-            , Function.inlineBuiltin(func), DAE.NO_TAIL()
-          );
-
-    call := TYPED_CALL(func, ty, var, args, ca);
+    call := makeTypedCall(func, args, ty, var);
 
     // If the matching was a vectorized one then create a map call
     // using the vectorization dim. This means going through each argument
@@ -659,6 +652,28 @@ uniontype Call
     end if;
 
   end matchTypedNormalCall;
+
+  function makeTypedCall
+    input Function fn;
+    input list<Expression> args;
+    input Type returnType;
+    input Variability variability;
+    output Call call;
+  protected
+    CallAttributes ca;
+  algorithm
+    ca := CallAttributes.CALL_ATTR(
+      returnType,
+      Type.isTuple(returnType),
+      Function.isBuiltin(fn),
+      Function.isImpure(fn),
+      Function.isFunctionPointer(fn),
+      Function.inlineBuiltin(fn),
+      DAE.NO_TAIL()
+    );
+
+    call := TYPED_CALL(fn, returnType, variability, args, ca);
+  end makeTypedCall;
 
   function vectorizeCall
     input Call base_call;

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -174,7 +174,7 @@ public function checkBinaryOperationOperatorRecords
   output Type outType;
 protected
   String opstr;
-  Function operfn;
+  Function fn;
   InstNode node1, node2;
   ComponentRef fn_ref;
   list<Function> candidates;
@@ -257,12 +257,14 @@ algorithm
 
   if listLength(exactMatches) == 1 then
     matchedFunc ::_ := exactMatches;
-    outType := Function.returnType(matchedFunc.func);
-    outExp := Expression.CALL(Call.TYPED_CALL(matchedFunc.func, outType, Variability.CONSTANT, list(Util.tuple31(a) for a in matchedFunc.args)
-                                              , CallAttributes.CALL_ATTR(
-                                                  outType, false, false, false, false, DAE.NO_INLINE(),DAE.NO_TAIL())
-                                              )
-                              );
+    fn := matchedFunc.func;
+    outType := Function.returnType(fn);
+    outExp := Expression.CALL(
+      Call.makeTypedCall(
+        matchedFunc.func,
+        list(Util.tuple31(a) for a in matchedFunc.args),
+        outType,
+        Variability.CONSTANT));
   else
     Error.addSourceMessage(Error.AMBIGUOUS_MATCHING_OPERATOR_FUNCTIONS_NFINST,
           {Expression.toString(Expression.BINARY(inExp1, inOp, inExp2))
@@ -902,9 +904,8 @@ protected
   Expression e1, e2;
   MatchKind mk;
 algorithm
-
   if Type.isComplex(Type.arrayElementType(type1)) or
-    Type.isComplex(Type.arrayElementType(type2)) then
+     Type.isComplex(Type.arrayElementType(type2)) then
     (outExp,resultType) := checkBinaryOperationOperatorRecords(exp1, type1, operator, exp2, type2, info);
     return;
   end if;


### PR DESCRIPTION
- Create real call attributes for overloaded operator calls, so that
  they get e.g. the correct inline attributes.