### PR TITLE
[NF] Fix typing of dimensions.

### DIFF
--- a/Compiler/NFFrontEnd/NFDimension.mo
+++ b/Compiler/NFFrontEnd/NFDimension.mo
@@ -101,7 +101,7 @@ public
                 fail();
           end match;
 
-      else Dimension.EXP(exp, var);
+      else EXP(exp, var);
     end match;
   end fromExp;
 

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -618,15 +618,15 @@ algorithm
         end match;
 
         // Make sure the dimension is constant evaluted, and also mark it as structural.
-        () := match dim
+        dim := match dim
           case Dimension.EXP(exp = exp)
             algorithm
               Inst.markStructuralParamsExp(exp);
-              dim.exp := Ceval.evalExp(exp, Ceval.EvalTarget.DIMENSION(component, index, exp, info));
+              exp := Ceval.evalExp(exp, Ceval.EvalTarget.DIMENSION(component, index, exp, info));
             then
-              ();
+              Dimension.fromExp(exp, dim.var);
 
-          else ();
+          else dim;
         end match;
 
         arrayUpdate(dimensions, index, dim);


### PR DESCRIPTION
- Use Dimension.fromExp when evaluating an expression dimension in
  Typing.typeDimension instead of just putting the evaluated expression
  back, since the whole point is to get rid of such dimensions.