### PR TITLE
[NF] Fixes for Modelica tables.

### DIFF
--- a/Compiler/NFFrontEnd/NFSimplifyModel.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyModel.mo
@@ -82,6 +82,7 @@ algorithm
   if Binding.isBound(binding) then
     exp := Binding.getTypedExp(binding);
     sexp := SimplifyExp.simplify(exp);
+    sexp := removeEmptyFunctionArguments(sexp);
 
     if not referenceEq(exp, sexp) then
       binding := Binding.setTypedExp(sexp, binding);


### PR DESCRIPTION
- Remove empty arrays in function calls from component bindings too.
- Don't evaluate constant arguments to external functions, the runtime
  doesn't handle array literals well in that context.