### PR TITLE
[NF] Use correct call attributes everywhere.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -298,36 +298,8 @@ public
     // We have all except dimension n having equal sizes; with matching types
 
     ty := resTy;
-    callExp := Expression.CALL(makeCall2(NFBuiltinFuncs.CAT, Expression.INTEGER(n)::res, resTy, variability));
+    callExp := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.CAT, Expression.INTEGER(n)::res, variability, resTy));
   end makeCatExp;
-
-  function makeCall
-    "Creates a call to a builtin function, given a Function and a list of
-     argument expressions."
-    input Function func;
-    input list<Expression> args;
-    input Variability var;
-    output Call call;
-  algorithm
-    call := Call.TYPED_CALL(func, func.returnType, var, args,
-      CallAttributes.CALL_ATTR(func.returnType, false, true, false, false,
-        DAE.NO_INLINE(), DAE.NO_TAIL()));
-  end makeCall;
-
-  function makeCall2
-    "Creates a call to a builtin function, given a Function, list of argument
-     expressions and a return type. Used for builtin functions defined with no
-     return type."
-    input Function func;
-    input list<Expression> args;
-    input Type returnType;
-    input Variability var;
-    output Call call;
-  algorithm
-    call := Call.TYPED_CALL(func, returnType, var, args,
-      CallAttributes.CALL_ATTR(returnType, false, true, false, false,
-        DAE.NO_INLINE(), DAE.NO_TAIL()));
-  end makeCall2;
 
 protected
   function assertNoNamedParams
@@ -432,13 +404,11 @@ protected
       end for;
 
       callExp := Expression.CALL(
-        Call.TYPED_CALL(
+        Call.makeTypedCall(
           matchedFunc.func,
-          outType,
-          var,
           list(Util.tuple31(a) for a in matchedFunc.args),
-          CallAttributes.CALL_ATTR(outType, false, false, false, false, DAE.NO_INLINE(),DAE.NO_TAIL()))
-      );
+          var,
+          outType));
       return;
     else
       Error.addSourceMessage(Error.AMBIGUOUS_MATCHING_FUNCTIONS_NFINST,
@@ -564,7 +534,7 @@ protected
     end if;
 
     {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, var));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, var, ty));
   end typePreChangeCall;
 
   function typeDerCall
@@ -611,7 +581,7 @@ protected
     end if;
 
     {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, variability));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, ty));
   end typeDerCall;
 
   function typeDiagonalCall
@@ -653,7 +623,7 @@ protected
     end match;
 
     {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, variability));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, ty));
   end typeDiagonalCall;
 
   function typeEdgeCall
@@ -783,7 +753,7 @@ protected
     end if;
 
     {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(makeCall2(fn, {arg1, arg2}, ty, var));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg1, arg2}, var, ty));
   end typeSmoothCall;
 
   function typeFillCall
@@ -866,7 +836,7 @@ protected
     if variability <= Variability.STRUCTURAL_PARAMETER and intBitAnd(origin, ExpOrigin.FUNCTION) == 0 then
       callExp := Ceval.evalBuiltinFill(ty_args);
     else
-      callExp := Expression.CALL(makeCall2(NFBuiltinFuncs.FILL_FUNC, ty_args, ty, variability));
+      callExp := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.FILL_FUNC, ty_args, variability, ty));
     end if;
   end typeFillCall2;
 
@@ -932,7 +902,7 @@ protected
 
     ty := Type.arrayElementType(ty);
     {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, variability));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, ty));
   end typeScalarCall;
 
   function typeVectorCall
@@ -986,7 +956,7 @@ protected
 
     ty := Type.ARRAY(Type.arrayElementType(ty), {Dimension.fromInteger(dim_size)});
     {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, variability));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, ty));
   end typeVectorCall;
 
   function typeMatrixCall
@@ -1042,7 +1012,7 @@ protected
 
     ty := Type.ARRAY(Type.arrayElementType(ty), dims);
     {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, variability));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, ty));
   end typeMatrixCall;
 
   function typeCatCall
@@ -1125,7 +1095,7 @@ protected
     end if;
 
     {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, variability));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, ty));
   end typeSymmetricCall;
 
   function typeTransposeCall
@@ -1168,7 +1138,7 @@ protected
     end match;
 
     {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, variability));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, ty));
   end typeTransposeCall;
 
   function typeCardinalityCall
