### PR TITLE
[NF] Allow Fortran 77 as external language.

### DIFF
--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -2475,6 +2475,8 @@ algorithm
     // generation only seems to support C.
     case "C" then ();
     case "FORTRAN 77" then ();
+    // Not in the specification, but used by libraries and allowed by other tools.
+    case "Fortran 77" then ();
     case "builtin" then ();
     else
       algorithm


### PR DESCRIPTION
- Allow Fortran 77 as an alternative to FORTRAN 77, since it's used by
  libraries and allowed by the old frontend and other tools.