### PR TITLE
[NF] Retype array constructors after ceval.

### DIFF
--- a/Compiler/NFFrontEnd/NFCall.mo
+++ b/Compiler/NFFrontEnd/NFCall.mo
@@ -810,6 +810,30 @@ uniontype Call
     end match;
   end isVectorizeable;
 
+  function retype
+    input output Call call;
+  algorithm
+    () := match call
+      local
+        Type ty;
+        list<Dimension> dims;
+
+      case TYPED_ARRAY_CONSTRUCTOR()
+        algorithm
+          dims := {};
+
+          for i in listReverse(call.iters) loop
+            dims := listAppend(Type.arrayDims(Expression.typeOf(Util.tuple22(i))), dims);
+          end for;
+
+          call.ty := Type.liftArrayLeftList(Type.arrayElementType(call.ty), dims);
+        then
+          ();
+
+      else ();
+    end match;
+  end retype;
+
 protected
   function instNormalCall
     input Absyn.ComponentRef functionName;

--- a/Compiler/NFFrontEnd/NFEvalConstants.mo
+++ b/Compiler/NFFrontEnd/NFEvalConstants.mo
@@ -168,7 +168,7 @@ algorithm
         (outExp, outChanged) := Expression.mapFoldShallow(exp,
           function evaluateExpTraverser(isExternalArg = Call.isExternal(exp.call)), false);
       then
-        outExp;
+        if outChanged then Expression.retype(outExp) else outExp;
 
     else
       algorithm

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -4701,6 +4701,12 @@ public
         then
           ();
 
+      case CALL(call = Call.TYPED_ARRAY_CONSTRUCTOR())
+        algorithm
+          exp.call := Call.retype(exp.call);
+        then
+          ();
+
       else ();
     end match;
   end retype;

--- a/Compiler/NFFrontEnd/NFVariable.mo
+++ b/Compiler/NFFrontEnd/NFVariable.mo
@@ -97,6 +97,7 @@ public
   protected
     IOStream.IOStream s;
     Boolean first;
+    Binding b;
   algorithm
     s := IOStream.create(getInstanceName(), IOStream.IOStreamType.LIST());
 
@@ -122,9 +123,15 @@ public
           s := IOStream.append(s, ", ");
         end if;
 
+        b := Util.tuple22(a);
+
+        if Binding.isEach(b) then
+          s := IOStream.append(s, "each ");
+        end if;
+
         s := IOStream.append(s, Util.tuple21(a));
         s := IOStream.append(s, " = ");
-        s := IOStream.append(s, Binding.toString(Util.tuple22(a)));
+        s := IOStream.append(s, Binding.toString(b));
       end for;
 
       s := IOStream.append(s, ")");


### PR DESCRIPTION
- Retype array constructors in EvalConstants.evalExp when necessary,
  to avoid the scalarization failing due to non-constant dimensions.
- Handle 'each' in Variable.toString.