### PR TITLE
[NF] Relax restriction on input/output prefixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -1571,7 +1571,7 @@ algorithm
     Component.Attributes.ATTRIBUTES(cty, par, var, dir, io, fin, redecl, repl) := outerAttr;
     cty := Prefixes.mergeConnectorType(cty, innerAttr.connectorType, node);
     var := Prefixes.variabilityMin(var, innerAttr.variability);
-    dir := Prefixes.mergeDirection(dir, innerAttr.direction, node);
+    dir := Prefixes.mergeDirection(dir, innerAttr.direction, node, allowSame = true);
     attr := Component.Attributes.ATTRIBUTES(cty, par, var, dir, io, fin, redecl, repl);
   end if;
 end mergeDerivedAttributes;

--- a/Compiler/NFFrontEnd/NFPrefixes.mo
+++ b/Compiler/NFFrontEnd/NFPrefixes.mo
@@ -375,12 +375,15 @@ function mergeDirection
   input Direction outerDir;
   input Direction innerDir;
   input InstNode node;
+  input Boolean allowSame = false;
   output Direction dir;
 algorithm
   if outerDir == Direction.NONE then
     dir := innerDir;
   elseif innerDir == Direction.NONE then
     dir := outerDir;
+  elseif allowSame and outerDir == innerDir then
+    dir := innerDir;
   else
     printPrefixError(directionString(outerDir), directionString(innerDir), node);
   end if;


### PR DESCRIPTION
- Allow an input/output prefix on a component with a short class type
  that also has an input/output prefix, as long as they are the same.