### PR TITLE
[NF] better error messages and more evaluation of parameters

### DIFF
--- a/Compiler/FrontEnd/Static.mo
+++ b/Compiler/FrontEnd/Static.mo
@@ -10013,7 +10013,7 @@ algorithm
         exp_str := ExpressionDump.printExpStr(inExp);
         c_str := Types.unparseConst(c2);
         Error.addSourceMessageAndFail(Error.FUNCTION_SLOT_VARIABILITY,
-          {fa1, exp_str, c_str}, inInfo);
+          {fa1, exp_str, Types.unparseConst(c1), c_str}, inInfo);
       end if;
 
       // Found a valid slot, fill it and reconstruct the slot list.

--- a/Compiler/FrontEnd/Types.mo
+++ b/Compiler/FrontEnd/Types.mo
@@ -2347,8 +2347,8 @@ algorithm
   outString := match(inConst)
     case DAE.C_CONST() then "constant";
     case DAE.C_PARAM() then "parameter";
-    case DAE.C_VAR() then "";
-    case DAE.C_UNKNOWN() then "#UNKNOWN#";
+    case DAE.C_VAR() then "continuous";
+    case DAE.C_UNKNOWN() then "unknown";
   end match;
 end unparseConst;
 

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -62,6 +62,7 @@ public
   import NFClass.Class;
   import NFComponentRef.Origin;
   import NFTyping.ExpOrigin;
+  import ExpressionSimplify;
 
   record INTEGER
     Integer value;
@@ -1083,6 +1084,8 @@ public
   function toDAE
     input Expression exp;
     output DAE.Exp dexp;
+  protected
+    Boolean changed = true;
   algorithm
     dexp := match exp
       local
@@ -1175,6 +1178,8 @@ public
           fail();
 
     end match;
+
+    // (dexp, changed) := ExpressionSimplify.simplify(dexp);
   end toDAE;
 
   function dimensionCount

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -798,6 +798,7 @@ uniontype Function
         correct := false;
         Error.addSourceMessage(Error.FUNCTION_SLOT_VARIABILITY, {
           InstNode.name(inputnode), Expression.toString(argexp),
+          Prefixes.variabilityString(var),
           Prefixes.variabilityString(Component.variability(comp))
         }, info);
         funcMatchKind := NO_MATCH;
@@ -865,6 +866,7 @@ uniontype Function
         correct := false;
         Error.addSourceMessage(Error.FUNCTION_SLOT_VARIABILITY, {
           InstNode.name(inputnode), Expression.toString(argexp),
+          Prefixes.variabilityString(var),
           Prefixes.variabilityString(Component.variability(comp))
         }, info);
         funcMatchKind := NO_MATCH;
@@ -1286,6 +1288,7 @@ protected
     ConnectorType cty;
     InnerOuter io;
     Visibility vis;
+    Variability var;
   algorithm
     Component.Attributes.ATTRIBUTES(
       connectorType = cty,
@@ -1293,6 +1296,7 @@ protected
       innerOuter = io) := Component.getAttributes(InstNode.component(component));
 
     vis := InstNode.visibility(component);
+    var := Component.variability(InstNode.component(component));
 
     // Function components may not be connectors.
     if cty <> ConnectorType.POTENTIAL then
@@ -1318,10 +1322,14 @@ protected
         fail();
       end if;
     else
+
       if vis == Visibility.PUBLIC then
         Error.addSourceMessage(Error.NON_FORMAL_PUBLIC_FUNCTION_VAR,
           {InstNode.name(component)}, InstNode.info(component));
-        fail();
+        // @adrpo: alow public constants and parameters in functions
+        if var > Variability.PARAMETER then
+          fail();
+        end if;
       end if;
     end if;
   end paramDirection;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -690,6 +690,11 @@ algorithm
 
   c := InstNode.component(node);
 
+  // @adrpo: if Evaluate=true make the parameter a structural parameter
+  if Component.getEvaluateAnnotation(c) then
+    c := Component.setVariability(Variability.STRUCTURAL_PARAMETER, c);
+  end if;
+
   () := match c
     // A component with a binding that's already been typed.
     case Component.TYPED_COMPONENT(binding = Binding.TYPED_BINDING()) then ();
@@ -734,8 +739,9 @@ algorithm
           end if;
         end if;
 
-        // Evaluate the binding if the component is a constant.
-        if comp_var <= Variability.STRUCTURAL_PARAMETER then
+        // Evaluate the binding if the component is a constant or has annotation(Evaluate=true)
+        if (comp_var <= Variability.STRUCTURAL_PARAMETER)
+        then
           // TODO: Allow this to fail for now. Once constant evaluation has
           // been improved we should print an error when a constant binding
           // couldn't be evaluated instead.

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -518,7 +518,7 @@ public constant Message ARRAY_TYPE_MISMATCH = MESSAGE(193, TRANSLATION(), ERROR(
 public constant Message VECTORIZE_TWO_UNKNOWN = MESSAGE(194, TRANSLATION(), ERROR(),
   Util.gettext("Could not vectorize call with unknown dimensions due to finding two for-iterators: %s and %s."));
 public constant Message FUNCTION_SLOT_VARIABILITY = MESSAGE(195, TRANSLATION(), ERROR(),
-  Util.gettext("Function argument %s=%s is not a %s expression."));
+  Util.gettext("Function argument %s=%s with variability %s is not a %s expression."));
 public constant Message INVALID_ARRAY_DIM_IN_CONVERSION_OP = MESSAGE(196, TRANSLATION(), ERROR(),
   Util.gettext("Invalid dimension %s of argument to %s, expected dimension size %s but got %s."));
 public constant Message DUPLICATE_REDECLARATION = MESSAGE(197, TRANSLATION(), ERROR(),
@@ -996,7 +996,8 @@ public constant Message FUNCTION_HIGHER_VARIABILITY_BINDING = MESSAGE(593, TRANS
   Util.gettext("Component ‘%s’ of variability %s has binding %s of higher variability %s."));
 public constant Message OCG_MISSING_BRANCH = MESSAGE(594, TRANSLATION(), WARNING(),
   Util.gettext("Connections.rooted(%s) needs exactly one statement Connections.branch(%s, B.R) involving %s but we found none in the graph. Run with -d=cgraphGraphVizFile to debug"));
-
+public constant Message UNBOUND_PARAMETER_EVALUATE_TRUE = MESSAGE(594, TRANSLATION(), WARNING(),
+  Util.gettext("Parameter %s has annotation(Evaluate=true) and no binding."));
 
 public constant Message MATCH_SHADOWING = MESSAGE(5001, TRANSLATION(), ERROR(),
   Util.gettext("Local variable '%s' shadows another variable."));


### PR DESCRIPTION
- evaluate parameters with annotation(Evaluate=true), make them structural parameters
- give the deduced variability of the expression that doesn't match the expected variability
- fix ticket:5062, add an warning message for parameter Type p(fixed=true) annotation(Evaluate=true); with no binding
- handle ticket:5061 by accepting parameters in the public section of the functions and issue a warning