### PR TITLE
[NF] Include root name when creating complex DAE types.

### DIFF
--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1384,7 +1384,8 @@ uniontype InstNode
 
             else
               algorithm
-                state := Restriction.toDAE(Class.restriction(cls), scopePath(clsNode));
+                state := Restriction.toDAE(Class.restriction(cls),
+                                           scopePath(clsNode, includeRoot = true));
               then
                 DAE.Type.T_COMPLEX(state, {}, NONE());
 
@@ -1426,7 +1427,8 @@ uniontype InstNode
 
             else
               algorithm
-                state := Restriction.toDAE(Class.restriction(cls), scopePath(clsNode));
+                state := Restriction.toDAE(Class.restriction(cls),
+                                           scopePath(clsNode, includeRoot = true));
                 vars := ConvertDAE.makeTypeVars(clsNode);
                 outType := DAE.Type.T_COMPLEX(state, vars, NONE());
                 Pointer.update(clsNode.cls, Class.DAE_TYPE(outType));


### PR DESCRIPTION
- The root is included when creating e.g. record constructors, so the
  created DAE types must match. Not including the root in either case
  could cause name conflicts.