### PR TITLE
[NF] Initial partial function application support.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -531,7 +531,7 @@ protected
     end if;
 
     // pre/change may not be used in a function context.
-    if intBitAnd(origin, ExpOrigin.FUNCTION) > 0 then
+    if ExpOrigin.flagSet(origin, ExpOrigin.FUNCTION) then
       Error.addSourceMessageAndFail(Error.EXP_INVALID_IN_FUNCTION,
         {ComponentRef.toString(fn_ref)}, info);
     end if;
@@ -570,7 +570,7 @@ protected
     Type ety;
   algorithm
     // der may not be used in a function context.
-    if intBitAnd(origin, ExpOrigin.FUNCTION) > 0 then
+    if ExpOrigin.flagSet(origin, ExpOrigin.FUNCTION) then
       Error.addSourceMessage(Error.EXP_INVALID_IN_FUNCTION, {"der"}, info);
       fail();
     end if;
@@ -659,7 +659,7 @@ protected
     CallAttributes ca;
   algorithm
     // edge may not be used in a function context.
-    if intBitAnd(origin, ExpOrigin.FUNCTION) > 0 then
+    if ExpOrigin.flagSet(origin, ExpOrigin.FUNCTION) then
       Error.addSourceMessage(Error.EXP_INVALID_IN_FUNCTION, {"edge"}, info);
       fail();
     end if;
@@ -950,7 +950,7 @@ protected
     {fn} := Function.typeRefCache(fnRef);
     ty := Type.liftArrayLeftList(fillType, dims);
 
-    if evaluated and intBitAnd(origin, ExpOrigin.FUNCTION) == 0 then
+    if evaluated and ExpOrigin.flagNotSet(origin, ExpOrigin.FUNCTION) then
       callExp := Ceval.evalBuiltinFill(ty_args);
     else
       callExp := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.FILL_FUNC, ty_args, variability, ty));
@@ -1286,7 +1286,7 @@ protected
         {Call.toString(call), ComponentRef.toString(fn_ref) + "(Connector) => Integer"}, info);
     end if;
 
-    if intBitAnd(origin, ExpOrigin.FUNCTION) > 0 then
+    if ExpOrigin.flagSet(origin, ExpOrigin.FUNCTION) then
       Error.addSourceMessageAndFail(Error.EXP_INVALID_IN_FUNCTION,
         {ComponentRef.toString(fn_ref)}, info);
     end if;
@@ -1334,7 +1334,7 @@ protected
         {Call.toString(call), ComponentRef.toString(fn_ref) + "(Connector, Connector)"}, info);
     end if;
 
-    if intBitAnd(origin, ExpOrigin.FUNCTION) > 0 then
+    if ExpOrigin.flagSet(origin, ExpOrigin.FUNCTION) then
       Error.addSourceMessageAndFail(Error.EXP_INVALID_IN_FUNCTION,
         {ComponentRef.toString(fn_ref)}, info);
     end if;
@@ -1373,7 +1373,7 @@ protected
         {Call.toString(call), ComponentRef.toString(fn_ref) + "(Connector)"}, info);
     end if;
 
-    if intBitAnd(origin, ExpOrigin.FUNCTION) > 0 then
+    if ExpOrigin.flagSet(origin, ExpOrigin.FUNCTION) then
       Error.addSourceMessageAndFail(Error.EXP_INVALID_IN_FUNCTION,
         {ComponentRef.toString(fn_ref)}, info);
     end if;
@@ -1421,7 +1421,7 @@ protected
         {Call.toString(call), ComponentRef.toString(fn_ref) + "(Connector, Integer = 0)"}, info);
     end if;
 
-    if intBitAnd(origin, ExpOrigin.FUNCTION) > 0 then
+    if ExpOrigin.flagSet(origin, ExpOrigin.FUNCTION) then
       Error.addSourceMessageAndFail(Error.EXP_INVALID_IN_FUNCTION,
         {ComponentRef.toString(fn_ref)}, info);
     end if;
@@ -1471,7 +1471,7 @@ protected
         {Call.toString(call), ComponentRef.toString(fn_ref) + "(Connector)"}, info);
     end if;
 
