### PR TITLE
[NF] Fill in field names when converting records.

### DIFF
--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -547,6 +547,7 @@ uniontype Class
       else node;
     end match;
   end lastBaseClass;
+
 end Class;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/Compiler/NFFrontEnd/NFComplexType.mo
+++ b/Compiler/NFFrontEnd/NFComplexType.mo
@@ -55,6 +55,7 @@ public
 
   record RECORD
     InstNode constructor;
+    list<String> fieldNames;
   end RECORD;
 
   record EXTERNAL_OBJECT

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -42,6 +42,7 @@ protected
   import NFPrefixes.Variability;
   import Prefixes = NFPrefixes;
   import Ceval = NFCeval;
+  import ComplexType = NFComplexType;
   import MetaModelica.Dangerous.listReverseInPlace;
 
 public
@@ -1084,6 +1085,7 @@ public
         DAE.Operator daeOp;
         Boolean swap;
         DAE.Exp dae1, dae2;
+        list<String> names;
 
       case INTEGER() then DAE.ICONST(exp.value);
       case REAL() then DAE.RCONST(exp.value);
@@ -1102,8 +1104,8 @@ public
         then DAE.ARRAY(Type.toDAE(exp.ty), Type.isScalarArray(exp.ty),
           list(toDAE(e) for e in exp.elements));
 
-      case RECORD()
-        then DAE.RECORD(exp.path, list(toDAE(e) for e in exp.elements), {}, Type.toDAE(exp.ty));
+      case RECORD(ty = Type.COMPLEX(complexTy = ComplexType.RECORD(fieldNames = names)))
+        then DAE.RECORD(exp.path, list(toDAE(e) for e in exp.elements), names, Type.toDAE(exp.ty));
 
       case RANGE()
         then DAE.RANGE(

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -1796,7 +1796,7 @@ algorithm
         // Instantiate local equation/algorithm sections.
         sections := instSections(node, scope, sections);
 
-        ty := makeComplexType(cls.restriction, node);
+        ty := makeComplexType(cls.restriction, node, cls);
         inst_cls := Class.INSTANCED_CLASS(ty, cls.elements, sections, cls.restriction);
         InstNode.updateClass(inst_cls, node);
 
@@ -1840,18 +1840,32 @@ end instExpressions;
 function makeComplexType
   input Restriction restriction;
   input InstNode node;
+  input Class cls;
   output Type ty;
 protected
   ComplexType cty;
 algorithm
   cty := match restriction
-    case Restriction.RECORD()
-      then ComplexType.RECORD(InstNode.classScope(InstNode.getDerivedNode(node)));
+    case Restriction.RECORD() then makeRecordComplexType(node, cls);
     else ComplexType.CLASS();
   end match;
 
   ty := Type.COMPLEX(node, cty);
 end makeComplexType;
+
+function makeRecordComplexType
+  input InstNode node;
+  input Class cls;
+  output ComplexType ty;
+protected
+  InstNode cls_node;
+  list<String> fields;
+algorithm
+  cls_node := InstNode.classScope(InstNode.getDerivedNode(node));
+  fields := list(InstNode.name(c) for c guard not InstNode.isEmpty(c) in
+    ClassTree.getComponents(Class.classTree(cls)));
+  ty := ComplexType.RECORD(cls_node, fields);
+end makeRecordComplexType;
 
 function instComplexType
   input Type ty;


### PR DESCRIPTION
- Fill in the field names when converting record expressions to DAE,
  since the old ExpressionSimplify relies on them being present.