### PR TITLE
[NF] Improvements to handling of 'when'.

### DIFF
--- a/Compiler/NFFrontEnd/NFAlgorithm.mo
+++ b/Compiler/NFFrontEnd/NFAlgorithm.mo
@@ -43,6 +43,30 @@ public
     ElementSource source;
   end ALGORITHM;
 
+  partial function ApplyFn
+    input Statement alg;
+  end ApplyFn;
+
+  function applyList
+    input list<Algorithm> algs;
+    input ApplyFn func;
+  algorithm
+    for alg in algs loop
+      for s in alg.statements loop
+        Statement.apply(s, func);
+      end for;
+    end for;
+  end applyList;
+
+  function apply
+    input Algorithm alg;
+    input ApplyFn func;
+  algorithm
+    for s in alg.statements loop
+      Statement.apply(s, func);
+    end for;
+  end apply;
+
   function mapExp
     input output Algorithm alg;
     input MapFunc func;

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -1999,6 +1999,227 @@ public
     end match;
   end foldSubscript;
 
+  function applyList
+    input list<Expression> expl;
+    input ApplyFunc func;
+
+    partial function ApplyFunc
+      input Expression exp;
+    end ApplyFunc;
+  algorithm
+    for e in expl loop
+      apply(e, func);
+    end for;
+  end applyList;
+
+  function apply
+    input Expression exp;
+    input ApplyFunc func;
+
+    partial function ApplyFunc
+      input Expression exp;
+    end ApplyFunc;
+  algorithm
+    () := match exp
+      local
+        Expression e;
+
+      case CREF() algorithm applyCref(exp.cref, func); then ();
+      case ARRAY() algorithm applyList(exp.elements, func); then ();
+
+      case MATRIX()
+        algorithm
+          for row in exp.elements loop
+            applyList(row, func);
+          end for;
+        then
+          ();
+
+      case RANGE(step = SOME(e))
+        algorithm
+          apply(exp.start, func);
+          apply(e, func);
+          apply(exp.stop, func);
+        then
+          ();
+
+      case RANGE()
+        algorithm
+          apply(exp.start, func);
+          apply(exp.stop, func);
+        then
+          ();
+
+      case TUPLE() algorithm applyList(exp.elements, func); then ();
+      case RECORD() algorithm applyList(exp.elements, func); then ();
+      case CALL() algorithm applyCall(exp.call, func); then ();
+
+      case SIZE(dimIndex = SOME(e))
+        algorithm
+          apply(exp.exp, func);
+          apply(e, func);
+        then
+          ();
+
+      case SIZE() algorithm apply(exp.exp, func); then ();
+
+      case BINARY()
+        algorithm
+          apply(exp.exp1, func);
+          apply(exp.exp2, func);
+        then
+          ();
+
+      case UNARY() algorithm apply(exp.exp, func); then ();
+
+      case LBINARY()
+        algorithm
+          apply(exp.exp1, func);
+          apply(exp.exp2, func);
+        then
+          ();
+
+      case LUNARY() algorithm apply(exp.exp, func); then ();
+
+      case RELATION()
+        algorithm
+          apply(exp.exp1, func);
+          apply(exp.exp2, func);
+        then
+          ();
+
+      case IF()
+        algorithm
+          apply(exp.condition, func);
+          apply(exp.trueBranch, func);
+          apply(exp.falseBranch, func);
+        then
+          ();
+
+      case CAST() algorithm apply(exp.exp, func); then ();
+      case UNBOX() algorithm apply(exp.exp, func); then ();
+
+      case SUBSCRIPTED_EXP()
+        algorithm
+          apply(exp.exp, func);
+          applyList(exp.subscripts, func);
+        then
+          ();
+
+      case TUPLE_ELEMENT() algorithm apply(exp.tupleExp, func); then ();
+      case BOX() algorithm apply(exp.exp, func); then ();
+      case MUTABLE() algorithm apply(Mutable.access(exp.exp), func); then ();
+      else ();
+    end match;
+
+    func(exp);
+  end apply;
+
+  function applyCall
+    input Call call;
+    input ApplyFunc func;
+
+    partial function ApplyFunc
+      input Expression exp;
+    end ApplyFunc;
+  algorithm
+    () := match call
+      local
+        Expression e;
+
+      case Call.UNTYPED_CALL()
+        algorithm
+          applyList(call.arguments, func);
+
+          for arg in call.named_args loop
+            (_, e) := arg;
+            apply(e, func);
+          end for;
+        then
+          ();
+
+      case Call.ARG_TYPED_CALL()
+        algorithm
+          for arg in call.arguments loop
+            (e, _, _) := arg;
+            apply(e, func);
+          end for;
+
+          for arg in call.named_args loop
+            (_, e, _, _) := arg;
+            apply(e, func);
+          end for;
+        then
+          ();
+
+      case Call.TYPED_CALL()
+        algorithm
+          applyList(call.arguments, func);
+        then
+          ();
+
+      case Call.UNTYPED_MAP_CALL()
+        algorithm
+          apply(call.exp, func);
+
+          for i in call.iters loop
+            apply(Util.tuple22(i), func);
+          end for;
+        then
+          ();
+
+      case Call.TYPED_MAP_CALL()
+        algorithm
+          apply(call.exp, func);
+
+          for i in call.iters loop
+            apply(Util.tuple22(i), func);
+          end for;
+        then
+          ();
+
+    end match;
+  end applyCall;
+
+  function applyCref
+    input ComponentRef cref;
+    input ApplyFunc func;
+
+    partial function ApplyFunc
+      input Expression exp;
+    end ApplyFunc;
+  algorithm
+    () := match cref
+      case ComponentRef.CREF()
+        algorithm
+          for s in cref.subscripts loop
+            applyCrefSubscript(s, func);
+          end for;
+
+          applyCref(cref.restCref, func);
+        then
+          ();
+
+      else ();
+    end match;
+  end applyCref;
+
+  function applyCrefSubscript
+    input Subscript subscript;
+    input ApplyFunc func;
+
+    partial function ApplyFunc
+      input Expression exp;
+    end ApplyFunc;
+  algorithm
+    () := match subscript
+      case Subscript.UNTYPED() algorithm apply(subscript.exp, func); then ();
+      case Subscript.INDEX()   algorithm apply(subscript.index, func); then ();
+      case Subscript.SLICE()   algorithm apply(subscript.slice, func); then ();
+      case Subscript.WHOLE()   then ();
+    end match;
+  end applyCrefSubscript;
+
   function mapFold<ArgT>
     input Expression exp;
     input MapFunc func;

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -60,6 +60,7 @@ import Subscript = NFSubscript;
 import Connector = NFConnector;
 import Connection = NFConnection;
 import Algorithm = NFAlgorithm;
