### PR TITLE
[NF] Improve functions called through components.

### DIFF
--- a/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/Compiler/NFFrontEnd/NFClassTree.mo
@@ -554,6 +554,10 @@ public
             // Copy the local classes into the new class array, and set the
             // class we're instantiating to be their parent.
             for c in old_clss loop
+              if not InstNode.isOperator(c) then
+                c := InstNode.clone(c);
+              end if;
+
               c := InstNode.setParent(clsNode, c);
 
               // If the class is outer, check that it's valid and link it with

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -431,7 +431,6 @@ algorithm
         checkExtendsLoop(base_node, base_path, info);
         checkReplaceableBaseClass(base_nodes, base_path, info);
         base_node := expand(base_node);
-        base_node := InstNode.clone(base_node);
 
         ext := InstNode.setNodeType(InstNodeType.BASE_CLASS(scope, def), base_node);
 
@@ -657,7 +656,6 @@ algorithm
   end if;
 
   ext_node := expand(ext_node);
-  ext_node := InstNode.clone(ext_node);
 
   // Fetch the needed information from the class definition and construct a EXPANDED_DERIVED.
   cls := InstNode.getClass(node);

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -442,6 +442,17 @@ uniontype InstNode
     end while;
   end hasParentExpandableConnector;
 
+  function isOperator
+    input InstNode node;
+    output Boolean op;
+  algorithm
+    op := match node
+      case CLASS_NODE() then SCode.isOperator(node.definition);
+      case INNER_OUTER_NODE() then isOperator(node.innerNode);
+      else false;
+    end match;
+  end isOperator;
+
   function name
     input InstNode node;
     output String name;


### PR DESCRIPTION
- Clone all classes except operators (because operators are special
  and cloning them causes typing loops) when instantiating a class
  tree, to ensure that classes inside of instantiated components have
  unique caches.
- Remove cloning of extends nodes, since cloning all classes makes
  that unnecessary.
- Implemented Statement.toString for debugging.