### PR TITLE
Fix FMU build on Windows and other FMI fixes

### DIFF
--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -3537,14 +3537,14 @@ algorithm
     ExecStat.execStat("buildModelFMU: Generate platform " + platform);
   end for;
 
-  cmd := "rm -f \"" + filenameprefix + ".fmu\" && cd \"" +  fmutmp + "\" && zip -r \"../" + fmuTargetName + ".fmu\" *";
+  cmd := "rm -f \"" + fmuTargetName + ".fmu\" && cd \"" +  fmutmp + "\" && zip -r \"../" + fmuTargetName + ".fmu\" *";
   if 0 <> System.systemCall(cmd, outFile=logfile) then
     Error.addMessage(Error.SIMULATOR_BUILD_ERROR, {cmd + "\n\n" + System.readFile(logfile)});
     ExecStat.execStat("buildModelFMU failed");
   end if;
 
   if not System.regularFileExists(fmuTargetName + ".fmu") then
-    Error.addMessage(Error.SIMULATOR_BUILD_ERROR, {"Build commands returned success, but " + filenameprefix + ".fmu does not exist"});
+    Error.addMessage(Error.SIMULATOR_BUILD_ERROR, {"Build commands returned success, but " + fmuTargetName + ".fmu does not exist"});
     fail();
   end if;
 

--- a/Compiler/Template/CodegenFMU.tpl
+++ b/Compiler/Template/CodegenFMU.tpl
@@ -1145,27 +1145,14 @@ match platform
   case "win32"
   case "win64" then
   <<
-  <%fileNamePrefix%>_FMU: $(MAINOBJ) <%fileNamePrefix%>_functions.h <%fileNamePrefix%>_literals.h $(OFILES) $(RUNTIMEFILES)
+  <%fileNamePrefix%>_FMU: nozip
+  <%\t%>cd .. && rm -f ../<%fileNamePrefix%>.fmu && zip -r ../<%fmuTargetName%>.fmu *
+  nozip: $(MAINOBJ) <%fileNamePrefix%>_functions.h <%fileNamePrefix%>_literals.h $(OFILES) $(RUNTIMEFILES)
   <%\t%>$(CXX) -shared -I. -o <%modelNamePrefix%>$(DLLEXT) $(MAINOBJ) $(RUNTIMEFILES) $(OFILES) $(CPPFLAGS) <%dirExtra%> <%libsPos1%> <%libsPos2%> $(CFLAGS) $(LDFLAGS) -llis -Wl,--kill-at
   <%\t%>mkdir.exe -p ../binaries/<%platform%>
   <%\t%>dlltool -d <%fileNamePrefix%>.def --dllname <%fileNamePrefix%>$(DLLEXT) --output-lib <%fileNamePrefix%>.lib --kill-at
   <%\t%>cp <%fileNamePrefix%>$(DLLEXT) <%fileNamePrefix%>.lib <%fileNamePrefix%>_FMU.libs ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libsundials_*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libopenblas.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libexpat*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libgfortran*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libquadmath*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libwinpthread*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/zlib*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libszip*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libhdf5*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libsystre*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libtre*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libintl*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libiconv*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libgcc_s_*.dll ../binaries/<%platform%>/
-  <%\t%>cp <%omhome%>/bin/libstdc*.dll ../binaries/<%platform%>/
-  <%\t%>rm -f <%fileNamePrefix%>.def <%fileNamePrefix%>.o <%fileNamePrefix%>$(DLLEXT) $(OFILES) $(RUNTIMEFILES)
+  <%\t%>rm -f *.o <%fileNamePrefix%>$(DLLEXT) $(OFILES) $(RUNTIMEFILES)
   <%\t%>cd .. && rm -f ../<%fileNamePrefix%>.fmu && zip -r ../<%fmuTargetName%>.fmu *
 
   >>

--- a/Compiler/Util/System.mo
+++ b/Compiler/Util/System.mo
@@ -482,11 +482,26 @@ public function directoryExists
   external "C" outBool=SystemImpl__directoryExists(inString) annotation(Library = "omcruntime");
 end directoryExists;
 
+
 public function removeDirectory
   input String inString;
   output Boolean outBool;
-  external "C" outBool=SystemImpl__removeDirectory(inString) annotation(Library = "omcruntime");
+algorithm
+  outBool := System.removeDirectory_dispatch(inString);
+  // oh Windows crap: stat fails on very long paths!
+  if (not outBool) then
+    if System.os() == "Windows_NT" then
+      // try rm as that somehow works on long paths
+      outBool := (0 == System.systemCall("rm -r " + inString));
+    end if;
+  end if;
 end removeDirectory;
+
+protected function removeDirectory_dispatch
+  input String inString;
+  output Boolean outBool;
+  external "C" outBool=SystemImpl__removeDirectory(inString) annotation(Library = "omcruntime");
+end removeDirectory_dispatch;
 
 public function platform
   output String outString;

--- a/Compiler/runtime/omc_config.h
+++ b/Compiler/runtime/omc_config.h
@@ -83,7 +83,7 @@
 #define DEFAULT_MAKE "make"
 
 /* adrpo: add -loleaut32 as is used by ExternalMedia */