+import ExpOrigin = NFTyping.ExpOrigin;
 
 protected
 import Array;
@@ -96,8 +97,6 @@ import FlatModel = NFFlatModel;
 import ElementSource;
 import SimplifyModel = NFSimplifyModel;
 import Record = NFRecord;
-
-type EquationScope = enumeration(NORMAL, INITIAL, WHEN);
 
 public
 function instClassInProgram
@@ -136,7 +135,8 @@ algorithm
   execStat("NFInst.instExpressions("+ name +")");
 
   // Mark structural parameters.
-  markStructuralParams(inst_cls);
+  updateImplicitVariability(inst_cls);
+  execStat("NFInst.updateImplicitVariability");
 
   // Type the class.
   Typing.typeClass(inst_cls, name);
@@ -1794,7 +1794,7 @@ algorithm
         InstNode.updateClass(cls, node);
 
         // Instantiate local equation/algorithm sections.
-        sections := instSections(node, scope, sections);
+        sections := instSections(node, scope, sections, Restriction.isFunction(cls.restriction));
 
         ty := makeComplexType(cls.restriction, node);
         inst_cls := Class.INSTANCED_CLASS(ty, cls.elements, sections, cls.restriction);
@@ -2247,16 +2247,17 @@ function instSections
   input InstNode node;
   input InstNode scope;
   input output Sections sections;
+  input Boolean isFunction;
 protected
   SCode.Element el = InstNode.definition(node);
   SCode.ClassDef def;
 algorithm
   sections := match el
     case SCode.CLASS(classDef = SCode.PARTS())
-      then instSections2(el.classDef, scope, sections);
+      then instSections2(el.classDef, scope, sections, isFunction);
 
     case SCode.CLASS(classDef = SCode.CLASS_EXTENDS(composition = def as SCode.PARTS()))
-      then instSections2(def, scope, sections);
+      then instSections2(def, scope, sections, isFunction);
 
     else sections;
   end match;
@@ -2266,12 +2267,14 @@ function instSections2
   input SCode.ClassDef parts;
   input InstNode scope;
   input output Sections sections;
+  input Boolean isFunction;
 algorithm
   sections := match (parts, sections)
     local
       list<Equation> eq, ieq;
       list<Algorithm> alg, ialg;
       SCode.ExternalDecl ext_decl;
+      ExpOrigin.Type origin, iorigin;
 
     case (_, Sections.EXTERNAL())
       algorithm
@@ -2285,10 +2288,13 @@ algorithm
 
     case (SCode.PARTS(), _)
       algorithm