-    if intBitAnd(origin, ExpOrigin.FUNCTION) > 0 then
+    if ExpOrigin.flagSet(origin, ExpOrigin.FUNCTION) then
       Error.addSourceMessageAndFail(Error.EXP_INVALID_IN_FUNCTION,
         {ComponentRef.toString(fn_ref)}, info);
     end if;
@@ -1506,7 +1506,7 @@ protected
         {Call.toString(call), ComponentRef.toString(fn_ref) + "(Connector)"}, info);
     end if;
 
-    if intBitAnd(origin, ExpOrigin.FUNCTION) > 0 then
+    if ExpOrigin.flagSet(origin, ExpOrigin.FUNCTION) then
       Error.addSourceMessageAndFail(Error.EXP_INVALID_IN_FUNCTION,
         {ComponentRef.toString(fn_ref)}, info);
     end if;
@@ -1588,7 +1588,7 @@ protected
     end if;
 
     {arg} := args;
-    (arg, ty, variability) := Typing.typeExp(arg, intBitOr(origin, ExpOrigin.NOEVENT), info);
+    (arg, ty, variability) := Typing.typeExp(arg, ExpOrigin.setFlag(origin, ExpOrigin.NOEVENT), info);
 
     {fn} := Function.typeRefCache(fn_ref);
     callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, ty));

--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -1054,10 +1054,13 @@ protected
         list<TypedArg> typedArgs;
         list<TypedNamedArg> typedNamedArgs;
         String name;
+        ExpOrigin.Type next_origin;
 
       case UNTYPED_CALL()
         algorithm
           typedArgs := {};
+          next_origin := ExpOrigin.setFlag(origin, ExpOrigin.SUBEXPRESSION);
+
           for arg in call.arguments loop
             (arg, arg_ty, arg_var) := Typing.typeExp(arg, origin, info);
             typedArgs := (arg, arg_ty, arg_var) :: typedArgs;

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -1498,6 +1498,14 @@ algorithm
       then
         ();
 
+    case Expression.PARTIAL_FUNCTION_APPLICATION()
+      algorithm
+        for f in Function.getRefCache(exp.fn) loop
+          funcs := flattenFunction(f, funcs);
+        end for;
+      then
+        ();
+
     else ();
   end match;
 end collectExpFuncs_traverse;

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -671,7 +671,7 @@ public
           case FunctionType.FUNCTION_REFERENCE
             then DAE.T_FUNCTION_REFERENCE_FUNC(Function.isBuiltin(ty.fn), Function.makeDAEType(ty.fn));
           case FunctionType.FUNCTIONAL_VARIABLE
-            then DAE.T_FUNCTION_REFERENCE_VAR(Function.makeDAEType(ty.fn));
+            then DAE.T_FUNCTION_REFERENCE_VAR(Function.makeDAEType(ty.fn, true));
         end match;
       case Type.NORETCALL() then DAE.T_NORETCALL_DEFAULT;
       case Type.UNKNOWN() then DAE.T_UNKNOWN_DEFAULT;

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -812,6 +812,8 @@ public constant Message OPERATOR_OVERLOADING_INVALID_OUTPUT_TYPE = MESSAGE(341, 
   Util.gettext("Output ‘%s‘ in operator %s must be of type %s, got type %s."));
 public constant Message OPERATOR_NOT_ENCAPSULATED = MESSAGE(342, TRANSLATION(), ERROR(),
   Util.gettext("Operator %s is not encapsulated."));
+public constant Message NO_SUCH_INPUT_PARAMETER = MESSAGE(343, TRANSLATION(), ERROR(),
+  Util.gettext("Function %s has no input parameter named %s."));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),


### PR DESCRIPTION
- Implemented handling of partial function applications.
- Changed TypeMatch.matchExpressions to handle type checking/casting by
  itself instead of relying on matchTypes, since matchTypes assumes a
  strict actual/expected relation between the types which is not the
  case for matchExpressions. This could e.g. lead to inconsistent
  boxing/unboxing of expressions depending on which side of a binary
  expression a boxed expression appeared on.
- Replaced all usage of intBitOr/intBitAnd for ExpOrigin flags with
  ExpOrigin.setFlag/flagSet.