### PR TITLE
Fixes for ticket:5117 and ticket:5119

### DIFF
--- a/Compiler/runtime/omc_config.h
+++ b/Compiler/runtime/omc_config.h
@@ -83,7 +83,7 @@
 #define DEFAULT_MAKE "make"
 
 /* adrpo: add -loleaut32 as is used by ExternalMedia */
-#define DEFAULT_LDFLAGS "-lregex -lexpat -lomcgc -Wl,-Bstatic -lpthread -Wl,-Bdynamic -fopenmp -loleaut32 -limagehlp -lz -lhdf5"
+#define DEFAULT_LDFLAGS "-fopenmp -Wl,-Bstatic -lregex -ltre -lintl -liconv -lexpat -lomcgc -lpthread -loleaut32 -limagehlp -lz -lhdf5 -lszip -Wl,-Bdynamic"
 
 
 #define CONFIG_WITH_OPENMP 1
@@ -96,10 +96,10 @@
 #endif
 
 /* adrpo: add -loleaut32 as is used by ExternalMedia */
-#define BASIC_LDFLAGS_RT " -lomcgc -lexpat -lregex -static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32 -llis -lumfpack -lklu -lcolamd -lbtf -lamd -lsundials_idas -lsundials_kinsol -lsundials_nvecserial -lipopt -lcoinmumps -Wl,-Bstatic -lpthread -Wl,-Bdynamic -lm -lgfortranbegin -lgfortran -lmingw32 -lgcc_eh -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32 -lopenblas -lcminpack"
+#define BASIC_LDFLAGS_RT " -Wl,-Bstatic -lomcgc -lregex -ltre -lintl -liconv -lexpat -static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32 -llis -lumfpack -lklu -lcolamd -lbtf -lamd  -Wl,-Bdynamic -lsundials_idas -lsundials_kinsol -lsundials_nvecserial -Wl,-Bstatic -lipopt -lcoinmumps -lpthread -lm -lgfortranbegin -lgfortran -lquadmath -lmingw32 -lgcc_eh -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32 -lopenblas -lcminpack -Wl,-Bdynamic"
 #define LDFLAGS_RT " -lOpenModelicaRuntimeC" BASIC_LDFLAGS_RT
-#define LDFLAGS_RT_SIM " -lSimulationRuntimeC" BASIC_LDFLAGS_RT " -lwsock32 -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic"
-#define LDFLAGS_RT_SOURCE_FMU " -lregex -static-libgcc -Wl,-Bstatic -lpthread -Wl,-Bdynamic -lm -lgfortranbegin -lgfortran -lmingw32 -lgcc_eh -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32 -limagehlp -lopenblas -lz -lhdf5"
+#define LDFLAGS_RT_SIM " -Wl,-Bstatic -lSimulationRuntimeC -Wl,-Bdynamic" BASIC_LDFLAGS_RT " -lwsock32 -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic"
+#define LDFLAGS_RT_SOURCE_FMU " -Wl,-Bstatic -lregex -ltre -lintl -liconv -static-libgcc -lpthread -lm -lgfortranbegin -lgfortran -lquadmath -lmingw32 -lgcc_eh -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32 -limagehlp -lopenblas -lz -lhdf5 -lszip -Wl,-Bdynamic"
 #define CONFIG_EXE_EXT ".exe"
 #define CONFIG_DLL_EXT ".dll"
 #define CONFIG_OS "Windows_NT"
@@ -115,7 +115,7 @@
    * Visual Studio then use the SSE instructions,
    * not the normal i387 FPU
    */
-  #define DEFAULT_CFLAGS "-falign-functions -msse2 -mfpmath=sse ${MODELICAUSERCFLAGS}"
+  #define DEFAULT_CFLAGS "-falign-functions -mstackrealign -msse2 -mfpmath=sse ${MODELICAUSERCFLAGS}"
 #else
   #define DEFAULT_CFLAGS "-falign-functions ${MODELICAUSERCFLAGS}"
 #endif

--- a/SimulationRuntime/c/Makefile.omdev.mingw
+++ b/SimulationRuntime/c/Makefile.omdev.mingw
@@ -17,7 +17,7 @@ AR = ar -ru
 CC = gcc
 FC = g77
 #include the sundials, ipopt from OMDev and the top_builddir for revision.h
-CONFIG_CFLAGS = -O2 -falign-functions -msse2 -mfpmath=sse \
+CONFIG_CFLAGS = -O2 -falign-functions -mstackrealign -msse2 -mfpmath=sse \
 -I$(OMDEV)/lib/3rdParty/Ipopt/include/ \
 -I$(top_builddir)/3rdParty/sundials/build/include \
 -I$(OMDEV)/include/lis -I$(top_builddir)/ -I$(builddir_inc)/ \


### PR DESCRIPTION
- link in static libs (even for Modelica tables) for FMU and for the generated executable (all except sundials)
- on 32bit, pass gcc flag -mstackrealign to reallign SSE functions (so they can be used from other Windows processes, such as fmuChecker)
- build SimulationRuntime/c/ with -mstackrealign