@@ -1213,7 +1183,7 @@ protected
 
     {fn} := Function.typeRefCache(fn_ref);
     ty := Type.INTEGER();
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, var));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, var, ty));
     // TODO: Check cardinality restrictions, 3.7.2.3.
   end typeCardinalityCall;
 
@@ -1253,7 +1223,7 @@ protected
 
     {fn} := Function.typeRefCache(fn_ref);
     ty := Type.NORETCALL();
-    callExp := Expression.CALL(makeCall2(fn, {arg1, arg2}, ty, var));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg1, arg2}, var, ty));
   end typeBranchCall;
 
   function typeIsRootCall
@@ -1288,7 +1258,7 @@ protected
 
     {fn} := Function.typeRefCache(fn_ref);
     ty := Type.BOOLEAN();
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, var));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, var, ty));
   end typeIsRootCall;
 
   function typePotentialRootCall
@@ -1351,7 +1321,7 @@ protected
 
     {fn} := Function.typeRefCache(fn_ref);
     ty := Type.NORETCALL();
-    callExp := Expression.CALL(makeCall2(fn, {arg1, arg2}, ty, var));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg1, arg2}, var, ty));
   end typePotentialRootCall;
 
   function typeRootCall
@@ -1386,7 +1356,7 @@ protected
 
     {fn} := Function.typeRefCache(fn_ref);
     ty := Type.NORETCALL();
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, var));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, var, ty));
   end typeRootCall;
 
   function typeRootedCall
@@ -1421,7 +1391,7 @@ protected
 
     {fn} := Function.typeRefCache(fn_ref);
     ty := Type.BOOLEAN();
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, var));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, var, ty));
   end typeRootedCall;
 
   function checkConnectionsArgument
@@ -1497,7 +1467,7 @@ protected
     (arg, ty, variability) := Typing.typeExp(arg, intBitOr(origin, ExpOrigin.NOEVENT), info);
 
     {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(makeCall2(fn, {arg}, ty, variability));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, ty));
   end typeNoEventCall;
 
   function typeGetInstanceName

--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -275,8 +275,8 @@ uniontype Call
   function makeTypedCall
     input Function fn;
     input list<Expression> args;
-    input Type returnType;
     input Variability variability;
+    input Type returnType = fn.returnType;
     output Call call;
   protected
     CallAttributes ca;
@@ -357,7 +357,7 @@ uniontype Call
       ty := evaluateCallType(ty, func, args);
     end if;
 
-    call := makeTypedCall(func, args, ty, var);
+    call := makeTypedCall(func, args, var, ty);
 
     // If the matching was a vectorized one then create a map call
     // using the vectorization dim. This means going through each argument

--- a/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -210,7 +210,7 @@ algorithm
     // Modelica doesn't allow == for Reals, so to keep the flat Modelica
     // somewhat valid we use 'abs(lhs - rhs) <= 0' instead.
     exp := Expression.BINARY(lhs_exp, Operator.makeSub(ty), rhs_exp);
-    exp := Expression.CALL(BuiltinCall.makeCall(NFBuiltinFuncs.ABS_REAL, {exp}, Expression.variability(exp)));
+    exp := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.ABS_REAL, {exp}, Expression.variability(exp)));
     exp := Expression.RELATION(exp, Operator.makeLessEq(ty), Expression.REAL(0.0));
   else
     // For any other type, generate assertion for 'lhs == rhs'.
@@ -510,7 +510,7 @@ function makeInStreamCall
   output Expression inStreamCall;
   annotation(__OpenModelica_EarlyInline = true);
 algorithm
