### PR TITLE
[NF] Fix function vectorization/cast conflict.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -970,6 +970,10 @@ protected
     if listLength(matchedFunctions) > 1 then
       exactMatches := MatchedFunction.getExactMatches(matchedFunctions);
 
+      if listEmpty(exactMatches) then
+        exactMatches := MatchedFunction.getExactVectorizedMatches(matchedFunctions);
+      end if;
+
       if listLength(exactMatches) > 1 then
         Error.addSourceMessage(Error.AMBIGUOUS_MATCHING_FUNCTIONS_NFINST,
           {typedString(call), Function.candidateFuncListString(list(mfn.func for mfn in matchedFunctions))}, info);


### PR DESCRIPTION
- Add the base type of match to vectorized functions, so that it's
  possible to differentiate between vectorized functions with exact or
  type cast arguments and choose the correct one.