### PR TITLE
[NF] Constant evaluation optimizations.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -200,7 +200,7 @@ public
       fail();
     end if;
 
-    arrayExp := Expression.ARRAY(Type.UNKNOWN(), posArgs);
+    arrayExp := Expression.makeArray(Type.UNKNOWN(), posArgs);
   end makeArrayExp;
 
   function makeCatExp

--- a/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -991,7 +991,7 @@ algorithm
         (n, strs) := System.regex(str, re, i, extended, insensitive);
         expl := list(Expression.STRING(s) for s in strs);
         strs_ty := Type.ARRAY(Type.STRING(), {Dimension.fromInteger(i)});
-        strs_exp := Expression.ARRAY(strs_ty, expl);
+        strs_exp := Expression.makeArray(strs_ty, expl, true);
       then
         Expression.TUPLE(Type.TUPLE({Type.INTEGER(), strs_ty}, NONE()),
                          {Expression.INTEGER(n), strs_exp});

--- a/Compiler/NFFrontEnd/NFEvalFunctionExt.mo
+++ b/Compiler/NFFrontEnd/NFEvalFunctionExt.mo
@@ -596,8 +596,9 @@ algorithm
     // Vector variable, matrix value => convert value to vector.
     case (Type.ARRAY(dimensions = {_}),
           Expression.ARRAY(ty = Type.ARRAY(dimensions = {_, _})))
-      then Expression.ARRAY(Type.unliftArray(value.ty),
-                            list(Expression.arrayScalarElement(e) for e in value.elements));
+      then Expression.makeArray(Type.unliftArray(value.ty),
+                                list(Expression.arrayScalarElement(e) for e in value.elements),
+                                literal = true);
 
     else value;
   end match;

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -2079,7 +2079,7 @@ algorithm
       algorithm
         expl := list(instExp(e, scope, info) for e in absynExp.arrayExp);
       then
-        Expression.ARRAY(Type.UNKNOWN(), expl);
+        Expression.makeArray(Type.UNKNOWN(), expl);
 
     case Absyn.Exp.MATRIX()
       algorithm

--- a/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -538,7 +538,7 @@ algorithm
           print("- NFOCConnectionGraph.addUniqueRoots(" + ComponentRef.toString(root) + ", " + Expression.toString(inMessage) + ")\n");
         end if;
         graph = GRAPH(updateGraph,definiteRoots,potentialRoots,(root,inMessage)::uniqueRoots,branches,connections);
-        graph = addUniqueRoots(graph, Expression.ARRAY(ty, rest), inMessage);
+        graph = addUniqueRoots(graph, Expression.makeArray(ty, rest), inMessage);
       then
         graph;
 
@@ -1378,7 +1378,7 @@ algorithm
               end if;
               lst = List.fill(Expression.INTEGER(1), listLength(lst)); // TODO! FIXME! actually implement this correctly
             then
-              Expression.ARRAY(Type.INTEGER(), lst);
+              Expression.makeArray(Type.INTEGER(), lst);
         end match;
       then
         res;

--- a/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -308,12 +308,12 @@ algorithm
 
         if dim_size == 0 then
           // Result is Array[0], return empty array expression.
-          outExp := Expression.ARRAY(ty, {});
+          outExp := Expression.makeEmptyArray(ty);
         elseif dim_size == 1 then
           // Result is Array[1], return array with the single element.
           (Expression.ARRAY(elements = {e}), _) := ExpandExp.expand(e);
           exp := Expression.replaceIterator(exp, iter, e);
-          exp := Expression.ARRAY(ty, {exp});
+          exp := Expression.makeArray(ty, {exp});
           outExp := simplify(exp);
         else
           fail();
@@ -361,8 +361,8 @@ algorithm
         dims := Type.arrayDims(Expression.typeOf(sizeExp.exp));
 
         if List.all(dims, function Dimension.isKnown(allowExp = true)) then
-          exp := Expression.ARRAY(Type.ARRAY(Type.INTEGER(), {Dimension.fromInteger(listLength(dims))}),
-                                  list(Dimension.sizeExp(d) for d in dims));
+          exp := Expression.makeArray(Type.ARRAY(Type.INTEGER(), {Dimension.fromInteger(listLength(dims))}),
+                                      list(Dimension.sizeExp(d) for d in dims));
         else
           exp := sizeExp;
         end if;

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -355,7 +355,7 @@ algorithm
         end if;
 
         outType := Type.setArrayElementType(type1, ty);
-        outExp := Expression.ARRAY(outType, expl);
+        outExp := Expression.makeArray(outType, expl, literal = exp1.literal and exp2.literal);
       then
         (outExp, outType);
 

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -1567,7 +1567,7 @@ algorithm
   end for;
 
   arrayType := Type.liftArrayLeft(ty1, Dimension.fromExpList(expl2));
-  arrayExp := Expression.ARRAY(arrayType, expl2);
+  arrayExp := Expression.makeArray(arrayType, expl2);
 end typeArray;
 
 function typeMatrix "The array concatenation operator"


### PR DESCRIPTION
- Added a field to NFExpression.ARRAY that indicates whether an array
  contains only literal expression or not, so that arrays that have
  already been evaluated can be skipped during constant evaluation.
- Implemented Ceval.evalExpPartial that only evaluates the parts of an
  expression that can be evaluated, keeping e.g. iterators intact.
- Use the function mentioned above to optimize the evaluation of array
  constructors and reductions, by partially evaluating the expression
  that's evaluated in each iteration.