-        eq := instEquations(parts.normalEquationLst, scope, EquationScope.NORMAL);
-        ieq := instEquations(parts.initialEquationLst, scope, EquationScope.INITIAL);
-        alg := instAlgorithmSections(parts.normalAlgorithmLst, scope);
-        ialg := instAlgorithmSections(parts.initialAlgorithmLst, scope);
+        origin := if isFunction then ExpOrigin.FUNCTION else ExpOrigin.CLASS;
+        iorigin := intBitOr(origin, ExpOrigin.INITIAL);
+
+        eq := instEquations(parts.normalEquationLst, scope, origin);
+        ieq := instEquations(parts.initialEquationLst, scope, iorigin);
+        alg := instAlgorithmSections(parts.normalAlgorithmLst, scope, origin);
+        ialg := instAlgorithmSections(parts.initialAlgorithmLst, scope, iorigin);
       then
         Sections.join(Sections.new(eq, ieq, alg, ialg), sections);
 
@@ -2350,37 +2356,37 @@ end checkExternalDeclLanguage;
 function instEquations
   input list<SCode.Equation> scodeEql;
   input InstNode scope;
-  input EquationScope eqScope;
+  input ExpOrigin.Type origin;
   output list<Equation> instEql;
 algorithm
-  instEql := list(instEquation(eq, scope, eqScope) for eq in scodeEql);
+  instEql := list(instEquation(eq, scope, origin) for eq in scodeEql);
 end instEquations;
 
 function instEquation
   input SCode.Equation scodeEq;
   input InstNode scope;
-  input EquationScope eqScope;
+  input ExpOrigin.Type origin;
   output Equation instEq;
 protected
   SCode.EEquation eq;
 algorithm
   SCode.EQUATION(eEquation = eq) := scodeEq;
-  instEq := instEEquation(eq, scope, eqScope);
+  instEq := instEEquation(eq, scope, origin);
 end instEquation;
 
 function instEEquations
   input list<SCode.EEquation> scodeEql;
   input InstNode scope;
-  input EquationScope eqScope;
+  input ExpOrigin.Type origin;
   output list<Equation> instEql;
 algorithm
-  instEql := list(instEEquation(eq, scope, eqScope) for eq in scodeEql);
+  instEql := list(instEEquation(eq, scope, origin) for eq in scodeEql);
 end instEEquations;
 
 function instEEquation
   input SCode.EEquation scodeEq;
   input InstNode scope;
-  input EquationScope eqScope;
+  input ExpOrigin.Type origin;
   output Equation instEq;
 algorithm
   instEq := match scodeEq
@@ -2393,13 +2399,14 @@ algorithm
       SourceInfo info;
       InstNode for_scope, iter;
       ComponentRef lhs_cr, rhs_cr;
+      ExpOrigin.Type next_origin;
 
     case SCode.EEquation.EQ_EQUALS(info = info)
       algorithm
         exp1 := instExp(scodeEq.expLeft, scope, info);
         exp2 := instExp(scodeEq.expRight, scope, info);
 
-        if eqScope == EquationScope.WHEN and not checkLhsInWhen(exp1) then
+        if intBitAnd(origin, ExpOrigin.WHEN) > 0 and not checkLhsInWhen(exp1) then
           Error.addSourceMessage(Error.WHEN_EQ_LHS, {Expression.toString(exp1)}, info);
           fail();
         end if;
@@ -2408,7 +2415,7 @@ algorithm
 
     case SCode.EEquation.EQ_CONNECT(info = info)
       algorithm
-        if eqScope == EquationScope.WHEN then
+        if intBitAnd(origin, ExpOrigin.WHEN) > 0 then
           Error.addSourceMessage(Error.CONNECT_IN_WHEN,
             {Dump.printComponentRefStr(scodeEq.crefLeft),
              Dump.printComponentRefStr(scodeEq.crefRight)}, info);
@@ -2424,7 +2431,8 @@ algorithm
       algorithm
         oexp := instExpOpt(scodeEq.range, scope, info);
         (for_scope, iter) := addIteratorToScope(scodeEq.index, scope, scodeEq.info);
-        eql := instEEquations(scodeEq.eEquationLst, for_scope, eqScope);
+        next_origin := intBitOr(origin, ExpOrigin.FOR);
+        eql := instEEquations(scodeEq.eEquationLst, for_scope, next_origin);
       then
         Equation.FOR(iter, oexp, eql, makeSource(scodeEq.comment, info));
 
@@ -2434,9 +2442,10 @@ algorithm
         expl := list(instExp(c, scope, info) for c in scodeEq.condition);
 
         // Instantiate each branch and pair it up with a condition.
+        next_origin := intBitOr(origin, ExpOrigin.IF);
         branches := {};
         for branch in scodeEq.thenBranch loop
-          eql := instEEquations(branch, scope, eqScope);
+          eql := instEEquations(branch, scope, next_origin);
           exp1 :: expl := expl;
           branches := (exp1, eql) :: branches;
         end for;
