### PR TITLE
[NF] Ignore some funcs in Expression.hasArrayCall.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -651,6 +651,26 @@ uniontype Call
     end match;
   end toDAE;
 
+  function isVectorizeable
+    input Call call;
+    output Boolean isVect;
+  algorithm
+    isVect := match call
+      local
+        String name;
+
+      case TYPED_CALL(fn = Function.FUNCTION(path = Absyn.IDENT(name = name)))
+        then match name
+          case "der" then false;
+          case "pre" then false;
+          case "previous" then false;
+          else true;
+        end match;
+
+      else true;
+    end match;
+  end isVectorizeable;
+
 protected
   function instNormalCall
     input Absyn.ComponentRef functionName;

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -3042,7 +3042,8 @@ public
     input output Boolean hasArrayCall;
   algorithm
     hasArrayCall := match exp
-      case CALL() then Type.isArray(Call.typeOf(exp.call));
+      case CALL() then hasArrayCall or
+                       (Type.isArray(Call.typeOf(exp.call)) and Call.isVectorizeable(exp.call));
       else hasArrayCall;
     end match;
   end hasArrayCall2;


### PR DESCRIPTION
- Ignore der/pre/previous when checking whether an equation contains
  function calls that shouldn't be scalarized, like the old frontend
  does.