### PR TITLE
Support more vectorized calls for Cpp runtime only, ticket:5110

### DIFF
--- a/Compiler/BackEnd/BackendDAETransform.mo
+++ b/Compiler/BackEnd/BackendDAETransform.mo
@@ -865,7 +865,7 @@ algorithm
   (exp1::exps) := Expression.flattenArrayExpToList(e);
   (cr1, call1) := match exp1
     case DAE.CREF(componentRef=cr1) then (cr1, "");
-    case DAE.CALL(path=Absyn.IDENT(name=call1), expLst={DAE.CREF(componentRef=cr1)}) then (cr1, call1);
+    case DAE.CALL(path=Absyn.IDENT(name="previous"), expLst={DAE.CREF(componentRef=cr1)}) then (cr1, "previous");
     else fail();
   end match;
   if call1 <> "" and Config.simCodeTarget() <> "Cpp" or call1 == "pre" then
@@ -886,7 +886,7 @@ algorithm
     //DAE.CREF(componentRef=cr2) := exp;
     (cr2, call2) := match exp
       case DAE.CREF(componentRef=cr2) then (cr2, "");
-      case DAE.CALL(path=Absyn.IDENT(name=call2), expLst={DAE.CREF(componentRef=cr2)}) then (cr2, call2);
+      case DAE.CALL(path=Absyn.IDENT(name="previous"), expLst={DAE.CREF(componentRef=cr2)}) then (cr2, "previous");
       else fail();
     end match;
     true := ndim==listLength(ComponentReference.crefLastSubs(cr2));

--- a/Compiler/BackEnd/BackendDAETransform.mo
+++ b/Compiler/BackEnd/BackendDAETransform.mo
@@ -865,9 +865,14 @@ algorithm
   (exp1::exps) := Expression.flattenArrayExpToList(e);
   (cr1, call1) := match exp1
     case DAE.CREF(componentRef=cr1) then (cr1, "");
-    case DAE.CALL(path=Absyn.IDENT(name="previous"), expLst={DAE.CREF(componentRef=cr1)}) then (cr1, "previous");
+    case DAE.CALL(path=Absyn.IDENT(name=call1), expLst={DAE.CREF(componentRef=cr1)}) then (cr1, call1);
     else fail();
   end match;
+  if call1 <> "" and Config.simCodeTarget() <> "Cpp" or call1 == "pre" then
+    // only Cpp runtime supports collapsed calls, except pre(array), see e.g.
+    // Modelica_Synchronous.Examples.Elementary.RealSignals.SampleWithADeffects
+    fail();
+  end if;
   // Check that the first element starts at index [1,...,1]
   subs := ComponentReference.crefLastSubs(cr1);
   true := ndim==listLength(subs);
@@ -881,7 +886,7 @@ algorithm
     //DAE.CREF(componentRef=cr2) := exp;
     (cr2, call2) := match exp
       case DAE.CREF(componentRef=cr2) then (cr2, "");
-      case DAE.CALL(path=Absyn.IDENT(name="previous"), expLst={DAE.CREF(componentRef=cr2)}) then (cr2, "previous");
+      case DAE.CALL(path=Absyn.IDENT(name=call2), expLst={DAE.CREF(componentRef=cr2)}) then (cr2, call2);
       else fail();
     end match;
     true := ndim==listLength(ComponentReference.crefLastSubs(cr2));


### PR DESCRIPTION
C runtime fails for previous(array), see e.g.
Modelica_Synchronous.Examples.Elementary.RealSignals.SampleWithADeffects