@@ -2444,7 +2453,7 @@ algorithm
         // Instantiate the else-branch, if there is one, and make it a branch
         // with condition true (so we only need a simple list of branches).
         if not listEmpty(scodeEq.elseBranch) then
-          eql := instEEquations(scodeEq.elseBranch, scope, eqScope);
+          eql := instEEquations(scodeEq.elseBranch, scope, next_origin);
           branches := (Expression.BOOLEAN(true), eql) :: branches;
         end if;
       then
@@ -2452,19 +2461,20 @@ algorithm
 
     case SCode.EEquation.EQ_WHEN(info = info)
       algorithm
-        if eqScope == EquationScope.WHEN then
+        if intBitAnd(origin, ExpOrigin.WHEN) > 0 then
           Error.addSourceMessageAndFail(Error.NESTED_WHEN, {}, info);
-        elseif eqScope == EquationScope.INITIAL then
+        elseif intBitAnd(origin, ExpOrigin.INITIAL) > 0 then
           Error.addSourceMessageAndFail(Error.INITIAL_WHEN, {}, info);
         end if;
 
+        next_origin := intBitOr(origin, ExpOrigin.WHEN);
         exp1 := instExp(scodeEq.condition, scope, info);
-        eql := instEEquations(scodeEq.eEquationLst, scope, EquationScope.WHEN);
+        eql := instEEquations(scodeEq.eEquationLst, scope, next_origin);
         branches := {(exp1, eql)};
 
         for branch in scodeEq.elseBranches loop
           exp1 := instExp(Util.tuple21(branch), scope, info);
-          eql := instEEquations(Util.tuple22(branch), scope, EquationScope.WHEN);
+          eql := instEEquations(Util.tuple22(branch), scope, next_origin);
           branches := (exp1, eql) :: branches;
         end for;
       then
@@ -2486,7 +2496,7 @@ algorithm
 
     case SCode.EEquation.EQ_REINIT(info = info)
       algorithm
-        if eqScope <> EquationScope.WHEN then
+        if intBitAnd(origin, ExpOrigin.WHEN) == 0 then
           Error.addSourceMessage(Error.REINIT_NOT_IN_WHEN, {}, info);
           fail();
         end if;
@@ -2522,31 +2532,35 @@ end makeSource;
 function instAlgorithmSections
   input list<SCode.AlgorithmSection> algorithmSections;
   input InstNode scope;
+  input ExpOrigin.Type origin;
   output list<Algorithm> algs;
 algorithm
-  algs := list(instAlgorithmSection(alg, scope) for alg in algorithmSections);
+  algs := list(instAlgorithmSection(alg, scope, origin) for alg in algorithmSections);
 end instAlgorithmSections;
 
 function instAlgorithmSection
   input SCode.AlgorithmSection algorithmSection;
   input InstNode scope;
+  input ExpOrigin.Type origin;
   output Algorithm alg;
 algorithm
