### PR TITLE
[Cpp] Fix derivative vars in XmlPropertyReader, ticket:4773

### DIFF
--- a/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
+++ b/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
@@ -16,14 +16,6 @@ XmlPropertyReader::XmlPropertyReader(IGlobalSettings *globalSettings, std::strin
   ,_isInitialized(false)
 {
 }
-XmlPropertyReader::XmlPropertyReader(IGlobalSettings *globalSettings, std::string propertyFile,int dimRHS)
-  : IPropertyReader()
-  ,_globalSettings(globalSettings)
-  ,_propertyFile(propertyFile)
-  ,_isInitialized(false)
-  ,_dimRHS(dimRHS)
-{
-}
 XmlPropertyReader::~XmlPropertyReader()
 {
 }
@@ -173,13 +165,13 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
         }
       }
 
-    int derSize=_dimRHS;
-    for(int i=0; i<derSize;i++)
-    {
-      string name="der";
-      string descripton="der";
-      _derVars.addOutputVar(name, descripton, derVars+i, false);
-    }
+      size_t derSize = sim_vars->getDimStateVars();
+      string name = "der";
+      string descripton = "der";
+      for (size_t i = 0; i < derSize; i++)
+      {
+        _derVars.addOutputVar(name, descripton, derVars + i, false);
+      }
 
       LOGGER_WRITE_END(LC_INIT, LL_DEBUG);
     }

--- a/SimulationRuntime/cpp/Include/Core/DataExchange/XmlPropertyReader.h
+++ b/SimulationRuntime/cpp/Include/Core/DataExchange/XmlPropertyReader.h
@@ -7,7 +7,6 @@ class BOOST_EXTENSION_XML_READER_DECL XmlPropertyReader : public IPropertyReader
 {
   public:
     XmlPropertyReader(IGlobalSettings *globalSettings, std::string propertyFile);
-    XmlPropertyReader(IGlobalSettings *globalSettings, std::string propertyFile, int dimRHS);
     ~XmlPropertyReader();
 
     void readInitialValues(IContinuous& system, shared_ptr<ISimVars> sim_vars);
@@ -28,6 +27,5 @@ class BOOST_EXTENSION_XML_READER_DECL XmlPropertyReader : public IPropertyReader
     output_real_vars_t _realVars;
     output_der_vars_t _derVars;
     output_res_vars_t _resVars;
-    int _dimRHS;
     bool _isInitialized;
 };

--- a/SimulationRuntime/cpp/Include/Core/System/ISimVars.h
+++ b/SimulationRuntime/cpp/Include/Core/System/ISimVars.h
@@ -27,6 +27,14 @@ public:
      virtual  void setBoolVarsVector(const bool* vars) = 0;
      virtual  void setStringVarsVector(const string* vars) = 0;
 
+    /*Methods to get sizes of variable vectors*/
+    virtual size_t getDimString() const = 0;
+    virtual size_t getDimBool() const = 0;
+    virtual size_t getDimInt() const = 0;
+    virtual size_t getDimPreVars() const = 0;
+    virtual size_t getDimReal() const = 0;
+    virtual size_t getDimStateVars() const = 0;
+    virtual size_t getStateVectorIndex() const = 0;
 
      /*Methods for initialize model array variables in simvars memory*/
     virtual double* initRealArrayVar(size_t size,size_t start_index)= 0;

--- a/SimulationRuntime/cpp/Include/Core/System/SimVars.h
+++ b/SimulationRuntime/cpp/Include/Core/System/SimVars.h
@@ -111,9 +111,6 @@ class BOOST_EXTENSION_SIMVARS_DECL SimVars: public ISimVars
     virtual int& getPreVar(const int& var);
     virtual bool& getPreVar(const bool& var);
 
-  protected:
-    void create(size_t dim_real, size_t dim_int, size_t dim_bool, size_t dim_string, size_t dim_pre_vars, size_t dim_state_vars, size_t state_index);
-
     virtual size_t getDimString() const;
     virtual size_t getDimBool() const;
     virtual size_t getDimInt() const;
@@ -121,6 +118,9 @@ class BOOST_EXTENSION_SIMVARS_DECL SimVars: public ISimVars
     virtual size_t getDimReal() const;
     virtual size_t getDimStateVars() const;
     virtual size_t getStateVectorIndex() const;
+
+  protected:
+    void create(size_t dim_real, size_t dim_int, size_t dim_bool, size_t dim_string, size_t dim_pre_vars, size_t dim_state_vars, size_t state_index);
 
     void *alignedMalloc(size_t required_bytes, size_t alignment);
     void alignedFree(void* p);


### PR DESCRIPTION
Commit b528b72f1484c42d12f1be9b91cf16cca894ab7d
(Fatemeh Davoudi implementation of the symbolic model reduction algorithm)
introduced _derVars and _resVars along with a second constructor that
initialized the dimension of _derVars as _dimRHS. This second constructor
was not used though, leaving _dimRHS undefined and running a for loop with
undefined end during initialization.

This commit removes the second constructor and the uninitialized variable.
It uses consistent size info from SimVars instead.