### PR TITLE
Added dependency for CPP runtime on Windows build

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -218,7 +218,7 @@ all-runtimeCPPinstall:  CMinpack sundials
 omc-and-runtimeCPPinstall:  CMinpack sundials
 	$(MAKE) omc runtimeCPPinstall OMBUILDDIR=$(OMBUILDDIR)
 
-runtimeCPP: CMinpack sundials antlr-copy $(MINGW_EXTRA_LIBS)
+runtimeCPP: CMinpack sundials antlr-copy $(MINGW_EXTRA_LIBS) omc
 	$(MAKE) -C SimulationRuntime/cpp/ -f $(defaultMakefileTarget) OMBUILDDIR=$(OMBUILDDIR)
 
 CMAKE_ARGS=$(filter CMAKE_%, $(MAKEFLAGS))
@@ -227,7 +227,7 @@ CMAKE_ARGS=$(filter CMAKE_%, $(MAKEFLAGS))
 omcCAPIinstall:
 	$(MAKE) -C SimulationRuntime/cpp/ -f $(defaultMakefileTarget) omcCAPIinstall CC="$(CC)" CXX="$(CXX)"  $(CMAKE_ARGS) OMBUILDDIR=$(OMBUILDDIR)
 
-runtimeCPPinstall: CMinpack sundials
+runtimeCPPinstall: runtimeCPP
 	$(MAKE) -C SimulationRuntime/cpp/ -f $(defaultMakefileTarget) CC="$(CC)" CXX="$(CXX)" install ANALYZATION_MODE="$(ANALYZATION_MODE)" $(CMAKE_ARGS) OMBUILDDIR=$(OMBUILDDIR)
 	test ! `uname` = Darwin || install_name_tool -id @rpath/cpp/libOMCppCVode.dylib $(OMBUILDDIR)/$(LIB_OMC)/cpp/libOMCppCVode.dylib
 	test ! `uname` = Darwin || install_name_tool -id @rpath/cpp/libOMCppDataExchange.dylib $(OMBUILDDIR)/$(LIB_OMC)/cpp/libOMCppDataExchange.dylib


### PR DESCRIPTION
  Now runnig `make -f Makefile.omdev.mingw runtimeCPPinstall` on Windows works.