### PR TITLE
[NF] Handle unassigned record field better.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -381,7 +381,7 @@ protected
       fail();
     end try;
 
-    fn_ref := Function.instFuncRef(fn_ref, InstNode.info(recopnode));
+    fn_ref := Function.instFunctionRef(fn_ref, InstNode.info(recopnode));
     candidates := Function.typeRefCache(fn_ref);
     for fn in candidates loop
       TypeCheck.checkValidOperatorOverload("'String'", fn, recopnode);

--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -666,8 +666,9 @@ protected
       // If it had iterators then it will not reach here. The args would have been parsed to
       // Absyn.FOR_ITER_FARG and that is handled in instIteratorCall.
       case "array" then BuiltinCall.makeArrayExp(args, named_args, info);
-      else algorithm
-        (fn_ref, _, _) := Function.instFunc(functionName,scope,info);
+      else
+        algorithm
+          fn_ref := Function.instFunction(functionName,scope,info);
         then
           Expression.CALL(UNTYPED_CALL(fn_ref, args, named_args, scope));
     end match;
@@ -744,14 +745,14 @@ protected
 
       // wrap the array call in the given function
       // e.g. sum(array(i for i in ...)).
-      fn_ref := Function.instFunc(functionName, scope, info);
+      fn_ref := Function.instFunction(functionName, scope, info);
       call := UNTYPED_CALL(fn_ref, {Expression.CALL(call)}, {}, scope);
     else
       // Otherwise, make an array call with the original function call as an argument.
       // But only if the original function is not array() itself.
       // e.g. Change myfunc(i for i in ...) TO array(myfunc(i) for i in ...).
       if not is_array then
-        fn_ref := Function.instFunc(functionName, scope, info);
+      fn_ref := Function.instFunction(functionName, scope, info);
         call := UNTYPED_CALL(fn_ref, {exp}, {}, scope);
         exp := Expression.CALL(call);
       end if;

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -3225,6 +3225,16 @@ public
     end match;
   end isMutable;
 
+  function isEmpty
+    input Expression exp;
+    output Boolean empty;
+  algorithm
+    empty := match exp
+      case EMPTY() then true;
+      else false;
+    end match;
+  end isEmpty;
+
   function lookupRecordField
     input String name;
     input Expression exp;

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -350,7 +350,14 @@ algorithm
   var := Binding.variability(binding);
 
   recordBindings := match binding_exp
