### PR TITLE
Fix FMU hybrj_ function signature

### DIFF
--- a/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -56,7 +56,7 @@ struct dataAndSys {
   int sysNumber;
 };
 
-static int wrapper_fvec_hybrj(const integer* n, const double* x, double* f, double* fjac, const integer* ldjac, const integer* iflag, void* data);
+static void wrapper_fvec_hybrj(const integer* n, const double* x, double* f, double* fjac, const integer* ldjac, const integer* iflag, void* data);
 
 /*! \fn allocate memory for nonlinear system solver hybrd
  *
@@ -304,7 +304,7 @@ static int getAnalyticalJacobian(struct dataAndSys* dataSys, double* jac)
  *
  *
  */
-static int wrapper_fvec_hybrj(const integer* n, const double* x, double* f, double* fjac, const integer* ldjac, const integer* iflag, void* dataAndSysNum)
+static void wrapper_fvec_hybrj(const integer* n, const double* x, double* f, double* fjac, const integer* ldjac, const integer* iflag, void* dataAndSysNum)
 {
   int i,j;
   struct dataAndSys *dataSys = (struct dataAndSys*) dataAndSysNum;
@@ -399,8 +399,6 @@ static int wrapper_fvec_hybrj(const integer* n, const double* x, double* f, doub
     throwStreamPrint(NULL, "Well, this is embarrasing. The non-linear solver should never call this case.%d", (int)*iflag);
     break;
   }
-
-  return 0;
 }
 
 /*! \fn solve non-linear system with hybrd method

--- a/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.h
+++ b/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.h
@@ -45,7 +45,7 @@ extern "C" {
 #endif
 
 extern
-int hybrj_( int(*) (const integer*, const double*, double*, double *, const integer*, const integer*, void*),  const integer *n, double *x, double *fvec, double *fjac, const integer *ldfjac,
+void hybrj_( void(*) (const integer*, const double*, double*, double *, const integer*, const integer*, void*),  const integer *n, double *x, double *fvec, double *fjac, const integer *ldfjac,
   const double *xtol, const integer *axfev, double *diag, const integer *mode,
   const double *factor, const integer *nprint, integer *info, integer *nfev, integer *njev,
   double *r, integer *lr, double *qtf, double *wa1, double *wa2,


### PR DESCRIPTION
3rdParty/CMinpack/hybrj_.c has void return value, FMU export uses int.

EMCC linking and WebAssembly runtime errors out on incorrect function signature.

emcc linking warning: 
`warning: unexpected return type i32 in call to 'hybrj_', should be void`

Wasm runtime error:
`Invalid function pointer '454' called with signature 'viiiiiii'. Perhaps this is an invalid value`

`This pointer might make sense in another type signature: viii: 0  viiii: 0  viiiii: 0  vii: 0  viiiiii: undefined  vi: 0  v: undefined  viiiiiiiiiiiiiiiiiiiiiii: 0  iiii: 0  iiiii: undefined  iiiiii: undefined  iii: 0  diii: 0  vidi: 0  viid: 0  viiidi: 0  iidi: 0  iiiiid: undefined  ii: 0  dii: 0  iid: 0  iiiiiiii: _wrapper_fvec_hybrj  viidd: undefined  di: 0  vd: undefined  iiiiiiiii: 0  i: undefined  iiiiiiiiii: 0`