### PR TITLE
[NF] Make array constructors structural in bindings.

### DIFF
--- a/Compiler/NFFrontEnd/NFBinding.mo
+++ b/Compiler/NFFrontEnd/NFBinding.mo
@@ -166,6 +166,13 @@ public
     end match;
   end typedExp;
 
+  function getUntypedExp
+    input Binding binding;
+    output Expression exp;
+  algorithm
+    UNTYPED_BINDING(bindingExp = exp) := binding;
+  end getUntypedExp;
+
   function getTypedExp
     input Binding binding;
     output Expression exp;

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -2906,6 +2906,10 @@ algorithm
           markStructuralParamsDim(dim);
         end for;
 
+        if Binding.isBound(c.binding) then
+          markStructuralParamsExpSize(Binding.getUntypedExp(c.binding));
+        end if;
+
         updateImplicitVariability(c.classInst);
       then
         ();
@@ -2970,6 +2974,31 @@ algorithm
     else ();
   end match;
 end markStructuralParamsExp_traverser;
+
+function markStructuralParamsExpSize
+  input Expression exp;
+algorithm
+  Expression.apply(exp, markStructuralParamsExpSize_traverser);
+end markStructuralParamsExpSize;
+
+function markStructuralParamsExpSize_traverser
+  input Expression exp;
+algorithm
+  () := match exp
+    local
+      list<tuple<InstNode, Expression>> iters;
+
+    case Expression.CALL(call = Call.UNTYPED_MAP_CALL(iters = iters))
+      algorithm
+        for iter in iters loop
+          markStructuralParamsExp(Util.tuple22(iter));
+        end for;
+      then
+        ();
+
+    else ();
+  end match;
+end markStructuralParamsExpSize_traverser;
 
 function updateImplicitVariabilityEql
   input list<Equation> eql;


### PR DESCRIPTION
- Mark the ranges of array constructors used in binding equations as
  structural, since bindings must have known sizes (with the exception
  of function parameters).