-  inStreamCall := Expression.CALL(BuiltinCall.makeCall(
+  inStreamCall := Expression.CALL(Call.makeTypedCall(
     NFBuiltinFuncs.IN_STREAM, {streamExp}, Expression.variability(streamExp)));
 end makeInStreamCall;
 
@@ -535,7 +535,7 @@ algorithm
     flow_threshold := flowThreshold;
   end if;
 
-  positiveMaxCall := Expression.CALL(BuiltinCall.makeCall(NFBuiltinFuncs.POSITIVE_MAX_REAL,
+  positiveMaxCall := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.POSITIVE_MAX_REAL,
     {flowExp, flow_threshold}, Connector.variability(element)));
 
   setGlobalRoot(Global.isInStream, SOME(true));

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -3105,8 +3105,8 @@ public
       // An expression with array type, but which is not an array expression.
       // Such an expression can't be promoted here, so we create a promote call instead.
       case (_, _) guard isArray
-        then CALL(BuiltinCall.makeCall2(
-          NFBuiltinFuncs.PROMOTE, {exp, INTEGER(dims)}, listHead(types), variability(exp)));
+        then CALL(Call.makeTypedCall(
+          NFBuiltinFuncs.PROMOTE, {exp, INTEGER(dims)}, variability(exp), listHead(types)));
 
       // A scalar expression, promote it as many times as the number of types given.
       else
@@ -3264,7 +3264,7 @@ public
   algorithm
     indexExp := match enumExp
       case ENUM_LITERAL() then INTEGER(enumExp.index);
-      else CALL(BuiltinCall.makeCall(
+      else CALL(Call.makeTypedCall(
         NFBuiltinFuncs.INTEGER_ENUM, {enumExp}, variability(enumExp)));
     end match;
   end enumIndexExp;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -981,7 +981,7 @@ algorithm
         next_origin := intBitOr(origin, ExpOrigin.SUBEXPRESSION);
         (e1, ty1, var1) := typeExp(exp.exp1, next_origin, info);
         (e2, ty2, var2) := typeExp(exp.exp2, next_origin, info);
-        (exp, ty) := TypeCheck.checkBinaryOperation(e1, ty1, exp.operator, e2, ty2, info);
+        (exp, ty) := TypeCheck.checkBinaryOperation(e1, ty1, var1, exp.operator, e2, ty2, var2, info);
       then
         (exp, ty, Prefixes.variabilityMax(var1, var2));
 
@@ -989,7 +989,7 @@ algorithm
       algorithm
         next_origin := intBitOr(origin, ExpOrigin.SUBEXPRESSION);
         (e1, ty1, var1) := typeExp(exp.exp, next_origin, info);
-        (exp, ty) := TypeCheck.checkUnaryOperation(e1, ty1, exp.operator, info);
+        (exp, ty) := TypeCheck.checkUnaryOperation(e1, ty1, var1, exp.operator, info);
       then
         (exp, ty, var1);
 
@@ -998,7 +998,7 @@ algorithm
         next_origin := intBitOr(origin, ExpOrigin.SUBEXPRESSION);
         (e1, ty1, var1) := typeExp(exp.exp1, next_origin, info);
         (e2, ty2, var2) := typeExp(exp.exp2, next_origin, info);
-        (exp, ty) := TypeCheck.checkLogicalBinaryOperation(e1, ty1, exp.operator, e2, ty2, info);
+        (exp, ty) := TypeCheck.checkLogicalBinaryOperation(e1, ty1, var1, exp.operator, e2, ty2, var2, info);
       then
         (exp, ty, Prefixes.variabilityMax(var1, var2));
 
@@ -1006,7 +1006,7 @@ algorithm
       algorithm
         next_origin := intBitOr(origin, ExpOrigin.SUBEXPRESSION);
         (e1, ty1, var1) := typeExp(exp.exp, next_origin, info);
-        (exp, ty) := TypeCheck.checkLogicalUnaryOperation(e1, ty1, exp.operator, info);
+        (exp, ty) := TypeCheck.checkLogicalUnaryOperation(e1, ty1, var1, exp.operator, info);
       then
         (exp, ty, var1);
 
@@ -1015,7 +1015,7 @@ algorithm
         next_origin := intBitOr(origin, ExpOrigin.SUBEXPRESSION);
         (e1, ty1, var1) := typeExp(exp.exp1, next_origin, info);
         (e2, ty2, var2) := typeExp(exp.exp2, next_origin, info);
-        (exp, ty) := TypeCheck.checkRelationOperation(e1, ty1, exp.operator, e2, ty2, origin, info);
+        (exp, ty) := TypeCheck.checkRelationOperation(e1, ty1, var1, exp.operator, e2, ty2, var2, origin, info);
         variability := Prefixes.variabilityMax(var1, var2);
 
         // A relation involving continuous expressions which is not inside


### PR DESCRIPTION
- Use Call.makeTypedCall everywhere a typed call is created, so that
  the calls get the correct attributes.
- Use correct variability for overloaded unary and binary operators.