### PR TITLE
[NF] Evaluate functions with constant arguments.

### DIFF
--- a/Compiler/NFFrontEnd/NFSimplifyModel.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyModel.mo
@@ -61,8 +61,8 @@ algorithm
   flatModel.variables := list(simplifyVariable(v) for v in flatModel.variables);
   flatModel.equations := simplifyEquations(flatModel.equations);
   flatModel.initialEquations := simplifyEquations(flatModel.initialEquations);
-  flatModel.algorithms := list(simplifyAlgorithm(a) for a in flatModel.algorithms);
-  flatModel.initialAlgorithms := list(simplifyAlgorithm(a) for a in flatModel.initialAlgorithms);
+  flatModel.algorithms := simplifyAlgorithms(flatModel.algorithms);
+  flatModel.initialAlgorithms := simplifyAlgorithms(flatModel.initialAlgorithms);
 
   functions := FunctionTree.map(functions, simplifyFunction);
 
@@ -184,6 +184,21 @@ algorithm
     else eq :: equations;
   end match;
 end simplifyEquation;
+
+function simplifyAlgorithms
+  input list<Algorithm> algs;
+  output list<Algorithm> outAlgs = {};
+algorithm
+  for alg in algs loop
+    alg := simplifyAlgorithm(alg);
+
+    if not listEmpty(alg.statements) then
+      outAlgs := alg :: outAlgs;
+    end if;
+  end for;
+
+  outAlgs := listReverseInPlace(outAlgs);
+end simplifyAlgorithms;
 
 function simplifyAlgorithm
   input output Algorithm alg;

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -532,7 +532,7 @@ constant DebugFlag DEBUG_DAEMODE = DEBUG_FLAG(178, "debugDAEmode", false,
   Util.gettext("Dump debug output for the DAEmode."));
 constant DebugFlag NF_SCALARIZE = DEBUG_FLAG(179, "nfScalarize", true,
   Util.gettext("Run scalarization in NF, default true."));
-constant DebugFlag NF_EVAL_CONST_ARG_FUNCS = DEBUG_FLAG(180, "nfEvalConstArgFuncs", false,
+constant DebugFlag NF_EVAL_CONST_ARG_FUNCS = DEBUG_FLAG(180, "nfEvalConstArgFuncs", true,
   Util.gettext("Evaluate all functions with constant arguments in the new frontend."));
 constant DebugFlag NF_EXPAND_OPERATIONS = DEBUG_FLAG(181, "nfExpandOperations", true,
   Util.gettext("Expand all unary/binary operations to scalar expressions in the new frontend."));


### PR DESCRIPTION
- Implemented -d=nfEvalConstArgFuncs to turn on evaluation of functions
  with constant arguments (on by default). Evaluation failures are
  silently ignored, -d=failtrace can be used to display errors.
- Remove empty algorithms in SimplifyModel.