### PR TITLE
Initial treatment of arrays in the backend and for FMI/Cpp code generation

### DIFF
--- a/Compiler/BackEnd/BackendDAETransform.mo
+++ b/Compiler/BackEnd/BackendDAETransform.mo
@@ -104,8 +104,13 @@ algorithm
     then (syst, comps);
 
     else algorithm
-      Error.addInternalError("function strongComponentsScalar failed (sorting strong components)", sourceInfo());
-    then fail();
+      if Flags.isSet(Flags.NF_SCALARIZE) then
+        Error.addInternalError("function strongComponentsScalar failed (sorting strong components)", sourceInfo());
+        fail();
+      else
+        Error.addCompilerWarning("BackendDAETransform.strongComponentsScalar failed (sorting strong components)");
+      end if;
+    then (inSystem, {});
   end matchcontinue;
 end strongComponentsScalar;
 

--- a/Compiler/BackEnd/BackendDAETransform.mo
+++ b/Compiler/BackEnd/BackendDAETransform.mo
@@ -104,13 +104,8 @@ algorithm
     then (syst, comps);
 
     else algorithm
-      if Flags.isSet(Flags.NF_SCALARIZE) then
-        Error.addInternalError("function strongComponentsScalar failed (sorting strong components)", sourceInfo());
-        fail();
-      else
-        Error.addCompilerWarning("BackendDAETransform.strongComponentsScalar failed (sorting strong components)");
-      end if;
-    then (inSystem, {});
+      Error.addInternalError("function strongComponentsScalar failed (sorting strong components)", sourceInfo());
+    then fail();
   end matchcontinue;
 end strongComponentsScalar;
 

--- a/Compiler/BackEnd/BackendEquation.mo
+++ b/Compiler/BackEnd/BackendEquation.mo
@@ -188,11 +188,17 @@ public function equationArraySize "author: lochel
   should correspond to the number of variables."
   input BackendDAE.EquationArray equationArray;
   output Integer outSize;
+protected
+  Boolean nfScalarize = Flags.isSet(Flags.NF_SCALARIZE);
 algorithm
   outSize := 0;
   for i in 1:ExpandableArray.getLastUsedIndex(equationArray) loop
     if ExpandableArray.occupied(i, equationArray) then
-      outSize := outSize + equationSize(ExpandableArray.get(i, equationArray));
+      if nfScalarize then
+        outSize := outSize + equationSize(ExpandableArray.get(i, equationArray));
+      else
+        outSize := outSize + 1;
+      end if;
     end if;
   end for;
 end equationArraySize;

--- a/Compiler/Template/CodegenFMUCommon.tpl
+++ b/Compiler/Template/CodegenFMUCommon.tpl
@@ -149,6 +149,11 @@ template ScalarVariable(SimVar simVar, SimCode simCode, list<SimVar> stateVars, 
  "Generates code for ScalarVariable file for FMU target."
 ::=
 match simVar
+case SIMVAR(type_ = T_ARRAY()) then
+  /* roll out array as XML file only supports scalars */
+  '<%getScalarElements(simVar) |> var =>
+    ScalarVariable(var, simCode, stateVars, FMUVersion)
+    ;separator="\n"%>'
 case SIMVAR(__) then
   if stringEq(crefStr(name),"$dummy") then
   <<>>

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -910,6 +910,11 @@ package SimCodeUtil
     output Integer outVariableIndex;
   end getStateSimVarIndexFromIndex;
 
+  function getScalarElements
+    input SimCodeVar.SimVar var;
+    output list<SimCodeVar.SimVar> elts;
+  end getScalarElements;
+
   function getVariableIndex
     input SimCodeVar.SimVar inVar;
     output Integer outVariableIndex;
@@ -3666,6 +3671,10 @@ package DAEUtil
 end DAEUtil;
 
 package Types
+  function arrayElementType
+    input DAE.Type inType;
+    output DAE.Type outType;
+  end arrayElementType;
   function getDimensionSizes
     input DAE.Type inType;
     output list<Integer> outIntegerLst;

--- a/SimulationRuntime/cpp/Core/System/SystemDefaultImplementation.cpp
+++ b/SimulationRuntime/cpp/Core/System/SystemDefaultImplementation.cpp
@@ -634,48 +634,112 @@ string& SystemDefaultImplementation::getStringStartValue(string& var)
   return _string_start_values.getGetStartValue(var);
 }
 
