### PR TITLE
Added flag to use only one instance of algebraich loop solver in cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ $RECYCLE.BIN/
 .Spotlight-V100
 .Trashes
 
+
+
 # Directories potentially created on remote AFP share
 .AppleDB
 .AppleDesktop
@@ -153,5 +155,7 @@ Parser/ParModelica_Lexer_BaseModelica_Lexer.h
 
 SimulationRuntime/**/test_files/*.jar
 SimulationRuntime/cpp/build_msvc/
-
+# Visual Studio 2015/2017 cache/options directory
+SimulationRuntime/cpp/.vs/
+SimulationRuntime/cpp/CMakeSettings.json
 tags

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -3551,7 +3551,7 @@ package Flags
   constant ConfigFlag LABELED_REDUCTION;
   constant ConfigFlag LOAD_MSL_MODEL;
   constant ConfigFlag Load_PACKAGE_FILE;
-
+   constant ConfigFlag SINGLE_INSTANCE_AGLSOLVER;
   function set
     input DebugFlag inFlag;
     input Boolean inValue;

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -1459,6 +1459,9 @@ constant ConfigFlag IGNORE_REPLACEABLE = CONFIG_FLAG(117, "ignoreReplaceable",
     "evalRecursionLimit", NONE(), EXTERNAL(), INT_FLAG(256), NONE(),
     Util.gettext("The recursion limit used when evaluating constant function calls."));
 
+  constant ConfigFlag SINGLE_INSTANCE_AGLSOLVER = CONFIG_FLAG(127, "singleInstanceAglSolver",
+  NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
+  Util.gettext("Sets to instantiate only  one algebraic loop solver all algebraic loops"));
 
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
@@ -1590,7 +1593,8 @@ constant list<ConfigFlag> allConfigFlags = {
   BUILDING_MODEL,
   POST_OPT_MODULES_DAE,
   EVAL_LOOP_LIMIT,
-  EVAL_RECURSION_LIMIT
+  EVAL_RECURSION_LIMIT,
+  SINGLE_INSTANCE_AGLSOLVER
 };
 
 public function new

--- a/SimulationRuntime/cpp/CMakeLists.txt
+++ b/SimulationRuntime/cpp/CMakeLists.txt
@@ -69,7 +69,7 @@ else()
   message(STATUS "Libs will be installed in ${LIBINSTALLEXT}")
 endif()
 
-PROJECT(CppSolverInterface)
+PROJECT(CppSimulationRuntime)
 SET(CMAKE_VERBOSE_MAKEFILE ON)
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")
 SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -93,11 +93,14 @@ OPTION(USE_CPP_03 "USE_CPP_03" OFF)
 #Set Variables
 IF(NOT FMU_TARGET)
  IF(MSVC)
-  SET(LIBINSTALLEXT "lib/omc/cpp/msvc" CACHE STRING "library directory")
+  SET(LIBINSTALLEXT "lib/omc/cpp/msvc" CACHE STRINGz "library directory")
  ELSE(MSVC)
   SET(LIBINSTALLEXT "lib/omc/cpp" CACHE STRING "library directory")
 ENDIF()
 ENDIF(NOT FMU_TARGET)
+
+MESSAGE(STATUS "Using library folder extension" ${LIBINSTALLEXT})
+
 SET(MODELICA_MODEL "ModelicaSystem")
 SET(LIBPREFIX "OMCpp")
 IF(BUILD_SHARED_LIBS)
@@ -350,7 +353,7 @@ IF(WIN32)
   SET(MICO_LIB_HOME $ENV{OMDEV}/lib/mico-msys-mingw/)
   SET(MICO_INCLUDE_HOME  $ENV{OMDEV}/include/mico-msys-mingw/)
 
-  SET(INSTALL_OMDEV_LIBS ON)
+  SET(INSTALL_OMDEV_LIBS OFF)
 ENDIF(WIN32)
 
 # Find OpenMP

--- a/SimulationRuntime/cpp/Core/Modelica/CMakeLists.txt
+++ b/SimulationRuntime/cpp/Core/Modelica/CMakeLists.txt
@@ -268,7 +268,7 @@ install (FILES
   				DESTINATION include/omc/cpp)
 ENDIF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
-install(FILES $<TARGET_PDB_FILE:${ModelicaName}> DESTINATION ${LIBINSTALLEXT} OPTIONAL)
+
 
 install(TARGETS ${ModelicaName} DESTINATION ${LIBINSTALLEXT})
 install (FILES  ${CMAKE_SOURCE_DIR}/Include/Core/Modelica.h ${CMAKE_SOURCE_DIR}/Include/Core/ModelicaDefine.h DESTINATION include/omc/cpp/Core)

--- a/SimulationRuntime/cpp/Core/SimController/Initialization.cpp
+++ b/SimulationRuntime/cpp/Core/SimController/Initialization.cpp
@@ -53,6 +53,8 @@ void Initialization::initializeSystem()
   if( _solver->stateSelection())
   {
     _system->initEquations();
+	continous_system->stepCompleted(0.0);
+
 
     /* report a warning about strange start values */
     if(_solver->stateSelection())

