### PR TITLE
[NF] Record fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFImport.mo
+++ b/Compiler/NFFrontEnd/NFImport.mo
@@ -112,10 +112,7 @@ public
   algorithm
     node := match imp
       case Absyn.Import.NAMED_IMPORT()
-        algorithm
-          node := Lookup.lookupImport(imp.path, scope, info);
-        then
-          InstNode.rename(imp.name, node);
+        then Lookup.lookupImport(imp.path, scope, info);
 
       case Absyn.Import.QUAL_IMPORT()
         then Lookup.lookupImport(imp.path, scope, info);

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -1879,7 +1879,8 @@ protected
   ComplexType cty;
 algorithm
   cty := match restriction
-    case Restriction.RECORD() then makeRecordComplexType(node, cls);
+    case Restriction.RECORD()
+      then makeRecordComplexType(InstNode.classScope(InstNode.getDerivedNode(node)), cls);
     else ComplexType.CLASS();
   end match;
 


### PR DESCRIPTION
- Use derived node when constructing record types.
- Don't rename imported nodes. They aren't used when creating the
  lookup trees anyway and just causes e.g. imported functions to be
  named incorrectly.