### PR TITLE
[NF] don't try to evaluate external functions in the backend

### DIFF
--- a/Compiler/BackEnd/EvaluateFunctions.mo
+++ b/Compiler/BackEnd/EvaluateFunctions.mo
@@ -491,6 +491,8 @@ algorithm
 
         // get the elements of the function and the algorithms
         SOME(func) = DAE.AvlTreePathFunction.get(funcsIn,path);
+        // fail if is an external function!
+        false = DAEUtil.isExtFunction(func);
         elements = DAEUtil.getFunctionElements(func);
 
         // get the input exps from the call
@@ -499,7 +501,7 @@ algorithm
         allInputExps = List.flatten(scalarExp);
           //print("allInputExps\n"+stringDelimitList(List.map(allInputExps,ExpressionDump.printExpStr),"\n")+"\n");
 
-        if listEmpty(elements) then  // its a record
+        if listEmpty(elements) and DAEUtil.funcIsRecord(func) then  // its a record
         //-----------------------its a record-----------------------
           expOut = DAE.TUPLE(allInputExps);
           if Flags.isSet(Flags.EVAL_FUNC_DUMP) then print("\nIts a record.\n");


### PR DESCRIPTION
In NFModelicaBuiltin.mo the builtin function max has no elements and because of that it was considered a record in the backend! Now we skip external functions and check if is actually a record.