### PR TITLE
Improve parsing of function partial applications.

### DIFF
--- a/Compiler/BackEnd/HpcOmMemory.mo
+++ b/Compiler/BackEnd/HpcOmMemory.mo
@@ -359,10 +359,10 @@ import Util;
           //Get not optimized variables (e.g. paramters that are not part of the task graph)
           //--------------------------------------------------------------------------------
           notOptimizedVars = getNotOptimizedVarsByCacheLineMapping(scVarCLMapping, allVarsMapping, simCodeVarTypes);
-          notOptimizedVarsFloatOpt = List.map(Util.tuple41(notOptimizedVars), function arrayGet(allVarsMapping));
-          notOptimizedVarsIntOpt = List.map(Util.tuple42(notOptimizedVars), function arrayGet(allVarsMapping));
-          notOptimizedVarsBoolOpt = List.map(Util.tuple43(notOptimizedVars), function arrayGet(allVarsMapping));
-          notOptimizedVarsStringOpt = List.map(Util.tuple44(notOptimizedVars), function arrayGet(allVarsMapping));
+          notOptimizedVarsFloatOpt = List.map(Util.tuple41(notOptimizedVars), function arrayGet(arr = allVarsMapping));
+          notOptimizedVarsIntOpt = List.map(Util.tuple42(notOptimizedVars), function arrayGet(arr = allVarsMapping));
+          notOptimizedVarsBoolOpt = List.map(Util.tuple43(notOptimizedVars), function arrayGet(arr = allVarsMapping));
+          notOptimizedVarsStringOpt = List.map(Util.tuple44(notOptimizedVars), function arrayGet(arr = allVarsMapping));
 
           notOptimizedVarsFloat = List.map(notOptimizedVarsFloatOpt, Util.getOption);
           notOptimizedVarsInt = List.map(notOptimizedVarsIntOpt, Util.getOption);

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -2154,6 +2154,9 @@ algorithm
     case Absyn.Exp.CALL()
       then Call.instantiate(absynExp.function_, absynExp.functionArgs, scope, info);
 
+    case Absyn.Exp.PARTEVALFUNCTION()
+      then instPartEvalFunction(absynExp.function_, absynExp.functionArgs, scope, info);
+
     case Absyn.Exp.END() then Expression.END();
 
     else
@@ -2342,6 +2345,32 @@ algorithm
         Subscript.fromExp(exp);
   end match;
 end instSubscript;
+
+function instPartEvalFunction
+  input Absyn.ComponentRef func;
+  input Absyn.FunctionArgs args;
+  input InstNode scope;
+  input SourceInfo info;
+  output Expression outExp;
+algorithm
+  outExp := match args
+    case Absyn.FUNCTIONARGS(args = {}, argNames = {})
+      then instCref(func, scope, info);
+
+    case Absyn.FUNCTIONARGS()
+      algorithm
+
+      then
+        fail();
+
+    case Absyn.FOR_ITER_FARG()
+      algorithm
+        print("Invalid argument to function partial application\n");
+      then
+        fail();
+
+  end match;
+end instPartEvalFunction;
 
 function instSections
   input InstNode node;

--- a/Parser/Modelica.g
+++ b/Parser/Modelica.g
@@ -1129,8 +1129,11 @@ expression[int allowPartEvalFunc] returns [void* ast] :
   ;
 
 part_eval_function_expression returns [void* ast]
-@init { cr.ast = 0; fc = 0; } :
-  FUNCTION cr=component_reference fc=function_call { ast = Absyn__PARTEVALFUNCTION(cr.ast, fc); }
+@init { cr.ast = 0; args = 0; } :
+  FUNCTION cr=component_reference LPAR (args=named_arguments)? RPAR
+  {
+    ast = Absyn__PARTEVALFUNCTION(cr.ast, Absyn__FUNCTIONARGS(mmc_mk_nil(), or_nil(args)));
+  }
   ;
 
 if_expression returns [void* ast]


### PR DESCRIPTION
- Change the parser to only accept named arguments for function partial
  applications, as defined by the grammar in the Modelica specification.