### PR TITLE
Fix ComponentReference.expandCref.

### DIFF
--- a/Compiler/FrontEnd/ComponentReference.mo
+++ b/Compiler/FrontEnd/ComponentReference.mo
@@ -3157,6 +3157,7 @@ algorithm
       DAE.ComponentRef cref;
       list<DAE.ComponentRef> crefs, crefs2;
       list<DAE.Var> varLst;
+      Integer missing_subs;
 
     // A scalar record ident cref. Expand record true
     case (DAE.CREF_IDENT(_, DAE.T_COMPLEX(varLst=varLst,complexClassType=ClassInf.RECORD(_)), {}),true)
@@ -3196,6 +3197,13 @@ algorithm
         // Flatten T_ARRAY(T_ARRAY(T_COMPLEX(), dim2,src), dim1,src) types to one level T_ARRAY(simpletype, alldims, src)
         (basety as DAE.T_COMPLEX(varLst=varLst,complexClassType=ClassInf.RECORD()), dims) = Types.flattenArrayType(ty);
         correctTy = DAE.T_ARRAY(basety,dims);
+
+        // Pad the list of subscripts with : if necessary to fill out all dimensions.
+        missing_subs = listLength(dims) - listLength(subs);
+        if missing_subs > 0 then
+          subs = listAppend(subs, List.fill(DAE.WHOLEDIM(), missing_subs));
+        end if;
+
         // Use the subscripts to generate only the wanted elements.
          crefs = expandCref2(id, correctTy, subs, dims);
       then
@@ -3207,6 +3215,12 @@ algorithm
         // Flatten T_ARRAY(T_ARRAY(T_..., dim2,src), dim1,src) types to one level T_ARRAY(simpletype, alldims, src)
         (basety, dims) = Types.flattenArrayType(ty);
         correctTy = DAE.T_ARRAY(basety,dims);
+
+        // Pad the list of subscripts with : if necessary to fill out all dimensions.
+        missing_subs = listLength(dims) - listLength(subs);
+        if missing_subs > 0 then
+          subs = listAppend(subs, List.fill(DAE.WHOLEDIM(), missing_subs));
+        end if;
         // Use the subscripts to generate only the wanted elements.
       then
         expandCref2(id, correctTy, subs, dims);

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -1323,6 +1323,11 @@ protected
   Subscript sub;
   Variability var;
 algorithm
+  if listEmpty(subscripts) then
+    typedSubs := subscripts;
+    return;
+  end if;
+
   dims := Type.arrayDims(crefType);
   typedSubs := {};
   next_origin := intBitOr(origin, ExpOrigin.SUBSCRIPT);


### PR DESCRIPTION
- Pad the subscript list of partially subscripted crefs in expandCref
  with : to fill up all dimensions, to make if actually expand the
  crefs instead of only saying it did. The backend sometimes creates
  such crefs when using the NF, since it doesn't expand as much.