### PR TITLE
[NF] Evaluation improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -816,6 +816,7 @@ protected
     InstNode iter;
     list<Dimension> dims = {};
     list<tuple<InstNode, Expression>> iters = {};
+    ExpOrigin.Type next_origin;
   algorithm
     (call, ty, variability) := match call
       // This is always a call to the function array()/$array(). See instIteratorCall.
@@ -833,7 +834,9 @@ protected
           end for;
           iters := listReverseInPlace(iters);
 
-          (arg, ty) := Typing.typeExp(call.exp, origin, info);
+          // ExpOrigin.FOR is used here as a marker that this expression may contain iterators.
+          next_origin := intBitOr(origin, ExpOrigin.FOR);
+          (arg, ty) := Typing.typeExp(call.exp, next_origin, info);
           ty := Type.liftArrayLeftList(ty, dims);
         then
           (TYPED_MAP_CALL(ty, variability, arg, iters), ty, variability);

--- a/Compiler/NFFrontEnd/NFConnections.mo
+++ b/Compiler/NFFrontEnd/NFConnections.mo
@@ -80,6 +80,8 @@ public
     DAE.ElementSource source;
     list<Equation> eql = {};
     list<Connector> cl1, cl2;
+    Expression e1, e2;
+    Type ty1, ty2;
   algorithm
     // Collect all flow variables.
     for var in flatModel.variables loop
@@ -95,12 +97,14 @@ public
     // Collect all connects.
     for eq in flatModel.equations loop
       eql := match eq
-        case Equation.CONNECT(lhs = Expression.CREF(cref = lhs),
-                              rhs = Expression.CREF(cref = rhs), source = source)
+        case Equation.CONNECT(lhs = Expression.CREF(ty = ty1, cref = lhs),
+                              rhs = Expression.CREF(ty = ty2, cref = rhs), source = source)
           algorithm
             if not (ComponentRef.isDeleted(lhs) or ComponentRef.isDeleted(rhs)) then
-              cl1 := Connector.fromExp(ExpandExp.expand(eq.lhs), source);
-              cl2 := Connector.fromExp(ExpandExp.expand(eq.rhs), source);
+              e1 := Expression.CREF(ty1, ComponentRef.simplifySubscripts(lhs));
+              cl1 := Connector.fromExp(ExpandExp.expand(e1), source);
+              e2 := Expression.CREF(ty2, ComponentRef.simplifySubscripts(rhs));
+              cl2 := Connector.fromExp(ExpandExp.expand(e2), source);
 
               for c1 in cl1 loop
                 c2 :: cl2 := cl2;

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -700,7 +700,9 @@ algorithm
   Equation.FOR(iterator = iter, range = SOME(range), body = body) := forLoop;
 
   // Unroll the loop by replacing the iterator with each of its values in the for loop body.
+  range := Ceval.evalExp(range, Ceval.EvalTarget.RANGE(Equation.info(forLoop)));
   range_iter := RangeIterator.fromExp(range);
+
   while RangeIterator.hasNext(range_iter) loop
     (range_iter, val) := RangeIterator.next(range_iter);
     unrolled_body := list(Equation.mapExp(eq,

--- a/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -119,7 +119,7 @@ algorithm
 
         // Use Ceval for builtin pure functions with literal arguments.
         if builtin and not Function.isImpure(call.fn) and List.all(args, Expression.isLiteral) then
-          callExp := Ceval.evalBuiltinCall(call.fn, args, EvalTarget.IGNORE_ERRORS());
+          callExp := Ceval.evalCall(call, EvalTarget.IGNORE_ERRORS());
         else
           callExp := Expression.CALL(call);
         end if;

--- a/Compiler/NFFrontEnd/NFSimplifyModel.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyModel.mo
@@ -147,7 +147,7 @@ algorithm
       algorithm
         eq.condition := SimplifyExp.simplify(eq.condition);
       then
-        if Expression.isFalse(eq.condition) then equations else eq :: equations;
+        if Expression.isTrue(eq.condition) then equations else eq :: equations;
 
     case Equation.REINIT()
       algorithm

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -73,8 +73,7 @@ import NFCall.CallAttributes;
 import ComponentRef = NFComponentRef;
 import ErrorExt;
 import NFBuiltin;
-
-
+import SimplifyExp = NFSimplifyExp;
 
 public
 type MatchKind = enumeration(
@@ -1996,7 +1995,10 @@ algorithm
 
     // Ranges like 1:n have size n.
     case (Expression.INTEGER(1), NONE(), _)
-      then Dimension.fromExp(stopExp, Expression.variability(stopExp));
+      algorithm
+        dim_exp := SimplifyExp.simplify(stopExp);
+      then
+        Dimension.fromExp(dim_exp, Expression.variability(dim_exp));
 
     // Ranges like n:n have size 1.
     case (_, NONE(), _)
@@ -2017,8 +2019,9 @@ algorithm
           dim_exp := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.DIV_INT, {dim_exp, step_exp}, var));
         end if;
 
-        dim_exp := Expression.BINARY(dim_exp, Operator.makeSub(Type.INTEGER()), Expression.INTEGER(1));
-        dim_exp := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.MAX_INT, {dim_exp}, var));
+        dim_exp := Expression.BINARY(dim_exp, Operator.makeAdd(Type.INTEGER()), Expression.INTEGER(1));
+        dim_exp := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.MAX_INT, {dim_exp, Expression.INTEGER(0)}, var));
+        dim_exp := SimplifyExp.simplify(dim_exp);
       then
         Dimension.fromExp(dim_exp, var);
 
@@ -2071,6 +2074,7 @@ algorithm
         dim_exp := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.FLOOR, {dim_exp}, var));
         dim_exp := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.INTEGER_REAL, {dim_exp}, var));
         dim_exp := Expression.BINARY(dim_exp, Operator.makeAdd(Type.INTEGER()), Expression.INTEGER(1));
+        dim_exp := SimplifyExp.simplify(dim_exp);
       then
         Dimension.fromExp(dim_exp, var);
 
@@ -2111,6 +2115,7 @@ algorithm
               Expression.INTEGER(2),
               Expression.INTEGER(0)));
 
+          dim_exp := SimplifyExp.simplify(dim_exp);
           dim := Dimension.fromExp(dim_exp, var);
         end if;
       then
@@ -2153,6 +2158,7 @@ algorithm
             Operator.makeAdd( Type.INTEGER()),
             Expression.INTEGER(1));
 
+          dim_exp := SimplifyExp.simplify(dim_exp);
           dim := Dimension.fromExp(dim_exp, var);
         end if;
       then


### PR DESCRIPTION
- Guard against evaluating expressions containing iterators.
- Move evaluation of for-loop ranges to the unrolling phase, to make it
  possible to handle ranges with iterators in them.
- Handle evaluation of min/max of empty arrays.
- Fix SimplifyModel so that it removes assertions with condition true,
  not false.