### PR TITLE
[NF] finalize overconstrained connection graph (OCG)

### DIFF
--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -794,5 +794,24 @@ public
     end match;
   end toListReverse;
 
+  function depth
+    input ComponentRef cref;
+    output Integer d = 0;
+  algorithm
+    d := match cref
+      case CREF(restCref = EMPTY())
+        then d + 1;
+
+      case CREF()
+        algorithm
+          d := 1 + depth(cref.restCref);
+        then
+          d;
+
+      case WILD() then 0;
+      else "EMPTY_CREF" then 0;
+    end match;
+  end depth;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFComponentRef;

--- a/Compiler/NFFrontEnd/NFEquation.mo
+++ b/Compiler/NFFrontEnd/NFEquation.mo
@@ -76,6 +76,7 @@ public
   record CONNECT
     Expression lhs;
     Expression rhs;
+    list<Equation> broken "equations which would replace a broken connect in the overconstrained connection graph";
     DAE.ElementSource source;
   end CONNECT;
 
@@ -297,6 +298,7 @@ public
     eq := match eq
       local
         Expression e1, e2, e3;
+        list<Equation> eql;
 
       case EQUALITY()
         algorithm
@@ -318,9 +320,10 @@ public
         algorithm
           e1 := func(eq.lhs);
           e2 := func(eq.rhs);
+          eql := mapExpList(eq.broken, func);
         then
           if referenceEq(e1, eq.lhs) and referenceEq(e2, eq.rhs)
-            then eq else CONNECT(e1, e2, eq.source);
+            then eq else CONNECT(e1, e2, eql, eq.source);
 
       case FOR()
         algorithm

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -2507,7 +2507,7 @@ algorithm
         exp1 := instCref(scodeEq.crefLeft, scope, info);
         exp2 := instCref(scodeEq.crefRight, scope, info);
       then
-        Equation.CONNECT(exp1, exp2, makeSource(scodeEq.comment, info));
+        Equation.CONNECT(exp1, exp2, {}, makeSource(scodeEq.comment, info));
 
     case SCode.EEquation.EQ_FOR(info = info)
       algorithm

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -86,6 +86,7 @@ import NFInstNode.CachedData;
 import Direction = NFPrefixes.Direction;
 import ElementSource;
 import StringUtil;
+import NFOCConnectionGraph;
 
 uniontype TypingError
   record NO_ERROR end NO_ERROR;
@@ -2355,6 +2356,7 @@ protected
   MatchKind mk;
   Integer next_origin;
   SourceInfo info;
+  list<Equation> eql;
 algorithm
   info := ElementSource.getInfo(source);
 
@@ -2398,7 +2400,12 @@ algorithm
   //  fail();
   //end if;
 
-  connEq := Equation.CONNECT(lhs, rhs, source);
+  // @adrpo: here we see if we have any overconstrained connectors in the connect
+  // if we do, we generate equation:
+  // zeros(:) = OverconstrainedType.equalityConstraint(lhs.overconstrained_component, rhs.overconstrained_component)
+  eql := NFOCConnectionGraph.generateEqualityConstraintEquation(lhs, lhs_ty, rhs, rhs_ty, origin, source);
+
+  connEq := Equation.CONNECT(lhs, rhs, eql, source);
 end typeConnect;
 
 function checkConnector


### PR DESCRIPTION
- generate zeros(:) = OverconstrainedType.equalityConstraint(A, B) equations
- replace broken connects with the generated equalityConstraint equation
- also run the Connections.* operator evaluation on initial equations
- do not delete inner outer nodes as it will fail miserably