### PR TITLE
[NF] Operator overloading fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -884,6 +884,7 @@ uniontype Function
     input list<TypedArg> args;
     input list<TypedNamedArg> named_args;
     input SourceInfo info;
+    input Boolean vectorize = true;
     output list<TypedArg> out_args;
     output FunctionMatchKind matchKind = NO_MATCH;
   protected
@@ -895,7 +896,7 @@ uniontype Function
 
       // If we failed to match a function normally then we try to see if
       // we can have a vectorized match.
-      if not matched then
+      if not matched and vectorize then
         (out_args, matched, matchKind) := matchArgsVectorize(func, out_args, info);
       end if;
     end if;
@@ -906,6 +907,7 @@ uniontype Function
     input list<TypedArg> args;
     input list<TypedNamedArg> named_args;
     input SourceInfo info;
+    input Boolean vectorize = true;
     output list<MatchedFunction> matchedFunctions;
   protected
     list<TypedArg> m_args;
@@ -914,7 +916,7 @@ uniontype Function
   algorithm
     matchedFunctions := {};
     for func in funcs loop
-      (m_args, matchKind) := matchFunction(func, args, named_args, info);
+      (m_args, matchKind) := matchFunction(func, args, named_args, info, vectorize);
 
       if FunctionMatchKind.isValid(matchKind) then
         matchedFunctions := MatchedFunction.MATCHED_FUNC(func,m_args,matchKind)::matchedFunctions;
@@ -927,11 +929,12 @@ uniontype Function
     input list<TypedArg> args;
     input list<TypedNamedArg> named_args;
     input SourceInfo info;
+    input Boolean vectorize = true;
     output list<MatchedFunction> matchedFunctions;
   protected
   algorithm
     ErrorExt.setCheckpoint("NFFunction:matchFunctions");
-    matchedFunctions := matchFunctions(funcs, args, named_args, info);
+    matchedFunctions := matchFunctions(funcs, args, named_args, info, vectorize);
     ErrorExt.rollBack("NFFunction:matchFunctions");
   end matchFunctionsSilent;
 

--- a/Compiler/NFFrontEnd/NFOperatorOverloading.mo
+++ b/Compiler/NFFrontEnd/NFOperatorOverloading.mo
@@ -32,9 +32,10 @@
 encapsulated package NFOperatorOverloading
   import Absyn;
   import NFInstNode.InstNode;
+  import NFFunction.Function;
+  import Type = NFType;
 
 protected
-  import NFFunction.Function;
   import Record = NFRecord;
   import ComponentRef = NFComponentRef;
   import NFClassTree.ClassTree;
@@ -126,6 +127,38 @@ public
       fail();
     end if;
   end checkOperatorRestrictions;
+
+  function lookupOperatorFunctionsInType
+    input String operatorName;
+    input Type ty;
+    output list<Function> functions;
+  protected
+    InstNode node;
+    ComponentRef fn_ref;
+    Boolean is_defined;
+  algorithm
+    functions := match Type.arrayElementType(ty)
+      case Type.COMPLEX(cls = node)
+        algorithm
+          try
+            fn_ref := Function.lookupFunctionSimple(operatorName, node);
+            is_defined := true;
+          else
+            is_defined := false;
+          end try;
+
+          if is_defined then
+            fn_ref := Function.instFunctionRef(fn_ref, InstNode.info(node));
+            functions := Function.typeRefCache(fn_ref);
+          else
+            functions := {};
+          end if;
+        then
+          functions;
+
+      else {};
+    end match;
+  end lookupOperatorFunctionsInType;
 
 protected
   function checkOperatorConstructorOutput

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -724,7 +724,7 @@ public
         then List.isEqualOnTrue(ty1.types, ty2.types, isEqual);
 
       case (TUPLE(), TUPLE()) then false;
-
+      case (COMPLEX(), COMPLEX()) then InstNode.isSame(ty1.cls, ty2.cls);
       else true;
     end match;
   end isEqual;


### PR DESCRIPTION
- Handle +/- with arrays when no exact matching operator is defined.
- Fix the matching so that the operator overloading can use operator
  functions that take operator record arrays as argument.
- Move some code from TypeCheck to OperatorOverloading.