### PR TITLE
[NF] Clone inherited classes.

### DIFF
--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -284,6 +284,24 @@ uniontype Class
     end match;
   end setClassTree;
 
+  function classTreeApply
+    input output Class cls;
+    input FuncType func;
+
+    partial function FuncType
+      input output ClassTree tree;
+    end FuncType;
+  algorithm
+    () := match cls
+      case Class.PARTIAL_CLASS()     algorithm cls.elements := func(cls.elements); then ();
+      case Class.EXPANDED_CLASS()    algorithm cls.elements := func(cls.elements); then ();
+      case Class.PARTIAL_BUILTIN()   algorithm cls.elements := func(cls.elements); then ();
+      case Class.INSTANCED_CLASS()   algorithm cls.elements := func(cls.elements); then ();
+      case Class.INSTANCED_BUILTIN() algorithm cls.elements := func(cls.elements); then ();
+      else ();
+    end match;
+  end classTreeApply;
+
   function getModifier
     input Class cls;
     output Modifier modifier;

--- a/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/Compiler/NFFrontEnd/NFClassTree.mo
@@ -704,6 +704,25 @@ public
       tree := FLAT_TREE(ltree, listArray({}), comps, listArray({}), DuplicateTree.new());
     end fromRecordConstructor;
 
+    function clone
+      input ClassTree tree;
+      output ClassTree outTree;
+    algorithm
+      outTree := match tree
+        local
+          array<InstNode> clss;
+
+        case EXPANDED_TREE()
+          algorithm
+            clss := arrayCopy(tree.classes);
+            clss := Array.mapNoCopy(clss, InstNode.clone);
+          then
+            EXPANDED_TREE(tree.tree, clss, tree.components, tree.exts, tree.imports, tree.duplicates);
+
+        else tree;
+      end match;
+    end clone;
+
     function mapRedeclareChains
       input ClassTree tree;
       input FuncT func;

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -431,6 +431,7 @@ algorithm
         checkExtendsLoop(base_node, base_path, info);
         checkReplaceableBaseClass(base_nodes, base_path, info);
         base_node := expand(base_node);
+        base_node := InstNode.clone(base_node);
 
         ext := InstNode.setNodeType(InstNodeType.BASE_CLASS(scope, def), base_node);
 
@@ -656,6 +657,7 @@ algorithm
   end if;
 
   ext_node := expand(ext_node);
+  ext_node := InstNode.clone(ext_node);
 
   // Fetch the needed information from the class definition and construct a EXPANDED_DERIVED.
   cls := InstNode.getClass(node);

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -50,6 +50,7 @@ protected
 import List;
 import ConvertDAE = NFConvertDAE;
 import Restriction = NFRestriction;
+import NFClassTree.ClassTree;
 
 public
 uniontype InstNodeType
@@ -1454,6 +1455,27 @@ uniontype InstNode
       else false;
     end match;
   end isPartial;
+
+  function clone
+    input output InstNode node;
+  algorithm
+    () := match node
+      local
+        Class cls;
+
+      case CLASS_NODE()
+        algorithm
+          cls := Pointer.access(node.cls);
+          cls := Class.classTreeApply(cls, ClassTree.clone);
+          node.cls := Pointer.create(cls);
+          node.caches := CachedData.empty();
+        then
+          ();
+
+      else ();
+    end match;
+  end clone;
+
 end InstNode;
 
 annotation(__OpenModelica_Interface="frontend");


### PR DESCRIPTION
- Clone inherited classes so that they get unique caches, to prevent e.g.
  the same record constructor instance from being shared between classes
  where the record has different modifiers or use package constants with
  different bindings.