### PR TITLE
Fix code generation for function outputs.

### DIFF
--- a/Compiler/Template/CodegenCFunctions.tpl
+++ b/Compiler/Template/CodegenCFunctions.tpl
@@ -1908,6 +1908,10 @@ case var as VARIABLE(__) then
     <%preExp%>
     <%params%>
     >>
+  // Treat shared array literals like other arrays, i.e. copy them. Array
+  // outputs in functions might otherwise end up pointing to shared literals,
+  // causing a segfault if such an array is then assigned to.
+  case SOME(arr as SHARED_LITERAL(__))
   case SOME(arr as ARRAY(__)) then
     let arrayExp = '<%daeExp(arr, contextFunction, &varInits, &varDecls, &auxFunction)%>'
     'copy_<%expTypeShort(var.ty)%>_array(<%arrayExp%>, &<%lhsVarName%>);<%\n%>'


### PR DESCRIPTION
- Fix code generation for array output function parameters with literal
  default values. Such outputs were previously set to be equal to the
  shared literal, which caused a segfault if the array was then assigned
  to. This fix makes sure that a new array is created from the literal
  instead.