### PR TITLE
Expand crefs when simplifying cat.

### DIFF
--- a/Compiler/FrontEnd/Algorithm.mo
+++ b/Compiler/FrontEnd/Algorithm.mo
@@ -287,7 +287,6 @@ algorithm
           case DAE.CALL(attr=DAE.CALL_ATTR(builtin=true), path=Absyn.IDENT("listAppend"), expLst=(e1 as DAE.CREF())::_)
             guard Expression.expEqual(lhs, e1)
             algorithm
-              print(stringDelimitList(list(SCodeDump.printCommentAndAnnotationStr(comment) for comment in ElementSource.getCommentsFromSource(source)), "\n"));
               if Flags.isSet(Flags.LIST_REVERSE_WRONG_ORDER) and not max(SCode.commentHasBooleanNamedAnnotation(comment, "__OpenModelica_DisableListAppendWarning") for comment in ElementSource.getCommentsFromSource(source)) then
                 Error.addSourceMessage(Error.LIST_REVERSE_WRONG_ORDER, {ExpressionDump.printExpStr(e1)}, ElementSource.getElementSourceFileInfo(source));
                 fail();

--- a/Compiler/FrontEnd/ComponentReference.mo
+++ b/Compiler/FrontEnd/ComponentReference.mo
@@ -3271,7 +3271,8 @@ algorithm
         // Pad the list of subscripts with : if necessary to fill out all dimensions.
         missing_subs = listLength(dims) - listLength(subs);
         if missing_subs > 0 then
-          subs = listAppend(subs, List.fill(DAE.WHOLEDIM(), missing_subs));
+          subs = listAppend(subs, List.fill(DAE.WHOLEDIM(), missing_subs))
+            annotation(__OpenModelica_DisableListAppendWarning=true);
         end if;
 
         // Use the subscripts to generate only the wanted elements.
@@ -3289,7 +3290,8 @@ algorithm
         // Pad the list of subscripts with : if necessary to fill out all dimensions.
         missing_subs = listLength(dims) - listLength(subs);
         if missing_subs > 0 then
-          subs = listAppend(subs, List.fill(DAE.WHOLEDIM(), missing_subs));
+          subs = listAppend(subs, List.fill(DAE.WHOLEDIM(), missing_subs))
+            annotation(__OpenModelica_DisableListAppendWarning=true);
         end if;
         // Use the subscripts to generate only the wanted elements.
       then

--- a/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -1556,7 +1556,7 @@ algorithm
 
     case (1, _)
       equation
-        expl = List.map(inExpList, Expression.matrixToArray);
+        expl = List.map(inExpList, simplifyCatArg);
       then
         simplifyCat2(inDim, expl, {}, false);
 
@@ -1564,6 +1564,21 @@ algorithm
 
   end match;
 end simplifyCat;
+
+function simplifyCatArg
+  input DAE.Exp arg;
+  output DAE.Exp outArg;
+algorithm
+  outArg := match arg
+    local
+      DAE.Dimension dim;
+
+    case DAE.MATRIX() then Expression.matrixToArray(arg);
+    case DAE.CREF(ty = DAE.T_ARRAY(dims = {dim})) guard Expression.dimensionKnown(dim)
+      then DAE.ARRAY(arg.ty, true, Expression.expandExpression(arg, false));
+    else arg;
+  end match;
+end simplifyCatArg;
 
 protected function simplifyCat2
   input Integer dim;


### PR DESCRIPTION
- Expand one-dimensional crefs before trying to simplify cat in
  ExpressionSimplify.simplifyCat. This is needed when using the new
  frontend, since it generally doesn't expand function arguments.