### PR TITLE
[NF] Expand complex array crefs.

### DIFF
--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -850,5 +850,29 @@ public
     end match;
   end depth;
 
+  function isComplexArray
+    input ComponentRef cref;
+    output Boolean complexArray;
+  algorithm
+    complexArray := match cref
+      case CREF() then isComplexArray2(cref.restCref);
+      else false;
+    end match;
+  end isComplexArray;
+
+  function isComplexArray2
+    input ComponentRef cref;
+    output Boolean complexArray;
+  algorithm
+    complexArray := match cref
+      case CREF(ty = Type.ARRAY())
+        guard Type.isArray(Type.subscript(cref.ty, cref.subscripts))
+        then true;
+
+      case CREF() then isComplexArray2(cref.restCref);
+      else false;
+    end match;
+  end isComplexArray2;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFComponentRef;

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -997,7 +997,7 @@ algorithm
         algorithm
           // Flatten the condition and body of the branch.
           cond := flattenExp(cond, prefix);
-          eql := flattenEquations(eql, prefix);
+          eql := listReverseInPlace(flattenEquations(eql, prefix));
 
           // Evaluate structural conditions.
           if var <= Variability.STRUCTURAL_PARAMETER then


### PR DESCRIPTION
- Expand crefs where one of the prefix nodes is an array, i.e.
  a.b.c => {a.b[1].c, a.b[2].c}, to work around backend issues.
- Fix order of equations in if-equations.