### PR TITLE
[NF] Add flag to expand unary/binary operations.

### DIFF
--- a/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -456,16 +456,22 @@ public
     Operator op;
   algorithm
     Expression.BINARY(exp1 = exp1, operator = op, exp2 = exp2) := exp;
-    (exp1, expanded) := expand(exp1);
 
-    if expanded then
-      (exp2, expanded) := expand(exp2);
-    end if;
+    if Type.isArray(Operator.typeOf(op)) then
+      (exp1, expanded) := expand(exp1);
 
-    if expanded then
-      outExp := expandBinaryElementWise2(exp1, op, exp2, makeBinaryOp);
+      if expanded then
+        (exp2, expanded) := expand(exp2);
+      end if;
+
+      if expanded then
+        outExp := expandBinaryElementWise2(exp1, op, exp2, makeBinaryOp);
+      else
+        outExp := exp;
+      end if;
     else
       outExp := exp;
+      expanded := true;
     end if;
   end expandBinaryElementWise;
 

--- a/Compiler/NFFrontEnd/NFOperator.mo
+++ b/Compiler/NFFrontEnd/NFOperator.mo
@@ -201,6 +201,12 @@ public
     op.ty := Type.arrayElementType(op.ty);
   end scalarize;
 
+  function unlift
+    input output Operator op;
+  algorithm
+    op.ty := Type.unliftArray(op.ty);
+  end unlift;
+
   function symbol
     input Operator op;
     input String spacing = " ";

--- a/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -36,6 +36,7 @@ import Operator = NFOperator;
 import Type = NFType;
 import NFCall.Call;
 import Subscript = NFSubscript;
+import NFOperator.Op;
 
 protected
 
@@ -273,7 +274,9 @@ algorithm
   se1 := simplify(e1);
   se2 := simplify(e2);
 
-  if Expression.isLiteral(se1) and Expression.isLiteral(se2) then
+  if Flags.isSet(Flags.NF_EXPAND_OPERATIONS) then
+    binaryExp := ExpandExp.expand(ExpandExp.makeBinaryOp(se1, op, se2));
+  elseif Expression.isLiteral(se1) and Expression.isLiteral(se2) then
     binaryExp := Ceval.evalBinaryOp(se1, op, se2);
   elseif not (referenceEq(e1, se1) and referenceEq(e2, se2)) then
     binaryExp := Expression.BINARY(se1, op, se2);

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -532,6 +532,10 @@ constant DebugFlag DEBUG_DAEMODE = DEBUG_FLAG(178, "debugDAEmode", false,
   Util.gettext("Dump debug output for the DAEmode."));
 constant DebugFlag NF_SCALARIZE = DEBUG_FLAG(179, "nfScalarize", true,
   Util.gettext("Run scalarization in NF, default true."));
+constant DebugFlag NF_EVAL_CONST_ARG_FUNCS = DEBUG_FLAG(180, "nfEvalConstArgFuncs", false,
+  Util.gettext("Evaluate all functions with constant arguments in the new frontend."));
+constant DebugFlag NF_EXPAND_OPERATIONS = DEBUG_FLAG(181, "nfExpandOperations", true,
+  Util.gettext("Expand all unary/binary operations to scalar expressions in the new frontend."));
 
 // This is a list of all debug flags, to keep track of which flags are used. A
 // flag can not be used unless it's in this list, and the list is checked at
@@ -717,7 +721,9 @@ constant list<DebugFlag> allDebugFlags = {
   OLD_FE_UNITCHECK,
   EXEC_STAT_EXTRA_GC,
   DEBUG_DAEMODE,
-  NF_SCALARIZE
+  NF_SCALARIZE,
+  NF_EVAL_CONST_ARG_FUNCS,
+  NF_EXPAND_OPERATIONS
 };
 
 public
