### PR TITLE
better handling of builtin and extern C functions

### DIFF
--- a/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1021,11 +1021,11 @@ package Internal "Contains internal implementations, e.g. overloaded builtin fun
   package Architecture
     function numBits
       output Integer numBit;
-      external "builtin";
+      external "builtin" numBit = architecture_numbits() annotation(Include="#define architecture_numbits() (8*sizeof(void*))");
     end numBits;
     function integerMax
       output Integer max;
-      external "builtin";
+      external "builtin" max = intMaxLit();
     end integerMax;
   end Architecture;
 

--- a/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -1142,11 +1142,11 @@ package Internal "Contains internal implementations, e.g. overloaded builtin fun
   package Architecture
     function numBits
       output Integer numBit;
-      external "builtin";
+      external "builtin" numBit = architecture_numbits() annotation(Include="#define architecture_numbits() (8*sizeof(void*))");
     end numBits;
     function integerMax
       output Integer max;
-      external "builtin";
+      external "builtin" max = intMaxLit();
     end integerMax;
   end Architecture;
 

--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -5800,13 +5800,16 @@ algorithm
         Flags.setConfigBool(Flags.CHECK_MODEL, true);
         (_,Values.STRING(str)) = checkModel(FCore.emptyCache(), env, className, msg);
         Flags.setConfigBool(Flags.CHECK_MODEL, false);
-        (_,Values.STRING(str)) = checkModel(FCore.emptyCache(), env, className, msg);
         t2 = clock();
         elapsedTime = t2 - t1;
         s = realString(elapsedTime);
         print (s + " seconds -> " + failOrSuccess(str) + "\n\t");
         print (System.stringReplace(str, "\n", "\n\t"));
         print ("\n");
+        print ("Error String:\n" + Print.getErrorString() + "\n");
+        print ("Error Buffer:\n" + ErrorExt.printMessagesStr(false) + "\n");
+        print ("# " + realString(elapsedTime) + " : " + Absyn.pathString(className) + "\n");
+        print ("-------------------------------------------------------------------------\n");
         checkAll(cache, env, rest, msg);
       then ();
 


### PR DESCRIPTION
- check if the name of the function is the same as the name of the external function
- if the name is not the same, generate the function and call the extern definition

- this fixes Models of the form:
```
model Atan2  
  partial model M  "Meter 2 terminal base, 3-phase dq0" 
  protected
    function atan2 = Modelica.Math.atan2;
  end M;

  model X  
    extends M;
    parameter Real a = 1;
    parameter Real b = 2;
    parameter Real z = atan2(a, b);
  end X;

  X x;
end Atan2;
```