### PR TITLE
Re-add local ModelicaExternalC to Cpp runtime, ticket:5227

### DIFF
--- a/SimulationRuntime/cpp/CMakeLists.txt
+++ b/SimulationRuntime/cpp/CMakeLists.txt
@@ -91,6 +91,8 @@ OPTION(TRILINOS_ROOT "TRILINOS ROOT" "")
 OPTION(USE_CPP_03 "USE_CPP_03" OFF)
 
 #Set Variables
+SET(MODELICAEXTERNALCDIR  "${CMAKE_SOURCE_DIR}/../../3rdParty/ModelicaExternalC/C-Sources")
+
 IF(NOT FMU_TARGET)
  IF(MSVC)
   SET(LIBINSTALLEXT "lib/omc/cpp/msvc" CACHE STRINGz "library directory")
@@ -112,6 +114,12 @@ SET(SolverName ${LIBPREFIX}Solver${LIBSUFFIX})
 SET(SystemName ${LIBPREFIX}System${LIBSUFFIX})
 SET(OMCFactoryName ${LIBPREFIX}OMCFactory${LIBSUFFIX})
 SET(MathName ${LIBPREFIX}Math${LIBSUFFIX})
+
+SET(ModelicaExternalName ModelicaExternalC) # only static version
+SET(ModelicaTablesName ModelicaStandardTables) # only static version
+SET(ModelicaIOName ModelicaIO) # only static version
+SET(ModelicaMatIOName ModelicaMatIO) # only static version
+SET(LibZName zlib) # only static version
 
 SET(SimulationSettings ${LIBPREFIX}SimulationSettings${LIBSUFFIX})
 SET(SimControllerName ${LIBPREFIX}SimController${LIBSUFFIX})
@@ -837,6 +845,7 @@ add_subdirectory(Core/Solver)
 add_subdirectory(Core/Math)
 add_subdirectory(Core/Utils/Modelica)
 add_subdirectory(Core/Utils/extension)
+add_subdirectory(Core/ModelicaExternalC)
 
 if(NOT FMU_TARGET)
   # add projects for generating a simulator

--- a/SimulationRuntime/cpp/Core/ModelicaExternalC/CMakeLists.txt
+++ b/SimulationRuntime/cpp/Core/ModelicaExternalC/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Build default ModelicaExternalC libs (without extra flags like HAVE_HDF5).
+# Note: zlib is only here because it is referred to from MSL Tables and
+# thus passed to the linker. It is not used by default ModelicaMatIO though.
+
+cmake_minimum_required(VERSION 2.8.9)
+project(${ModelicaExternalName})
+
+include_directories(${MODELICAEXTERNALCDIR})
+add_definitions(-DDUMMY_FUNCTION_USERTAB) # yet an extra flag
+
+add_library(${ModelicaExternalName} STATIC ${MODELICAEXTERNALCDIR}/ModelicaFFT.c ${MODELICAEXTERNALCDIR}/ModelicaInternal.c ${MODELICAEXTERNALCDIR}/ModelicaRandom.c ${MODELICAEXTERNALCDIR}/ModelicaStrings.c)
+add_library(${ModelicaTablesName} STATIC ${MODELICAEXTERNALCDIR}/ModelicaStandardTables.c)
+add_library(${ModelicaIOName} STATIC ${MODELICAEXTERNALCDIR}/ModelicaIO.c)
+add_library(${ModelicaMatIOName} STATIC ${MODELICAEXTERNALCDIR}/ModelicaMatIO.c)
+add_library(${LibZName} STATIC ${MODELICAEXTERNALCDIR}/zlib/adler32.c ${MODELICAEXTERNALCDIR}/zlib/compress.c ${MODELICAEXTERNALCDIR}/zlib/crc32.c ${MODELICAEXTERNALCDIR}/zlib/deflate.c ${MODELICAEXTERNALCDIR}/zlib/gzclose.c ${MODELICAEXTERNALCDIR}/zlib/gzlib.c ${MODELICAEXTERNALCDIR}/zlib/gzread.c ${MODELICAEXTERNALCDIR}/zlib/gzwrite.c ${MODELICAEXTERNALCDIR}/zlib/infback.c ${MODELICAEXTERNALCDIR}/zlib/inffast.c ${MODELICAEXTERNALCDIR}/zlib/inflate.c ${MODELICAEXTERNALCDIR}/zlib/inftrees.c ${MODELICAEXTERNALCDIR}/zlib/trees.c ${MODELICAEXTERNALCDIR}/zlib/uncompr.c ${MODELICAEXTERNALCDIR}/zlib/zutil.c)
+
+install(TARGETS ${ModelicaExternalName} DESTINATION ${LIBINSTALLEXT})
+install(TARGETS ${ModelicaTablesName} DESTINATION ${LIBINSTALLEXT})
+install(TARGETS ${ModelicaIOName} DESTINATION ${LIBINSTALLEXT})
+install(TARGETS ${ModelicaMatIOName} DESTINATION ${LIBINSTALLEXT})
+install(TARGETS ${LibZName} DESTINATION ${LIBINSTALLEXT})


### PR DESCRIPTION
They had been removed in commit 90621756a8e8f3978a17347146a6fc3b044f3e71,
but are needed to avoid unclear dependencies from MSL to HDF5 (and ZLIB).