### PR TITLE
[NF] Function output type fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -1122,7 +1122,7 @@ protected
           exp := Expression.map(dim.exp, function evaluateCallTypeDimExp(ptree = ptree));
           exp := Ceval.evalExp(exp, Ceval.EvalTarget.IGNORE_ERRORS());
         then
-          Dimension.fromExp(exp, dim.var);
+          Dimension.fromExp(exp, Variability.CONSTANT);
 
       else dim;
     end match;


### PR DESCRIPTION
- Set the variability of expression dimensions in function outputs to
  constant. This might not be strictly correct, but will cause fewer
  issues than using the actual variability of the output which isn't
  correct either.
- Evaluate function output dimensions too when evaluating functions.