### PR TITLE
Fix capability flag maxOutputDerivativeOrder

### DIFF
--- a/Compiler/Template/CodegenFMU2.tpl
+++ b/Compiler/Template/CodegenFMU2.tpl
@@ -140,7 +140,7 @@ case SIMCODE(__) then
     needsExecutionTool="false"
     canHandleVariableCommunicationStepSize="true"
     canInterpolateInputs="false"
-    maxOutputDerivativeOrder="1"
+    maxOutputDerivativeOrder="0"
     canRunAsynchronuously = "false"
     canBeInstantiatedOnlyOncePerProcess="false"
     canNotUseMemoryManagementFunctions="false"

--- a/Compiler/Template/CodegenFMUCommon.tpl
+++ b/Compiler/Template/CodegenFMUCommon.tpl
@@ -301,7 +301,7 @@ template Implementation()
         canHandleEvents="true"
         canBeInstantiatedOnlyOncePerProcess="false"
         canInterpolateInputs="true"
-        maxOutputDerivativeOrder="1"/>
+        maxOutputDerivativeOrder="0"/>
     </CoSimulation_StandAlone>
   </Implementation>
   >>


### PR DESCRIPTION
Apparently, the function `fmi2GetRealOutputDerivatives` is not implemented, so `maxOutputDerivativeOrder` shouldn't be set to 1.
