### PR TITLE
[NF] Revert to first base class lookup fix.

### DIFF
--- a/Compiler/NFFrontEnd/NFLookup.mo
+++ b/Compiler/NFFrontEnd/NFLookup.mo
@@ -359,7 +359,7 @@ function lookupSimpleName
   input InstNode scope;
   output InstNode node;
 protected
-  InstNode cur_scope = InstNode.classScope(scope);
+  InstNode cur_scope = scope;
 algorithm
   // Look for the name in each enclosing scope, until it's either found or we
   // run out of scopes.
@@ -370,13 +370,13 @@ algorithm
     else
       // TODO: Handle encapsulated scopes.
       // If the scope has the same name as we're looking for we can just return it.
-      if name == InstNode.name(cur_scope) then
+      if name == InstNode.name(cur_scope) and InstNode.isClass(cur_scope) then
         node := cur_scope;
         return;
-      else
-        // Otherwise, continue in the enclosing scope.
-        cur_scope := InstNode.parentScope(cur_scope);
       end if;
+
+      // Otherwise, continue in the enclosing scope.
+      cur_scope := InstNode.parentScope(cur_scope);
     end try;
   end for;
 


### PR DESCRIPTION
- Just checking that the scope is a class is probably the best way
  after all.