### PR TITLE
[NF] Improve handling of reductions.

### DIFF
--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -3036,7 +3036,7 @@ algorithm
     local
       list<tuple<InstNode, Expression>> iters;
 
-    case Expression.CALL(call = Call.UNTYPED_MAP_CALL(iters = iters))
+    case Expression.CALL(call = Call.UNTYPED_ARRAY_CONSTRUCTOR(iters = iters))
       algorithm
         for iter in iters loop
           markStructuralParamsExp(Util.tuple22(iter));

--- a/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -455,14 +455,12 @@ function cardinality "Number of connectors in connection"
 </html>"),version="Deprecated");
 end cardinality;
 
-/*
 function array "Constructs an array"
   external "builtin";
   annotation(Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'array()'\">array()</a>
 </html>"));
 end array;
-*/
 
 function zeros "Returns a zero array"
   external "builtin";

--- a/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -172,7 +172,14 @@ algorithm
       then
         callExp;
 
-    case Call.TYPED_MAP_CALL()
+    case Call.TYPED_ARRAY_CONSTRUCTOR()
+      algorithm
+        call.exp := simplify(call.exp);
+        call.iters := list((Util.tuple21(i), simplify(Util.tuple22(i))) for i in call.iters);
+      then
+        Expression.CALL(call);
+
+    case Call.TYPED_REDUCTION()
       algorithm
         call.exp := simplify(call.exp);
         call.iters := list((Util.tuple21(i), simplify(Util.tuple22(i))) for i in call.iters);

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -766,5 +766,12 @@ public
     end match;
   end lookupRecordFieldType;
 
+  function enumName
+    input Type ty;
+    output Absyn.Path name;
+  algorithm
+    ENUMERATION(typePath = name) := ty;
+  end enumName;
+
   annotation(__OpenModelica_Interface="frontend");
 end NFType;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -1351,10 +1351,6 @@ algorithm
     i := i + 1;
   end for;
 
-  for dim in dims loop
-    typedSubs := Subscript.WHOLE() :: typedSubs;
-  end for;
-
   typedSubs := listReverseInPlace(typedSubs);
 end typeSubscripts;
 


### PR DESCRIPTION
- Separate the handling of array constructors and reductions so
  reductions can be handled properly.
- Implement expansion of type names, to better handle enumeration names
  as iteration ranges.
- Expand enumeration type names in Expression.toDAE, so that they can be
  converted to DAE-form.
- Add missing case for enumeration literals in Expression.compare.
- Don't fill in "missing" subscripts in crefs with :, it interfers with
  reductions in some cases and doesn't seem to have any benefits.