### PR TITLE
fix ticket:5305

### DIFF
--- a/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -2051,6 +2051,7 @@ algorithm
   (strs,names) := matchcontinue exp
     local
       String str;
+      list<String> strs1, strs2, names1, names2;
 
     // seems lapack can show on Lapack form or lapack (different case) (MLS revision 6155)
     // Lapack on MinGW/Windows is linked against f2c
@@ -2078,9 +2079,19 @@ algorithm
 
     // If the string starts with a -, it's probably -l or -L gcc flags
     case Absyn.STRING(str)
-      equation
-        true = "-" == stringGetStringChar(str, 1);
-      then ({str},{});
+      algorithm
+        if str=="ModelicaStandardTables" then
+          (strs1,names1) := getLibraryStringInMSVCFormat(Absyn.STRING("ModelicaIO"));
+          (strs2,names2) := getLibraryStringInMSVCFormat(Absyn.STRING("ModelicaMatIO"));
+          strs := listAppend(strs1, strs2);
+          names := listAppend(names1, names2);
+        else
+          strs := {};
+          names := {};
+        end if;
+        true := "-" == stringGetStringChar(str, 1);
+        strs := str::strs;
+      then (strs,names);
 
     case Absyn.STRING(str)
       equation

--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -5841,7 +5841,7 @@ case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simula
   # /MD - link with MSVCRT.LIB
   # /link - [linker options and libraries]
   # /LIBPATH: - Directories where libs can be found
-  LDFLAGS=/MD /link /NODEFAULTLIB:libcmt /STACK:0x2000000 /pdb:"<%fileNamePrefix%>.pdb" /LIBPATH:"<%makefileParams.omhome%>/lib/<%getTriple()%>/omc/msvc/" /LIBPATH:"<%makefileParams.omhome%>/lib/<%getTriple()%>/omc/msvc/release/" <%dirExtra%> <%libsPos1%> <%libsPos2%> f2c.lib initialization.lib libexpat.lib math-support.lib meta.lib results.lib simulation.lib solver.lib sundials_kinsol.lib sundials_nvecserial.lib util.lib lapack_win32_MT.lib lis.lib  gc-lib.lib user32.lib pthreadVC2.lib wsock32.lib cminpack.lib umfpack.lib amd.lib
+  LDFLAGS=/MD /link /NODEFAULTLIB:libcmt /STACK:0x2000000 /pdb:"<%fileNamePrefix%>.pdb" /LIBPATH:"<%makefileParams.omhome%>/lib/<%getTriple()%>/omc/msvc/" /LIBPATH:"<%makefileParams.omhome%>/lib/<%getTriple()%>/omc/msvc/release/" /LIBPATH:"<%makefileParams.omhome%>/lib/<%getTriple()%>/omc/cpp/msvc/" <%dirExtra%> <%libsPos1%> <%libsPos2%> f2c.lib initialization.lib libexpat.lib math-support.lib meta.lib results.lib simulation.lib solver.lib sundials_kinsol.lib sundials_nvecserial.lib util.lib lapack_win32_MT.lib lis.lib  gc-lib.lib user32.lib pthreadVC2.lib wsock32.lib cminpack.lib umfpack.lib amd.lib
 
   # /MDd link with MSVCRTD.LIB debug lib
   # lib names should not be appended with a d just switch to lib/omc/msvc/debug
@@ -6018,7 +6018,7 @@ template optimizationComponents( list<DAE.ClassAttributes> classAttributes ,SimC
 ::=
     match classAttributes
     case{} then
-        let fail = 'throwStreamPrint(NULL, "The model was not compiled with -g=Optimica and the corresponding goal function. The optimization solver cannot be used.");'
+        let fail = 'throwStreamPrint(NULL, "The model was not compiled with -g=Optimica and the corresponding goal function. The optimization solver cannot be used.");<%\n%>return 0;'
         <<
         int <%symbolName(modelNamePrefixStr,"mayer")%>(DATA* data, modelica_real** res,short *i) {
           <%fail%>

--- a/SimulationRuntime/c/openmodelica.h
+++ b/SimulationRuntime/c/openmodelica.h
@@ -183,6 +183,8 @@ static inline int sign(double v)
 #define OMC_DISABLE_OPT __attribute__((optnone))
 #elif defined(__GNUC__)
 #define OMC_DISABLE_OPT __attribute__((optimize(0)))
+#elif defined(_MSC_VER)
+#define OMC_DISABLE_OPT /* nothing */
 #endif
 #endif
 


### PR DESCRIPTION
- handle ModelicaStandardTables in SimCodeFunctionUtil.getLibraryStringInMSVCFormat
- fix some msvc C codegen issues (some linker issues stil remain)
- now models with tables work fine with --target=msvc --simCodeTarget=Cpp