### PR TITLE
[NF] fixes to overconstrained connection graph (OCG)

### DIFF
--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -152,7 +152,10 @@ algorithm
   flat_model := Package.collectConstants(flat_model, funcs);
 
   // Scalarize array components in the flat model.
-  flat_model := Scalarize.scalarize(flat_model, name);
+  if Flags.isSet(Flags.NF_SCALARIZE) then
+    flat_model := Scalarize.scalarize(flat_model, name);
+  end if;
+
   // Convert the flat model to a DAE.
   (dae, daeFuncs) := ConvertDAE.convert(flat_model, funcs, name, InstNode.info(inst_cls));
 

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -530,6 +530,8 @@ constant DebugFlag EXEC_STAT_EXTRA_GC = DEBUG_FLAG(177, "execstatGCcollect", fal
   Util.gettext("When running execstat, also perform an extra full garbage collection."));
 constant DebugFlag DEBUG_DAEMODE = DEBUG_FLAG(178, "debugDAEmode", false,
   Util.gettext("Dump debug output for the DAEmode."));
+constant DebugFlag NF_SCALARIZE = DEBUG_FLAG(179, "nfScalarize", true,
+  Util.gettext("Run scalarization in NF, default true."));
 
 // This is a list of all debug flags, to keep track of which flags are used. A
 // flag can not be used unless it's in this list, and the list is checked at
@@ -714,7 +716,8 @@ constant list<DebugFlag> allDebugFlags = {
   SUSAN_MATCHCONTINUE_DEBUG,
   OLD_FE_UNITCHECK,
   EXEC_STAT_EXTRA_GC,
-  DEBUG_DAEMODE
+  DEBUG_DAEMODE,
+  NF_SCALARIZE
 };
 
 public


### PR DESCRIPTION
- remove subscripts from the overconstrained conmponents when given as arguments to the equalityConstraint function
- lookup "fill" in top
- add flag (no)nfScalarize to be able to disable scalarization in NF