### PR TITLE
[NF] Don't evaluate impure funcs in if-conditions.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -486,7 +486,7 @@ uniontype Call
     output Boolean isImpure;
   algorithm
     isImpure := match call
-      case TYPED_CALL() then Function.isImpure(call.fn);
+      case TYPED_CALL() then Function.isImpure(call.fn) or Function.isOMImpure(call.fn);
       else false;
     end match;
   end isImpure;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -2798,7 +2798,7 @@ algorithm
       then match Absyn.pathFirstIdent(fn.path)
         case "Connections" then true;
         case "cardinality" then true;
-        else false;
+        else Call.isImpure(exp.call);
       end match;
     else false;
   end match;


### PR DESCRIPTION
- Add check for impure functions in isNonConstantIfCondition.