### PR TITLE
Fix inline type checking.

### DIFF
--- a/Compiler/FrontEnd/Inline.mo
+++ b/Compiler/FrontEnd/Inline.mo
@@ -792,7 +792,7 @@ algorithm
           ty1 = Expression.typeof(inExp1);
           ty2 = Expression.typeof(inExp2);
           ty2 = Types.traverseType(ty2, -1, Types.makeExpDimensionsUnknown);
-          b = Types.equivtypes(ty1,ty2);
+          b = Types.equivtypesOrRecordSubtypeOf(ty1,ty2);
         end if;
       then b;
   end match;


### PR DESCRIPTION
- Allow record types to have different names when checking that the type
  of the call to be inlined and its output is the same.