-#define DEFAULT_LDFLAGS "-lregex -lexpat -lomcgc -lpthread -fopenmp -loleaut32 -limagehlp -lz -lhdf5"
+#define DEFAULT_LDFLAGS "-lregex -lexpat -lomcgc -Wl,-Bstatic -lpthread -Wl,-Bdynamic -fopenmp -loleaut32 -limagehlp -lz -lhdf5"
 
 
 #define CONFIG_WITH_OPENMP 1
@@ -96,10 +96,10 @@
 #endif
 
 /* adrpo: add -loleaut32 as is used by ExternalMedia */
-#define BASIC_LDFLAGS_RT " -lomcgc -lexpat -lregex -static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32 -llis -lumfpack -lklu -lcolamd -lbtf -lamd -lsundials_idas -lsundials_kinsol -lsundials_nvecserial -lipopt -lcoinmumps -lpthread -lm -lgfortranbegin -lgfortran -lmingw32 -lgcc_eh -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32 -lopenblas -lcminpack"
+#define BASIC_LDFLAGS_RT " -lomcgc -lexpat -lregex -static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32 -llis -lumfpack -lklu -lcolamd -lbtf -lamd -lsundials_idas -lsundials_kinsol -lsundials_nvecserial -lipopt -lcoinmumps -Wl,-Bstatic -lpthread -Wl,-Bdynamic -lm -lgfortranbegin -lgfortran -lmingw32 -lgcc_eh -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32 -lopenblas -lcminpack"
 #define LDFLAGS_RT " -lOpenModelicaRuntimeC" BASIC_LDFLAGS_RT
-#define LDFLAGS_RT_SIM " -lSimulationRuntimeC" BASIC_LDFLAGS_RT " -lwsock32 -lstdc++"
-#define LDFLAGS_RT_SOURCE_FMU " -lregex -static-libgcc -lpthread -lm -lgfortranbegin -lgfortran -lmingw32 -lgcc_eh -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32 -limagehlp -lopenblas -lz -lhdf5"
+#define LDFLAGS_RT_SIM " -lSimulationRuntimeC" BASIC_LDFLAGS_RT " -lwsock32 -static-libstdc++"
+#define LDFLAGS_RT_SOURCE_FMU " -lregex -static-libgcc -Wl,-Bstatic -lpthread -Wl,-Bdynamic -lm -lgfortranbegin -lgfortran -lmingw32 -lgcc_eh -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32 -limagehlp -lopenblas -lz -lhdf5"
 #define CONFIG_EXE_EXT ".exe"
 #define CONFIG_DLL_EXT ".dll"
 #define CONFIG_OS "Windows_NT"

--- a/SimulationRuntime/c/Makefile.common
+++ b/SimulationRuntime/c/Makefile.common
@@ -4,13 +4,14 @@
 # If you need to add files, etc, you modify Makefile.common - a common file
 # for both UNIX/Linux and Windows platforms.
 
+BUILDPATH=build/c
+
 # Forces the generation of the dgesv sources
 NEED_DGESV=1
 include Makefile.objs
 
 LIBSIMULATIONFMI=libSimulationRuntimeFMI.a
 OMC_MINIMAL_RUNTIME=
-BUILDPATH=build/c
 
 CPPFLAGS = -I. -I$(top_builddir)/Compiler/runtime -I$(top_builddir)/3rdParty/gc/include -I$(top_builddir)/3rdParty/FMIL/install/include/ -I$(top_builddir)/3rdParty/lis-1.4.12/include/ -I$(top_builddir)/3rdParty/Ipopt/include/ -I$(builddir_inc)/c/sundials/ $(CONFIG_CPPFLAGS) -DGC_REDIRECT_TO_LOCAL -I$(builddir_inc)/c
 override CFLAGS += $(CPPFLAGS) $(CONFIG_CFLAGS) $(EXTRA_CFLAGS)

--- a/SimulationRuntime/c/Makefile.omdev.mingw
+++ b/SimulationRuntime/c/Makefile.omdev.mingw
@@ -32,8 +32,17 @@ CONFIG_H=$(top_builddir)/Compiler/runtime/config.h
 LIBSIMULATION=libSimulationRuntimeC.a
 LIBRUNTIME=libOpenModelicaRuntimeC.a
 LIBFMIRUNTIME=libOpenModelicaFMIRuntimeC.a
-OBJ_EXT=.o
 CMINPACK_NO_DLL=-DCMINPACK_NO_DLL
+
+ifeq ($(OMC_MINIMAL_RUNTIME),)
+OBJ_EXT=.o
+else
+ifeq ($(OMC_FMI_RUNTIME),)
+OBJ_EXT=.minimal.o
+else
+OBJ_EXT=.o
+endif
+endif
 
 defaultMakefileTarget = Makefile.omdev.mingw
 


### PR DESCRIPTION
- use fmuTargetName instead of fileNamePrefix to remove the fmu
- use rm -f if System.removeDirectory doesn't work on Windows
- compile with static libstdc++ and pthreads
- don't add extra dlls to the binary directory
- fix resource copy on Windows