### PR TITLE
[NF] Various fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -519,7 +519,10 @@ algorithm
       algorithm
         exp := makeRecordBindingExp(component.classInst, rec_node, component.ty, cref);
         binding := Binding.CEVAL_BINDING(exp, {node});
-        InstNode.updateComponent(Component.setBinding(binding, component), node);
+
+        if not ComponentRef.hasSubscripts(cref) then
+          InstNode.updateComponent(Component.setBinding(binding, component), node);
+        end if;
       then
         binding;
 
@@ -530,7 +533,10 @@ algorithm
         exp := makeRecordBindingExp(component.classInst, rec_node, component.ty, cref);
         exp := splitRecordArrayExp(exp);
         binding := Binding.CEVAL_BINDING(exp, {node});
-        InstNode.updateComponent(Component.setBinding(binding, component), node);
+
+        if not ComponentRef.hasSubscripts(cref) then
+          InstNode.updateComponent(Component.setBinding(binding, component), node);
+        end if;
       then
         binding;
 

--- a/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -164,7 +164,6 @@ protected
   list<Connector> cl1, cl2, lhsl, rhsl;
   Equation replaceEq;
   Expression exp;
-  Boolean added = false;
 algorithm
   // go over all equations, connect, Connection.branch
   for eq in flatModel.equations loop
@@ -173,7 +172,6 @@ algorithm
                             rhs = Expression.CREF(ty = ty2, cref = rhs),
                             source = source)
         algorithm
-          added := false;
           if not (ComponentRef.isDeleted(lhs) or ComponentRef.isDeleted(rhs))
           then
             cl1 := NFConnections.makeConnectors(lhs, ty1, source);
@@ -193,19 +191,12 @@ algorithm
                     lhs := getOverconstrainedCref(lhs);
                     rhs := getOverconstrainedCref(rhs);
 
-                    lhs := ComponentRef.stripSubscripts(lhs);
-                    rhs := ComponentRef.stripSubscripts(rhs);
-
                     eq.broken := generateEqualityConstraintEquation(eq.lhs, ty1, eq.rhs, ty2, ExpOrigin.EQUATION, source);
                     graph := addConnection(graph, lhs, rhs, eq.broken);
-                    added := true;
                     break;
                   end if;
                 end if;
               end for;
-              if added then
-                break;
-              end if;
             end for;
           end if;
         then

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -2424,9 +2424,9 @@ algorithm
 
       // Record()-tmp = 0
       /* Expand the tmp record and any arrays */
-      e1lst = Expression.expandExpression(e1_1);
+      e1lst = Expression.expandExpression(e1_1, expandRecord = true);
       /* Expand the varLst. Each var might be an array or record. */
-      e2lst = List.mapFlat(e2lst, Expression.expandExpression);
+      e2lst = List.mapFlat(e2lst, function Expression.expandExpression(expandRecord = true));
       /* pair each of the expanded expressions to coressponding one*/
       exptl = List.threadTuple(e1lst, e2lst);
       /* Create residual equations for each pair*/


### PR DESCRIPTION
- Don't cache bindings created in NFCeval.makeComponentBinding if the cref
  has subscripts, it might not be safe.
- Don't ignore subscripts in connections when building the connection
  graph.
- Don't expand record in Expression.extendArrExp. Doing so causes record
  crefs to be expanded into arrays of record fields, which causes
  BackendVarTransform to make invalid replacements.