### PR TITLE
[NF] Evaluate actualStream.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -276,5 +276,10 @@ constant Function FILL_FUNC = Function.FUNCTION(Path.IDENT("fill"),
     Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {},
     Pointer.createImmutable(true), Pointer.createImmutable(0));
 
+constant Function SMOOTH = Function.FUNCTION(Path.IDENT("smooth"),
+  InstNode.EMPTY_NODE(), {}, {}, {}, {},
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {},
+    Pointer.createImmutable(true), Pointer.createImmutable(0));
+
 annotation(__OpenModelica_Interface="frontend");
 end NFBuiltinFuncs;

--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -175,6 +175,13 @@ public
     CREF(node = node) := cref;
   end node;
 
+  function nodeType
+    input ComponentRef cref;
+    output Type ty;
+  algorithm
+    CREF(ty = ty) := cref;
+  end nodeType;
+
   function firstName
     input ComponentRef cref;
     output String name;

--- a/Compiler/Util/DisjointSets.mo
+++ b/Compiler/Util/DisjointSets.mo
@@ -208,14 +208,13 @@ function find
   input output Sets sets;
         output Integer index;
 algorithm
-  // TODO: Replace with try once the bootstrapping has been updated.
-  _ := matchcontinue () case () algorithm
+  try
     // Check if a node already exists in the forest.
     index := BaseHashTable.get(entry, sets.elements);
-  then (); else algorithm
+  else
     // If a node doesn't already exist, create a new one.
     (sets, index) := add(entry, sets);
-  then (); end matchcontinue;
+  end try;
 end find;
 
 function findRoot


### PR DESCRIPTION
- Add missing evaluation of actualStream to ConnectEquations.
- Remove the associated flow cref stored in stream connectors,
  since it doesn't work for actualStream and we can just look it up
  in the type of the connector instead.