### PR TITLE
[NF] Allow both types to be unknown in matchTypes.

### DIFF
--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -1585,6 +1585,12 @@ algorithm
       then
         compatibleType;
 
+    case Type.UNKNOWN()
+      algorithm
+        matchKind := if allowUnknown then MatchKind.EXACT else MatchKind.NOT_COMPATIBLE;
+      then
+        actualType;
+
     case Type.COMPLEX()
       algorithm
         (expression, compatibleType, matchKind) :=


### PR DESCRIPTION
- When allowing unknown types, allow both the actual and the expected
  type to be unknown. This can happen with e.g. : subscripts on a
  function parameter with : dimensions.