### PR TITLE
Avoid backslashes in JSON strings

### DIFF
--- a/Examples/ComplianceSuite.mos
+++ b/Examples/ComplianceSuite.mos
@@ -68,7 +68,10 @@ success := if shouldPass then resultFile<>\"\" else resultFile==\"\";
 messages := rec.messages;
 messages := messages + err;
 messages := messages + (if not success and not shouldPass /* This is correct; try to figure out why (hint: success is a poor name) */ then \"\nSucceeded, but expected failure\" else \"\");
-messages := stringReplace(stringReplace(firstPart(messages),\"\\\"\",\"\\\\\\\"\"),\"\n\",\"\\\\n\");
+messages := firstPart(messages);
+messages := stringReplace(messages, \"\\\\\",\"/\");
+messages := stringReplace(messages, \"\\\"\",\"'\");
+messages := stringReplace(messages,\"\n\",\"\\\\n\");
 errorType := if shouldPass then \"failed\" else \"expected failure\";
 if resultFile <> \"\" then
   time := rec.timeTotal;

--- a/Examples/ComplianceSuite.py
+++ b/Examples/ComplianceSuite.py
@@ -12,7 +12,12 @@ def readTest(f, expectedFailures):
   cl = ".".join(f.split(".")[:-1])
   name = f.split(".")[-2]
   with open(f) as fin:
-    res = simplejson.load(fin)
+    try:
+      res = simplejson.load(fin)
+    except simplejson.errors.JSONDecodeError:
+      print("Error loading file %s" % f)
+      raise
+
   if "killed" in res:
     tc = TestCase(name, cl, 0, '', '')
     tc.add_error_info('Killed or crashed')


### PR DESCRIPTION
This helps generating valid JSON for the compliance suite.