### PR TITLE
[Cpp] Implement flags for input and output path, ticket:4773

### DIFF
--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -5791,20 +5791,7 @@ case SIMCODE(modelInfo = MODELINFO(__),makefileParams = MAKEFILE_PARAMS(__))  th
    void <%lastIdentOfPath(modelInfo.name)%>Initialize::initializeFreeVariables()
    {
       #if !defined(FMU_BUILD)
-        #if defined(__vxworks)
-        _reader  = shared_ptr<IPropertyReader>(new XmlPropertyReader(_global_settings, "/SYSTEM/bundles/com.boschrexroth.<%modelname%>/<%fileNamePrefix%>_init.xml"));
-        #else
-         <%if (Flags.getConfigBool(Flags.LABELED_REDUCTION)) then
-            <<
-            _reader  =  shared_ptr<IPropertyReader>(new XmlPropertyReader(_global_settings, "<%makefileParams.compileDir%>/<%fileNamePrefix%>_init.xml",_dimRHS));
-            >>
-            else
-            <<
-            _reader  =  shared_ptr<IPropertyReader>(new XmlPropertyReader(_global_settings, "<%makefileParams.compileDir%>/<%fileNamePrefix%>_init.xml"));
-            >>
-            %>
-
-        #endif
+        _reader  = shared_ptr<IPropertyReader>(new XmlPropertyReader(_global_settings, "<%fileNamePrefix%>_init.xml"));
         _reader->readInitialValues(*this, getSimVars());
       #endif
 

--- a/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
+++ b/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
@@ -12,7 +12,7 @@
 XmlPropertyReader::XmlPropertyReader(IGlobalSettings *globalSettings, std::string propertyFile)
   : IPropertyReader()
   ,_globalSettings(globalSettings)
-  ,_propertyFile(propertyFile)
+  ,_propertyFile(globalSettings->getInputPath() + string("/") + propertyFile)
   ,_isInitialized(false)
 {
 }

--- a/SimulationRuntime/cpp/Core/SimController/SimController.cpp
+++ b/SimulationRuntime/cpp/Core/SimController/SimController.cpp
@@ -161,6 +161,9 @@ void SimController::Start(SimSettings simsettings, string modelKey)
         global_settings->setEmitResults(simsettings.emitResults);
         global_settings->setNonLinearSolverContinueOnError(simsettings.nonLinearSolverContinueOnError);
         global_settings->setSolverThreads(simsettings.solverThreads);
+        global_settings->setInputPath(simsettings.inputPath);
+        global_settings->setOutputPath(simsettings.outputPath);
+
         /*shared_ptr<SimManager>*/ _simMgr = shared_ptr<SimManager>(new SimManager(mixedsystem, _config.get()));
 
         ISolverSettings* solver_settings = _config->getSolverSettings();

--- a/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
+++ b/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
@@ -135,6 +135,16 @@ void GlobalSettings::setOutputPath(string path)
   _output_path = path;
 }
 