-    case Expression.RECORD() then list(Binding.FLAT_BINDING(e, var) for e in binding_exp.elements);
+    case Expression.RECORD() then
+      list(if Expression.isEmpty(e) then
+               // The binding for a record field might be Expression.EMPTY if it comes
+               // from an evaluated function call where it wasn't assigned a value.
+               NFBinding.EMPTY_BINDING
+             else
+               Binding.FLAT_BINDING(e, var)
+           for e in binding_exp.elements);
     else
       algorithm
         Error.assertion(false, getInstanceName() + " got non-record binding " +

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -857,8 +857,8 @@ algorithm
 
   if not (InstNode.isClass(par) and Class.isExternalObject(InstNode.getClass(par))) then
     Type.COMPLEX(complexTy = ComplexType.EXTERNAL_OBJECT(constructor, destructor)) := ty;
-    Function.instFuncNode(constructor);
-    Function.instFuncNode(destructor);
+    Function.instFunctionNode(constructor);
+    Function.instFunctionNode(destructor);
   end if;
 end instExternalObjectStructors;
 
@@ -2218,7 +2218,7 @@ function instCrefFunction
 protected
   ComponentRef fn_ref;
 algorithm
-  fn_ref := Function.instFuncRef(cref, info);
+  fn_ref := Function.instFunctionRef(cref, info);
   crefExp := Expression.CREF(Type.UNKNOWN(), fn_ref);
 end instCrefFunction;
 

--- a/Compiler/NFFrontEnd/NFRecord.mo
+++ b/Compiler/NFFrontEnd/NFRecord.mo
@@ -88,7 +88,7 @@ algorithm
 
   if ctor_defined then
     ctor_over := ComponentRef.node(con_ref);
-    ctor_over := Function.instFunc2(InstNode.scopePath(ctor_over, includeRoot = true), ctor_over, InstNode.info(ctor_over));
+    ctor_over := Function.instFunction2(InstNode.scopePath(ctor_over, includeRoot = true), ctor_over, InstNode.info(ctor_over));
     for f in Function.getCachedFuncs(ctor_over) loop
       node := InstNode.cacheAddFunc(node, f, false);
     end for;
@@ -105,7 +105,7 @@ algorithm
   if ctor_defined then
     ctor_over := ComponentRef.node(con_ref);
 
-    ctor_over := Function.instFunc2(InstNode.scopePath(ctor_over, includeRoot = true), ctor_over, InstNode.info(ctor_over));
+    ctor_over := Function.instFunction2(InstNode.scopePath(ctor_over, includeRoot = true), ctor_over, InstNode.info(ctor_over));
     for f in Function.getCachedFuncs(ctor_over) loop
       node := InstNode.cacheAddFunc(node, f, false);
     end for;
@@ -230,7 +230,7 @@ algorithm
         for i in arrayLength(mclss):-1:1 loop
           op := mclss[i];
           path := InstNode.scopePath(op);
-          Function.instFunc2(path, op, info);
+          Function.instFunction2(path, op, info);
           funcs := Function.getCachedFuncs(op);
           allfuncs := listAppend(allfuncs,funcs);
         end for;

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -203,7 +203,7 @@ algorithm
     end try;
 
     if oper_defined then
-      fn_ref := Function.instFuncRef(fn_ref, InstNode.info(node1));
+      fn_ref := Function.instFunctionRef(fn_ref, InstNode.info(node1));
       for fn in Function.typeRefCache(fn_ref) loop
         checkValidOperatorOverload(opstr, fn, node1);
         candidates := fn::candidates;
@@ -225,7 +225,7 @@ algorithm
         end try;
 
         if oper_defined then
-          fn_ref := Function.instFuncRef(fn_ref, InstNode.info(node2));
+          fn_ref := Function.instFunctionRef(fn_ref, InstNode.info(node2));
           for fn in Function.typeRefCache(fn_ref) loop
             checkValidOperatorOverload(opstr, fn, node2);
             candidates := fn::candidates;
@@ -310,14 +310,14 @@ algorithm
     if mk1 == MatchKind.EXACT then
       // We only want overloaded constructors when trying to implicitly construct. Default constructors are not considered.
       scope := InstNode.classScope(in2);
-      (fn_ref, _, _) := Function.instFunc(Absyn.CREF_IDENT("'constructor'",{}),scope,InstNode.info(in2));
+      fn_ref := Function.instFunction(Absyn.CREF_IDENT("'constructor'",{}),scope,InstNode.info(in2));
       exp2 := Expression.CALL(NFCall.UNTYPED_CALL(fn_ref, {inExp2}, {}, scope));
       (exp2, ty, var) := Call.typeCall(exp2, 0, InstNode.info(in1));
       matchedfuncs := (fn,{inExp1,exp2}, var)::matchedfuncs;
     elseif mk2 == MatchKind.EXACT then
       // We only want overloaded constructors when trying to implicitly construct. Default constructors are not considered.
       scope := InstNode.classScope(in1);
-      (fn_ref, _, _) := Function.instFunc(Absyn.CREF_IDENT("'constructor'",{}),scope,InstNode.info(in1));
+      fn_ref := Function.instFunction(Absyn.CREF_IDENT("'constructor'",{}),scope,InstNode.info(in1));
       exp1 := Expression.CALL(NFCall.UNTYPED_CALL(fn_ref, {inExp1}, {}, scope));
       (exp1, ty, var) := Call.typeCall(exp1, 0, InstNode.info(in2));
       matchedfuncs := (fn,{exp1,inExp2},var)::matchedfuncs;
@@ -860,7 +860,7 @@ algorithm
   Type.COMPLEX(cls=node1) := inType1;
 
   fn_ref := Function.lookupFunctionSimple(opstr, node1);
-  fn_ref := Function.instFuncRef(fn_ref, InstNode.info(node1));
+  fn_ref := Function.instFunctionRef(fn_ref, InstNode.info(node1));
   candidates := Function.typeRefCache(fn_ref);
   for fn in candidates loop
     checkValidOperatorOverload(opstr, fn, node1);


### PR DESCRIPTION
- Ignore record fields that are Expression.EMPTY in record expressions
  during flattening (such expressions can be created when evaluating a
  function that doesn't assign all fields of a record).
- Rename Function.instFunc => instFunction for consistency.