### PR TITLE
[NF] Fix ExpandExp.expandRange.

### DIFF
--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -251,7 +251,7 @@ end evalExp;
 
 function evalExpOpt
   input output Option<Expression> oexp;
-  input EvalTarget target;
+  input EvalTarget target = EvalTarget.IGNORE_ERRORS();
 algorithm
   oexp := match oexp
     local

--- a/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -47,6 +47,7 @@ protected
   import SimplifyExp = NFSimplifyExp;
   import NFPrefixes.Variability;
   import MetaModelica.Dangerous.*;
+  import EvalTarget = NFCeval.EvalTarget;
 
 public
   function expand
@@ -209,8 +210,7 @@ public
     expanded := Type.hasKnownSize(ty);
 
     if expanded then
-      range_iter := RangeIterator.fromExp(exp);
-      outExp := Expression.ARRAY(ty, RangeIterator.toList(range_iter));
+      outExp := Ceval.evalExp(exp);
     else
       outExp := exp;
     end if;

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -39,13 +39,11 @@ protected
   import BuiltinCall = NFBuiltinCall;
   import Expression = NFExpression;
   import Function = NFFunction;
-  import RangeIterator = NFRangeIterator;
   import NFPrefixes.Variability;
   import Prefixes = NFPrefixes;
   import Ceval = NFCeval;
   import ComplexType = NFComplexType;
   import MetaModelica.Dangerous.listReverseInPlace;
-  import ExpandExp = NFExpandExp;
 
 public
   import Absyn.Path;


### PR DESCRIPTION
- Use Ceval instead of RangeIterator to create the array of elements,
  since the range might contain expressions that need to be evaluated.