--- a/SimulationRuntime/cpp/Core/Solver/CMakeLists.txt
+++ b/SimulationRuntime/cpp/Core/Solver/CMakeLists.txt
@@ -15,7 +15,8 @@ install(FILES $<TARGET_PDB_FILE:${SolverName}> DESTINATION ${LIBINSTALLEXT} OPTI
 
 install(TARGETS ${SolverName} DESTINATION ${LIBINSTALLEXT})
 install(FILES
-  ${CMAKE_SOURCE_DIR}/Include/Core/Solver/IAlgLoopSolver.h
+  ${CMAKE_SOURCE_DIR}/Include/Core/Solver/ILinearAlgLoopSolver.h
+  ${CMAKE_SOURCE_DIR}/Include/Core/Solver/INonLinearAlgLoopSolver.h
   ${CMAKE_SOURCE_DIR}/Include/Core/Solver/ILinSolverSettings.h
   ${CMAKE_SOURCE_DIR}/Include/Core/Solver/INonLinSolverSettings.h
   ${CMAKE_SOURCE_DIR}/Include/Core/Solver/ISolver.h

--- a/SimulationRuntime/cpp/Core/System/AlgLoopSolverFactory.cpp
+++ b/SimulationRuntime/cpp/Core/System/AlgLoopSolverFactory.cpp
@@ -20,15 +20,15 @@ AlgLoopSolverFactory::~AlgLoopSolverFactory()
 {
 }
 
-shared_ptr<IAlgLoopSolver> AlgLoopSolverFactory::createLinearAlgLoopSolver(ILinearAlgLoop* algLoop)
+shared_ptr<ILinearAlgLoopSolver> AlgLoopSolverFactory::createLinearAlgLoopSolver(shared_ptr<ILinearAlgLoop> algLoop)
 {
       try
       {
         string linsolver_name = _global_settings->getSelectedLinSolver();
 		shared_ptr<ILinSolverSettings> algsolversetting= createLinSolverSettings(linsolver_name);
 		_linalgsolversettings.push_back(algsolversetting);
-        shared_ptr<IAlgLoopSolver> algsolver= createLinSolver(algLoop,linsolver_name,algsolversetting);
-        _algsolvers.push_back(algsolver);
+        shared_ptr<ILinearAlgLoopSolver> algsolver= createLinSolver(linsolver_name,algsolversetting,algLoop);
+        _linear_algsolvers.push_back(algsolver);
         return algsolver;
       }
       catch(std::exception &arg)
@@ -39,24 +39,23 @@ shared_ptr<IAlgLoopSolver> AlgLoopSolverFactory::createLinearAlgLoopSolver(ILine
 }
 
 /// Creates a nonlinear solver according to given system of equations of type algebraic loop
-shared_ptr<IAlgLoopSolver> AlgLoopSolverFactory::createNonLinearAlgLoopSolver(INonLinearAlgLoop* algLoop)
+shared_ptr<INonLinearAlgLoopSolver> AlgLoopSolverFactory::createNonLinearAlgLoopSolver(shared_ptr<INonLinearAlgLoop> algLoop)
 {
-  if(algLoop->getDimReal() > 0)
-  {
+	try
+    {
+		string nonlinsolver_name = _global_settings->getSelectedNonLinSolver();
+		shared_ptr<INonLinSolverSettings> algsolversetting= createNonLinSolverSettings(nonlinsolver_name);
+		algsolversetting->setContinueOnError(_global_settings->getNonLinearSolverContinueOnError());
+		_algsolversettings.push_back(algsolversetting);
 
-    string nonlinsolver_name = _global_settings->getSelectedNonLinSolver();
-    shared_ptr<INonLinSolverSettings> algsolversetting= createNonLinSolverSettings(nonlinsolver_name);
-    algsolversetting->setContinueOnError(_global_settings->getNonLinearSolverContinueOnError());
-    _algsolversettings.push_back(algsolversetting);
+		shared_ptr<INonLinearAlgLoopSolver> algsolver= createNonLinSolver(nonlinsolver_name,algsolversetting,algLoop);
+		_non_linear_algsolvers.push_back(algsolver);
+		return algsolver;
+	}
+    catch(std::exception &arg)
+    {
+      throw ModelicaSimulationError(MODEL_FACTORY,"Linear AlgLoop solver is not available");
+    }
 
-    shared_ptr<IAlgLoopSolver> algsolver= createNonLinSolver(algLoop,nonlinsolver_name,algsolversetting);
-    _algsolvers.push_back(algsolver);
-    return algsolver;
-  }
-  else
-  {
-    // TODO: Throw an error message here.
-    throw ModelicaSimulationError(MODEL_FACTORY,"AlgLoop solver is not available");
-  }
 }
 /** @} */ // end of coreSystem

--- a/SimulationRuntime/cpp/Core/System/LinearAlgLoopDefaultImplementation.cpp
+++ b/SimulationRuntime/cpp/Core/System/LinearAlgLoopDefaultImplementation.cpp
@@ -12,13 +12,18 @@ LinearAlgLoopDefaultImplementation::LinearAlgLoopDefaultImplementation()
   ,_b(NULL)
   ,_AData(NULL)
   ,_Ax(NULL)
+  ,_x0(NULL)
+ , _firstcall(true)
 {
+
 }
 
 LinearAlgLoopDefaultImplementation::~LinearAlgLoopDefaultImplementation()
 {
   if(_b)
     delete [] _b;
+ if (_x0)
+	 delete [] _x0;
 }
 
 /// Provide number (dimension) of variables according to data type
@@ -37,6 +42,9 @@ void LinearAlgLoopDefaultImplementation::initialize()
     delete [] _b;
   _b     = new double[_dimAEq];
   memset(_b,0,_dimAEq*sizeof(double));
+  if(_x0)
+	  delete [] _x0;
+  _x0 = new double[_dimAEq];
 };
 
 void LinearAlgLoopDefaultImplementation::getb(double* res) const
@@ -52,7 +60,10 @@ bool LinearAlgLoopDefaultImplementation::getUseSparseFormat(){
 void LinearAlgLoopDefaultImplementation::setUseSparseFormat(bool value){
   _useSparseFormat = value;
 }
-
+void LinearAlgLoopDefaultImplementation::getRealStartValues(double* vars) const
+{
+    memcpy(vars, _x0, sizeof(double) * _dimAEq);
+}
 
 
 //void LinearAlgLoopDefaultImplementation::getSparseAdata(double* data, int nonzeros)

--- a/SimulationRuntime/cpp/Core/System/NonLinearAlgLoopDefaultImplementation.cpp
+++ b/SimulationRuntime/cpp/Core/System/NonLinearAlgLoopDefaultImplementation.cpp
@@ -17,6 +17,8 @@ NonLinearAlgLoopDefaultImplementation::NonLinearAlgLoopDefaultImplementation()
   ,_res(NULL)
   ,_AData(NULL)
   ,_Ax(NULL)
+  ,_x0(NULL)
+, _firstcall(true)
 {
 }
 
@@ -24,6 +26,8 @@ NonLinearAlgLoopDefaultImplementation::~NonLinearAlgLoopDefaultImplementation()
 {
   if(_res)
     delete [] _res;
+if (_x0)
+	 delete _x0;
 }
 
 /// Provide number (dimension) of variables according to data type
@@ -42,6 +46,9 @@ void NonLinearAlgLoopDefaultImplementation::initialize()
     delete [] _res;
   _res     = new double[_dimAEq];
   memset(_res,0,_dimAEq*sizeof(double));
+   if(_x0)
+	  delete [] _x0;
+   _x0 = new double[_dimAEq];
 };
 
 //in algloop default verschieben
@@ -57,6 +64,13 @@ bool NonLinearAlgLoopDefaultImplementation::getUseSparseFormat(){
 void NonLinearAlgLoopDefaultImplementation::setUseSparseFormat(bool value){
   _useSparseFormat = value;
 }
+
+void NonLinearAlgLoopDefaultImplementation::getRealStartValues(double* vars) const
+{
+
+	 memcpy(vars, _x0, sizeof(double) * _dimAEq);
+}
+
 
 //void NonLinearAlgLoopDefaultImplementation::getSparseAdata(double* data, int nonzeros)
 //{

--- a/SimulationRuntime/cpp/Include/Core/Modelica.h
+++ b/SimulationRuntime/cpp/Include/Core/Modelica.h
@@ -219,7 +219,8 @@ typedef ublas::matrix<double, ublas::column_major> matrix_t;
 #include <Core/System/INonLinearAlgLoop.h>
 #include <Core/System/ISystemTypes.h>
 #include <Core/Solver/ISolver.h>
-#include <Core/Solver/IAlgLoopSolver.h>
+#include <Core/Solver/ILinearAlgLoopSolver.h>
+#include <Core/Solver/INonLinearAlgLoopSolver.h>
 #include <Core/System/IAlgLoopSolverFactory.h>
 #include <Core/System/ISimVars.h>
 #include <Core/DataExchange/ISimVar.h>

--- a/SimulationRuntime/cpp/Include/Core/Solver/ILinearAlgLoopSolver.h
+++ b/SimulationRuntime/cpp/Include/Core/Solver/ILinearAlgLoopSolver.h
@@ -1,0 +1,50 @@
+#pragma once
+/** @addtogroup coreSolver
+ *
+ *  @{
+ */
+class ILinearAlgLoop;
+
+
+/*****************************************************************************/
+/**
+
+Abstract interface class for numerical methods for the (possibly iterative)
+solution of algebraic loops in open modelica.
+
+\date     October, 1st, 2008
+\author
+
+*/
+/*****************************************************************************
+Copyright (c) 2008, OSMC
+*****************************************************************************/
+
+class ILinearAlgLoopSolver
+{
+public:
+  /// Enumeration to denote the status of iteration
+  enum ITERATIONSTATUS
+  {
+    CONTINUE,
+    SOLVERERROR,
+    DONE,
+  };
+
+  virtual ~ILinearAlgLoopSolver() {};
+
+  /// (Re-) initialize the solver
+  virtual void initialize() = 0;
+
+  /// Solution of a (non-)linear system of equations
+  virtual void solve() = 0;
+  //solve for a single instance call
+  virtual void solve(shared_ptr<ILinearAlgLoop> algLoop,bool first_solve = false) = 0;
+
+  /// Returns the status of iteration
+  virtual ITERATIONSTATUS getIterationStatus() = 0;
+  virtual void stepCompleted(double time) = 0;
+  virtual void restoreOldValues() = 0;
+  virtual void restoreNewValues() = 0;
+};
+ /** @} */ // end of coreSolver

--- a/SimulationRuntime/cpp/Include/Core/Solver/INonLinearAlgLoopSolver.h
+++ b/SimulationRuntime/cpp/Include/Core/Solver/INonLinearAlgLoopSolver.h
@@ -3,8 +3,8 @@
  *
  *  @{
  */
-class IAlgLoop;
-class IContinuous;
+class INonLinearAlgLoop;
+
 
 /*****************************************************************************/
 /**
@@ -20,7 +20,7 @@ solution of algebraic loops in open modelica.
 Copyright (c) 2008, OSMC
 *****************************************************************************/
 
-class IAlgLoopSolver
+class INonLinearAlgLoopSolver
 {
 public:
   /// Enumeration to denote the status of iteration
@@ -31,13 +31,16 @@ public:
     DONE,
   };
 
-  virtual ~IAlgLoopSolver() {};
+  virtual ~INonLinearAlgLoopSolver() {};
 
   /// (Re-) initialize the solver
   virtual void initialize() = 0;
 
-  /// Solution of a (non-)linear system of equations
+   /// Solution of a (non-)linear system of equations
   virtual void solve() = 0;
+  //solve for a single instance call
+  virtual void solve(shared_ptr<INonLinearAlgLoop> algLoop,bool first_solve = false) = 0;
+
 
   /// Returns the status of iteration
   virtual ITERATIONSTATUS getIterationStatus() = 0;

--- a/SimulationRuntime/cpp/Include/Core/System/AlgLoopSolverFactory.h
+++ b/SimulationRuntime/cpp/Include/Core/System/AlgLoopSolverFactory.h
@@ -17,13 +17,14 @@ public:
   virtual ~AlgLoopSolverFactory();
 
   /// Creates a solver according to given system of equations of type algebraic loop
-  virtual shared_ptr<IAlgLoopSolver> createLinearAlgLoopSolver(ILinearAlgLoop* algLoop);
-  virtual shared_ptr<IAlgLoopSolver> createNonLinearAlgLoopSolver(INonLinearAlgLoop* algLoop);
+  virtual shared_ptr<ILinearAlgLoopSolver> createLinearAlgLoopSolver(shared_ptr<ILinearAlgLoop> algLoop = shared_ptr<ILinearAlgLoop>());
+  virtual shared_ptr<INonLinearAlgLoopSolver> createNonLinearAlgLoopSolver(shared_ptr<INonLinearAlgLoop> algLoop = shared_ptr<INonLinearAlgLoop>());
 private:
   //std::vector<shared_ptr<IKinsolSettings> > _algsolversettings;
   std::vector<shared_ptr<INonLinSolverSettings> > _algsolversettings;
   std::vector<shared_ptr<ILinSolverSettings> > _linalgsolversettings;
-  std::vector<shared_ptr<IAlgLoopSolver> > _algsolvers;
+  std::vector<shared_ptr<ILinearAlgLoopSolver> > _linear_algsolvers;
+  std::vector<shared_ptr<INonLinearAlgLoopSolver> > _non_linear_algsolvers;
   IGlobalSettings* _global_settings;
 };
 /** @} */ // end of coreSystem

--- a/SimulationRuntime/cpp/Include/Core/System/IAlgLoopSolverFactory.h
+++ b/SimulationRuntime/cpp/Include/Core/System/IAlgLoopSolverFactory.h
@@ -23,7 +23,7 @@ class IAlgLoopSolverFactory
 public:
   IAlgLoopSolverFactory() {};
   virtual ~IAlgLoopSolverFactory() {};
-  virtual  shared_ptr<IAlgLoopSolver> createLinearAlgLoopSolver(ILinearAlgLoop* algLoop) = 0;
-  virtual  shared_ptr<IAlgLoopSolver> createNonLinearAlgLoopSolver(INonLinearAlgLoop* algLoop) = 0;
+  virtual  shared_ptr<ILinearAlgLoopSolver> createLinearAlgLoopSolver(shared_ptr<ILinearAlgLoop> algLoop = shared_ptr<ILinearAlgLoop>()) = 0;
+  virtual  shared_ptr<INonLinearAlgLoopSolver> createNonLinearAlgLoopSolver(shared_ptr<INonLinearAlgLoop> algLoop = shared_ptr<INonLinearAlgLoop>()) = 0;
 };
 /** @} */ // end of coreSystem

--- a/SimulationRuntime/cpp/Include/Core/System/ILinearAlgLoop.h
+++ b/SimulationRuntime/cpp/Include/Core/System/ILinearAlgLoop.h
@@ -48,7 +48,8 @@ public:
   virtual void getReal(double* lambda) const = 0;
   /// Set variables with given data type
   virtual void setReal(const double* lambda) = 0;
-
+  virtual void setRealStartValues() = 0;
+  virtual void getRealStartValues(double* vars) const= 0;
   /// Evaluate equations for given variables
   virtual void evaluate() = 0;
 

--- a/SimulationRuntime/cpp/Include/Core/System/INonLinearAlgLoop.h
+++ b/SimulationRuntime/cpp/Include/Core/System/INonLinearAlgLoop.h
@@ -57,7 +57,8 @@ public:
   virtual void getReal(double* lambda) const = 0;
   /// Set variables with given data type
   virtual void setReal(const double* lambda) = 0;
-
+  virtual void setRealStartValues() = 0;
+  virtual void getRealStartValues(double* vars) const = 0;
   /// Evaluate equations for given variables
   virtual void evaluate() = 0;
 

--- a/SimulationRuntime/cpp/Include/Core/System/LinearAlgLoopDefaultImplementation.h
+++ b/SimulationRuntime/cpp/Include/Core/System/LinearAlgLoopDefaultImplementation.h
@@ -37,7 +37,7 @@ public:
   bool getUseSparseFormat();
 
   void setUseSparseFormat(bool value);
-
+  virtual void getRealStartValues(double* vars) const;
   //void getSparseAdata(double* data, int nonzeros);
 
   // Member variables
@@ -45,11 +45,12 @@ public:
 protected:
   int _dimAEq;                        ///< Number (dimension) of unknown/equations (the index denotes the data type; 0: double, 1: int, 2: bool)
   double* _b;
-
+  double* _x0;
 
   double * _AData;
   double* _Ax;
   bool _useSparseFormat;
+  bool _firstcall;
 
 };
 /** @} */ // end of coreSystem

--- a/SimulationRuntime/cpp/Include/Core/System/NonLinearAlgLoopDefaultImplementation.h
+++ b/SimulationRuntime/cpp/Include/Core/System/NonLinearAlgLoopDefaultImplementation.h
@@ -70,6 +70,7 @@ public:
 
   void setUseSparseFormat(bool value);
 
+  virtual void getRealStartValues(double* vars) const;
   //void getSparseAdata(double* data, int nonzeros);
 
   // Member variables
@@ -77,11 +78,12 @@ public:
 protected:
   int _dimAEq;                        ///< Number (dimension) of unknown/equations (the index denotes the data type; 0: double, 1: int, 2: bool)
   double* _res;
-
+  double* _x0;
 
   double * _AData;
   double* _Ax;
   bool _useSparseFormat;
+  bool _firstcall;
 
 };
 /** @} */ // end of coreSystem

