### PR TITLE
[NF] Improve evaluation of record fields.

### DIFF
--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -325,8 +325,8 @@ protected
   list<Subscript> subs;
 algorithm
   exp := match cref
-    case ComponentRef.CREF(node = c as InstNode.COMPONENT_NODE(),
-                           origin = NFComponentRef.Origin.CREF)
+    case ComponentRef.CREF(node = c as InstNode.COMPONENT_NODE())
+      guard not ComponentRef.isIterator(cref)
       then evalComponentBinding(c, cref, defaultExp, target, evalSubscripts);
 
     else defaultExp;
@@ -353,7 +353,7 @@ algorithm
   exp_origin := if InstNode.isFunction(InstNode.explicitParent(node))
     then ExpOrigin.FUNCTION else ExpOrigin.CLASS;
 
-  Typing.typeComponentBinding(node, exp_origin);
+  Typing.typeComponentBinding(node, exp_origin, typeChildren = false);
   comp := InstNode.component(node);
   binding := Component.getBinding(comp);
 

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -753,6 +753,7 @@ end typeBindings;
 function typeComponentBinding
   input InstNode component;
   input ExpOrigin.Type origin;
+  input Boolean typeChildren = true;
 protected
   InstNode node = InstNode.resolveOuter(component);
   Component c;
@@ -807,7 +808,10 @@ algorithm
         end if;
 
         InstNode.updateComponent(c, node);
-        typeBindings(c.classInst, component, origin);
+
+        if typeChildren then
+          typeBindings(c.classInst, component, origin);
+        end if;
       then
         ();
 
@@ -821,7 +825,9 @@ algorithm
           InstNode.updateComponent(c, node);
         end if;
 
-        typeBindings(c.classInst, component, origin);
+        if typeChildren then
+          typeBindings(c.classInst, component, origin);
+        end if;
       then
         ();
 


### PR DESCRIPTION
- Change the check in Ceval.evalCref that checked that the cref had a
  cref origin to instead check that it doesn't have an iterator origin.
  The cref might have a scope origin when evaluating the parent of a
  record field, and the intent was only to make sure that iterators are
  not evaluated by mistake.
- Add a flag to Typing.typeComponentBinding to make it possible to skip
  typing the component's children, otherwise we might get loops when
  calling it from Ceval.evalComponentBinding.