### PR TITLE
[NF] Make protected class lookup possible.

### DIFF
--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -118,7 +118,7 @@ algorithm
   name := Absyn.pathString(classPath);
 
   // Look up the class to instantiate and mark it as the root class.
-  cls := Lookup.lookupClassName(classPath, top, Absyn.dummyInfo);
+  cls := Lookup.lookupClassName(classPath, top, Absyn.dummyInfo, checkAccessViolations = false);
   cls := InstNode.setNodeType(InstNodeType.ROOT_CLASS(), cls);
 
   // Initialize the storage for automatically generated inner elements.

--- a/Compiler/NFFrontEnd/NFLookupState.mo
+++ b/Compiler/NFFrontEnd/NFLookupState.mo
@@ -335,15 +335,19 @@ uniontype LookupState
      print a (hopefully relevant) error message and fail."
     input InstNode node;
     input LookupState currentState;
+    input Boolean checkAccessViolations = true;
     output LookupState nextState;
   protected
     LookupState entry_ty;
     SCode.Element el;
   algorithm
-    // Check that the element is allowed to be accessed given its visibility.
-    checkProtection(node, currentState);
-    // Check that we're allowed to look in the current scope.
-    //checkPackageLikeAccess(inCurrentState, el, inEnv);
+    if checkAccessViolations then
+      // Check that the element is allowed to be accessed given its visibility.
+      checkProtection(node, currentState);
+      // Check that we're allowed to look in the current scope.
+      //checkPackageLikeAccess(inCurrentState, el, inEnv);
+    end if;
+
     // Get the state for the found element, and check that the transition to the
     // new state is valid.
     entry_ty := nodeState(node);


### PR DESCRIPTION
- Added a flag to Lookup.lookupClassName that allows lookup of a class
  without checking for access violations, so that e.g. protected
  classes can be instantiated by Inst.instClassInProgram.