--- a/SimulationRuntime/cpp/Include/FMU/FactoryExport.h
+++ b/SimulationRuntime/cpp/Include/FMU/FactoryExport.h
@@ -24,7 +24,7 @@
  {
    throw ModelicaSimulationError(ALGLOOP_SOLVER,"Kinsol was disabled during build");
  }
- shared_ptr<IAlgLoopSolver> createKinsolSolver(INonLinearAlgLoop* algLoop, shared_ptr<INonLinSolverSettings> solver_settings)
+ shared_ptr<INonLinearAlgLoopSolver> createKinsolSolver(shared_ptr<INonLinSolverSettings> solver_settings,shared_ptr<INonLinearAlgLoop> algLoop)
  {
    throw ModelicaSimulationError(ALGLOOP_SOLVER,"Kinsol was disabled during build");
  }

--- a/SimulationRuntime/cpp/Include/SimCoreFactory/Policies/FactoryConfig.h
+++ b/SimulationRuntime/cpp/Include/SimCoreFactory/Policies/FactoryConfig.h
@@ -95,7 +95,8 @@
   #include <Core/System/INonLinearAlgLoop.h>
   #include <Core/Solver/ISolverSettings.h>
   #include <Core/Solver/ISolver.h>
-  #include <Core/Solver/IAlgLoopSolver.h>
+  #include <Core/Solver/ILinearAlgLoopSolver.h>
+  #include <Core/Solver/INonLinearAlgLoopSolver.h>
   #include <Core/System/IAlgLoopSolverFactory.h>
   #include <Core/System/ISimVars.h>
   #include <Core/DataExchange/ISimVar.h>

--- a/SimulationRuntime/cpp/Include/SimCoreFactory/Policies/LinSolverOMCFactory.h
+++ b/SimulationRuntime/cpp/Include/SimCoreFactory/Policies/LinSolverOMCFactory.h
@@ -68,18 +68,18 @@ public:
         return linsolversetting;
   }
 
-  virtual shared_ptr<IAlgLoopSolver> createLinSolver(ILinearAlgLoop* algLoop, string solver_name, shared_ptr<ILinSolverSettings> solver_settings)
+  virtual shared_ptr<ILinearAlgLoopSolver> createLinSolver(string solver_name, shared_ptr<ILinSolverSettings> solver_settings,shared_ptr<ILinearAlgLoop> algLoop = shared_ptr<ILinearAlgLoop>())
   {
     if(_last_selected_solver.compare(solver_name) == 0)
     {
-            std::map<std::string, factory<IAlgLoopSolver,ILinearAlgLoop*, ILinSolverSettings*> >::iterator iter;
-            std::map<std::string, factory<IAlgLoopSolver,ILinearAlgLoop*, ILinSolverSettings*> >& linSolverFactory(_linsolver_type_map->get());
+            std::map<std::string, factory<ILinearAlgLoopSolver, ILinSolverSettings*,shared_ptr<ILinearAlgLoop> > >::iterator iter;
+            std::map<std::string, factory<ILinearAlgLoopSolver, ILinSolverSettings*,shared_ptr<ILinearAlgLoop> > >& linSolverFactory(_linsolver_type_map->get());
             iter = linSolverFactory.find(solver_name);
             if (iter == linSolverFactory.end())
             {
                 throw ModelicaSimulationError(MODEL_FACTORY,"No such linear Solver");
             }
-            shared_ptr<IAlgLoopSolver> solver = shared_ptr<IAlgLoopSolver>(iter->second.create(algLoop,solver_settings.get()));
+            shared_ptr<ILinearAlgLoopSolver> solver = shared_ptr<ILinearAlgLoopSolver>(iter->second.create(solver_settings.get(),algLoop));
 
             return solver;
     }

--- a/SimulationRuntime/cpp/Include/SimCoreFactory/Policies/NonLinSolverOMCFactory.h
+++ b/SimulationRuntime/cpp/Include/SimCoreFactory/Policies/NonLinSolverOMCFactory.h
@@ -112,18 +112,18 @@ public:
 
    }
 
