### PR TITLE
[NF] Use correct origin in Typing.typeCref.

### DIFF
--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -298,7 +298,7 @@ protected
   Option<Expression> start_exp;
   Integer pcount;
 algorithm
-  exp_origin := if Class.isFunction(InstNode.getClass(InstNode.parent(node)))
+  exp_origin := if InstNode.isFunction(InstNode.explicitParent(node))
     then ExpOrigin.FUNCTION else ExpOrigin.CLASS;
 
   Typing.typeComponentBinding(node, exp_origin);

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -347,6 +347,16 @@ uniontype InstNode
     end match;
   end isUserdefinedClass;
 
+  function isFunction
+    input InstNode node;
+    output Boolean isFunc;
+  algorithm
+    isFunc := match node
+      case CLASS_NODE() then Class.isFunction(Pointer.access(node.cls));
+      else false;
+    end match;
+  end isFunction;
+
   function isComponent
     input InstNode node;
     output Boolean isComponent;
@@ -502,6 +512,11 @@ uniontype InstNode
       else EMPTY_NODE();
     end match;
   end parent;
+
+  function explicitParent
+    input InstNode node;
+    output InstNode parentNode = explicitScope(parent(node));
+  end explicitParent;
 
   function classParent
     input InstNode node;
@@ -1120,6 +1135,18 @@ uniontype InstNode
       else IMPLICIT_SCOPE(scope, {});
     end match;
   end openImplicitScope;
+
+  function explicitScope
+    "Returns the first parent of the node that's not an implicit scope, or the
+     node itself if it's not an implicit scope."
+    input InstNode node;
+    output InstNode scope;
+  algorithm
+    scope := match node
+      case IMPLICIT_SCOPE() then explicitScope(node.parentScope);
+      else node;
+    end match;
+  end explicitScope;
 
   function addIterator
     input InstNode iterator;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -1279,6 +1279,7 @@ algorithm
       Type node_ty;
       list<Subscript> subs;
       Variability subs_var, rest_var;
+      ExpOrigin.Type node_origin;
 
     case ComponentRef.CREF(origin = Origin.SCOPE)
       algorithm
@@ -1288,7 +1289,13 @@ algorithm
 
     case ComponentRef.CREF(node = InstNode.COMPONENT_NODE())
       algorithm
-        node_ty := typeComponent(cref.node, origin);
+        // The origin used when typing a component node depends on where the
+        // component was declared, not where it's used. This can be different to
+        // the given origin, e.g. for package constants used in a function.
+        node_origin := if InstNode.isFunction(InstNode.explicitParent(cref.node)) then
+          ExpOrigin.FUNCTION else ExpOrigin.CLASS;
+        node_ty := typeComponent(cref.node, node_origin);
+
         (subs, subs_var) := typeSubscripts(cref.subscripts, node_ty, cref, origin, info);
         (rest_cr, rest_var) := typeCref2(cref.restCref, origin, info);
         subsVariability := Prefixes.variabilityMax(subs_var, rest_var);


### PR DESCRIPTION
- Base the origin on where the component is declared when typing a cref
  node, rather than where it's used.