### PR TITLE
[NF] Try harder.

### DIFF
--- a/Compiler/NFFrontEnd/NFExpressionIterator.mo
+++ b/Compiler/NFFrontEnd/NFExpressionIterator.mo
@@ -128,7 +128,7 @@ public
         then if binding.isEach then EACH_ITERATOR(binding.bindingExp) else fromExp(binding.bindingExp);
 
       case Binding.FLAT_BINDING()
-        then SCALAR_ITERATOR(binding.bindingExp);
+        then EACH_ITERATOR(binding.bindingExp);
     end match;
   end fromBinding;
 


### PR DESCRIPTION
- Allow FLAT_BINDINGs to repeat when using them with
  ExpressionIterator, to avoid having to create unnecessary arrays.