### PR TITLE
[NF] Expand function call arguments.

### DIFF
--- a/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -76,6 +76,7 @@ public
       case Expression.UNARY() then expandUnary(exp.exp, exp.operator);
       case Expression.LBINARY() then expandLogicalBinary(exp);
       case Expression.LUNARY() then expandLogicalUnary(exp.exp, exp.operator);
+      case Expression.RELATION() then (exp, true);
       case Expression.CAST() then expandCast(exp.exp, exp.ty);
       else expandGeneric(exp);
     end match;
@@ -880,16 +881,22 @@ public
     Operator op;
   algorithm
     Expression.LBINARY(exp1 = exp1, operator = op, exp2 = exp2) := exp;
-    (exp1, expanded) := expand(exp1);
 
-    if expanded then
-      (exp2, expanded) := expand(exp2);
-    end if;
+    if Type.isArray(Operator.typeOf(op)) then
+      (exp1, expanded) := expand(exp1);
 
-    if expanded then
-      outExp := expandBinaryElementWise2(exp1, op, exp2, makeLBinaryOp);
+      if expanded then
+        (exp2, expanded) := expand(exp2);
+      end if;
+
+      if expanded then
+        outExp := expandBinaryElementWise2(exp1, op, exp2, makeLBinaryOp);
+      else
+        outExp := exp;
+      end if;
     else
       outExp := exp;
+      expanded := true;
     end if;
   end expandLogicalBinary;
 

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -119,6 +119,7 @@ algorithm
   if not Flags.isSet(Flags.NF_SCALARIZE) then
     // make sure we don't expand anything
     Flags.set(Flags.NF_EXPAND_OPERATIONS, false);
+    Flags.set(Flags.NF_EXPAND_FUNC_ARGS, false);
   end if;
 
   // Create a root node from the given top-level classes.

--- a/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -145,9 +145,13 @@ algorithm
   Expression.CALL(call = call) := callExp;
 
   callExp := match call
-    case Call.TYPED_CALL() guard not Call.isExternal(call)
+    case Call.TYPED_CALL(arguments = args) guard not Call.isExternal(call)
       algorithm
-        args := list(simplify(arg) for arg in call.arguments);
+        if Flags.isSet(Flags.NF_EXPAND_FUNC_ARGS) then
+          args := list(if Expression.hasArrayCall(arg) then arg else ExpandExp.expand(arg) for arg in args);
+        end if;
+
+        args := list(simplify(arg) for arg in args);
         call.arguments := args;
         builtin := Function.isBuiltin(call.fn);
         is_pure := not Function.isImpure(call.fn);

--- a/Compiler/Util/Flags.mo
+++ b/Compiler/Util/Flags.mo
@@ -542,6 +542,8 @@ constant DebugFlag FMI20_DEPENDENCIES = DEBUG_FLAG(183, "disableFMIDependency", 
   Util.gettext("Disables the dependency analysis and generation for FMI 2.0."));
 constant DebugFlag WARNING_MINMAX_ATTRIBUTES = DEBUG_FLAG(184, "warnMinMax", true,
   Util.gettext("Makes a warning assert from min/max variable attributes instead of error."));
+constant DebugFlag NF_EXPAND_FUNC_ARGS = DEBUG_FLAG(185, "nfExpandFuncArgs", true,
+  Util.gettext("Expand all function arguments in the new frontend."));
 
 // This is a list of all debug flags, to keep track of which flags are used. A
 // flag can not be used unless it's in this list, and the list is checked at
@@ -732,7 +734,8 @@ constant list<DebugFlag> allDebugFlags = {
   NF_EXPAND_OPERATIONS,
   NF_API,
   FMI20_DEPENDENCIES,
-  WARNING_MINMAX_ATTRIBUTES
+  WARNING_MINMAX_ATTRIBUTES,
+  NF_EXPAND_FUNC_ARGS
 };
 
 public


### PR DESCRIPTION
- Added a new debug flag nfExpandFuncArgs (on by default, off when
  nfScalarize is off) that tries to mimic the old frontend by expanding
  all function call arguments, except those containing function calls
  that return arrays.