### PR TITLE
[NF] Potential fix for #5063.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -353,6 +353,12 @@ uniontype Call
       ty := getSpecialReturnType(func, args);
     end if;
 
+    // Functions that return a discrete type, e.g. Integer, should probably be
+    // treated as implicitly discrete if the arguments are continuous.
+    if Type.isDiscrete(ty) and var == Variability.CONTINUOUS then
+      var := Variability.IMPLICITLY_DISCRETE;
+    end if;
+
     if intBitAnd(origin, ExpOrigin.FUNCTION) == 0 then
       ty := evaluateCallType(ty, func, args);
     end if;


### PR DESCRIPTION
- Treat functions with a discrete output variable as implicitly
  discrete if the arguments are continuous.