-  alg := Algorithm.ALGORITHM(instStatements(algorithmSection.statements, scope),
+  alg := Algorithm.ALGORITHM(instStatements(algorithmSection.statements, scope, origin),
                              DAE.emptyElementSource);
 end instAlgorithmSection;
 
 function instStatements
   input list<SCode.Statement> scodeStmtl;
   input InstNode scope;
+  input ExpOrigin.Type origin;
   output list<Statement> statements;
 algorithm
-  statements := list(instStatement(stmt, scope) for stmt in scodeStmtl);
+  statements := list(instStatement(stmt, scope, origin) for stmt in scodeStmtl);
 end instStatements;
 
 function instStatement
   input SCode.Statement scodeStmt;
   input InstNode scope;
+  input ExpOrigin.Type origin;
   output Statement statement;
 algorithm
   statement := match scodeStmt
@@ -2557,6 +2571,7 @@ algorithm
       list<tuple<Expression, list<Statement>>> branches;
       SourceInfo info;
       InstNode for_scope, iter;
+      ExpOrigin.Type next_origin;
 
     case SCode.Statement.ALG_ASSIGN(info = info)
       algorithm
@@ -2569,21 +2584,24 @@ algorithm
       algorithm
         oexp := instExpOpt(scodeStmt.range, scope, info);
         (for_scope, iter) := addIteratorToScope(scodeStmt.index, scope, info);
-        stmtl := instStatements(scodeStmt.forBody, for_scope);
+        next_origin := intBitOr(origin, ExpOrigin.FOR);
+        stmtl := instStatements(scodeStmt.forBody, for_scope, next_origin);
       then
         Statement.FOR(iter, oexp, stmtl, makeSource(scodeStmt.comment, info));
 
     case SCode.Statement.ALG_IF(info = info)
       algorithm
         branches := {};
+        next_origin := intBitOr(origin, ExpOrigin.FOR);
+
         for branch in (scodeStmt.boolExpr, scodeStmt.trueBranch) :: scodeStmt.elseIfBranch loop
           exp1 := instExp(Util.tuple21(branch), scope, info);
-          stmtl := instStatements(Util.tuple22(branch), scope);
+          stmtl := instStatements(Util.tuple22(branch), scope, next_origin);
           branches := (exp1, stmtl) :: branches;
         end for;
 
         if not listEmpty(scodeStmt.elseBranch) then
-          stmtl := instStatements(scodeStmt.elseBranch, scope);
+          stmtl := instStatements(scodeStmt.elseBranch, scope, next_origin);
           branches := (Expression.BOOLEAN(true), stmtl) :: branches;
         end if;
       then
@@ -2591,10 +2609,21 @@ algorithm
 
     case SCode.Statement.ALG_WHEN_A(info = info)
       algorithm
+        if origin > 0 then
+          if intBitAnd(origin, ExpOrigin.WHEN) > 0 then
+            Error.addSourceMessageAndFail(Error.NESTED_WHEN, {}, info);
+          elseif intBitAnd(origin, ExpOrigin.INITIAL) > 0 then
+            Error.addSourceMessageAndFail(Error.INITIAL_WHEN, {}, info);
+          else
+            Error.addSourceMessageAndFail(Error.INVALID_WHEN_STATEMENT_CONTEXT, {}, info);
+          end if;
+        end if;
+
         branches := {};
         for branch in scodeStmt.branches loop
           exp1 := instExp(Util.tuple21(branch), scope, info);
-          stmtl := instStatements(Util.tuple22(branch), scope);
+          next_origin := intBitOr(origin, ExpOrigin.WHEN);
+          stmtl := instStatements(Util.tuple22(branch), scope, next_origin);
           branches := (exp1, stmtl) :: branches;
         end for;
       then
@@ -2629,7 +2658,8 @@ algorithm
     case SCode.Statement.ALG_WHILE(info = info)
       algorithm
         exp1 := instExp(scodeStmt.boolExpr, scope, info);
-        stmtl := instStatements(scodeStmt.whileBody, scope);
+        next_origin := intBitOr(origin, ExpOrigin.WHILE);
+        stmtl := instStatements(scodeStmt.whileBody, scope, next_origin);
       then
         Statement.WHILE(exp1, stmtl, makeSource(scodeStmt.comment, info));
 
@@ -2641,7 +2671,7 @@ algorithm
 
     case SCode.Statement.ALG_FAILURE()
       algorithm
-        stmtl := instStatements(scodeStmt.stmts, scope);
+        stmtl := instStatements(scodeStmt.stmts, scope, origin);
       then
         Statement.FAILURE(stmtl, makeSource(scodeStmt.comment, scodeStmt.info));
 
@@ -2747,38 +2777,24 @@ algorithm
   end if;
 end insertGeneratedInners;
 
-function markStructuralParams
+function updateImplicitVariability
   input InstNode node;
 protected
   Class cls = InstNode.getClass(node);
   ClassTree cls_tree;
-  Sections sections;
 algorithm
   () := match cls
-    case Class.INSTANCED_CLASS(elements = cls_tree as ClassTree.FLAT_TREE(),
-                               sections = sections)
+    case Class.INSTANCED_CLASS(elements = cls_tree as ClassTree.FLAT_TREE())
       algorithm
         for c in cls_tree.components loop
           if not InstNode.isEmpty(c) then
-            markStructuralParamsComp(c);
+            updateImplicitVariabilityComp(c);
           end if;
         end for;
 
-        () := match sections
-          case Sections.SECTIONS()
-            algorithm
-              for eq in sections.equations loop
-                markStructuralParamsEq(eq);
-              end for;
-
-              for ieq in sections.initialEquations loop
-                markStructuralParamsEq(ieq);
-              end for;
-            then
-              ();
-
-          else ();
-        end match;
+        Sections.apply(cls.sections,
+          function updateImplicitVariabilityEq(inWhen = false),
+          updateImplicitVariabilityAlg);
       then
         ();
 
@@ -2788,15 +2804,15 @@ algorithm
           markStructuralParamsDim(dim);
         end for;
 
-        markStructuralParams(cls.baseClass);
+        updateImplicitVariability(cls.baseClass);
       then
         ();
 
     else ();
   end match;
-end markStructuralParams;
+end updateImplicitVariability;
 
-function markStructuralParamsComp
+function updateImplicitVariabilityComp
   input InstNode component;
 protected
   Component c = InstNode.component(InstNode.resolveOuter(component));
@@ -2808,13 +2824,13 @@ algorithm
           markStructuralParamsDim(dim);
         end for;
 
-        markStructuralParams(c.classInst);
+        updateImplicitVariability(c.classInst);
       then
         ();
 
     else ();
   end match;
-end markStructuralParamsComp;
+end updateImplicitVariabilityComp;
 
 function markStructuralParamsDim
   input Dimension dimension;
@@ -2838,14 +2854,12 @@ end markStructuralParamsDim;
 
 function markStructuralParamsExp
   input Expression exp;
-  input output Integer dummy = 0;
 algorithm
-  Expression.fold(exp, markStructuralParamsExp_traverser, dummy);
+  Expression.apply(exp, markStructuralParamsExp_traverser);
 end markStructuralParamsExp;
 
 function markStructuralParamsExp_traverser
   input Expression exp;
-  input output Integer dummy;
 algorithm
   () := match exp
     local
@@ -2875,12 +2889,32 @@ algorithm
   end match;
 end markStructuralParamsExp_traverser;
 
-function markStructuralParamsEq
+function updateImplicitVariabilityEql
+  input list<Equation> eql;
+  input Boolean inWhen = false;
+algorithm
+  for eq in eql loop
+    updateImplicitVariabilityEq(eq, inWhen);
+  end for;
+end updateImplicitVariabilityEql;
+
+function updateImplicitVariabilityEq
   input Equation eq;
+  input Boolean inWhen = false;
 algorithm
   () := match eq
     local
       Expression exp;
+      list<Equation> eql;
+      Boolean all_params;
+
+    case Equation.EQUALITY()
+      algorithm
+        if inWhen then
+          markImplicitWhenExp(eq.lhs);
+        end if;
+      then
+        ();
 
     case Equation.CONNECT()
       algorithm
@@ -2889,23 +2923,114 @@ algorithm
       then
         ();
 
+    case Equation.FOR()
+      algorithm
+        updateImplicitVariabilityEql(eq.body, inWhen);
+      then
+        ();
+
     case Equation.IF()
       algorithm
-        for branch in eq.branches loop
-          (exp, _) := branch;
+        all_params := true;
 
-          if Expression.variability(exp) == Variability.PARAMETER then
+        for branch in eq.branches loop
+          (exp, eql) := branch;
+
+          if all_params and Expression.variability(exp) == Variability.PARAMETER then
             markStructuralParamsExp(exp);
           else
-            return;
+            all_params := false;
           end if;
+
+          updateImplicitVariabilityEql(eql);
+        end for;
+      then
+        ();
+
+    case Equation.WHEN()
+      algorithm
+        for branch in eq.branches loop
+          (_, eql) := branch;
+          updateImplicitVariabilityEql(eql, inWhen = true);
         end for;
       then
         ();
 
     else ();
   end match;
-end markStructuralParamsEq;
+end updateImplicitVariabilityEq;
+
+function updateImplicitVariabilityAlg
+  input Algorithm alg;
+algorithm
+  updateImplicitVariabilityStmts(alg.statements);
+end updateImplicitVariabilityAlg;
+
+function updateImplicitVariabilityStmts
+  input list<Statement> stmtl;
+  input Boolean inWhen = false;
+algorithm
+  for s in stmtl loop
+    updateImplicitVariabilityStmt(s, inWhen);
+  end for;
+end updateImplicitVariabilityStmts;
+
+function updateImplicitVariabilityStmt
+  input Statement stmt;
+  input Boolean inWhen;
+algorithm
+  () := match stmt
+    case Statement.ASSIGNMENT()
+      algorithm
+        if inWhen then
+          markImplicitWhenExp(stmt.lhs);
+        end if;
+      then
+        ();
+
+    case Statement.FOR()
+      algorithm
+        // 'when' is not allowed in 'for', so we only need to keep going if
+        // we're already in a 'when'.
+        if inWhen then
+          updateImplicitVariabilityStmts(stmt.body);
+        end if;
+      then
+        ();
+
+    case Statement.IF()
+      algorithm
+        // 'when' is not allowed in 'if', so we only need to keep going if
+        // we're already in a 'when.
+        if inWhen then
+          for branch in stmt.branches loop
+            updateImplicitVariabilityStmts(Util.tuple22(branch));
+          end for;
+        end if;
+      then
+        ();
+
+    case Statement.WHEN()
+      algorithm
+        for branch in stmt.branches loop
+          updateImplicitVariabilityStmts(Util.tuple22(branch), true);
+        end for;
+      then
+        ();
+
+    case Statement.WHILE()
+      algorithm
+        // 'when' is not allowed in 'while', so we only need to keep going if
+        // we're already in a 'when.
+        if inWhen then
+          updateImplicitVariabilityStmts(stmt.body);
+        end if;
+      then
+        ();
+
+    else ();
+  end match;
+end updateImplicitVariabilityStmt;
 
 function markStructuralParamsSubs
   input Expression exp;
@@ -2927,12 +3052,44 @@ function markStructuralParamsSub
   input output Integer dummy;
 algorithm
   () := match sub
-    case Subscript.UNTYPED() algorithm markStructuralParamsExp(sub.exp); then ();
-    case Subscript.INDEX() algorithm markStructuralParamsExp(sub.index); then ();
-    case Subscript.SLICE() algorithm markStructuralParamsExp(sub.slice); then ();
+      case Subscript.UNTYPED() algorithm markStructuralParamsExp(sub.exp); then ();
+      case Subscript.INDEX() algorithm markStructuralParamsExp(sub.index); then ();
+      case Subscript.SLICE() algorithm markStructuralParamsExp(sub.slice); then ();
     else ();
   end match;
 end markStructuralParamsSub;
+
+function markImplicitWhenExp
+  input Expression exp;
+algorithm
+  Expression.apply(exp, markImplicitWhenExp_traverser);
+end markImplicitWhenExp;
+
+function markImplicitWhenExp_traverser
+  input Expression exp;
+algorithm
+  () := match exp
+    local
+      InstNode node;
+      Component comp;
+
+    case Expression.CREF(cref = ComponentRef.CREF(node = node))
+      algorithm
+        if InstNode.isComponent(node) then
+          comp := InstNode.component(node);
+
+          if Component.variability(comp) == Variability.CONTINUOUS then
+            comp := Component.setVariability(Variability.IMPLICITLY_DISCRETE, comp);
+            InstNode.updateComponent(comp, node);
+          end if;
+        end if;
+      then
+        ();
+
+    else ();
+  end match;
+end markImplicitWhenExp_traverser;
+
 
 annotation(__OpenModelica_Interface="frontend");
 end NFInst;

--- a/Compiler/NFFrontEnd/NFSections.mo
+++ b/Compiler/NFFrontEnd/NFSections.mo
@@ -215,6 +215,46 @@ public
     end match;
   end map1;
 
+  function apply
+    input Sections sections;
+    input EquationFn eqFn;
+    input AlgorithmFn algFn;
+    input EquationFn ieqFn = eqFn;
+    input AlgorithmFn ialgFn = algFn;
+
+    partial function EquationFn
+      input Equation eq;
+    end EquationFn;
+
+    partial function AlgorithmFn
+      input Algorithm alg;
+    end AlgorithmFn;
+  algorithm
+    () := match sections
+      case SECTIONS()
+        algorithm
+          for eq in sections.equations loop
+            eqFn(eq);
+          end for;
+
+          for ieq in sections.initialEquations loop
+            ieqFn(ieq);
+          end for;
+
+          for alg in sections.algorithms loop
+            algFn(alg);
+          end for;
+
+          for ialg in sections.initialAlgorithms loop
+            ialgFn(ialg);
+          end for;
+        then
+          ();
+
+      else ();
+    end match;
+  end apply;
+
   function isEmpty
     input Sections sections;
     output Boolean isEmpty;

--- a/Compiler/NFFrontEnd/NFStatement.mo
+++ b/Compiler/NFFrontEnd/NFStatement.mo
@@ -143,6 +143,63 @@ public
     output SourceInfo info = ElementSource.getInfo(source(stmt));
   end info;
 
+  partial function ApplyFn
+    input Statement stmt;
+  end ApplyFn;
+
+  function apply
+    input Statement stmt;
+    input ApplyFn func;
+  algorithm
+    () := match stmt
+      case FOR()
+        algorithm
+          for e in stmt.body loop
+            apply(e, func);
+          end for;
+        then
+          ();
+
+      case IF()
+        algorithm
+          for b in stmt.branches loop
+            for e in Util.tuple22(b) loop
+              apply(e, func);
+            end for;
+          end for;
+        then
+          ();
+
+      case WHEN()
+        algorithm
+          for b in stmt.branches loop
+            for e in Util.tuple22(b) loop
+              apply(e, func);
+            end for;
+          end for;
+        then
+          ();
+
+      case WHILE()
+        algorithm
+          for e in stmt.body loop
+            apply(e, func);
+          end for;
+        then
+          ();
+
+      case FAILURE()
+        algorithm
+          for e in stmt.body loop
+            apply(e, func);
+          end for;
+        then
+          ();
+    end match;
+
+    func(stmt);
+  end apply;
+
   function mapExpList
     input output list<Statement> stmtl;
     input MapFunc func;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -111,24 +111,26 @@ package ExpOrigin
   type Type = Integer;
 
   // Flag values:
-  constant Type CLASS           = 0;     // In class.
-  constant Type FUNCTION        = 1;     // In function.
-  constant Type ALGORITHM       = 2;     // In algorithm section.
-  constant Type EQUATION        = 4;     // In equation section.
-  constant Type INITIAL         = 8;     // In initial section.
-  constant Type LHS             = 16;    // On left hand side of equality/assignment.
-  constant Type RHS             = 32;    // On right hand side of equality/assignment.
-  constant Type WHEN            = 64;    // In when equation/statement.
-  constant Type FOR_LOOP        = 128;   // In a for loop.
-  constant Type NONEXPANDABLE   = 256;   // In non-parameter if/for.
-  constant Type ITERATION_RANGE = 512;   // In range used for iteration.
-  constant Type DIMENSION       = 1024;  // In dimension.
-  constant Type BINDING         = 2048;  // In binding.
-  constant Type CONDITION       = 4096;  // In conditional expression.
-  constant Type SUBSCRIPT       = 8192;  // In subscript.
-  constant Type SUBEXPRESSION   = 16384; // Part of a larger expression.
-  constant Type CONNECT         = 32768; // Part of connect argument.
-  constant Type NOEVENT         = 65536; // Part of noEvent argument.
+  constant Type CLASS           = 0;                   // In class.
+  constant Type FUNCTION        = intBitLShift(1,  0); // In function.
+  constant Type ALGORITHM       = intBitLShift(1,  1); // In algorithm section.
+  constant Type EQUATION        = intBitLShift(1,  2); // In equation section.
+  constant Type INITIAL         = intBitLShift(1,  3); // In initial section.
+  constant Type LHS             = intBitLShift(1,  4); // On left hand side of equality/assignment.
+  constant Type RHS             = intBitLShift(1,  5); // On right hand side of equality/assignment.
+  constant Type WHEN            = intBitLShift(1,  6); // In when equation/statement.
+  constant Type FOR             = intBitLShift(1,  7); // In a for loop.
+  constant Type IF              = intBitLShift(1,  8); // In an if equation/statement.
+  constant Type WHILE           = intBitLShift(1,  9); // In a while loop.
+  constant Type NONEXPANDABLE   = intBitLShift(1, 10); // In non-parameter if/for.
+  constant Type ITERATION_RANGE = intBitLShift(1, 11); // In range used for iteration.
+  constant Type DIMENSION       = intBitLShift(1, 12); // In dimension.
+  constant Type BINDING         = intBitLShift(1, 13); // In binding.
+  constant Type CONDITION       = intBitLShift(1, 14); // In conditional expression.
+  constant Type SUBSCRIPT       = intBitLShift(1, 15); // In subscript.
+  constant Type SUBEXPRESSION   = intBitLShift(1, 16); // Part of a larger expression.
+  constant Type CONNECT         = intBitLShift(1, 17); // Part of connect argument.
+  constant Type NOEVENT         = intBitLShift(1, 18); // Part of noEvent argument.
 
   // Combined flags:
   constant Type EQ_SUBEXPRESSION = intBitOr(EQUATION, SUBEXPRESSION);
@@ -2235,7 +2237,7 @@ algorithm
           fail();
         end if;
 
-        next_origin := intBitOr(origin, ExpOrigin.FOR_LOOP);
+        next_origin := intBitOr(origin, ExpOrigin.FOR);
         body := list(typeEquation(e, next_origin) for e in eq.body);
       then
         Equation.FOR(eq.iterator, SOME(e1), body, eq.source);
@@ -2461,7 +2463,7 @@ algorithm
           fail();
         end if;
 
-        next_origin := intBitOr(origin, ExpOrigin.FOR_LOOP);
+        next_origin := intBitOr(origin, ExpOrigin.FOR);
         body := typeStatements(st.body, next_origin);
       then
         Statement.FOR(st.iterator, SOME(e1), body, st.source);

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -797,6 +797,8 @@ public constant Message EVAL_RECURSION_LIMIT_REACHED = MESSAGE(334, TRANSLATION(
   Util.gettext("The recursion limit (--evalRecursionLimit=%s) was exceeded during evaluation of %s."));
 public constant Message UNASSIGNED_FUNCTION_OUTPUT = MESSAGE(335, TRANSLATION(), ERROR(),
   Util.gettext("Output parameter %s was not assigned a value"));
+public constant Message INVALID_WHEN_STATEMENT_CONTEXT = MESSAGE(336, TRANSLATION(), ERROR(),
+  Util.gettext("A when-statement may not be used inside a function or a while, if, or for-clause."));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),


### PR DESCRIPTION
- Replace NFInst.EquationScope with ExpOrigin.
- Extend the structural parameter marking phase to also mark variables
  assigned in 'when' as implicitly discrete.
- Add more error checking for how 'when' is used.