+string GlobalSettings::getInputPath()
+{
+  return _input_path;
+}
+
+void GlobalSettings::setInputPath(string path)
+{
+  _input_path = path;
+}
+
 string GlobalSettings::getSelectedSolver()
 {
   return _selected_solver;

--- a/SimulationRuntime/cpp/Include/Core/SimController/ISimController.h
+++ b/SimulationRuntime/cpp/Include/Core/SimController/ISimController.h
@@ -23,6 +23,8 @@ struct SimSettings
   int solverThreads;
   OutputFormat outputFormat;
   EmitResults emitResults;
+  string inputPath;
+  string outputPath;
 };
 
 /**

--- a/SimulationRuntime/cpp/Include/Core/SimulationSettings/GlobalSettings.h
+++ b/SimulationRuntime/cpp/Include/Core/SimulationSettings/GlobalSettings.h
@@ -29,6 +29,9 @@ public:
   virtual void setInfoOutput(bool);
   virtual bool useEndlessSim();
   virtual void useEndlessSim(bool);
+  ///path for input files, like init xml
+  virtual string getInputPath();
+  virtual void setInputPath(string);
   ///path for simulation results in textfile
   virtual string getOutputPath();
   virtual void setOutputPath(string);
@@ -73,6 +76,7 @@ private:
       _endless_sim,
       _nonLinSolverContinueOnError;
   string
+      _input_path,
       _output_path,
       _selected_solver,
       _selected_lin_solver,

--- a/SimulationRuntime/cpp/Include/Core/SimulationSettings/IGlobalSettings.h
+++ b/SimulationRuntime/cpp/Include/Core/SimulationSettings/IGlobalSettings.h
@@ -72,7 +72,7 @@ public:
   virtual LogSettings getLogSettings() = 0;
   virtual void setLogSettings(LogSettings) = 0;
   virtual void setAlarmTime(unsigned int) = 0;
-   virtual unsigned int getAlarmTime() = 0;
+  virtual unsigned int getAlarmTime() = 0;
 
   virtual OutputFormat getOutputFormat() = 0;
   virtual void setOutputFormat(OutputFormat) = 0;
@@ -94,6 +94,9 @@ public:
   virtual string getResultsFileName() = 0;
   virtual void setRuntimeLibrarypath(string) = 0;
   virtual string getRuntimeLibrarypath() = 0;
+  ///< Directory for input files, like init.xml
+  virtual string getInputPath() = 0;
+  virtual void setInputPath(string) = 0;
 
   virtual void setNonLinearSolverContinueOnError(bool) = 0;
   virtual bool getNonLinearSolverContinueOnError() = 0;

--- a/SimulationRuntime/cpp/Include/FMU/FMUGlobalSettings.h
+++ b/SimulationRuntime/cpp/Include/FMU/FMUGlobalSettings.h
@@ -32,12 +32,14 @@ public:
     ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false,true]; default: true)
     virtual bool getInfoOutput() { return false; }
     virtual void setInfoOutput(bool) {}
-    virtual string    getOutputPath() { return "./"; }
+    virtual string    getOutputPath() { return "."; }
+    virtual string    getInputPath() { return "."; }
     virtual LogSettings getLogSettings() {return LogSettings(LF_FMI);}
     virtual void setLogSettings(LogSettings) {}
     virtual OutputPointType getOutputPointType() { return OPT_ALL; };
     virtual void setOutputPointType(OutputPointType) {};
     virtual void setOutputPath(string) {}
+    virtual void setInputPath(string) {}
     virtual string    getSelectedSolver() { return "euler"; }
     virtual void setSelectedSolver(string) {}
     virtual string    getSelectedLinSolver() { return "dgesvSolver"; }

--- a/SimulationRuntime/cpp/Include/FMU2/FMU2GlobalSettings.h
+++ b/SimulationRuntime/cpp/Include/FMU2/FMU2GlobalSettings.h
@@ -64,12 +64,14 @@ class FMU2GlobalSettings : public IGlobalSettings
   ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false,true]; default: true)
   virtual bool            getInfoOutput() { return false; }
   virtual void            setInfoOutput(bool) {}
-  virtual string          getOutputPath() { return "./"; }
+  virtual string          getOutputPath() { return "."; }
+  virtual string          getInputPath() { return "."; }
   virtual LogSettings     getLogSettings() { return LogSettings(LF_FMI2); }
   virtual void            setLogSettings(LogSettings) {}
   virtual OutputPointType getOutputPointType() { return OPT_ALL; };
   virtual void            setOutputPointType(OutputPointType) {};
   virtual void            setOutputPath(string) {}
+  virtual void            setInputPath(string) {}
   virtual string          getSelectedSolver() { return "euler"; }
   virtual void            setSelectedSolver(string) {}
   virtual string          getSelectedLinSolver() { return "dgesvSolver"; }

--- a/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
+++ b/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
@@ -307,6 +307,8 @@ SimSettings OMCFactory::readSimulationParameter(int argc, const char* argv[])
           ("nls-continue", po::bool_switch()->default_value(false), "non linear solver will continue if it can not reach the given precision")
           ("runtime-library,R", po::value<string>(), "path to cpp runtime libraries")
           ("modelica-system-library,M",  po::value<string>(), "path to Modelica library")
+          ("input-path", po::value< string >(), "directory with input files, like init xml (defaults to modelica-system-library)")
+          ("output-path", po::value< string >(), "directory for output files, like results (defaults to modelica-system-library)")
           ("results-file,F", po::value<vector<string> >(),"name of results file")
           ("start-time,S", po::value< double >()->default_value(0.0), "simulation start time")
           ("stop-time,E", po::value< double >()->default_value(1.0), "simulation stop time")
@@ -401,6 +403,16 @@ SimSettings OMCFactory::readSimulationParameter(int argc, const char* argv[])
      else
          throw ModelicaSimulationError(MODEL_FACTORY,"Modelica library path is not set");
 
+     string inputPath, outputPath;
+     if (vm.count("input-path"))
+         inputPath = vm["input-path"].as<string>();
+     else
+         inputPath = modelica_lib_path;
+     if (vm.count("output-path"))
+         outputPath = vm["output-path"].as<string>();
+     else
+         outputPath = modelica_lib_path;
+
      string resultsfilename;
      if (vm.count("results-file"))
      {
@@ -453,7 +465,7 @@ SimSettings OMCFactory::readSimulationParameter(int argc, const char* argv[])
      libraries_path.make_preferred();
      modelica_path.make_preferred();
 
-     SimSettings settings = {solver,linSolver,nonLinSolver,starttime,stoptime,stepsize,1e-24,0.01,tolerance,resultsfilename,timeOut,outputPointType,logSettings,nlsContinueOnError,solverThreads,outputFormat,emitResults};
+     SimSettings settings = {solver, linSolver, nonLinSolver, starttime, stoptime, stepsize, 1e-24, 0.01, tolerance, resultsfilename, timeOut, outputPointType, logSettings, nlsContinueOnError, solverThreads, outputFormat, emitResults, inputPath, outputPath};
 
      _library_path = libraries_path.string();
      _modelicasystem_path = modelica_path.string();
@@ -592,6 +604,8 @@ void OMCFactory::fillArgumentsToReplace()
   _argumentsToReplace.insert(pair<string,string>("-port", "--log-port"));
   _argumentsToReplace.insert(pair<string,string>("-alarm", "--alarm"));
   _argumentsToReplace.insert(pair<string,string>("-emit_protected", "--emit-results all"));
+  _argumentsToReplace.insert(pair<string,string>("-inputPath", "--input-path"));
+  _argumentsToReplace.insert(pair<string,string>("-outputPath", "--output-path"));
 }
 
 pair<shared_ptr<ISimController>,SimSettings>


### PR DESCRIPTION
This follows up 1be2a07fd09f6bc5eab46ffcd568011d99d007be that implemented
these flags to the C runtime.

Both flags are added to GlobalSettings and default to the path of the
compiled model. The flag inputPath replaces the previously hard coded
path in OMCpp<Model>Initialize.cpp.

The flag outputPath is not yet used (the results file has an own flag).
These flags make sense once more that one input or output file will be used.