### PR TITLE
make impure functions be of variability continuous (ticket:5127)

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -343,7 +343,9 @@ uniontype Call
     typed_args := matchedFunc.args;
 
     args := {};
-    var := Variability.CONSTANT;
+    var := if Function.isImpure(func) or Function.isOMImpure(func) // if is impure, make it highest variability
+           then Variability.CONTINUOUS
+           else Variability.CONSTANT;
     for a in typed_args loop
       (arg_exp, _, arg_var) := a;
       args := arg_exp :: args;

--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -174,9 +174,7 @@ algorithm
 
     case Expression.CALL()
       then
-        if Call.isImpure(exp.call) // do NOT evaluate impure calls!
-        then exp
-        else evalCall(exp.call, target);
+        evalCall(exp.call, target);
 
     case Expression.SIZE(dimIndex = SOME(exp1))
       algorithm

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -1288,6 +1288,11 @@ uniontype Function
     output Boolean isImpure = fn.attributes.isImpure;
   end isImpure;
 
+  function isOMImpure
+    input Function fn;
+    output Boolean isImpure = not fn.attributes.isOpenModelicaPure;
+  end isOMImpure;
+
   function isFunctionPointer
     input Function fn;
     output Boolean isPointer = fn.attributes.isFunctionPointer;


### PR DESCRIPTION
- remove the check for impure in NFFrontEnd/NFCeval.mo
- add check for impure in NFFrontEnd/NFCall.mo