### PR TITLE
[NF] Record constructor fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -124,17 +124,19 @@ uniontype Component
       Replaceable isReplaceable;
     end ATTRIBUTES;
 
-   function toDAE
-     input Attributes ina;
-     output DAE.Attributes outa;
-   algorithm
-     outa := DAE.ATTR(connectorTypeToDAE(ina.connectorType)
-                      , parallelismToSCode(ina.parallelism)
-                      , variabilityToSCode(ina.variability)
-                      , directionToAbsyn(ina.direction)
-                      , innerOuterToAbsyn(ina.innerOuter)
-                      , SCode.PUBLIC() // TODO: Use the actual visibility.
-                     );
+    function toDAE
+      input Attributes ina;
+      input Visibility vis;
+      output DAE.Attributes outa;
+    algorithm
+      outa := DAE.ATTR(
+        connectorTypeToDAE(ina.connectorType),
+        parallelismToSCode(ina.parallelism),
+        variabilityToSCode(ina.variability),
+        directionToAbsyn(ina.direction),
+        innerOuterToAbsyn(ina.innerOuter),
+        visibilityToSCode(vis)
+      );
     end toDAE;
 
     function toString

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -1892,12 +1892,12 @@ function makeRecordComplexType
   output ComplexType ty;
 protected
   InstNode cls_node;
+  list<String> inputs;
   list<String> fields;
 algorithm
   cls_node := if SCode.isOperatorRecord(InstNode.definition(node))
     then InstNode.classScope(node) else InstNode.classScope(InstNode.getDerivedNode(node));
-  fields := list(InstNode.name(c) for c guard not InstNode.isEmpty(c) in
-    ClassTree.getComponents(Class.classTree(cls)));
+  fields := list(InstNode.name(c) for c in Record.collectRecordParams(cls));
   ty := ComplexType.RECORD(cls_node, fields);
 end makeRecordComplexType;
 

--- a/Compiler/NFFrontEnd/NFPrefixes.mo
+++ b/Compiler/NFFrontEnd/NFPrefixes.mo
@@ -453,6 +453,12 @@ function visibilityToDAE
     DAE.VarVisibility.PUBLIC() else DAE.VarVisibility.PROTECTED();
 end visibilityToDAE;
 
+function visibilityToSCode
+  input Visibility vis;
+  output SCode.Visibility scodeVis = if vis == Visibility.PUBLIC then
+    SCode.Visibility.PUBLIC() else SCode.Visibility.PROTECTED();
+end visibilityToSCode;
+
 function visibilityString
   input Visibility vis;
   output String str = if vis == Visibility.PUBLIC then "public" else "protected";

--- a/Compiler/NFFrontEnd/NFRecord.mo
+++ b/Compiler/NFFrontEnd/NFRecord.mo
@@ -101,7 +101,7 @@ algorithm
   Inst.instExpressions(ctor_node);
 
   // Collect the record fields.
-  (inputs, locals) := collectRecordParams(ctor_node);
+  (inputs, locals) := collectRecordParams(InstNode.getClass(ctor_node));
 
   // Create the output record element, using the instance created above as both parent and type.
   out_comp := Component.UNTYPED_COMPONENT(ctor_node, listArray({}),
@@ -121,7 +121,7 @@ algorithm
 end instDefaultConstructor;
 
 function collectRecordParams
-  input InstNode recNode;
+  input Class recClass;
   output list<InstNode> inputs = {};
   output list<InstNode> locals = {};
 protected
@@ -131,8 +131,7 @@ protected
   Component comp;
   ClassTree tree;
 algorithm
-  Error.assertion(InstNode.isClass(recNode), getInstanceName() + " got non-class node", sourceInfo());
-  tree := Class.classTree(InstNode.getClass(recNode));
+  tree := Class.classTree(recClass);
 
   () := match tree
     case ClassTree.FLAT_TREE(components = components)


### PR DESCRIPTION
- Only add constructor inputs to the list of field names when
  constructing ComplexType.RECORD types.
- Make non-modifiable fields protected when creating the DAE type, like
  the old frontend does.
- Propagate visibility to Component.Attributes.toDAE so we get the
  actual visibility in the DAE.ATTR.