### PR TITLE
Fix for Windows paths in URIs

### DIFF
--- a/SimulationRuntime/c/simulation/omc_simulation_util.c
+++ b/SimulationRuntime/c/simulation/omc_simulation_util.c
@@ -48,6 +48,13 @@ extern const char* OpenModelica_parseFmuResourcePath(const char *path)
     while (path[0] && path[1]=='/') {
       path++;
     }
+#if defined(__MINGW32__) || defined(_MSC_VER)
+    if (strchr(path,':')) {
+      while (path[0]) {
+        path++;
+      }
+    }
+#endif
     return path;
   }
   return NULL;


### PR DESCRIPTION
If a path contains a colon and starts with / (`file:///C:/`), we should
return `C:/` and not `/C:/`.