### PR TITLE
[NF] Fix scoping of redeclared components.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -160,25 +160,35 @@ constant ClassTree REAL_CLASS_TREE = ClassTree.FLAT_TREE(
   listArrayLiteral({}),
   listArrayLiteral({
     InstNode.COMPONENT_NODE("quantity", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("unit", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("displayUnit", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("min", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.REAL(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.REAL(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("max", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.REAL(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.REAL(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("start", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.REAL(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.REAL(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("fixed", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.BOOLEAN(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.BOOLEAN(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("nominal", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.REAL(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.REAL(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("unbounded", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.BOOLEAN(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.BOOLEAN(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("stateSelect", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(STATESELECT_TYPE, Modifier.NOMOD())), InstNode.EMPTY_NODE())
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(STATESELECT_TYPE,
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP())
   }),
   listArray({}), // TODO: #4895: This should be listArrayLiteral too, but causes compilation issues.
   DuplicateTree.EMPTY());
@@ -208,15 +218,20 @@ constant ClassTree INTEGER_CLASS_TREE = ClassTree.FLAT_TREE(
   listArrayLiteral({}),
   listArrayLiteral({
     InstNode.COMPONENT_NODE("quantity", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("min", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.INTEGER(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.INTEGER(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("max", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.INTEGER(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.INTEGER(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("start", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.INTEGER(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.INTEGER(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("fixed", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.BOOLEAN(), Modifier.NOMOD())), InstNode.EMPTY_NODE())
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.BOOLEAN(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP())
   }),
   listArray({}), // TODO: #4895: This should be listArrayLiteral too, but causes compilation issues.
   DuplicateTree.EMPTY());
@@ -240,11 +255,14 @@ constant ClassTree BOOLEAN_CLASS_TREE = ClassTree.FLAT_TREE(
   listArrayLiteral({}),
   listArrayLiteral({
     InstNode.COMPONENT_NODE("quantity", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("start", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.BOOLEAN(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.BOOLEAN(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("fixed", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.BOOLEAN(), Modifier.NOMOD())), InstNode.EMPTY_NODE())
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.BOOLEAN(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP())
   }),
   listArray({}), // TODO: #4895: This should be listArrayLiteral too, but causes compilation issues.
   DuplicateTree.EMPTY());
@@ -271,11 +289,14 @@ constant ClassTree STRING_CLASS_TREE = ClassTree.FLAT_TREE(
   listArrayLiteral({}),
   listArrayLiteral({
     InstNode.COMPONENT_NODE("quantity", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("start", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("fixed", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.BOOLEAN(), Modifier.NOMOD())), InstNode.EMPTY_NODE())
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.BOOLEAN(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP())
   }),
   listArray({}), // TODO: #4895: This should be listArrayLiteral too, but causes compilation issues.
   DuplicateTree.EMPTY());
@@ -333,11 +354,14 @@ constant ClassTree CLOCK_CLASS_TREE = ClassTree.FLAT_TREE(
   listArrayLiteral({}),
   listArrayLiteral({
     InstNode.COMPONENT_NODE("quantity", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.STRING(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("start", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.CLOCK(), Modifier.NOMOD())), InstNode.EMPTY_NODE()),
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.CLOCK(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP()),
     InstNode.COMPONENT_NODE("fixed", Visibility.PUBLIC,
-      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.CLOCK(), Modifier.NOMOD())), InstNode.EMPTY_NODE())
+      Pointer.createImmutable(Component.TYPE_ATTRIBUTE(Type.CLOCK(),
+      Modifier.NOMOD())), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP())
   }),
   listArray({}), // TODO: #4895: This should be listArrayLiteral too, but causes compilation issues.
   DuplicateTree.EMPTY());
@@ -362,7 +386,8 @@ constant InstNode TIME =
       NFComponent.INPUT_ATTR,
       NONE(),
       Absyn.dummyInfo)),
-    InstNode.EMPTY_NODE());
+    InstNode.EMPTY_NODE(),
+    InstNodeType.NORMAL_COMP());
 
 constant ComponentRef TIME_CREF = ComponentRef.CREF(TIME, {}, Type.REAL(), Origin.CREF, ComponentRef.EMPTY());
 

--- a/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -81,7 +81,8 @@ constant Component INT_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NO
 
 constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
   Visibility.PUBLIC,
-  Pointer.createImmutable(INT_COMPONENT), InstNode.EMPTY_NODE());
+  Pointer.createImmutable(INT_COMPONENT), InstNode.EMPTY_NODE(),
+  InstNodeType.NORMAL_COMP());
 
 // Default Real parameter.
 constant Component REAL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
@@ -89,7 +90,8 @@ constant Component REAL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_N
 
 constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
   Visibility.PUBLIC,
-  Pointer.createImmutable(REAL_COMPONENT), InstNode.EMPTY_NODE());
+  Pointer.createImmutable(REAL_COMPONENT), InstNode.EMPTY_NODE(),
+  InstNodeType.NORMAL_COMP());
 
 // Default Boolean parameter.
 constant Component BOOL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
@@ -97,7 +99,8 @@ constant Component BOOL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_N
 
 constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
   Visibility.PUBLIC,
-  Pointer.createImmutable(BOOL_COMPONENT), InstNode.EMPTY_NODE());
+  Pointer.createImmutable(BOOL_COMPONENT), InstNode.EMPTY_NODE(),
+  InstNodeType.NORMAL_COMP());
 
 // Default String parameter.
 constant Component STRING_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
@@ -105,7 +108,8 @@ constant Component STRING_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY
 
 constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
   Visibility.PUBLIC,
-  Pointer.createImmutable(STRING_COMPONENT), InstNode.EMPTY_NODE());
+  Pointer.createImmutable(STRING_COMPONENT), InstNode.EMPTY_NODE(),
+  InstNodeType.NORMAL_COMP());
 
 // Default enumeration(:) parameter.
 constant Component ENUM_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
@@ -113,7 +117,8 @@ constant Component ENUM_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_N
 
 constant InstNode ENUM_PARAM = InstNode.COMPONENT_NODE("e",
   Visibility.PUBLIC,
-  Pointer.createImmutable(ENUM_COMPONENT), InstNode.EMPTY_NODE());
+  Pointer.createImmutable(ENUM_COMPONENT), InstNode.EMPTY_NODE(),
+  InstNodeType.NORMAL_COMP());
 
 // Integer(e)
 constant array<NFInstNode.CachedData> EMPTY_NODE_CACHE = listArrayLiteral({
@@ -289,7 +294,8 @@ constant Component CLOCK_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_
 
 constant InstNode CLOCK_PARAM = InstNode.COMPONENT_NODE("s",
   Visibility.PUBLIC,
-  Pointer.createImmutable(CLOCK_COMPONENT), InstNode.EMPTY_NODE());
+  Pointer.createImmutable(CLOCK_COMPONENT), InstNode.EMPTY_NODE(),
+  InstNodeType.NORMAL_COMP());
 
 constant InstNode CLOCK_DUMMY_NODE = NFInstNode.CLASS_NODE("Clock",
   DUMMY_ELEMENT, Visibility.PUBLIC, Pointer.createImmutable(Class.NOT_INSTANTIATED()),

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -88,6 +88,7 @@ import SimplifyExp = NFSimplifyExp;
 import Restriction = NFRestriction;
 import EvalConstants = NFEvalConstants;
 import SimplifyModel = NFSimplifyModel;
+import InstNodeType = NFInstNode.InstNodeType;
 
 public
 type FunctionTree = FunctionTreeImpl.Tree;
@@ -649,7 +650,11 @@ algorithm
       algorithm
         iter := match ComponentRef.node(prefix)
           case prefix_node as InstNode.COMPONENT_NODE()
-            then InstNode.COMPONENT_NODE("$i", prefix_node.visibility, Pointer.create(Component.ITERATOR(Type.INTEGER(), Variability.IMPLICITLY_DISCRETE, Component.info(Pointer.access(prefix_node.component)))), prefix_node.parent);
+            then InstNode.COMPONENT_NODE(
+              "$i", prefix_node.visibility,
+              Pointer.create(Component.ITERATOR(Type.INTEGER(), Variability.IMPLICITLY_DISCRETE,
+                             Component.info(Pointer.access(prefix_node.component)))),
+              prefix_node.parent, InstNodeType.NORMAL_COMP());
         end match;
         {Dimension.INTEGER(size = stop)} := dimensions;
         range := Expression.RANGE(Type.INTEGER(), Expression.INTEGER(1), NONE(), Expression.INTEGER(stop));
@@ -679,7 +684,11 @@ algorithm
       algorithm
         iter := match ComponentRef.node(prefix)
           case prefix_node as InstNode.COMPONENT_NODE()
-            then InstNode.COMPONENT_NODE("$i", prefix_node.visibility, Pointer.create(Component.ITERATOR(Type.INTEGER(), Variability.IMPLICITLY_DISCRETE, Component.info(Pointer.access(prefix_node.component)))), prefix_node.parent);
+            then InstNode.COMPONENT_NODE(
+              "$i", prefix_node.visibility,
+              Pointer.create(Component.ITERATOR(Type.INTEGER(), Variability.IMPLICITLY_DISCRETE,
+                             Component.info(Pointer.access(prefix_node.component)))),
+              prefix_node.parent, InstNodeType.NORMAL_COMP());
         end match;
         {Dimension.INTEGER(size = stop)} := dimensions;
         range := Expression.RANGE(Type.INTEGER(), Expression.INTEGER(1), NONE(), Expression.INTEGER(stop));

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -1400,6 +1400,8 @@ protected
   Component.Attributes attr;
   array<Dimension> dims;
   Option<SCode.Comment> cmt;
+  InstNode rdcl_node;
+  InstNodeType rdcl_type;
 algorithm
   // Check that the redeclare element actually is a component.
   if not InstNode.isComponent(redeclareNode) then
@@ -1409,9 +1411,11 @@ algorithm
     fail();
   end if;
 
-  instComponent(redeclareNode, outerAttr, constrainingMod, true);
+  rdcl_type := InstNodeType.REDECLARED_COMP(InstNode.parent(originalNode));
+  rdcl_node := InstNode.setNodeType(rdcl_type, redeclareNode);
+  instComponent(rdcl_node, outerAttr, constrainingMod, true);
   orig_comp := InstNode.component(originalNode);
-  rdcl_comp := InstNode.component(redeclareNode);
+  rdcl_comp := InstNode.component(rdcl_node);
 
   new_comp := match (orig_comp, rdcl_comp)
     case (Component.UNTYPED_COMPONENT(), Component.UNTYPED_COMPONENT())


### PR DESCRIPTION
- Add InstNodeType to component nodes too, and use it to keep track of
  the parent of the replaced component. This is then used by
  InstNode.scopeList, so that crefs pointing to redeclared components
  are generated correctly.