### PR TITLE
[NF] Tuple and array equation improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -160,6 +160,12 @@ algorithm
         if EvalTarget.isRange(target) then
           Expression.RANGE(exp.ty, exp1, oexp, exp3) else evalRange(exp1, oexp, exp3);
 
+    case Expression.TUPLE()
+      algorithm
+        exp.elements := list(evalExp(e, target) for e in exp.elements);
+      then
+        exp;
+
     case Expression.RECORD()
       algorithm
         exp.elements := list(evalExp(e, target) for e in exp.elements);
@@ -224,14 +230,20 @@ algorithm
         exp1 := evalExp(exp.exp, target);
       then Expression.UNBOX(exp1, exp.ty);
 
+    case Expression.SUBSCRIPTED_EXP()
+      then evalSubscriptedExp(exp.exp, exp.subscripts, target);
+
+    case Expression.TUPLE_ELEMENT()
+      algorithm
+        exp1 := evalExp(exp.tupleExp, target);
+      then
+        Expression.tupleElement(exp1, exp.ty, exp.index);
+
     case Expression.MUTABLE()
       algorithm
         exp1 := evalExp(Mutable.access(exp.exp), target);
       then
         exp1;
-
-    case Expression.SUBSCRIPTED_EXP()
-      then evalSubscriptedExp(exp.exp, exp.subscripts, target);
 
     else exp;
   end match;

--- a/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -107,7 +107,6 @@ public
     end match;
   end expandCref;
 
-protected
   function expandCref2
     input ComponentRef cref;
     input output list<list<list<Subscript>>> subs = {};

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -3333,5 +3333,28 @@ public
     end match;
   end toScalar;
 
+  function tupleElement
+    input Expression exp;
+    input Type ty;
+    input Integer index;
+    output Expression tupleElem;
+  algorithm
+    tupleElem := match exp
+      local
+        Type ety;
+
+      case Expression.TUPLE() then listGet(exp.elements, index);
+
+      case Expression.ARRAY()
+        algorithm
+          ety := Type.unliftArray(ty);
+          exp.elements := list(tupleElement(e, ety, index) for e in exp.elements);
+        then
+          exp;
+
+      else Expression.TUPLE_ELEMENT(exp, index, ty);
+    end match;
+  end tupleElement;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFExpression;

--- a/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/Compiler/NFFrontEnd/NFScalarize.mo
@@ -193,22 +193,26 @@ algorithm
       SourceInfo info;
       list<Equation> eql;
 
-    case Equation.EQUALITY(ty = ty, source = src) guard Type.isArray(ty)
+    case Equation.EQUALITY(lhs = lhs, rhs = rhs, ty = ty, source = src) guard Type.isArray(ty)
       algorithm
-        lhs_iter := ExpressionIterator.fromExp(eq.lhs);
-        rhs_iter := ExpressionIterator.fromExp(eq.rhs);
-        ty := Type.arrayElementType(ty);
+        if Expression.hasArrayCall(lhs) or Expression.hasArrayCall(rhs) then
+          equations := Equation.ARRAY_EQUALITY(lhs, rhs, ty, src) :: equations;
+        else
+          lhs_iter := ExpressionIterator.fromExp(lhs);
+          rhs_iter := ExpressionIterator.fromExp(rhs);
+          ty := Type.arrayElementType(ty);
 
-        while ExpressionIterator.hasNext(lhs_iter) loop
-          if not ExpressionIterator.hasNext(rhs_iter) then
-            Error.addInternalError(getInstanceName() + " could not expand rhs " +
-              Expression.toString(eq.rhs), ElementSource.getInfo(src));
-          end if;
+          while ExpressionIterator.hasNext(lhs_iter) loop
+            if not ExpressionIterator.hasNext(rhs_iter) then
+              Error.addInternalError(getInstanceName() + " could not expand rhs " +
+                Expression.toString(eq.rhs), ElementSource.getInfo(src));
+            end if;
 
-          (lhs_iter, lhs) := ExpressionIterator.next(lhs_iter);
-          (rhs_iter, rhs) := ExpressionIterator.next(rhs_iter);
-          equations := Equation.EQUALITY(lhs, rhs, ty, src) :: equations;
-        end while;
+            (lhs_iter, lhs) := ExpressionIterator.next(lhs_iter);
+            (rhs_iter, rhs) := ExpressionIterator.next(rhs_iter);
+            equations := Equation.EQUALITY(lhs, rhs, ty, src) :: equations;
+          end while;
+        end if;
       then
         equations;
 

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -436,6 +436,7 @@ public
   algorithm
     outTy := match ty
       case TUPLE() then listHead(ty.types);
+      case ARRAY() then Type.ARRAY(firstTupleType(ty.elementType), ty.dimensions);
       else ty;
     end match;
   end firstTupleType;

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -1967,7 +1967,8 @@ algorithm
         if isCompatibleMatch(matchKind) then
           expression := match expression
             case Expression.TUPLE() then listHead(expression.elements);
-            else Expression.TUPLE_ELEMENT(expression, 1, compatibleType);
+            else Expression.TUPLE_ELEMENT(expression, 1,
+              Type.setArrayElementType(Expression.typeOf(expression), compatibleType));
           end match;
 
           matchKind := MatchKind.CAST;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -1033,7 +1033,7 @@ algorithm
         // equation/algorithm, select the first output.
         if Type.isTuple(ty) and not ExpOrigin.isSingleExpression(origin) then
           ty := Type.firstTupleType(ty);
-          e1 := Expression.TUPLE_ELEMENT(e1, 1, ty);
+          e1 := Expression.tupleElement(e1, ty, 1);
         end if;
       then
         (e1, ty, var1);
@@ -2188,7 +2188,6 @@ algorithm
       MatchKind mk;
       Variability var, bvar;
       Integer next_origin;
-      Equation tyeq;
       SourceInfo info;
 
     case Equation.EQUALITY()
@@ -2204,15 +2203,8 @@ algorithm
              Type.toString(ty1) + " = " + Type.toString(ty2)}, info);
           fail();
         end if;
-
-        // Array equations containing function calls should not be scalarized.
-        if Type.isArray(ty) and (Expression.hasArrayCall(e1) or Expression.hasArrayCall(e2)) then
-          tyeq := Equation.ARRAY_EQUALITY(e1, e2, ty, eq.source);
-        else
-          tyeq := Equation.EQUALITY(e1, e2, ty, eq.source);
-        end if;
       then
-        tyeq;
+        Equation.EQUALITY(e1, e2, ty, eq.source);
 
     case Equation.CONNECT()
       then typeConnect(eq.lhs, eq.rhs, origin, eq.source);


### PR DESCRIPTION
- Simplify `cat` calls.
- Simplify "tuple subscripted" arrays by making each array element a
  tuple subscript.
- Move the check whether an array equation should be scalarized or not
  from the typing to the scalarization, so it's done after
  simplification (which might affect the decision).
- Evaluate "tuple subscripted" expressions in Ceval.