### PR TITLE
[BE] added debug flag to enable error asserts from  min/max attributes

### DIFF
--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -1871,7 +1871,7 @@ public function getMinMaxAsserts "author: Frenkel TUD 2011-03"
 algorithm
   outAsserts := matchcontinue(inVar)
     local
-      DAE.Exp e, cond, msg;
+      DAE.Exp e, cond, msg, level;
       Option<DAE.Exp> min, max;
       String str, varStr, format;
       DAE.Type tp;
@@ -1897,11 +1897,17 @@ algorithm
       false = Expression.isConstTrue(cond);
       str = getMinMaxAsserts1Str(min, max, ComponentReference.printComponentRefStr(name));
 
+      if Flags.isSet(Flags.WARNING_MINMAX_ATTRIBUTES) then
+        level = DAE.ASSERTIONLEVEL_WARNING;
+      else
+        level = DAE.ASSERTIONLEVEL_ERROR;
+      end if;
+
       // if is real use %g otherwise use %d (ints and enums)
       format = if Types.isRealOrSubTypeReal(tp) then "g" else "d";
       msg = DAE.BINARY(DAE.SCONST(str), DAE.ADD(DAE.T_STRING_DEFAULT), DAE.CALL(Absyn.IDENT("String"), {e, DAE.SCONST(format)}, DAE.callAttrBuiltinString));
-      BackendDAEUtil.checkAssertCondition(cond, msg, DAE.ASSERTIONLEVEL_WARNING, ElementSource.getElementSourceFileInfo(source));
-    then DAE.ALGORITHM_STMTS({DAE.STMT_ASSERT(cond, msg, DAE.ASSERTIONLEVEL_WARNING, source)})::inAsserts;
+      BackendDAEUtil.checkAssertCondition(cond, msg, level, ElementSource.getElementSourceFileInfo(source));
+    then DAE.ALGORITHM_STMTS({DAE.STMT_ASSERT(cond, msg, level, source)})::inAsserts;
 
     else inAsserts;
   end matchcontinue;

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -540,6 +540,8 @@ constant DebugFlag NF_API = DEBUG_FLAG(182, "nfAPI", false,
   Util.gettext("Enables experimental new instantiation use in the OMC API."));
 constant DebugFlag FMI20_DEPENDENCIES = DEBUG_FLAG(183, "disableFMIDependency", false,
   Util.gettext("Disables the dependency analysis and generation for FMI 2.0."));
+constant DebugFlag WARNING_MINMAX_ATTRIBUTES = DEBUG_FLAG(184, "warnMinMax", true,
+  Util.gettext("Makes a warning assert from min/max variable attributes instead of error."));
 
 // This is a list of all debug flags, to keep track of which flags are used. A
 // flag can not be used unless it's in this list, and the list is checked at
@@ -729,7 +731,8 @@ constant list<DebugFlag> allDebugFlags = {
   NF_EVAL_CONST_ARG_FUNCS,
   NF_EXPAND_OPERATIONS,
   NF_API,
-  FMI20_DEPENDENCIES
+  FMI20_DEPENDENCIES,
+  WARNING_MINMAX_ATTRIBUTES
 };
 
 public

--- a/SimulationRuntime/c/simulation/solver/initialization/initialization.c
+++ b/SimulationRuntime/c/simulation/solver/initialization/initialization.c
@@ -731,6 +731,9 @@ int initialization(DATA *data, threadData_t *threadData, const char* pInitMethod
   printZeroCrossings(data, LOG_EVENTS);
 #endif
 
+  /* Check for warning of variables out of range assert(min<x || x>xmax, ...)*/
+  data->callback->checkForAsserts(data, threadData);
+
   /* valid system for the first time! */
   TRACE_POP
   return retVal;


### PR DESCRIPTION
 - debug flag warnMinMax is default to true, because the desired
   behavior is an error assert
 - also check min/max assert in the initialization
 - fixing ticket:4985