### PR TITLE
on mingw C runtime link statically with sundials

### DIFF
--- a/SimulationRuntime/c/Makefile.common
+++ b/SimulationRuntime/c/Makefile.common
@@ -225,13 +225,9 @@ $(RESULTSOBJSPATH):$(BUILDPATH)/%$(OBJ_EXT): %.cpp $(RESULTSFILESPATH) $(COMMON_
 	$(MKBUILDDIR)
 	$(CXX) -c $(CXXFLAGS) -o $@ $<
 
-$(SIMOBJSPATH):$(BUILDPATH)/%$(OBJ_EXT): %.cpp linearization/linearize.cpp $(SIMHFILESPATH) $(COMMON_HEADERS)
+$(SIMOBJSPATH):$(BUILDPATH)/%$(OBJ_EXT): %.cpp linearization/linearize.cpp dataReconciliation/dataReconciliation.cpp $(SIMHFILESPATH) $(COMMON_HEADERS)
 	$(MKBUILDDIR)
-	$(CXX) -c -Ilinearization/ $(CXXFLAGS) -o $@ $<
-
-$(SIMOBJSPATH):$(BUILDPATH)/%$(OBJ_EXT): %.cpp dataReconciliation/dataReconciliation.cpp $(SIMHFILESPATH) $(COMMON_HEADERS)
-	$(MKBUILDDIR)
-	$(CXX) -c -IdataReconciliation/ $(CXXFLAGS) -o $@ $<
+	$(CXX) -c -Ilinearization/ -IdataReconciliation/ $(CXXFLAGS) -o $@ $<
 
 $(SIMOBJSPATHC):$(BUILDPATH)/%$(OBJ_EXT): %.c $(SIMHFILESPATH) $(COMMON_HEADERS)
 	@echo Deps: $(SIMHFILESPATH) $(COMMON_HEADERS)

--- a/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -56,6 +56,11 @@
 
 #ifdef WITH_SUNDIALS
 
+/* adrpo: on mingw link with static sundials */
+#if defined(__MINGW32__)
+#define LINK_SUNDIALS_STATIC
+#endif
+
 /* readability */
 #define SCALE_MODE 0
 #define RESCALE_MODE 1

--- a/SimulationRuntime/c/simulation/solver/ida_solver.h
+++ b/SimulationRuntime/c/simulation/solver/ida_solver.h
@@ -41,6 +41,11 @@
 
 #ifdef WITH_SUNDIALS
 
+/* adrpo: on mingw link with static sundials */
+#if defined(__MINGW32__)
+#define LINK_SUNDIALS_STATIC
+#endif
+
 #include <sundials/sundials_nvector.h>
 #include <nvector/nvector_serial.h>
 #include <idas/idas.h>

--- a/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -41,6 +41,11 @@
 
 #ifdef WITH_SUNDIALS
 
+/* adrpo: on mingw link with static sundials */
+#if defined(__MINGW32__)
+#define LINK_SUNDIALS_STATIC
+#endif
+
 #include <math.h>
 #include <stdlib.h>
 #include <string.h> /* memcpy */

--- a/SimulationRuntime/c/simulation/solver/radau.c
+++ b/SimulationRuntime/c/simulation/solver/radau.c
@@ -44,6 +44,11 @@
 #include "simulation/options.h"
 #ifdef WITH_SUNDIALS
 
+/* adrpo: on mingw link with static sundials */
+#if defined(__MINGW32__)
+#define LINK_SUNDIALS_STATIC
+#endif
+
 #include <kinsol/kinsol.h>
 #include <kinsol/kinsol_dense.h>
 #include <kinsol/kinsol_spgmr.h>

--- a/SimulationRuntime/c/simulation/solver/radau.h
+++ b/SimulationRuntime/c/simulation/solver/radau.h
@@ -41,6 +41,11 @@
 
 #ifdef WITH_SUNDIALS
 
+  /* adrpo: on mingw link with static sundials */
+  #if defined(__MINGW32__)
+  #define LINK_SUNDIALS_STATIC
+  #endif
+
   #define DEFAULT_IMPRK_ORDER 5
 
   #include <math.h>


### PR DESCRIPTION
- on mingw define LINK_SUNDIALS_STATIC before including sundials headers
- fix rule for dataReconcilation.cpp (was overwritten before)