### PR TITLE
[NF] Evaluate parameter subscripts.

### DIFF
--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -2914,7 +2914,7 @@ algorithm
     case Class.INSTANCED_BUILTIN(elements = cls_tree as ClassTree.FLAT_TREE())
       algorithm
         for c in cls_tree.components loop
-        updateImplicitVariabilityComp(c, evalAllParams);
+          updateImplicitVariabilityComp(c, evalAllParams);
         end for;
       then
         ();
@@ -3236,7 +3236,7 @@ end markStructuralParamsSubs;
 
 function markStructuralParamsSub
   input Subscript sub;
-  input output Integer dummy;
+  input output Integer dummy = 0;
 algorithm
   () := match sub
       case Subscript.UNTYPED() algorithm markStructuralParamsExp(sub.exp); then ();

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -1447,6 +1447,13 @@ algorithm
     typedSubs := sub :: typedSubs;
     variability := Prefixes.variabilityMax(variability, var);
     i := i + 1;
+
+    // Mark parameter subscripts as structural so that they're evaluated.
+    // TODO: Ideally this shouldn't be needed, but the old frontend does it and
+    //       the backend relies on it.
+    if var == Variability.PARAMETER then
+      Inst.markStructuralParamsSub(sub);
+    end if;
   end for;
 
   typedSubs := listReverseInPlace(typedSubs);


### PR DESCRIPTION
- Mark parameter subscripts as structural so that they're evaluated.
  This should ideally not be necessary, but the backend relies on it
  since the old frontend does it.