### PR TITLE
Treat array flows as array equations and solve them for code generation

### DIFF
--- a/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -304,7 +304,7 @@ algorithm
     end for;
   end if;
 
-  equations := {Equation.EQUALITY(sum, Expression.REAL(0.0), Type.REAL(), src)};
+  equations := {Equation.EQUALITY(sum, Expression.REAL(0.0), c.ty, src)};
 end generateFlowEquations;
 
 function makeFlowExp


### PR DESCRIPTION
Note that ExpressionSolve.solveSimpleEquations does not cover array
equations, even though it would work. This is why SimCodeUtil calls
ExpressionSolve.solve2 now. The overall SimCodeUtil code reduces.