### PR TITLE
[NF] Use System.setUsesCardinality.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -1311,6 +1311,8 @@ protected
     ty := Type.INTEGER();
     callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, var, ty));
     // TODO: Check cardinality restrictions, 3.7.2.3.
+
+    System.setUsesCardinality(true);
   end typeCardinalityCall;
 
   function typeBranchCall

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -123,6 +123,8 @@ algorithm
     Flags.set(Flags.NF_EXPAND_FUNC_ARGS, false);
   end if;
 
+  System.setUsesCardinality(false);
+
   // Create a root node from the given top-level classes.
   top := makeTopNode(program);
   name := Absyn.pathString(classPath);


### PR DESCRIPTION
- Call System.setUsesCardinality to indicate whether the model uses
  cardinality or not, instead of just using whatever value it happens to
  be set to.