### PR TITLE
[NF] Optimize cref evaluation.

### DIFF
--- a/Compiler/NFFrontEnd/NFBinding.mo
+++ b/Compiler/NFFrontEnd/NFBinding.mo
@@ -79,6 +79,7 @@ uniontype Binding
     Variability variability;
     list<InstNode> parents;
     Boolean isEach;
+    Boolean evaluated;
     SourceInfo info;
   end TYPED_BINDING;
 
@@ -277,7 +278,7 @@ public
           ty := Expression.typeOf(exp);
           var := Expression.variability(exp);
         then
-          TYPED_BINDING(exp, ty, var, fieldBinding.parents, fieldBinding.isEach, fieldBinding.info);
+          TYPED_BINDING(exp, ty, var, fieldBinding.parents, fieldBinding.isEach, fieldBinding.evaluated, fieldBinding.info);
 
       case FLAT_BINDING()
         algorithm

--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -329,12 +329,17 @@ algorithm
   (exp, evaluated) := match binding
     case Binding.TYPED_BINDING()
       algorithm
-        exp := evalExp(binding.bindingExp, target);
+        if binding.evaluated then
+          exp := binding.bindingExp;
+        else
+          exp := evalExp(binding.bindingExp, target);
 
-        if not referenceEq(exp, binding.bindingExp) then
-          binding.bindingExp := exp;
-          comp := Component.setBinding(binding, comp);
-          InstNode.updateComponent(comp, node);
+          if not referenceEq(exp, binding.bindingExp) then
+            binding.bindingExp := exp;
+            binding.evaluated := true;
+            comp := Component.setBinding(binding, comp);
+            InstNode.updateComponent(comp, node);
+          end if;
         end if;
       then
         (exp, true);

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -2279,7 +2279,7 @@ algorithm
              Type.toString(binding.bindingType)}, {Binding.getInfo(binding), InstNode.info(component)});
           fail();
         elseif isCastMatch(ty_match) then
-          binding := Binding.TYPED_BINDING(exp, ty, binding.variability, binding.parents, binding.isEach, binding.info);
+          binding := Binding.TYPED_BINDING(exp, ty, binding.variability, binding.parents, binding.isEach, binding.evaluated, binding.info);
         end if;
       then
         ();

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -840,7 +840,7 @@ algorithm
         info := Binding.getInfo(binding);
         (exp, ty, var) := typeExp(exp, origin, info);
       then
-        Binding.TYPED_BINDING(exp, ty, var, binding.parents, binding.isEach, binding.info);
+        Binding.TYPED_BINDING(exp, ty, var, binding.parents, binding.isEach, false, binding.info);
 
     case Binding.TYPED_BINDING() then binding;
     case Binding.UNBOUND() then binding;
@@ -903,7 +903,7 @@ algorithm
           fail();
         end if;
       then
-        Binding.TYPED_BINDING(exp, ty, var, condition.parents, false, info);
+        Binding.TYPED_BINDING(exp, ty, var, condition.parents, false, false, info);
 
   end match;
 end typeComponentCondition;


### PR DESCRIPTION
- Keep track of which bindings have been evaluated so we don't need to
  evaluate a component's binding multiple times.