### PR TITLE
[NF] Optimize evaluation of for loops.

### DIFF
--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -44,6 +44,7 @@ import Visibility = NFPrefixes.Visibility;
 import NFModifier.Modifier;
 import SCodeDump;
 import DAE;
+import Expression = NFExpression;
 
 protected
 import List;
@@ -244,6 +245,10 @@ uniontype InstNode
     InstNode parentScope;
     list<InstNode> locals;
   end IMPLICIT_SCOPE;
+
+  record EXP_NODE
+    Expression exp;
+  end EXP_NODE;
 
   record EMPTY_NODE end EMPTY_NODE;
 

--- a/Compiler/NFFrontEnd/NFStatement.mo
+++ b/Compiler/NFFrontEnd/NFStatement.mo
@@ -196,10 +196,55 @@ public
           end for;
         then
           ();
+
+      else ();
     end match;
 
     func(stmt);
   end apply;
+
+  function map
+    input output Statement stmt;
+    input MapFn func;
+
+    partial function MapFn
+      input output Statement stmt;
+    end MapFn;
+  algorithm
+    () := match stmt
+      case FOR()
+        algorithm
+          stmt.body := list(map(s, func) for s in stmt.body);
+        then
+          ();
+
+      case IF()
+        algorithm
+          stmt.branches := list(
+            (Util.tuple21(b),
+             list(map(s, func) for s in Util.tuple22(b))) for b in stmt.branches);
+        then
+          ();
+
+      case WHEN()
+        algorithm
+          stmt.branches := list(
+            (Util.tuple21(b),
+             list(map(s, func) for s in Util.tuple22(b))) for b in stmt.branches);
+        then
+          ();
+
+      case WHILE()
+        algorithm
+          stmt.body := list(map(s, func) for s in stmt.body);
+        then
+          ();
+
+      else ();
+    end match;
+
+    stmt := func(stmt);
+  end map;
 
   function mapExpList
     input output list<Statement> stmtl;


### PR DESCRIPTION
- Replace for loop iterators with mutable expressions before starting to
  evaluate a function, so we don't have to do it each time a for loop is
  entered.