### PR TITLE
Fix String inputs/outputs handling for FMUs

### DIFF
--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -1654,7 +1654,7 @@ template functionInput(SimCode simCode, ModelInfo modelInfo, String modelNamePre
     {
       TRACE_PUSH
 
-      <%vars.inputVars |> SIMVAR(__) hasindex i0 =>
+      <%vars.inputVars |> SIMVAR(name=name, type_=T_REAL()) hasindex i0 =>
         '<%cref(name)%> = data->simulationInfo->inputVars[<%i0%>];'
         ;separator="\n"
       %>
@@ -1667,7 +1667,7 @@ template functionInput(SimCode simCode, ModelInfo modelInfo, String modelNamePre
     {
       TRACE_PUSH
 
-      <%vars.inputVars |> SIMVAR(__) hasindex i0 =>
+      <%vars.inputVars |> SIMVAR(name=name, type_=T_REAL()) hasindex i0 =>
         match cref2simvar(name, simCode)
         case SIMVAR(aliasvar=NOALIAS()) then
         'data->simulationInfo->inputVars[<%i0%>] = data->modelData-><%expTypeShort(type_)%>VarsData[<%index%>].attribute.start;'
@@ -1683,7 +1683,7 @@ template functionInput(SimCode simCode, ModelInfo modelInfo, String modelNamePre
     {
       TRACE_PUSH
 
-      <%vars.inputVars |> SIMVAR(__) hasindex i0 =>
+      <%vars.inputVars |> SIMVAR(name=name, type_=T_REAL()) hasindex i0 =>
         match cref2simvar(name, simCode)
         case SIMVAR(aliasvar=NOALIAS()) then
         'data->modelData-><%expTypeShort(type_)%>VarsData[<%index%>].attribute.start = data->simulationInfo->inputVars[<%i0%>];'
@@ -1723,7 +1723,7 @@ template functionOutput(ModelInfo modelInfo, String modelNamePrefix)
     {
       TRACE_PUSH
 
-      <%vars.outputVars |> SIMVAR(__) hasindex i0 =>
+      <%vars.outputVars |> SIMVAR(name=name, type_=T_REAL()) hasindex i0 =>
         'data->simulationInfo->outputVars[<%i0%>] = <%cref(name)%>;'
         ;separator="\n"
       %>


### PR DESCRIPTION
Fix compilation of FMUs with String inputs/outputs. Frankly speaking, I'm not experienced at all with FMU runtime, but analyzing compiler errors and generated code I have made this 4-line modification. It seems that now it successfully compiles
```modelica
model Test
  output Real x;
  output Real y;
  input Real w;
  input String inStr;
  input Boolean b;
  output String outStr;
  output String msg;
initial equation
  x = 1;
equation
  der(x) = y;
  der(y) = -w * w * x;
  outStr = inStr;
  msg = (if x < 0 then "negative" else "positive") + " & " + (if b then "true" else "false");
end Test;
```
... with command like `buildModelFMU(Test, "1.0", "me");` and runs under FMUChecker with input
```csv
"time";"w";"b"
0.0;3.1415926;0
0.7;3.1415926;1
```
... in 1.0 ME and 2.0 CS modes. With 2.0 ME, it seems that something is broken with setting Booleans (removing the `"b"` column helps) but this error presents before this PR too.

Cannot test _setting_ String inputs right now, since FMUChecker does not support this.

PS: Hope compliance tests will catch regressions if any... :)