### PR TITLE
Removed unused makefile rule mkbuilddir

### DIFF
--- a/SimulationRuntime/c/Makefile.common
+++ b/SimulationRuntime/c/Makefile.common
@@ -137,7 +137,7 @@ RUNTIMEINITIALIZATION_HEADERS = \
 # ./simulation/solver/solver_main.h \
 # ./util/list.h \
 
-.PHONY : clean all emcc emcc-clean emcc/libSimulationRuntimeC.so fmi-runtime mkbuilddir
+.PHONY : clean all emcc emcc-clean emcc/libSimulationRuntimeC.so fmi-runtime
 
 all : install
 


### PR DESCRIPTION
Removed forgotten `mkbuilddir` rule in a Makefile.common.
Belongs to commit 358f0dcc97ecb318c4796c4612cb4b31c120700a and issue  #2656