### PR TITLE
[NF] Expandable Connectors [ticket:5015]

### DIFF
--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -469,6 +469,11 @@ uniontype Class
     output Boolean isConnector = Restriction.isConnector(restriction(cls));
   end isConnectorClass;
 
+  function isExpandableConnectorClass
+    input Class cls;
+    output Boolean isConnector = Restriction.isExpandableConnector(restriction(cls));
+  end isExpandableConnectorClass;
+
   function isExternalObject
     input Class cls;
     output Boolean isExternalObject = Restriction.isExternalObject(restriction(cls));

--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -659,6 +659,12 @@ uniontype Component
       Class.isConnectorClass(InstNode.getDerivedClass(classInstance(component)));
   end isConnector;
 
+  function isExpandableConnector
+    input Component component;
+    output Boolean isExpandableConnector =
+      Class.isExpandableConnectorClass(InstNode.getDerivedClass(classInstance(component)));
+  end isExpandableConnector;
+
   function isIdentical
     input Component comp1;
     input Component comp2;

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -398,6 +398,34 @@ uniontype InstNode
     end match;
   end isConnector;
 
+  function isExpandableConnector
+    input InstNode node;
+    output Boolean isConnector;
+  algorithm
+    isConnector := match node
+      case COMPONENT_NODE() then Component.isExpandableConnector(component(node));
+      else false;
+    end match;
+  end isExpandableConnector;
+
+  function hasParentExpandableConnector
+  "@author: adrpo
+   returns true if itself or any of the parents are expandable connectors"
+    input InstNode node;
+    output Boolean b = isExpandableConnector(node);
+  protected
+    InstNode p;
+  algorithm
+    p := node;
+    while not isEmpty(p) loop
+      p := parent(p);
+      b := boolOr(b, isExpandableConnector(p));
+      if b then
+        break;
+      end if;
+    end while;
+  end hasParentExpandableConnector;
+
   function name
     input InstNode node;
     output String name;

--- a/Compiler/NFFrontEnd/NFRestriction.mo
+++ b/Compiler/NFFrontEnd/NFRestriction.mo
@@ -103,6 +103,16 @@ public
     end match;
   end isConnector;
 
+  function isExpandableConnector
+    input Restriction res;
+    output Boolean isConnector;
+  algorithm
+    isConnector := match res
+      case CONNECTOR() then res.isExpandable;
+      else false;
+    end match;
+  end isExpandableConnector;
+
   function isExternalObject
     input Restriction res;
     output Boolean isExternalObject;


### PR DESCRIPTION
- partial implementation
- during lookup create virtual crefs
- during typing, type virtual crefs

Short on what remains:
Not sure how/when to add the virtual crefs as components in the ClassTree.
We need to collect all connects, do the union of expandable connectors and
then add all the virtual components to the FLAT_TREE before we do the
flattening.