### PR TITLE
[NF] Fix DAE conversion of ^ operator.

### DIFF
--- a/Compiler/NFFrontEnd/NFOperator.mo
+++ b/Compiler/NFFrontEnd/NFOperator.mo
@@ -149,7 +149,7 @@ public
       case Op.SUB               then if Type.isArray(op.ty) then DAE.SUB_ARR(ty) else DAE.SUB(ty);
       case Op.MUL               then if Type.isArray(op.ty) then DAE.MUL_ARR(ty) else DAE.MUL(ty);
       case Op.DIV               then if Type.isArray(op.ty) then DAE.DIV_ARR(ty) else DAE.DIV(ty);
-      case Op.POW               then DAE.POW(ty);
+      case Op.POW               then if Type.isArray(op.ty) then DAE.POW_ARR2(ty) else DAE.POW(ty);
       case Op.ADD_SCALAR_ARRAY  algorithm swapArguments := true; then DAE.ADD_ARRAY_SCALAR(ty);
       case Op.ADD_ARRAY_SCALAR  then DAE.ADD_ARRAY_SCALAR(ty);
       case Op.SUB_SCALAR_ARRAY  then DAE.SUB_SCALAR_ARRAY(ty);


### PR DESCRIPTION
- Element-wise exponentiation of arrays should use DAE.POW_ARR2 and not
  DAE.POW.