### PR TITLE
[Cpp] Don't use outputPath for results file, ticket:4773

### DIFF
--- a/Compiler/Template/CodegenCpp.tpl
+++ b/Compiler/Template/CodegenCpp.tpl
@@ -2283,7 +2283,7 @@ case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simula
       opts["-R"] = "<%simulationLibDir(simulationCodeTarget(),simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace)%>";
       opts["-M"] = "<%moLib%>";
       opts["-F"] = "<%simulationResults(getRunningTestsuite(),simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace)%>";
-      opts["--solverThreads"] = "<%if(intGt(getConfigInt(NUM_PROC), 0)) then getConfigInt(NUM_PROC) else 1%>";
+      opts["--solver-threads"] = "<%if(intGt(getConfigInt(NUM_PROC), 0)) then getConfigInt(NUM_PROC) else 1%>";
       <%if (stringEq(settings.outputFormat, "empty")) then 'opts["-O"] = "none";' else ""%>
       <%
       match(getConfigString(PROFILING_LEVEL))

--- a/SimulationRuntime/cpp/Include/Core/DataExchange/HistoryImpl.h
+++ b/SimulationRuntime/cpp/Include/Core/DataExchange/HistoryImpl.h
@@ -20,7 +20,7 @@ class HistoryImpl : public IHistory,
 {
 public:
   HistoryImpl(IGlobalSettings& globalSettings,size_t dim)
-    : ResultsPolicy((globalSettings.getEndTime()-globalSettings.getStartTime())/globalSettings.gethOutput(),globalSettings.getOutputPath(),globalSettings.getResultsFileName())
+    : ResultsPolicy((globalSettings.getEndTime()-globalSettings.getStartTime())/globalSettings.gethOutput(), globalSettings.getResultsFileName())
     , _globalSettings(globalSettings)
     , _dim(dim)
   {
@@ -40,7 +40,7 @@ public:
 
   virtual void init()
   {
-    ResultsPolicy::init(_globalSettings.getOutputPath(), _globalSettings.getResultsFileName(),_dim);
+    ResultsPolicy::init(_globalSettings.getResultsFileName(), _dim);
   }
 
   virtual void getOutputNames(vector<string>& output_names)

--- a/SimulationRuntime/cpp/Include/Core/DataExchange/Policies/BufferReaderWriter.h
+++ b/SimulationRuntime/cpp/Include/Core/DataExchange/Policies/BufferReaderWriter.h
@@ -21,7 +21,7 @@ class BufferReaderWriter : public ContainerManager
 {
     //typedef TextFileWriter<dim_1,dim_2> TextwriterType;
 public:
-    BufferReaderWriter(unsigned long size, string output_path, string file_name)
+    BufferReaderWriter(unsigned long size, string file_name)
         : ContainerManager(),
             _buffer_pos(0)
     {
@@ -45,7 +45,7 @@ public:
         }
     }
 
-    void init(/*string output_path,string file_name*/std::string output_path, std::string file_name, size_t dim)
+    void init(std::string file_name, size_t dim)
     {
     }
     /**

--- a/SimulationRuntime/cpp/Include/Core/DataExchange/Policies/DefaultWriter.h
+++ b/SimulationRuntime/cpp/Include/Core/DataExchange/Policies/DefaultWriter.h
@@ -14,7 +14,7 @@
 class DefaultWriter : public ContainerManager
 {
  public:
-    DefaultWriter(unsigned long size, string output_path, string file_name)
+    DefaultWriter(unsigned long size, string file_name)
             : ContainerManager()
 
     {
@@ -25,7 +25,7 @@ class DefaultWriter : public ContainerManager
 
     }
 
-    void init(std::string output_path, std::string file_name,size_t dim)
+    void init(std::string file_name, size_t dim)
     {
 
     }

--- a/SimulationRuntime/cpp/Include/Core/DataExchange/Policies/MatfileWriter.h
+++ b/SimulationRuntime/cpp/Include/Core/DataExchange/Policies/MatfileWriter.h
@@ -27,13 +27,12 @@ using std::ios;
 class MatFileWriter : public ContainerManager
 {
  public:
-    MatFileWriter(unsigned long size, string output_path, string file_name)
+    MatFileWriter(unsigned long size, string file_name)
             : ContainerManager(),
               _dataHdrPos(),
               _dataEofPos(),
               _curser_position(0),
               _uiValueCount(0),
-              _output_path(output_path),
               _file_name(file_name),
               _doubleMatrixData1(NULL),
               _doubleMatrixData2(NULL),
@@ -221,15 +220,11 @@ class MatFileWriter : public ContainerManager
 
     /*=={function}===================================================================================*/
     /*!
-     *  void  init(std::string output_path,std::string file_name)
+     *  void  init(std::string file_name)
      *
      *  brief:
      *  ------
      *  function initialize a matlab file
-     *
-     * \param[in]       output_path
-     * \n        usage: path name
-     * \n        range: not relevant
      *
      * \param[in]       file_name
      * \n        usage: file name
@@ -238,22 +233,19 @@ class MatFileWriter : public ContainerManager
      * \return
      */
     /*========================================================================================{end}==*/
-    void init(std::string output_path, std::string file_name,size_t dim)
+    void init(std::string file_name, size_t dim)
     {
         const char Aclass[] = "A1 bt. ir1 na  Tj  re  ac  nt  so   r   y   ";  // special header string
 
         _file_name = file_name;
-        _output_path = output_path;
 
         if (_output_stream.is_open())
             _output_stream.close();
 
-        // building complete file path
-        std::stringstream res_output_path;
-        res_output_path << output_path << file_name;
-
         // open new file
-        _output_stream.open(res_output_path.str().c_str(), ios::binary | ios::trunc);
+        _output_stream.open(file_name.c_str(), ios::binary | ios::trunc);
+        if (_output_stream.fail())
+          throw ModelicaSimulationError(DATASTORAGE, string("Failed to open results file ") + file_name);
 
         // write header matrix
         writeMatVer4Matrix("Aclass", 4, 11, Aclass, sizeof(char));
@@ -815,7 +807,6 @@ class MatFileWriter : public ContainerManager
     std::ofstream::pos_type _dataEofPos;
     unsigned int _curser_position;
     unsigned int _uiValueCount;
-    std::string _output_path;
     std::string _file_name;
     double *_doubleMatrixData1;
     double *_doubleMatrixData2;

--- a/SimulationRuntime/cpp/Include/Core/DataExchange/Policies/TextfileWriter.h
+++ b/SimulationRuntime/cpp/Include/Core/DataExchange/Policies/TextfileWriter.h
@@ -16,11 +16,10 @@ const char EXTENSION = ',';
 class TextFileWriter : public ContainerManager
 {
  public:
-    TextFileWriter(unsigned long size, string output_path, string file_name)
+    TextFileWriter(unsigned long size, string file_name)
             : ContainerManager(),
               _output_stream(),
               _curser_position(0),
-              _output_path(output_path),
               _file_name(file_name)
     {
     }
@@ -31,16 +30,15 @@ class TextFileWriter : public ContainerManager
             _output_stream.close();
     }
 
-    void init(std::string output_path, std::string file_name,size_t dim)
+    void init(std::string file_name, size_t dim)
     {
         _file_name = file_name;
-        _output_path = output_path;
         if (_output_stream.is_open())
             _output_stream.close();
-        std::stringstream res_output_path;
-        res_output_path << output_path << file_name;
-        _output_stream.open(res_output_path.str().c_str(), ios::out);
 
+        _output_stream.open(file_name.c_str(), ios::out);
+        if (_output_stream.fail())
+          throw ModelicaSimulationError(DATASTORAGE, string("Failed to open results file ") + file_name);
     }
     void read(ublas::matrix<double>& R, ublas::matrix<double>& dR)
     {
@@ -150,7 +148,6 @@ class TextFileWriter : public ContainerManager
 
     std::fstream _output_stream;
     unsigned int _curser_position;       ///< Controls current Curser-Position
-    std::string _output_path;
     std::string _file_name;
     vector<string> _var_outputs;
 };

--- a/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
+++ b/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
@@ -333,7 +333,7 @@ SimSettings OMCFactory::readSimulationParameter(int argc, const char* argv[])
      descHidden.add_options()
           ("ignored", po::value<vector<string> >(), "ignored options")
           ("unrecognized", po::value<vector<string> >(), "unsupported options")
-          ("solverThreads", po::value<int>()->default_value(1), "number of threads that can be used by the solver")
+          ("solver-threads", po::value<int>()->default_value(1), "number of threads that can be used by the solver")
           ;
 
      po::options_description descAll("All options");
@@ -377,7 +377,7 @@ SimSettings OMCFactory::readSimulationParameter(int argc, const char* argv[])
      double stoptime = vm["stop-time"].as<double>();
      double stepsize =vm["step-size"].as<double>();
      bool nlsContinueOnError = vm["nls-continue"].as<bool>();
-     int solverThreads = vm["solverThreads"].as<int>();
+     int solverThreads = vm["solver-threads"].as<int>();
 
      if (!(stepsize > 0.0))
          stepsize = (stoptime - starttime) / vm["number-of-intervals"].as<int>();


### PR DESCRIPTION
The results file has its own call argument -F (or -r for the C runtime)
that is typically used with an absolute file name, including path.
A results file with relative name should be placed in the current
directory according to discussions at dev meeting on 12/03, 2018.

Moreover raise an error if open of the results file fails.