### PR TITLE
[NF] Various fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -70,7 +70,6 @@ import Operator = NFOperator;
 public
   uniontype CallAttributes
     record CALL_ATTR
-      Type ty "The type of the return value, if several return values this is undefined";
       Boolean tuple_ "tuple" ;
       Boolean builtin "builtin Function call" ;
       Boolean isImpure "if the function has prefix *impure* is true, else false";
@@ -81,9 +80,10 @@ public
 
     function toDAE
       input CallAttributes attr;
+      input Type returnType;
       output DAE.CallAttributes fattr;
     algorithm
-      fattr := DAE.CALL_ATTR(Type.toDAE(attr.ty), attr.tuple_, attr.builtin,
+      fattr := DAE.CALL_ATTR(Type.toDAE(returnType), attr.tuple_, attr.builtin,
         attr.isImpure, attr.isFunctionPointerCall, attr.inlineType, attr.tailCall);
     end toDAE;
   end CallAttributes;
@@ -297,7 +297,6 @@ uniontype Call
     CallAttributes ca;
   algorithm
     ca := CallAttributes.CALL_ATTR(
-      returnType,
       Type.isTuple(returnType),
       Function.isBuiltin(fn),
       Function.isImpure(fn),
@@ -685,7 +684,7 @@ uniontype Call
         then DAE.CALL(
           Function.nameConsiderBuiltin(call.fn),
           list(Expression.toDAE(e) for e in call.arguments),
-          CallAttributes.toDAE(call.attributes));
+          CallAttributes.toDAE(call.attributes, call.ty));
 
       case TYPED_ARRAY_CONSTRUCTOR()
         algorithm

--- a/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -353,7 +353,6 @@ public
   algorithm
     Call.TYPED_CALL(fn, ty, var, {arg}, attr) := call;
     ty := Type.arrayElementType(ty);
-    attr.ty := ty;
 
     (arg, true) := expand(arg);
     outExp := expandBuiltinGeneric2(arg, fn, ty, var, attr);

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -1475,6 +1475,23 @@ uniontype Function
     end if;
   end isSpecialBuiltin;
 
+  function isSubscriptableBuiltin
+    input Function fn;
+    output Boolean scalarBuiltin;
+  protected
+  algorithm
+    if not isBuiltin(fn) then
+      scalarBuiltin := false;
+    else
+      scalarBuiltin := match Absyn.pathFirstIdent(Function.nameConsiderBuiltin(fn))
+        case "change" then true;
+        case "der" then true;
+        case "pre" then true;
+        else false;
+      end match;
+    end if;
+  end isSubscriptableBuiltin;
+
   function isImpure
     input Function fn;
     output Boolean isImpure = fn.attributes.isImpure;

--- a/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -588,7 +588,13 @@ algorithm
     case Expression.BOOLEAN()
       then simplify(if cond.value then tb else fb);
 
-    else Expression.IF(cond, simplify(tb), simplify(fb));
+    else
+      algorithm
+        tb := simplify(tb);
+        fb := simplify(fb);
+      then
+        if Expression.isEqual(tb, fb) then tb else Expression.IF(cond, tb, fb);
+
   end match;
 end simplifyIf;
 

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -515,12 +515,16 @@ public
     input Type dstType;
     output Type ty;
   algorithm
-    ty := match dstType
-      case ARRAY()
-        then ARRAY(dstType.elementType, arrayDims(srcType));
+    if listEmpty(arrayDims(srcType)) then
+      ty := arrayElementType(dstType);
+    else
+      ty := match dstType
+        case ARRAY()
+          then ARRAY(dstType.elementType, arrayDims(srcType));
 
-      else ARRAY(dstType, arrayDims(srcType));
-    end match;
+        else ARRAY(dstType, arrayDims(srcType));
+      end match;
+    end if;
   end copyDims;
 
   function nthDimension


### PR DESCRIPTION
- Remove the type in Call.CallAttributes, the call itself already
  contains the same type.
- Improve subscripting of calls such as pre(), where the argument can
  be subscripted instead of the whole call expression.
- Fix Type.copyDims so that it doesn't create an array with no
  dimensions if the source type is a scalar type.
- Add simplification 'if ... then x else x' => 'x'.