-void SystemDefaultImplementation::setRealStartValue(double& var,double val)
+void SystemDefaultImplementation::setRealStartValue(double& var, double val, bool overwriteOldValue)
 {
-  setRealStartValue(var,val,false);
+  var = val;
+  _real_start_values.setStartValue(var, val, overwriteOldValue);
 }
 
-void SystemDefaultImplementation::setRealStartValue(double& var,double val,bool overwriteOldValue)
+void SystemDefaultImplementation::setRealStartValue(BaseArray<double>& avar, double val, bool overwriteOldValue)
 {
-  var=val;
-  _real_start_values.setStartValue(var,val,overwriteOldValue);
+  double *varp = avar.getData();
+  size_t nel = avar.getNumElems();
+  for (size_t i = 0; i < nel; varp++, i++) {
+    *varp = val;
+    _real_start_values.setStartValue(*varp, val, overwriteOldValue);
+  }
 }
 
-void SystemDefaultImplementation::setBoolStartValue(bool& var,bool val)
+void SystemDefaultImplementation::setRealStartValue(BaseArray<double>& avar, const BaseArray<double>& aval, bool overwriteOldValue)
 {
-  setBoolStartValue(var,val,false);
+  double *varp = avar.getData();
+  const double *valp = aval.getData();
+  size_t nel = avar.getNumElems();
+  for (size_t i = 0; i < nel; varp++, valp++, i++) {
+    *varp = *valp;
+    _real_start_values.setStartValue(*varp, *valp, overwriteOldValue);
+  }
 }
 
-void SystemDefaultImplementation::setBoolStartValue(bool& var,bool val,bool overwriteOldValue)
+void SystemDefaultImplementation::setBoolStartValue(bool& var, bool val, bool overwriteOldValue)
 {
-  var=val;
-  _bool_start_values.setStartValue(var,val,overwriteOldValue);
+  var = val;
+  _bool_start_values.setStartValue(var, val, overwriteOldValue);
 }
 
-void SystemDefaultImplementation::setIntStartValue(int& var,int val)
+void SystemDefaultImplementation::setBoolStartValue(BaseArray<bool>& avar, bool val, bool overwriteOldValue)
 {
-  setIntStartValue(var,val,false);
+  bool *varp = avar.getData();
+  size_t nel = avar.getNumElems();
+  for (size_t i = 0; i < nel; varp++, i++) {
+    *varp = val;
+    _bool_start_values.setStartValue(*varp, val, overwriteOldValue);
+  }
 }
 
-void SystemDefaultImplementation::setIntStartValue(int& var,int val,bool overwriteOldValue)
+void SystemDefaultImplementation::setBoolStartValue(BaseArray<bool>& avar, const BaseArray<bool>& aval, bool overwriteOldValue)
 {
-  var=val;
-  _int_start_values.setStartValue(var,val,overwriteOldValue);
+  bool *varp = avar.getData();
+  const bool *valp = aval.getData();
+  size_t nel = avar.getNumElems();
+  for (size_t i = 0; i < nel; varp++, valp++, i++) {
+    *varp = *valp;
+    _bool_start_values.setStartValue(*varp, *valp, overwriteOldValue);
+  }
 }
 
-void SystemDefaultImplementation::setStringStartValue(string& var,string val)
+void SystemDefaultImplementation::setIntStartValue(int& var, int val, bool overwriteOldValue)
 {
-  setStringStartValue(var,val,false);
+  var = val;
+  _int_start_values.setStartValue(var, val, overwriteOldValue);
 }
 