-   virtual shared_ptr<IAlgLoopSolver> createNonLinSolver(INonLinearAlgLoop* algLoop, string solver_name, shared_ptr<INonLinSolverSettings>  solver_settings)
+   virtual shared_ptr<INonLinearAlgLoopSolver> createNonLinSolver(string solver_name, shared_ptr<INonLinSolverSettings>  solver_settings,shared_ptr<INonLinearAlgLoop> algLoop = shared_ptr<INonLinearAlgLoop>())
    {
        if(_last_selected_solver.compare(solver_name)==0)
        {
-            std::map<std::string, factory<IAlgLoopSolver,INonLinearAlgLoop*, INonLinSolverSettings*> >::iterator iter;
-            std::map<std::string, factory<IAlgLoopSolver,INonLinearAlgLoop*, INonLinSolverSettings*> >& nonlinSolverFactory(_non_linsolver_type_map->get());
+            std::map<std::string, factory<INonLinearAlgLoopSolver, INonLinSolverSettings*,shared_ptr<INonLinearAlgLoop> > >::iterator iter;
+            std::map<std::string, factory<INonLinearAlgLoopSolver, INonLinSolverSettings*,shared_ptr<INonLinearAlgLoop> > >& nonlinSolverFactory(_non_linsolver_type_map->get());
             iter = nonlinSolverFactory.find(solver_name);
             if (iter ==nonlinSolverFactory.end())
             {
                 throw ModelicaSimulationError(MODEL_FACTORY,"No such non linear Solver");
             }
-            shared_ptr<IAlgLoopSolver> solver = shared_ptr<IAlgLoopSolver>(iter->second.create(algLoop,solver_settings.get()));
+            shared_ptr<INonLinearAlgLoopSolver> solver = shared_ptr<INonLinearAlgLoopSolver>(iter->second.create(solver_settings.get(),algLoop));
             return solver;
        }
        else

--- a/SimulationRuntime/cpp/Include/SimCoreFactory/Policies/StaticLinSolverOMCFactory.h
+++ b/SimulationRuntime/cpp/Include/SimCoreFactory/Policies/StaticLinSolverOMCFactory.h
@@ -5,9 +5,9 @@
  */
 #include <SimCoreFactory/ObjectFactory.h>
 shared_ptr<ILinSolverSettings> createLinearSolverSettings();
-shared_ptr<IAlgLoopSolver> createLinearSolver(ILinearAlgLoop* algLoop, shared_ptr<ILinSolverSettings> solver_settings);
+shared_ptr<ILinearAlgLoopSolver> createLinearSolver(shared_ptr<ILinSolverSettings> solver_settings,shared_ptr<ILinearAlgLoop> algLoop = shared_ptr<ILinearAlgLoop>());
 shared_ptr<ILinSolverSettings> createDgesvSolverSettings();
-shared_ptr<IAlgLoopSolver> createDgesvSolver(ILinearAlgLoop* algLoop, shared_ptr<ILinSolverSettings> solver_settings);
+shared_ptr<ILinearAlgLoopSolver> createDgesvSolver(shared_ptr<ILinSolverSettings> solver_settings,shared_ptr<ILinearAlgLoop> algLoop = shared_ptr<ILinearAlgLoop>());
 template<class CreationPolicy>
 struct StaticLinSolverOMCFactory : virtual public ObjectFactory<CreationPolicy>{
 
@@ -34,7 +34,7 @@ public:
       else
         throw ModelicaSimulationError(MODEL_FACTORY,"Selected lin solver is not available");
   }
-  virtual shared_ptr<IAlgLoopSolver> createLinSolver(ILinearAlgLoop* algLoop, string solver_name, shared_ptr<ILinSolverSettings> solver_settings)
+  virtual shared_ptr<ILinearAlgLoopSolver> createLinSolver(string solver_name, shared_ptr<ILinSolverSettings> solver_settings,shared_ptr<ILinearAlgLoop> algLoop = shared_ptr<ILinearAlgLoop>())
   {
 
        if(solver_name.compare("linearSolver")==0)
@@ -43,7 +43,7 @@ public:
        }
        else if(solver_name.compare("dgesvSolver")==0)
        {
-           shared_ptr<IAlgLoopSolver> solver =createDgesvSolver(algLoop,solver_settings);
+           shared_ptr<ILinearAlgLoopSolver> solver =createDgesvSolver(solver_settings,algLoop);
            return solver;
        }
        else

--- a/SimulationRuntime/cpp/Include/SimCoreFactory/Policies/StaticNonLinSolverOMCFactory.h
+++ b/SimulationRuntime/cpp/Include/SimCoreFactory/Policies/StaticNonLinSolverOMCFactory.h
@@ -8,8 +8,8 @@
 
 shared_ptr<INonLinSolverSettings> createNewtonSettings();
  shared_ptr<INonLinSolverSettings> createKinsolSettings();
- shared_ptr<IAlgLoopSolver> createNewtonSolver(INonLinearAlgLoop* algLoop, shared_ptr<INonLinSolverSettings> solver_settings);
- shared_ptr<IAlgLoopSolver> createKinsolSolver(INonLinearAlgLoop* algLoop, shared_ptr<INonLinSolverSettings> solver_settings);
+ shared_ptr<INonLinearAlgLoopSolver> createNewtonSolver(shared_ptr<INonLinSolverSettings> solver_settings,shared_ptr<INonLinearAlgLoop> algLoop);
+ shared_ptr<INonLinearAlgLoopSolver> createKinsolSolver(shared_ptr<INonLinSolverSettings> solver_settings,shared_ptr<INonLinearAlgLoop> algLoop);
 template <class CreationPolicy>
 class StaticNonLinSolverOMCFactory : virtual public ObjectFactory<CreationPolicy>
 {
@@ -41,18 +41,18 @@ public:
       throw ModelicaSimulationError(MODEL_FACTORY,"Selected nonlin solver is not available");
       //return NonLinSolverOMCFactory<CreationPolicy>::createNonLinSolverSettings(nonlin_solver);
    }
-   virtual shared_ptr<IAlgLoopSolver> createNonLinSolver(INonLinearAlgLoop* algLoop, string solver_name, shared_ptr<INonLinSolverSettings> solver_settings)
+   virtual shared_ptr<INonLinearAlgLoopSolver> createNonLinSolver(string solver_name, shared_ptr<INonLinSolverSettings> solver_settings,shared_ptr<INonLinearAlgLoop> algLoop = shared_ptr<INonLinearAlgLoop>())
    {
       if(solver_name.compare("newton")==0)
       {
-        shared_ptr<IAlgLoopSolver> newton = createNewtonSolver(algLoop,solver_settings);
+        shared_ptr<INonLinearAlgLoopSolver> newton = createNewtonSolver(solver_settings,algLoop);
         return newton;
       }
 
       #ifdef ENABLE_SUNDIALS_STATIC
       if(solver_name.compare("kinsol")==0)
       {
-        shared_ptr<IAlgLoopSolver> kinsol = createKinsolSolver(algLoop,solver_settings);
+        shared_ptr<INonLinearAlgLoopSolver> kinsol = createKinsolSolver(solver_settings,algLoop);
         return kinsol;
       }
       #endif //ENABLE_SUNDIALS_STATIC

--- a/SimulationRuntime/cpp/Include/Solver/Broyden/Broyden.h
+++ b/SimulationRuntime/cpp/Include/Solver/Broyden/Broyden.h
@@ -7,10 +7,7 @@
 
 #include "FactoryExport.h"
 
-#include <Core/System/ILinearAlgLoop.h>               // Interface to AlgLoo
-#include <Core/System/INonLinearAlgLoop.h>               // Interface to AlgLoo
-#include <Core/Solver/IAlgLoopSolver.h>        // Export function from dll
-#include <Core/Solver/INonLinSolverSettings.h>
+
 #include <Solver/Broyden/BroydenSettings.h>
 
 #include <Core/Utils/extension/logger.hpp>
@@ -45,19 +42,23 @@ where A is an n-by-n matrix and y and B are n-by-n(right hand side) matrices.
 /*****************************************************************************
 OSMS(c) 2008
 *****************************************************************************/
-class Broyden : public IAlgLoopSolver
+class Broyden : public INonLinearAlgLoopSolver
 {
 public:
 
-    Broyden(INonLinearAlgLoop* algLoop,INonLinSolverSettings* settings);
+    Broyden(INonLinSolverSettings* settings,shared_ptr<INonLinearAlgLoop> algLoop=shared_ptr<INonLinearAlgLoop>());
 
     virtual ~Broyden();
 
     /// (Re-) initialize the solver
     virtual void initialize();
 
+
     /// Solution of a (non-)linear system of equations
     virtual void solve();
+    //solve for a single instance call
+    virtual void solve(shared_ptr<INonLinearAlgLoop> algLoop,bool first_solve = false);
+
 
     /// Returns the status of iteration
     virtual ITERATIONSTATUS getIterationStatus();
@@ -76,8 +77,7 @@ private:
     INonLinSolverSettings
         *_BroydenSettings;            ///< Settings for the solver
 
-    INonLinearAlgLoop
-        *_algLoop;                    ///< Algebraic loop to be solved
+    shared_ptr<INonLinearAlgLoop> _algLoop;                    ///< Algebraic loop to be solved
 
     ITERATIONSTATUS
         _iterationStatus;            ///< Output        - Denotes the status of iteration

--- a/SimulationRuntime/cpp/Include/Solver/Dgesv/DgesvSolver.h
+++ b/SimulationRuntime/cpp/Include/Solver/Dgesv/DgesvSolver.h
@@ -4,10 +4,10 @@
  *  @{
  */
 
-class DgesvSolver : public IAlgLoopSolver
+class DgesvSolver : public ILinearAlgLoopSolver
 {
  public:
-  DgesvSolver(ILinearAlgLoop* algLoop, ILinSolverSettings* settings);
+  DgesvSolver(ILinSolverSettings* settings,shared_ptr<ILinearAlgLoop> algLoop=shared_ptr<ILinearAlgLoop>());
   virtual ~DgesvSolver();
 
   /// (Re-) initialize the solver
@@ -15,6 +15,8 @@ class DgesvSolver : public IAlgLoopSolver
 
   /// Solution of a (non-)linear system of equations
   virtual void solve();
+  //solve for a single instance call
+  virtual void solve(shared_ptr<ILinearAlgLoop> algLoop,bool first_solve = false);
 
   /// Returns the status of iteration
   virtual ITERATIONSTATUS getIterationStatus();
@@ -26,8 +28,7 @@ class DgesvSolver : public IAlgLoopSolver
   // Member variables
   //---------------------------------------------------------------
 
-  ILinearAlgLoop
-    *_algLoop;            ///< Algebraic loop to be solved
+  shared_ptr<ILinearAlgLoop> _algLoop;            ///< Algebraic loop to be solved
 
   ITERATIONSTATUS
     _iterationStatus;     ///< Output   - Denotes the status of iteration

--- a/SimulationRuntime/cpp/Include/Solver/Hybrj/Hybrj.h
+++ b/SimulationRuntime/cpp/Include/Solver/Hybrj/Hybrj.h
@@ -16,19 +16,23 @@
  see documentation: http://www.math.utah.edu/software/minpack/minpack/hybrj.html
 */
 
-class Hybrj : public IAlgLoopSolver
+class Hybrj : public INonLinearAlgLoopSolver
 {
 public:
 
-    Hybrj(INonLinearAlgLoop* algLoop,INonLinSolverSettings* settings);
+    Hybrj(INonLinSolverSettings* settings,shared_ptr<INonLinearAlgLoop> algLoop=shared_ptr<INonLinearAlgLoop>());
 
     virtual ~Hybrj();
 
     /// (Re-) initialize the solver
     virtual void initialize();
 
+
     /// Solution of a (non-)linear system of equations
     virtual void solve();
+    //solve for a single instance call
+    virtual void solve(shared_ptr<INonLinearAlgLoop> algLoop,bool first_solve = false);
+
 
     /// Returns the status of iteration
     virtual ITERATIONSTATUS getIterationStatus();
@@ -50,8 +54,7 @@ private:
     INonLinSolverSettings
         *_newtonSettings;            ///< Settings for the solver
 
-    INonLinearAlgLoop
-        *_algLoop;                    ///< Algebraic loop to be solved
+    shared_ptr<INonLinearAlgLoop> _algLoop;                    ///< Algebraic loop to be solved
 
     ITERATIONSTATUS
         _iterationStatus;            ///< Output        - Denotes the status of iteration

--- a/SimulationRuntime/cpp/Include/Solver/Kinsol/Kinsol.h
+++ b/SimulationRuntime/cpp/Include/Solver/Kinsol/Kinsol.h
@@ -3,16 +3,11 @@
  *
  *  @{
  */
-#if defined(__vxworks)
-//#include <klu.h>
-#else
-//#include <Solver/KLU/klu.h>
-#endif
 
-class Kinsol : public IAlgLoopSolver
+class Kinsol : public INonLinearAlgLoopSolver
 {
 public:
-  Kinsol(INonLinearAlgLoop* algLoop, INonLinSolverSettings* settings);
+  Kinsol(INonLinSolverSettings* settings,shared_ptr<INonLinearAlgLoop> algLoop=shared_ptr<INonLinearAlgLoop>());
   virtual ~Kinsol();
 
   /// (Re-) initialize the solver
@@ -20,7 +15,8 @@ public:
 
   /// Solution of a (non-)linear system of equations
   virtual void solve();
-
+  //solve for a single instance call
+  virtual void solve(shared_ptr<INonLinearAlgLoop> algLoop,bool first_solve = false);
   /// Returns the status of iteration
   virtual ITERATIONSTATUS getIterationStatus();
   virtual void stepCompleted(double time);
@@ -47,8 +43,7 @@ private:
   INonLinSolverSettings
     *_kinsolSettings;     ///< Settings for the solver
 
-  INonLinearAlgLoop
-    *_algLoop;            ///< Algebraic loop to be solved
+  shared_ptr<INonLinearAlgLoop> _algLoop;            ///< Algebraic loop to be solved
 
   ITERATIONSTATUS
     _iterationStatus;     ///< Output   - Denotes the status of iteration

--- a/SimulationRuntime/cpp/Include/Solver/LinearSolver/LinearSolver.h
+++ b/SimulationRuntime/cpp/Include/Solver/LinearSolver/LinearSolver.h
@@ -8,10 +8,10 @@
   #include <../../../../build/include/omc/c/suitesparse/Include/klu.h>
 #endif
 
-class LinearSolver : public IAlgLoopSolver
+class LinearSolver : public ILinearAlgLoopSolver
 {
 public:
-  LinearSolver(ILinearAlgLoop* algLoop, ILinSolverSettings* settings);
+  LinearSolver(ILinSolverSettings* settings,shared_ptr<ILinearAlgLoop> algLoop=shared_ptr<ILinearAlgLoop>());
   virtual ~LinearSolver();
 
   /// (Re-) initialize the solver
@@ -19,6 +19,8 @@ public:
 
   /// Solution of a (non-)linear system of equations
   virtual void solve();
+  //solve for a single instance call
+  virtual void solve(shared_ptr<ILinearAlgLoop> algLoop,bool first_solve = false);
 
   /// Returns the status of iteration
   virtual ITERATIONSTATUS getIterationStatus();
@@ -32,8 +34,8 @@ private:
   // Member variables
   //---------------------------------------------------------------
 
-  ILinearAlgLoop
-    *_algLoop;            ///< Algebraic loop to be solved
+  shared_ptr<ILinearAlgLoop>
+    _algLoop;            ///< Algebraic loop to be solved
 
   ITERATIONSTATUS
     _iterationStatus;     ///< Output   - Denotes the status of iteration
@@ -64,6 +66,7 @@ private:
     *_scale;            //scaling parameter to prevent overflow in singular systems
   bool _sparse;
   bool _generateoutput;   //prints nothing, if set to false. Prints Matrix, right hand side, and solution of the linear system, if set to true.
+  bool _single_instance;
 #if defined(klu)
   klu_symbolic* _kluSymbolic;
   klu_numeric* _kluNumeric;

--- a/SimulationRuntime/cpp/Include/Solver/Newton/Newton.h
+++ b/SimulationRuntime/cpp/Include/Solver/Newton/Newton.h
@@ -7,7 +7,7 @@
 
 #include <Core/System/ILinearAlgLoop.h>                // Interface to AlgLoo
 #include <Core/System/INonLinearAlgLoop.h>                // Interface to AlgLoo
-#include <Core/Solver/IAlgLoopSolver.h>        // Export function from dll
+#include <Core/Solver/INonLinearAlgLoopSolver.h>        // Export function from dll
 #include <Core/Solver/INonLinSolverSettings.h>
 #include <Solver/Newton/NewtonSettings.h>
 
@@ -32,18 +32,20 @@
 /*****************************************************************************
  * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
  *****************************************************************************/
-class Newton : public IAlgLoopSolver
+class Newton : public INonLinearAlgLoopSolver
 {
  public:
-  Newton(INonLinearAlgLoop* algLoop,INonLinSolverSettings* settings);
+  Newton(INonLinSolverSettings* settings,shared_ptr<INonLinearAlgLoop> algLoop=shared_ptr<INonLinearAlgLoop>());
 
   virtual ~Newton();
 
   /// (Re-) initialize the solver
   virtual void initialize();
 
-  /// Solution of a (non-)linear system of equations
-  virtual void solve();
+   /// Solution of a (non-)linear system of equations
+   virtual void solve();
+   //solve for a single instance call
+   virtual void solve(shared_ptr<INonLinearAlgLoop> algLoop,bool first_solve = false);
 
   /// Returns the status of iteration
   virtual ITERATIONSTATUS getIterationStatus();
@@ -62,8 +64,7 @@ class Newton : public IAlgLoopSolver
   INonLinSolverSettings
     *_newtonSettings;           ///< Settings for the solver
 
-  INonLinearAlgLoop
-    *_algLoop;                  ///< Algebraic loop to be solved
+   shared_ptr<INonLinearAlgLoop> _algLoop;                  ///< Algebraic loop to be solved
 
   ITERATIONSTATUS
     _iterationStatus;           ///< Output      - Denotes the status of iteration

--- a/SimulationRuntime/cpp/Include/Solver/Nox/Nox.h
+++ b/SimulationRuntime/cpp/Include/Solver/Nox/Nox.h
@@ -8,17 +8,19 @@
 #include <Solver/Nox/NOX_StatusTest_SgnChange.H>
 
 
-class Nox : public IAlgLoopSolver
+class Nox : public INonLinearAlgLoopSolver
 {
 public:
-  Nox(INonLinearAlgLoop* algLoop, INonLinSolverSettings* settings);
+  Nox(INonLinSolverSettings* settings,shared_ptr<INonLinearAlgLoop> algLoop=shared_ptr<INonLinearAlgLoop>());
   virtual ~Nox();
 
   /// (Re-) initialize the solver
   virtual void initialize();
 
-  /// Solution of a (non-)linear system of equations
+   /// Solution of a (non-)linear system of equations
   virtual void solve();
+  //solve for a single instance call
+  virtual void solve(shared_ptr<INonLinearAlgLoop> algLoop,bool first_solve = false);
 
   /// Returns the status of iteration
   virtual ITERATIONSTATUS getIterationStatus();

--- a/SimulationRuntime/cpp/Include/Solver/Nox/NoxLapackInterface.h
+++ b/SimulationRuntime/cpp/Include/Solver/Nox/NoxLapackInterface.h
@@ -39,7 +39,7 @@ class NoxLapackInterface : public LOCA::LAPACK::Interface {
 
   //! Initial guess
   Teuchos::RCP<NOX::LAPACK::Vector> _initialGuess;
-	INonLinearAlgLoop *_algLoop;///< Algebraic loop to be solved, required to obtain value of f
+	 shared_ptr<INonLinearAlgLoop> _algLoop;///< Algebraic loop to be solved, required to obtain value of f
 	double *_yScale, *_fScale, *_hugeabsolutevalues, *_xtemp, *_rhs;
 	int _dimSys;
 	bool _useDomainScaling;

--- a/SimulationRuntime/cpp/Include/Solver/UmfPack/UmfPack.h
+++ b/SimulationRuntime/cpp/Include/Solver/UmfPack/UmfPack.h
@@ -2,21 +2,24 @@
 
 #include <Core/System/ILinearAlgLoop.h>              // Interface to AlgLoo
 #include <Core/System/INonLinearAlgLoop.h>              // Interface to AlgLoo
-#include <Core/Solver/IAlgLoopSolver.h>        // Export function from dll
+#include <Core/Solver/ILinearAlgLoopSolver.h>        // Export function from dll
 #include <Core/Solver/ILinSolverSettings.h>
 #include <Solver/UmfPack/UmfPackSettings.h>
 
 
-class UmfPack : public IAlgLoopSolver
+class UmfPack : public ILinearAlgLoopSolver
 {
 public:
-  UmfPack(ILinearAlgLoop* algLoop,ILinSolverSettings* settings);
+  UmfPack(ILinSolverSettings* settings,shared_ptr<ILinearAlgLoop> algLoop=shared_ptr<ILinearAlgLoop>());
   virtual ~UmfPack();
 
     virtual void initialize();
 
     /// Solution of a (non-)linear system of equations
     virtual void solve();
+    //solve for a single instance call
+    virtual void solve(shared_ptr<ILinearAlgLoop> algLoop,bool first_solve = false);
+
 
     /// Returns the status of iteration
     virtual ITERATIONSTATUS getIterationStatus();
@@ -26,7 +29,7 @@ public:
 private:
     ITERATIONSTATUS _iterationStatus;
     ILinSolverSettings *_umfpackSettings;
-    ILinearAlgLoop *_algLoop;
+    shared_ptr<ILinearAlgLoop> _algLoop;
 
     double * _jacd;
     double * _rhs;

--- a/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/CMakeLists.txt
+++ b/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(${OMCFactoryName} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${Ex
 ENDIF(WIN32)
 add_precompiled_header(${OMCFactoryName} Include/Core/Modelica.h)
 
-install(FILES $<TARGET_PDB_FILE:${OMCFactoryName}> DESTINATION ${LIBINSTALLEXT} OPTIONAL)
+
 
 install(TARGETS ${OMCFactoryName} DESTINATION ${LIBINSTALLEXT})
 install(FILES

--- a/SimulationRuntime/cpp/Solver/Broyden/FactoryExport.cpp
+++ b/SimulationRuntime/cpp/Solver/Broyden/FactoryExport.cpp
@@ -4,22 +4,7 @@
  */
 #include <Core/ModelicaDefine.h>
 #include <Core/Modelica.h>
-#if defined(__vxworks)
-#include <Solver/Broyden/Broyden.h>
-#include <Solver/Broyden/BroydenSettings.h>
-extern "C" IAlgLoopSolver* createBroyden(INonLinearAlgLoop* algLoop, INonLinSolverSettings* settings)
-{
-    return new Broyden(algLoop, settings);
-}
-
-extern "C" INonLinSolverSettings* createBroydenSettings()
-{
-    return new BroydenSettings();
-}
-
-
-
-#elif defined(OMC_BUILD) && !defined(RUNTIME_STATIC_LINKING)
+#if defined(OMC_BUILD) && !defined(RUNTIME_STATIC_LINKING)
 
 #include <Solver/Broyden/Broyden.h>
 #include <Solver/Broyden/BroydenSettings.h>
@@ -28,7 +13,7 @@ extern "C" INonLinSolverSettings* createBroydenSettings()
     using boost::extensions::factory;
 
 BOOST_EXTENSION_TYPE_MAP_FUNCTION {
-  types.get<std::map<std::string, factory<IAlgLoopSolver,INonLinearAlgLoop*, INonLinSolverSettings*> > >()
+  types.get<std::map<std::string, factory<INonLinearAlgLoopSolver, INonLinSolverSettings*,shared_ptr<INonLinearAlgLoop> > > >()
     ["broyden"].set<Broyden>();
   types.get<std::map<std::string, factory<INonLinSolverSettings> > >()
     ["broydenSettings"].set<BroydenSettings>();
@@ -41,9 +26,9 @@ BOOST_EXTENSION_TYPE_MAP_FUNCTION {
      shared_ptr<INonLinSolverSettings> settings = shared_ptr<INonLinSolverSettings>(new BroydenSettings());
       return settings;
  }
- shared_ptr<IAlgLoopSolver> createBroydenSolver(INonLinearAlgLoop* algLoop, shared_ptr<INonLinSolverSettings> solver_settings)
+ shared_ptr<INonLinearAlgLoopSolver> createBroydenSolver(shared_ptr<INonLinSolverSettings> solver_settings,shared_ptr<INonLinearAlgLoop> algloop)
  {
-     shared_ptr<IAlgLoopSolver> solver = shared_ptr<IAlgLoopSolver>(new Broyden(algLoop,solver_settings.get()));
+     shared_ptr<INonLinearAlgLoopSolver> solver = shared_ptr<INonLinearAlgLoopSolver>(new Broyden(solver_settings.get(),algloop));
         return solver;
  }
 #else

--- a/SimulationRuntime/cpp/Solver/Dgesv/CMakeLists.txt
+++ b/SimulationRuntime/cpp/Solver/Dgesv/CMakeLists.txt
@@ -14,7 +14,6 @@ IF(DGESV_FOUND)
   add_library(${DgesvSolverName} STATIC DgesvSolver.cpp DgesvSolverSettings.cpp FactoryExport.cpp)
 
   set_target_properties(${DgesvSolverName} PROPERTIES COMPILE_DEFINITIONS "RUNTIME_STATIC_LINKING;ENABLE_SUNDIALS_STATIC")
-  install(FILES $<TARGET_PDB_FILE:${DgesvSolverName}> DESTINATION ${LIBINSTALLEXT} OPTIONAL)
   install(TARGETS ${DgesvSolverName} DESTINATION ${LIBINSTALLEXT})
   install(FILES
     ${CMAKE_SOURCE_DIR}/Include/Solver/Dgesv/DgesvSolver.h

--- a/SimulationRuntime/cpp/Solver/Dgesv/DgesvSolver.cpp
+++ b/SimulationRuntime/cpp/Solver/Dgesv/DgesvSolver.cpp
@@ -15,7 +15,7 @@
 #include <Core/Utils/numeric/bindings/ublas.hpp>
 #include <Core/Utils/numeric/utils.h>
 
-DgesvSolver::DgesvSolver(ILinearAlgLoop* algLoop, ILinSolverSettings* settings)
+DgesvSolver::DgesvSolver(ILinSolverSettings* settings,shared_ptr<ILinearAlgLoop> algLoop)
   : _algLoop            (algLoop)
   , _dimSys             (0)
   , _yNames             (NULL)
@@ -57,7 +57,10 @@ void DgesvSolver::initialize()
 {
   _firstCall = false;
   //(Re-) Initialization of algebraic loop
+  if(_algLoop)
   _algLoop->initialize();
+  else
+	  throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop system is not initialized");
 
   int dimDouble = _algLoop->getDimReal();
   int ok = 0;
@@ -117,12 +120,22 @@ void DgesvSolver::initialize()
   LOGGER_WRITE_END(LC_LS, LL_DEBUG);
 }
 
+void DgesvSolver::solve(shared_ptr<ILinearAlgLoop> algLoop,bool first_solve)
+{
+	throw ModelicaSimulationError(ALGLOOP_SOLVER, "solve for single instance is not supported");
+}
+
 void DgesvSolver::solve()
 {
-  if (_firstCall) {
-    initialize();
-  }
 
+
+  if(!_algLoop)
+    throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop system is not initialized");
+
+   if (_firstCall)
+   {
+    initialize();
+   }
   _iterationStatus = CONTINUE;
 
   LOGGER_WRITE_BEGIN("DgesvSolver: eq" + to_string(_algLoop->getEquationIndex()) +
@@ -211,7 +224,7 @@ void DgesvSolver::solve()
   LOGGER_WRITE_END(LC_LS, LL_DEBUG);
 }
 
-IAlgLoopSolver::ITERATIONSTATUS DgesvSolver::getIterationStatus()
+ILinearAlgLoopSolver::ITERATIONSTATUS DgesvSolver::getIterationStatus()
 {
   return _iterationStatus;
 }

--- a/SimulationRuntime/cpp/Solver/Dgesv/FactoryExport.cpp
+++ b/SimulationRuntime/cpp/Solver/Dgesv/FactoryExport.cpp
@@ -5,17 +5,7 @@
 
 #include <Core/ModelicaDefine.h>
 #include <Core/Modelica.h>
-#if defined(__vxworks)
-#include <Solver/Dgesv/DgesvSolver.h>
-
-extern "C" IAlgLoopSolver* createDgesvSolver(ILinearAlgLoop* algLoop,ILinSolverSettings*)
-{
-  return new DgesvSolver(algLoop);
-}
-
-
-
-#elif defined(OMC_BUILD) && !defined(RUNTIME_STATIC_LINKING)
+#if defined(OMC_BUILD) && !defined(RUNTIME_STATIC_LINKING)
 
 //do not use for dynamic linking
 
@@ -27,9 +17,9 @@ shared_ptr<ILinSolverSettings> createDgesvSolverSettings()
        shared_ptr<ILinSolverSettings> settings = shared_ptr<ILinSolverSettings>(new DgesvSolverSettings());
         return settings;
    }
-shared_ptr<IAlgLoopSolver> createDgesvSolver(ILinearAlgLoop* algLoop,shared_ptr<ILinSolverSettings> solver_settings)
+shared_ptr<ILinearAlgLoopSolver> createDgesvSolver(shared_ptr<ILinSolverSettings> solver_settings,shared_ptr<ILinearAlgLoop> algLoop)
 {
-  shared_ptr<IAlgLoopSolver> solver = shared_ptr<IAlgLoopSolver>(new DgesvSolver(algLoop,solver_settings.get()));
+  shared_ptr<ILinearAlgLoopSolver> solver = shared_ptr<ILinearAlgLoopSolver>(new DgesvSolver(solver_settings.get(),algLoop));
   return solver;
 }
 

--- a/SimulationRuntime/cpp/Solver/Hybrj/FactoryExport.cpp
+++ b/SimulationRuntime/cpp/Solver/Hybrj/FactoryExport.cpp
@@ -4,23 +4,7 @@
  */
 #include <Core/ModelicaDefine.h>
 #include <Core/Modelica.h>
-#if defined(__vxworks)
-
-
-#elif defined(SIMSTER_BUILD)
-
-#include <Solver/Hybrj/Hybrj.h>
-#include <Solver/Hybrj/HybrjSettings.h>
-
-
-/*Simster factory*/
-extern "C" void BOOST_EXTENSION_EXPORT_DECL extension_export_hybrj(boost::extensions::factory_map & fm)
-{
-    fm.get<IAlgLoopSolver,int,INonLinearAlgLoop*, INonLinSolverSettings*>()[1].set<Hybrj>();
-    fm.get<INonLinSolverSettings,int >()[2].set<HybrjSettings>();
-}
-
-#elif defined(OMC_BUILD)
+#if defined(OMC_BUILD)
 
 #include <Solver/Hybrj/Hybrj.h>
 #include <Solver/Hybrj/HybrjSettings.h>
@@ -29,7 +13,7 @@ extern "C" void BOOST_EXTENSION_EXPORT_DECL extension_export_hybrj(boost::extens
 using boost::extensions::factory;
 
 BOOST_EXTENSION_TYPE_MAP_FUNCTION {
-  types.get<std::map<std::string, factory<IAlgLoopSolver,INonLinearAlgLoop*, INonLinSolverSettings*> > >()
+  types.get<std::map<std::string, factory<INonLinearAlgLoopSolver, INonLinSolverSettings*,shared_ptr<INonLinearAlgLoop> > > >()
     ["hybrj"].set<Hybrj>();
   types.get<std::map<std::string, factory<INonLinSolverSettings> > >()
     ["hybrjSettings"].set<HybrjSettings>();

--- a/SimulationRuntime/cpp/Solver/Kinsol/Kinsol.cpp
+++ b/SimulationRuntime/cpp/Solver/Kinsol/Kinsol.cpp
@@ -106,7 +106,7 @@ int kin_DlsDenseJacFn(long int N, N_Vector u, N_Vector fu,DlsMat J, void *user_d
 }
 */
 
-Kinsol::Kinsol(INonLinearAlgLoop* algLoop, INonLinSolverSettings* settings)
+Kinsol::Kinsol(INonLinSolverSettings* settings,shared_ptr<INonLinearAlgLoop> algLoop)
 	: _algLoop            (algLoop)
 	, _kinsolSettings     ((INonLinSolverSettings*)settings)
 	, _y                  (NULL)
@@ -145,7 +145,7 @@ Kinsol::Kinsol(INonLinearAlgLoop* algLoop, INonLinSolverSettings* settings)
   , _solverErrorNotificationGiven(false)
 {
 	_data = ((void*)this);
-	_sparse = _algLoop->getUseSparseFormat();
+
 }
 
 Kinsol::~Kinsol()
@@ -201,10 +201,15 @@ void Kinsol::initialize()
 {
 	int idid;
 
+	if(_firstCall)
+	   _algLoop->initialize();
+
 	_firstCall = false;
 
-	//(Re-) Initialization of algebraic loop
-	_algLoop->initialize();
+     if(!_algLoop)
+        throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop system is not initialized");
+
+	 _sparse = _algLoop->getUseSparseFormat();
 
 	// Dimension of the system (number of variables)
 	int
@@ -212,9 +217,7 @@ void Kinsol::initialize()
 		dimInt    = 0,
 		dimBool    = 0;
 
-	// Check system dimension
-	if (dimDouble != _dimSys)
-	{
+
 		_dimSys = dimDouble;
 
 		if(_dimSys > 0)
@@ -263,6 +266,19 @@ void Kinsol::initialize()
 					_yScale[i] = 1/_yScale[i];
 				else
 					_yScale[i] = 1;
+
+
+			if (_Kin_y)
+
+				N_VDestroy_Serial(_Kin_y);
+			if (_Kin_y0)
+				N_VDestroy_Serial(_Kin_y0);
+			if (_Kin_yScale)
+				N_VDestroy_Serial(_Kin_yScale);
+			if (_Kin_fScale)
+				N_VDestroy_Serial(_Kin_fScale);
+			if (_kinMem)
+				KINFree(&_kinMem);
 
 			_Kin_y = N_VMake_Serial(_dimSys, _y);
 			_Kin_y0 = N_VMake_Serial(_dimSys, _y0);
@@ -348,28 +364,41 @@ void Kinsol::initialize()
 
 			_counter = 0;
 
-		}
-		else
-		{
-			_iterationStatus = SOLVERERROR;
-		}
 	}
 	LOGGER_WRITE("Kinsol: initialized",LC_NLS,LL_DEBUG);
+}
+
+void Kinsol::solve(shared_ptr<INonLinearAlgLoop> algLoop, bool first_solve)
+{
+	if (first_solve)
+	{
+		_algLoop = algLoop;
+		_firstCall = true;
+	}
+	if (_algLoop != algLoop)
+		throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop system is not initialized");
+	solve();
 }
 
 
 void Kinsol::solve()
 {
 	if (_firstCall)
+	{
 		initialize();
+	}
 
+	if(!_algLoop)
+      throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop system is not initialized");
 	_iterationStatus = CONTINUE;
 
 	int idid;
 	_counter++;
 	_eventRetry = false;
 	_iterationStatus = CONTINUE;
-
+	//get variables vectors for last accepted step
+	_algLoop->getReal(_y);
+	_algLoop->getRealStartValues(_y0);
 
 	// Try Dense first
 	////////////////////////////
@@ -558,7 +587,7 @@ void Kinsol::solve()
 	}
 }
 
-IAlgLoopSolver::ITERATIONSTATUS Kinsol::getIterationStatus()
+INonLinearAlgLoopSolver::ITERATIONSTATUS Kinsol::getIterationStatus()
 {
 	return _iterationStatus;
 }
@@ -566,6 +595,9 @@ IAlgLoopSolver::ITERATIONSTATUS Kinsol::getIterationStatus()
 
 void Kinsol::calcFunction(const double *y, double *residual)
 {
+
+	if(!_algLoop)
+      throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop system is not initialized");
 	_fValid = true;
 	_algLoop->setReal(y);
 	try
@@ -587,6 +619,7 @@ void Kinsol::calcFunction(const double *y, double *residual)
 
 int Kinsol::kin_f(N_Vector y,N_Vector fval, void *user_data)
 {
+
 	((Kinsol*) user_data)->calcFunction(NV_DATA_S(y),NV_DATA_S(fval));
 
 	if(((Kinsol*) user_data)->_fValid)
@@ -876,6 +909,8 @@ void Kinsol::restoreNewValues()
 
 void Kinsol::check4EventRetry(double* y)
 {
+	if(!_algLoop)
+      throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop system is not initialized");
 	_algLoop->setReal(y);
 	if(!(_algLoop->isConsistent()) && !_eventRetry)
 	{

--- a/SimulationRuntime/cpp/Solver/LinearSolver/FactoryExport.cpp
+++ b/SimulationRuntime/cpp/Solver/LinearSolver/FactoryExport.cpp
@@ -5,17 +5,7 @@
 
 #include <Core/ModelicaDefine.h>
 #include <Core/Modelica.h>
-#if defined(__vxworks)
-#include <Solver/LinearSolver/LinearSolver.h>
-
-extern "C" IAlgLoopSolver* createLinearSolver(ILinearAlgLoop* algLoop,ILinSolverSettings*)
-{
-  return new LinearSolver(algLoop);
-}
-
-
-
-#elif defined(OMC_BUILD) && !defined(RUNTIME_STATIC_LINKING)
+#if defined(OMC_BUILD) && !defined(RUNTIME_STATIC_LINKING)
 
 #include <Solver/LinearSolver/LinearSolver.h>
 #include <Solver/LinearSolver/LinearSolverSettings.h>
@@ -24,7 +14,7 @@ extern "C" IAlgLoopSolver* createLinearSolver(ILinearAlgLoop* algLoop,ILinSolver
 using boost::extensions::factory;
 
 BOOST_EXTENSION_TYPE_MAP_FUNCTION {
-types.get<std::map<std::string, factory<IAlgLoopSolver,ILinearAlgLoop*,ILinSolverSettings*> > >()
+types.get<std::map<std::string, factory<ILinearAlgLoopSolver,ILinSolverSettings*,shared_ptr<ILinearAlgLoop> > > >()
     ["linearSolver"].set<LinearSolver>();
 types.get<std::map<std::string, factory<ILinSolverSettings> > >()
     ["linearSolverSettings"].set<LinearSolverSettings>();
@@ -38,9 +28,9 @@ shared_ptr<ILinSolverSettings> createLinearSolverSettings()
        shared_ptr<ILinSolverSettings> settings = shared_ptr<ILinSolverSettings>(new LinearSolverSettings());
         return settings;
    }
-shared_ptr<IAlgLoopSolver> createLinearSolver(ILinearAlgLoop* algLoop,shared_ptr<ILinSolverSettings> solver_settings)
+shared_ptr<ILinearAlgLoopSolver> createLinearSolver(shared_ptr<ILinSolverSettings> solver_settings,shared_ptr<ILinearAlgLoop> algLoop)
 {
-  shared_ptr<IAlgLoopSolver> solver = shared_ptr<IAlgLoopSolver>(new LinearSolver(algLoop,solver_settings.get()));
+  shared_ptr<ILinearAlgLoopSolver> solver = shared_ptr<ILinearAlgLoopSolver>(new LinearSolver(solver_settings.get(),algLoop));
   return solver;
 }
 

--- a/SimulationRuntime/cpp/Solver/Newton/FactoryExport.cpp
+++ b/SimulationRuntime/cpp/Solver/Newton/FactoryExport.cpp
@@ -5,21 +5,7 @@
 
 #include <Core/ModelicaDefine.h>
 #include <Core/Modelica.h>
-#if defined(__vxworks)
-#include <Solver/Newton/Newton.h>
-#include <Solver/Newton/NewtonSettings.h>
-
-extern "C" IAlgLoopSolver* createNewton(INonLinearAlgLoop* algLoop, INonLinSolverSettings* settings)
-{
-  return new Newton(algLoop, settings);
-}
-
-extern "C" INonLinSolverSettings* createNewtonSettings()
-{
-  return new NewtonSettings();
-}
-
-#elif defined(OMC_BUILD) && !defined(RUNTIME_STATIC_LINKING)
+#if defined(OMC_BUILD) && !defined(RUNTIME_STATIC_LINKING)
 
 #include <Solver/Newton/Newton.h>
 #include <Solver/Newton/NewtonSettings.h>
@@ -28,7 +14,7 @@ extern "C" INonLinSolverSettings* createNewtonSettings()
 using boost::extensions::factory;
 
 BOOST_EXTENSION_TYPE_MAP_FUNCTION {
-  types.get<std::map<std::string, factory<IAlgLoopSolver,INonLinearAlgLoop*, INonLinSolverSettings*> > >()
+  types.get<std::map<std::string, factory<INonLinearAlgLoopSolver, INonLinSolverSettings*,shared_ptr<INonLinearAlgLoop> > > >()
     ["newton"].set<Newton>();
   types.get<std::map<std::string, factory<INonLinSolverSettings> > >()
     ["newtonSettings"].set<NewtonSettings>();
@@ -44,9 +30,9 @@ shared_ptr<INonLinSolverSettings> createNewtonSettings()
   return settings;
 }
 
-shared_ptr<IAlgLoopSolver> createNewtonSolver(INonLinearAlgLoop* algLoop, shared_ptr<INonLinSolverSettings> solver_settings)
+shared_ptr<INonLinearAlgLoopSolver> createNewtonSolver(shared_ptr<INonLinSolverSettings> solver_settings,shared_ptr<INonLinearAlgLoop> algloop)
 {
-  shared_ptr<IAlgLoopSolver> solver = shared_ptr<IAlgLoopSolver>(new Newton(algLoop,solver_settings.get()));
+  shared_ptr<INonLinearAlgLoopSolver> solver = shared_ptr<INonLinearAlgLoopSolver>(new Newton(solver_settings.get(),algloop));
   return solver;
 }
 

--- a/SimulationRuntime/cpp/Solver/Nox/FactoryExport.cpp
+++ b/SimulationRuntime/cpp/Solver/Nox/FactoryExport.cpp
@@ -5,25 +5,7 @@
 #include <Core/ModelicaDefine.h>
 #include <Core/Modelica.h>
 
-#if defined(__vxworks) || defined(__TRICORE__)
-#include <NOX.H>
-#include <Solver/Nox/NoxLapackInterface.h>
-#include <Solver/Nox/Nox.h>
-#include <Solver/Nox/NoxSettings.h>
-
-extern "C" IAlgLoopSolver* createNox(INonLinearAlgLoop* algLoop, INonLinSolverSettings* settings)
-{
-    return new Nox(algLoop, settings);
-}
-
-extern "C" INonLinSolverSettings* createNoxSettings()
-{
-    return new NoxSettings();
-}
-
-#elif defined(SIMSTER_BUILD)
-
-#elif defined(OMC_BUILD)  && !defined(RUNTIME_STATIC_LINKING)
+#if defined(OMC_BUILD)  && !defined(RUNTIME_STATIC_LINKING)
 #include <NOX.H>
 #include <Solver/Nox/NoxLapackInterface.h>
 #include <Solver/Nox/Nox.h>
@@ -32,7 +14,7 @@ extern "C" INonLinSolverSettings* createNoxSettings()
 using boost::extensions::factory;
 
 BOOST_EXTENSION_TYPE_MAP_FUNCTION {
-  types.get<std::map<std::string, factory<IAlgLoopSolver,INonLinearAlgLoop*, INonLinSolverSettings*> > >()
+  types.get<std::map<std::string, factory<IAlgLoopSolver,INonLinSolverSettings*>,shared_ptr<INonLinearAlgLoop> > >()
     ["nox"].set<Nox>();
   types.get<std::map<std::string, factory<INonLinSolverSettings> > >()
     ["noxSettings"].set<NoxSettings>();
@@ -51,7 +33,7 @@ shared_ptr<INonLinSolverSettings> createNoxSettings()
 {
  throw ModelicaSimulationError(ALGLOOP_SOLVER,"Nox was disabled during build");
 }
-shared_ptr<IAlgLoopSolver> createNoxSolver(INonLinearAlgLoop* algLoop, shared_ptr<INonLinSolverSettings> solver_settings)
+shared_ptr<IAlgLoopSolver> createNoxSolver( shared_ptr<INonLinSolverSettings> solver_settings,shared_ptr<INonLinearAlgLoop> algLoop)
 {
  throw ModelicaSimulationError(ALGLOOP_SOLVER,"Nox was disabled during build");
 }

--- a/SimulationRuntime/cpp/Solver/Nox/Nox.cpp
+++ b/SimulationRuntime/cpp/Solver/Nox/Nox.cpp
@@ -24,7 +24,7 @@
 
 
 //!Constructor
-Nox::Nox(INonLinearAlgLoop* algLoop, INonLinSolverSettings* settings)
+Nox::Nox(INonLinSolverSettings* settings,shared_ptr<INonLinearAlgLoop> algLoop)
 	: _algLoop            (algLoop)
 	, _noxSettings        ((INonLinSolverSettings*)settings)
 	, _iterationStatus    (CONTINUE)
@@ -66,8 +66,10 @@ Nox::~Nox()
 void Nox::initialize()
 {
 	_firstCall = false;
-	_algLoop->initialize();//this sets values in the real variable
-
+	 if(_algLoop)
+      _algLoop->initialize();
+    else
+	  throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop system is not initialized");
 
 	if(_y) delete [] _y;
 	if(_y0) delete [] _y0;
@@ -133,6 +135,11 @@ void Nox::initialize()
  *  For detailed calibration, check https://trilinos.org/docs/dev/packages/nox/doc/html/parameters.html
  *
  */
+
+void Nox::solve(shared_ptr<INonLinearAlgLoop> algLoop,bool first_solve = false)
+{
+	throw ModelicaSimulationError(ALGLOOP_SOLVER, "solve for single instance is not supported");
+}
 void Nox::solve()
 {
 	int iter=-1; //Iterationcount of proper methods
@@ -144,11 +151,16 @@ void Nox::solve()
   LOGGER_WRITE_BEGIN("Nox: start solving algebraic loop no. " + to_string(_algLoop->getEquationIndex()) + " at Simulation time " + to_string(_algLoop->getSimTime()), _lc, LL_DEBUG);
 
   //setup solver
-  if (_firstCall){
-    LOGGER_WRITE("initialize...",_lc, LL_DEBUG);
+  if (!restart)
+  {
+
+	LOGGER_WRITE("initialize...",_lc, LL_DEBUG);
+    _algLoop = algLoop;
     initialize();
-    LOGGER_WRITE("init done!",_lc, LL_DEBUG);
+	LOGGER_WRITE("init done!",_lc, LL_DEBUG);
   }
+  if(!_algLoop)
+    throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop system is not initialized");
 
 	// Create the list of solver parameters. For detailed calibration, check https://trilinos.org/docs/dev/packages/nox/doc/html/parameters.html
   _solverParametersPtr = Teuchos::rcp(new Teuchos::ParameterList);
@@ -350,7 +362,7 @@ void Nox::solve()
  *
  *  \details Details
  */
-IAlgLoopSolver::ITERATIONSTATUS Nox::getIterationStatus()
+INonLinearAlgLoopSolver::ITERATIONSTATUS Nox::getIterationStatus()
 {
 	return _iterationStatus;
 }
@@ -364,6 +376,9 @@ IAlgLoopSolver::ITERATIONSTATUS Nox::getIterationStatus()
  */
 void Nox::stepCompleted(double time)
 {
+   if(!_algLoop)
+      throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop system is not initialized");
+
 	memcpy(_y0,_y,_dimSys*sizeof(double));
   memcpy(_y_old,_y_new,_dimSys*sizeof(double));
   memcpy(_y_new,_y,_dimSys*sizeof(double));
@@ -402,6 +417,8 @@ void Nox::restoreNewValues()
  */
 void Nox::check4EventRetry(double* y)
 {
+	 if(!_algLoop)
+      throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop system is not initialized");
 	_algLoop->setReal(y);
 	if(!(_algLoop->isConsistent()) && !_eventRetry)
 	{

--- a/SimulationRuntime/cpp/Solver/UmfPack/FactoryExport.cpp
+++ b/SimulationRuntime/cpp/Solver/UmfPack/FactoryExport.cpp
@@ -1,10 +1,7 @@
 
 #include <Core/ModelicaDefine.h>
 #include <Core/Modelica.h>
-#if defined(__vxworks)
-
-
-#elif defined(OMC_BUILD) && !defined(RUNTIME_STATIC_LINKING)
+#if defined(OMC_BUILD) && !defined(RUNTIME_STATIC_LINKING)
 
 #include <Solver/UmfPack/UmfPack.h>
 #include <Solver/UmfPack/UmfPackSettings.h>
@@ -13,7 +10,7 @@
     using boost::extensions::factory;
 
 BOOST_EXTENSION_TYPE_MAP_FUNCTION {
-  types.get<std::map<std::string, factory<IAlgLoopSolver,ILinearAlgLoop*, ILinSolverSettings*> > >()
+  types.get<std::map<std::string, factory<ILinearAlgLoopSolver, ILinSolverSettings*,shared_ptr<ILinearAlgLoop> > > >()
     ["umfpack"].set<UmfPack>();
   types.get<std::map<std::string, factory<ILinSolverSettings> > >()
     ["umfpackSettings"].set<UmfPackSettings>();
@@ -28,9 +25,9 @@ shared_ptr<ILinSolverSettings> createUmfpackSettings()
      return settings;
 }
 
-shared_ptr<IAlgLoopSolver> createUmfpackSolver(ILinearAlgLoop* algLoop, shared_ptr<ILinSolverSettings> solver_settings)
+shared_ptr<ILinearAlgLoopSolver> createUmfpackSolver(shared_ptr<ILinSolverSettings> solver_settings,shared_ptr<ILinearAlgLoop> algLoop)
 {
-   shared_ptr<IAlgLoopSolver> solver = shared_ptr<IAlgLoopSolver>(new UmfPack(algLoop,solver_settings.get()));
+   shared_ptr<ILinearAlgLoopSolver> solver = shared_ptr<ILinearAlgLoopSolver>(new UmfPack(solver_settings.get(),algLoop));
    return solver;
 }
 


### PR DESCRIPTION
runtime

[cppRuntime] Simplified handling algebraic loops in cpp runtime
Use only one solver for linear and one for nonlinear system. If needed a
own solver can used for a system

removed accidentally added files

added new AlglooperSolver class for linear and nonlinear systems

adapted linear and nonlinear solvers on new interfaces ILinearAlgloopSolver and INonLinearAlgloopSolver

added restart attribute to solve methode of algloopsolver, to restart without initialisation of algloop system

Adapted cpp template for new algloop solver interface

fix for intialize algloops at first solve call

fix for init algloop solvers used by analytic jacobians

fix for start algebraic loop solver without initializing

Combined initialize and evaluate function from algebraic loops

for parallel simulation use multiple instances of algloopsolver

fix typo

added flag to use only one instance of algloop solver in cpp runtime

removed initiequation call for some kind of linear equations