### PR TITLE
Implement *_get_5D(...) array accessors

### DIFF
--- a/SimulationRuntime/c/util/base_array.h
+++ b/SimulationRuntime/c/util/base_array.h
@@ -37,8 +37,9 @@
 #include "omc_msvc.h"
 
 static OMC_INLINE size_t getIndex_2D(_index_t *dim, int i, int j) {return i*dim[1]+j;}
-static OMC_INLINE size_t getIndex_3D(_index_t *dim, int i, int j, int k) {return i*dim[1]*dim[2]+j*dim[2]+k;}
-static OMC_INLINE size_t getIndex_4D(_index_t *dim, int i, int j, int k, int l) {return i*dim[1]*dim[2]*dim[3]+j*dim[2]*dim[3]+k*dim[3]+l;}
+static OMC_INLINE size_t getIndex_3D(_index_t *dim, int i, int j, int k) {return (i*dim[1]+j)*dim[2]+k;}
+static OMC_INLINE size_t getIndex_4D(_index_t *dim, int i, int j, int k, int l) {return ((i*dim[1]+j)*dim[2]+k)*dim[3]+l;}
+static OMC_INLINE size_t getIndex_5D(_index_t *dim, int i, int j, int k, int l, int m) {return (((i*dim[1]+j)*dim[2]+k)*dim[3]+l)*dim[4]+m;}
 
 /* Settings the fields of a base_array */
 void base_array_create(base_array_t *dest, void *data, int ndims, va_list ap);

--- a/SimulationRuntime/c/util/boolean_array.h
+++ b/SimulationRuntime/c/util/boolean_array.h
@@ -57,6 +57,11 @@ static OMC_INLINE modelica_boolean boolean_get_4D(const boolean_array_t a, size_
     return boolean_get(a, getIndex_4D(a.dim_size,i,j,k,l));
 }
 
+static OMC_INLINE modelica_boolean boolean_get_5D(const boolean_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
+{
+    return boolean_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
+}
+
 /* Setting the fields of a boolean_array */
 extern void boolean_array_create(boolean_array_t *dest, modelica_boolean *data, int ndims, ...);
 

--- a/SimulationRuntime/c/util/integer_array.h
+++ b/SimulationRuntime/c/util/integer_array.h
@@ -58,6 +58,11 @@ static OMC_INLINE modelica_integer integer_get_4D(const integer_array_t a, size_
   return integer_get(a, getIndex_4D(a.dim_size,i,j,k,l));
 }
 
+static OMC_INLINE modelica_integer integer_get_5D(const integer_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
+{
+  return integer_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
+}
+
 /* Settings the fields of a integer_array */
 extern void integer_array_create(integer_array_t *dest, modelica_integer *data,
                                  int ndims, ...);

--- a/SimulationRuntime/c/util/real_array.h
+++ b/SimulationRuntime/c/util/real_array.h
@@ -59,6 +59,11 @@ static OMC_INLINE modelica_real real_get_4D(const real_array_t a, size_t i, size
   return real_get(a, getIndex_4D(a.dim_size,i,j,k,l));
 }
 
+static OMC_INLINE modelica_real real_get_5D(const real_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
+{
+  return real_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
+}
+
 /* Setting the fields of a real_array */
 extern void real_array_create(real_array_t *dest, modelica_real *data, int ndims, ...);
 

--- a/SimulationRuntime/c/util/string_array.h
+++ b/SimulationRuntime/c/util/string_array.h
@@ -41,6 +41,26 @@ static OMC_INLINE modelica_string string_get(const string_array_t a, size_t i)
     return ((modelica_string *) a.data)[i];
 }
 
+static OMC_INLINE modelica_string string_get_2D(const string_array_t a, size_t i, size_t j)
+{
+  return string_get(a, getIndex_2D(a.dim_size,i,j));
+}
+
+static OMC_INLINE modelica_string string_get_3D(const string_array_t a, size_t i, size_t j, size_t k)
+{
+  return string_get(a, getIndex_3D(a.dim_size,i,j,k));
+}
+
+static OMC_INLINE modelica_string string_get_4D(const string_array_t a, size_t i, size_t j, size_t k, size_t l)
+{
+  return string_get(a, getIndex_4D(a.dim_size,i,j,k,l));
+}
+
+static OMC_INLINE modelica_string string_get_5D(const string_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
+{
+  return string_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
+}
+
 /* Setting the fields of a string_array */
 extern void string_array_create(string_array_t *dest, modelica_string *data, int ndims, ...);
 


### PR DESCRIPTION
This PR should technically fix the possibility to at least build models like `Buildings.HeatTransfer.Windows.BaseClasses.Examples.AbsorbedRadiation` and looks similar to what already exists.

I have rephrased the `getIndex_nD` function implementation, so they should be easier to read and, possibly, faster to compute (but this highly depends on what the optimizer already does). This may interfere with some corner cases like integer overflow, but these are probably UB-like cases anyway. In case the old implementation was written in such a way for a purpose, then maybe it would be worth to write some comment like

```c
// Index = i0 * dim[1] * dim[2] * ... * dim[n] + i1 * dim[2] * ... * dim[n] + ... + i{n-1} * dim[n] + i{n}
```