@@ -1413,31 +1419,31 @@ constant ConfigFlag IGNORE_REPLACEABLE = CONFIG_FLAG(117, "ignoreReplaceable",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Sets whether to ignore replaceability or not when redeclaring."));
 
-  constant ConfigFlag LABELED_REDUCTION = CONFIG_FLAG(118,
+constant ConfigFlag LABELED_REDUCTION = CONFIG_FLAG(118,
   "labeledReduction", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Turns on labeling and reduce terms to do whole process of reduction."));
 
-  constant ConfigFlag DISABLE_EXTRA_LABELING = CONFIG_FLAG(119,
+constant ConfigFlag DISABLE_EXTRA_LABELING = CONFIG_FLAG(119,
   "disableExtraLabeling", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Disable adding extra label into the whole experssion with more than one term and +,- operations."));
 
-  constant ConfigFlag LOAD_MSL_MODEL = CONFIG_FLAG(120,
+constant ConfigFlag LOAD_MSL_MODEL = CONFIG_FLAG(120,
   "loadMSLModel", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Used to know loadFile doesn't need to be called in cpp-runtime (for labeled model reduction)."));
 
-  constant ConfigFlag Load_PACKAGE_FILE = CONFIG_FLAG(121,
+constant ConfigFlag Load_PACKAGE_FILE = CONFIG_FLAG(121,
   "loadPackageFile", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("used when the outside name is different with the inside name of the packge, in cpp-runtime (for labeled model reduction)."));
 
-  constant ConfigFlag BUILDING_FMU = CONFIG_FLAG(122,
+constant ConfigFlag BUILDING_FMU = CONFIG_FLAG(122,
   "", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Is true when building an FMU (so the compiler can look for URIs to package as FMI resources)."));
 
-  constant ConfigFlag BUILDING_MODEL = CONFIG_FLAG(123,
+constant ConfigFlag BUILDING_MODEL = CONFIG_FLAG(123,
   "", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Is true when building a model (as opposed to running a Modelica script)."));
 
-  constant ConfigFlag POST_OPT_MODULES_DAE = CONFIG_FLAG(124, "postOptModulesDAE",
+constant ConfigFlag POST_OPT_MODULES_DAE = CONFIG_FLAG(124, "postOptModulesDAE",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({
     "lateInlineFunction",
     "wrapFunctionCalls",
@@ -1454,15 +1460,15 @@ constant ConfigFlag IGNORE_REPLACEABLE = CONFIG_FLAG(117, "ignoreReplaceable",
     }),NONE(),
     Util.gettext("Sets the optimization modules for the DAEmode in the back end. See --help=optmodules for more info."));
 
-  constant ConfigFlag EVAL_LOOP_LIMIT = CONFIG_FLAG(125,
-    "evalLoopLimit", NONE(), EXTERNAL(), INT_FLAG(100000), NONE(),
-    Util.gettext("The loop iteration limit used when evaluating constant function calls."));
+constant ConfigFlag EVAL_LOOP_LIMIT = CONFIG_FLAG(125,
+  "evalLoopLimit", NONE(), EXTERNAL(), INT_FLAG(100000), NONE(),
+  Util.gettext("The loop iteration limit used when evaluating constant function calls."));
 
-  constant ConfigFlag EVAL_RECURSION_LIMIT = CONFIG_FLAG(126,
-    "evalRecursionLimit", NONE(), EXTERNAL(), INT_FLAG(256), NONE(),
-    Util.gettext("The recursion limit used when evaluating constant function calls."));
+constant ConfigFlag EVAL_RECURSION_LIMIT = CONFIG_FLAG(126,
+  "evalRecursionLimit", NONE(), EXTERNAL(), INT_FLAG(256), NONE(),
+  Util.gettext("The recursion limit used when evaluating constant function calls."));
 
-  constant ConfigFlag SINGLE_INSTANCE_AGLSOLVER = CONFIG_FLAG(127, "singleInstanceAglSolver",
+constant ConfigFlag SINGLE_INSTANCE_AGLSOLVER = CONFIG_FLAG(127, "singleInstanceAglSolver",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Util.gettext("Sets to instantiate only  one algebraic loop solver all algebraic loops"));
 


### PR DESCRIPTION
- Add new debug flag nfExpandOperations that expands the operators
  of unary and binary operations, to mimic the old frontend behaviour.
  This flag is on by default.
- Fixed some small issues with ExpandExp so that it doesn't fail on
  basic arithmetic operations involving scalars.