### PR TITLE
[NF] Equation scalarization fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -179,6 +179,7 @@ function typeClass
   input InstNode cls;
   input String name;
 algorithm
+  typeClassType(cls, NFBinding.EMPTY_BINDING, ExpOrigin.CLASS);
   typeComponents(cls, ExpOrigin.CLASS);
   execStat("NFTyping.typeComponents(" + name + ")");
   typeBindings(cls, cls, ExpOrigin.CLASS);


### PR DESCRIPTION
- Handle expansion failure when creating ExpressionIterator from cref.
- Mark ranges in equality equations as structural, since the equations
  must have known sizes.