### PR TITLE
allow disabling of LOG_STDOUT and LOG_ASSERT streams

### DIFF
--- a/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -131,6 +131,10 @@ void setGlobalVerboseLevel(int argc, char**argv)
     return; // no lv flag given.
   }
 
+  /* default activated, but it can be disabled with -stdout or -assert */
+  useStream[LOG_STDOUT] = 1;
+  useStream[LOG_ASSERT] = 1;
+
   if(flags->find("LOG_ALL", 0) != string::npos)
   {
     for(i=1; i<SIM_LOG_MAX; ++i)
@@ -180,10 +184,6 @@ void setGlobalVerboseLevel(int argc, char**argv)
       }
     }while(pos != string::npos);
   }
-
-  /* default activated */
-  useStream[LOG_STDOUT] = 1;
-  useStream[LOG_ASSERT] = 1;
 
   /* print LOG_SOTI if LOG_INIT is enabled */
   if(useStream[LOG_INIT])

--- a/SimulationRuntime/c/util/omc_error.c
+++ b/SimulationRuntime/c/util/omc_error.c
@@ -34,7 +34,7 @@
 /* For MMC_THROW, so we can end this thing */
 #include "meta/meta_modelica.h"
 
-const int firstOMCErrorStream = 3;
+const int firstOMCErrorStream = 1;
 
 const char *LOG_STREAM_NAME[SIM_LOG_MAX] = {
   "LOG_UNKNOWN",
@@ -85,8 +85,8 @@ const char *LOG_STREAM_NAME[SIM_LOG_MAX] = {
 
 const char *LOG_STREAM_DESC[SIM_LOG_MAX] = {
   "unknown",
-  "this stream is always active",                                               /* LOG_STDOUT */
-  "this stream is always active",                                               /* LOG_ASSERT */
+  "this stream is always active, can be disabled with -lv=-stdout",             /* LOG_STDOUT */
+  "this stream is always active, can be disabled with -lv=-assert",             /* LOG_ASSERT */
 
   "additional information about dassl solver",                                  /* LOG_DASSL */
   "outputs the states at every dassl call",                                     /* LOG_DASSL_STATES */


### PR DESCRIPTION
I implemented a fix for ticket:5039 (https://trac.openmodelica.org/OpenModelica/ticket/5039).
@lochel, @wibraun please have a look if is OK with you.
I changed the stream names 
"stdout" to "LOG_STDOUT"
"assert" to "LOG_ASSERT"
but maybe they should be kept, what do you think?