### PR TITLE
[NF] Handle initial complex equations better.

### DIFF
--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -453,19 +453,14 @@ algorithm
       list<DAE.Dimension> dims;
       list<DAE.Element> body;
 
-    case Equation.EQUALITY() guard Type.isComplex(eq.ty)
-      algorithm
-        e1 := Expression.toDAE(eq.lhs);
-        e2 := Expression.toDAE(eq.rhs);
-      then
-        DAE.Element.COMPLEX_EQUATION(e1, e2, eq.source) :: elements;
-
     case Equation.EQUALITY()
       algorithm
         e1 := Expression.toDAE(eq.lhs);
         e2 := Expression.toDAE(eq.rhs);
       then
-        DAE.Element.EQUATION(e1, e2, eq.source) :: elements;
+        (if Type.isComplex(eq.ty) then
+           DAE.Element.COMPLEX_EQUATION(e1, e2, eq.source) else
+           DAE.Element.EQUATION(e1, e2, eq.source)) :: elements;
 
     case Equation.CREF_EQUALITY()
       algorithm
@@ -605,7 +600,9 @@ algorithm
         e1 := Expression.toDAE(eq.lhs);
         e2 := Expression.toDAE(eq.rhs);
       then
-        DAE.Element.INITIALEQUATION(e1, e2, eq.source) :: elements;
+        (if Type.isComplex(eq.ty) then
+           DAE.Element.INITIAL_COMPLEX_EQUATION(e1, e2, eq.source) else
+           DAE.Element.INITIALEQUATION(e1, e2, eq.source)) :: elements;
 
     case Equation.ARRAY_EQUALITY()
       algorithm

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -83,6 +83,7 @@ import ElementSource;
 import Ceval = NFCeval;
 import NFTyping.ExpOrigin;
 import SimplifyExp = NFSimplifyExp;
+import Restriction = NFRestriction;
 
 public
 type FunctionTree = FunctionTreeImpl.Tree;

--- a/Compiler/NFFrontEnd/NFOperatorOverloading.mo
+++ b/Compiler/NFFrontEnd/NFOperatorOverloading.mo
@@ -72,11 +72,9 @@ public
         checkOperatorConstructorOutput(f, Class.lastBaseClass(recordNode), ctor_path, info);
         recordNode := InstNode.cacheAddFunc(recordNode, f, false);
       end for;
-    else
-      // If it doesn't have an an overloaded constructor, construct a default
-      // record constructor and use that instead.
-      recordNode := Record.instDefaultConstructor(path, recordNode, info);
     end if;
+
+    recordNode := Record.instDefaultConstructor(path, recordNode, info);
   end instConstructor;
 
   function instOperatorFunctions

--- a/Compiler/NFFrontEnd/NFRestriction.mo
+++ b/Compiler/NFFrontEnd/NFRestriction.mo
@@ -125,13 +125,23 @@ public
 
   function isRecord
     input Restriction res;
-    output Boolean isFunction;
+    output Boolean isRecord;
   algorithm
-    isFunction := match res
+    isRecord := match res
       case RECORD() then true;
       else false;
     end match;
   end isRecord;
+
+  function isOperatorRecord
+    input Restriction res;
+    output Boolean isOpRecord;
+  algorithm
+    isOpRecord := match res
+      case RECORD() then res.isOperator;
+      else false;
+    end match;
+  end isOperatorRecord;
 
   function isType
     input Restriction res;


### PR DESCRIPTION
- Create the appropriate DAE element for initial complex equations.
- Always generate default constructors for operator records, but hide
  them from the function matching if an overloaded constructor exists.