### PR TITLE
Optionally cache stackBottom in mmc_init_stackoverflow()

### DIFF
--- a/SimulationRuntime/c/meta/meta_modelica_segv.c
+++ b/SimulationRuntime/c/meta/meta_modelica_segv.c
@@ -231,9 +231,22 @@ void init_metamodelica_segv_handler()
   sigfillset(&segvset);
 }
 
+
+#ifdef HAS_STACK_CACHING
+__thread int mmc_cache_stack = 0;
+#endif
 void mmc_init_stackoverflow(threadData_t *threadData)
 {
-  threadData->stackBottom = getStackBase();
+#ifdef HAS_STACK_CACHING
+  static __thread void *stackBottom;
+  if (!stackBottom || !mmc_cache_stack)
+#else
+  void *stackBottom;
+#endif
+  {
+    stackBottom = getStackBase();
+  }
+  threadData->stackBottom = stackBottom;
 }
 
 #else

--- a/SimulationRuntime/c/meta/meta_modelica_segv.h
+++ b/SimulationRuntime/c/meta/meta_modelica_segv.h
@@ -57,6 +57,11 @@ static inline void mmc_init_stackoverflow(threadData_t *threadData)
 void mmc_init_stackoverflow(threadData_t *threadData);
 #endif
 
+#ifdef __linux
+#define HAS_STACK_CACHING
+extern __thread int mmc_cache_stack;
+#endif
+
 #ifndef __has_builtin
   #define __has_builtin(x) 0  /* Compatibility with non-clang compilers */
 #endif


### PR DESCRIPTION
... in case calling thread does not plan to use coroutines, etc.

This can make OMEdit start 3 times faster on Linux. 

Required by OpenModelica/OMEdit#173