### PR TITLE
[NF] Move overconstrained equation generation.

### DIFF
--- a/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -171,7 +171,6 @@ algorithm
     eql := match eq
       case Equation.CONNECT(lhs = Expression.CREF(ty = ty1, cref = lhs),
                             rhs = Expression.CREF(ty = ty2, cref = rhs),
-                            broken = eqlBroken,
                             source = source)
         algorithm
           added := false;
@@ -197,7 +196,8 @@ algorithm
                     lhs := ComponentRef.stripSubscripts(lhs);
                     rhs := ComponentRef.stripSubscripts(rhs);
 
-                    graph := addConnection(graph, lhs, rhs, eqlBroken);
+                    eq.broken := generateEqualityConstraintEquation(eq.lhs, ty1, eq.rhs, ty2, ExpOrigin.EQUATION, source);
+                    graph := addConnection(graph, lhs, rhs, eq.broken);
                     added := true;
                     break;
                   end if;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -2475,12 +2475,7 @@ algorithm
   //  fail();
   //end if;
 
-  // @adrpo: here we see if we have any overconstrained connectors in the connect
-  // if we do, we generate equation:
-  // zeros(:) = OverconstrainedType.equalityConstraint(lhs.overconstrained_component, rhs.overconstrained_component)
-  eql := NFOCConnectionGraph.generateEqualityConstraintEquation(lhs, lhs_ty, rhs, rhs_ty, origin, source);
-
-  connEq := Equation.CONNECT(lhs, rhs, eql, source);
+  connEq := Equation.CONNECT(lhs, rhs, {}, source);
 end typeConnect;
 
 function typeExpandableConnectors


### PR DESCRIPTION
- Move the generation of equations for overconstrained connections from
  Typing to Flattening, so that it can handle e.g. iterators correctly.