### PR TITLE
use 'start' attribute if parameter has no binding (ticket:5065)

### DIFF
--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -303,6 +303,13 @@ algorithm
   binding := Component.getBinding(comp);
 
   if Binding.isUnbound(binding) then
+   // use the start value only if the component is a parameter(fixed=true)
+   if Component.getFixedAttribute(comp) and (Component.isParameter(comp) or Component.isStructuralParameter(comp)) then
+     binding := Class.lookupAttributeBinding("start", InstNode.getClass(node));
+   end if;
+  end if;
+
+  if Binding.isUnbound(binding) then
     binding := makeComponentBinding(comp, node, Expression.toCref(defaultExp), target);
   end if;
 

--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -780,34 +780,22 @@ uniontype Component
     list<Modifier> typeAttrs = {};
     Binding binding;
   algorithm
-    try
-	    typeAttrs := match (component)
-	      case (TYPED_COMPONENT())
-	        then Class.getTypeAttributes(InstNode.getClass(component.classInst));
-	      else {};
-	    end match;
-	  else
-	    typeAttrs := {};
-	  end try;
-    if listEmpty(typeAttrs) then
-      // for parameters the default is fixed = true
-      if isParameter(component) then
-        fixed := true;
-      else
-        fixed := false;
-      end if;
+    // for parameters the default is fixed = true
+    if isParameter(component) or isStructuralParameter(component) then
+      fixed := true;
+    else
+      fixed := false;
+    end if;
+
+    binding := Class.lookupAttributeBinding("fixed", InstNode.getClass(classInstance(component)));
+
+    // no fixed attribute present
+    if Binding.isUnbound(binding) then
       return;
     end if;
-    for m in typeAttrs loop
-      fixed := matchcontinue(m)
-        case Modifier.MODIFIER(name = "fixed", binding = binding)
-          algorithm
-            fixed := fixed and Expression.isTrue(Binding.getTypedExp(binding));
-          then
-            fixed;
-         else fixed;
-      end matchcontinue;
-    end for;
+
+    fixed := fixed and Expression.isTrue(Binding.getTypedExp(binding));
+
   end getFixedAttribute;
 
   function isDeleted


### PR DESCRIPTION
- better Component.getFixedAttribute implementation
- use start attribute if the component has no binding and has fixed=true (or has no fixed and is a parameter or structural parameter)