### PR TITLE
[NF] Fix instantiation of derived classes.

### DIFF
--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -179,6 +179,7 @@ function typeClass
   input InstNode cls;
   input String name;
 algorithm
+  typeClassType(cls, NFBinding.EMPTY_BINDING, ExpOrigin.CLASS);
   typeComponents(cls, ExpOrigin.CLASS);
   execStat("NFTyping.typeComponents(" + name + ")");
   typeBindings(cls, cls, ExpOrigin.CLASS);


### PR DESCRIPTION
- Fix Typing.typeClass so that it correctly handles the case where the
  root class is a short class definition.