-void SystemDefaultImplementation::setStringStartValue(string& var,string val,bool overwriteOldValue)
+void SystemDefaultImplementation::setIntStartValue(BaseArray<int>& avar, int val, bool overwriteOldValue)
 {
-  var=val;
-  _string_start_values.setStartValue(var,val,overwriteOldValue);
+  int *varp = avar.getData();
+  size_t nel = avar.getNumElems();
+  for (size_t i = 0; i < nel; varp++, i++) {
+    *varp = val;
+    _int_start_values.setStartValue(*varp, val, overwriteOldValue);
+  }
+}
+
+void SystemDefaultImplementation::setIntStartValue(BaseArray<int>& avar, const BaseArray<int>& aval, bool overwriteOldValue)
+{
+  int *varp = avar.getData();
+  const int *valp = aval.getData();
+  size_t nel = avar.getNumElems();
+  for (size_t i = 0; i < nel; varp++, valp++, i++) {
+    *varp = *valp;
+    _int_start_values.setStartValue(*varp, *valp, overwriteOldValue);
+  }
+}
+
+void SystemDefaultImplementation::setStringStartValue(string& var, string val, bool overwriteOldValue)
+{
+  var = val;
+  _string_start_values.setStartValue(var, val, overwriteOldValue);
+}
+
+void SystemDefaultImplementation::setStringStartValue(BaseArray<string>& avar, string val, bool overwriteOldValue)
+{
+  string *varp = avar.getData();
+  size_t nel = avar.getNumElems();
+  for (size_t i = 0; i < nel; varp++, i++) {
+    *varp = val;
+    _string_start_values.setStartValue(*varp, val, overwriteOldValue);
+  }
+}
+
+void SystemDefaultImplementation::setStringStartValue(BaseArray<string>& avar, const BaseArray<string>& aval, bool overwriteOldValue)
+{
+  string *varp = avar.getData();
+  const string *valp = aval.getData();
+  size_t nel = avar.getNumElems();
+  for (size_t i = 0; i < nel; varp++, valp++, i++) {
+    *varp = *valp;
+    _string_start_values.setStartValue(*varp, *valp, overwriteOldValue);
+  }
 }
 
 /**

--- a/SimulationRuntime/cpp/Include/Core/System/SystemDefaultImplementation.h
+++ b/SimulationRuntime/cpp/Include/Core/System/SystemDefaultImplementation.h
@@ -146,14 +146,18 @@ public:
   virtual bool& getBoolStartValue(bool& var);
   virtual int& getIntStartValue(int& var);
   virtual string& getStringStartValue(string& var);
-  virtual void setRealStartValue(double& var,double val);
-  virtual void setRealStartValue(double& var,double val,bool overwriteOldValue);
-  virtual void setBoolStartValue(bool& var,bool val);
-  virtual void setBoolStartValue(bool& var,bool val,bool overwriteOldValue);
-  virtual void setIntStartValue(int& var,int val);
-  virtual void setIntStartValue(int& var,int val,bool overwriteOldValue);
-  virtual void setStringStartValue(string& var,string val);
-  virtual void setStringStartValue(string& var,string val,bool overwriteOldValue);
+  virtual void setRealStartValue(double& var, double val, bool overwriteOldValue = false);
+  virtual void setRealStartValue(BaseArray<double>& avar, double val, bool overwriteOldValue = false);
+  virtual void setRealStartValue(BaseArray<double>& avar, const BaseArray<double>& aval, bool overwriteOldValue = false);
+  virtual void setBoolStartValue(bool& var, bool val, bool overwriteOldValue = false);
+  virtual void setBoolStartValue(BaseArray<bool>& avar, bool val, bool overwriteOldValue = false);
+  virtual void setBoolStartValue(BaseArray<bool>& avar, const BaseArray<bool>& aval, bool overwriteOldValue = false);
+  virtual void setIntStartValue(int& var,int val, bool overwriteOldValue = false);
+  virtual void setIntStartValue(BaseArray<int>& avar, int val, bool overwriteOldValue = false);
+  virtual void setIntStartValue(BaseArray<int>& avar, const BaseArray<int>& aval, bool overwriteOldValue = false);
+  virtual void setStringStartValue(string& var, string val, bool overwriteOldValue = false);
+  virtual void setStringStartValue(BaseArray<string>& avar, string val, bool overwriteOldValue = true);
+  virtual void setStringStartValue(BaseArray<string>& avar, const BaseArray<string>& aval, bool overwriteOldValue = true);
 protected:
     void Assert(bool cond, const string& msg);
     void Terminate(string msg);


### PR DESCRIPTION
This works for simple models along with `omc -d=newInst,-nfScalarize`. Some post opt modules may be disabled: `--postOptModules-=wrapFunctionCalls,inlineArrayEqn`. See ticket:5110.