### PR TITLE
fix for ticket:5340

### DIFF
--- a/Compiler/BackEnd/BackendDAECreate.mo
+++ b/Compiler/BackEnd/BackendDAECreate.mo
@@ -1438,7 +1438,11 @@ algorithm
 
     case DAE.TERMINATE(message=msg,source=source)
       then
-        (inEquations,inREquations,BackendDAE.ALGORITHM(0, DAE.ALGORITHM_STMTS({DAE.STMT_TERMINATE(msg,source)}), source, DAE.NOT_EXPAND(), BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC)::inIEquations);
+        (inEquations, BackendDAE.ALGORITHM(0, DAE.ALGORITHM_STMTS({DAE.STMT_TERMINATE(msg,source)}), source, DAE.NOT_EXPAND(), BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC)::inREquations, inIEquations);
+
+    case DAE.INITIAL_TERMINATE(message=msg, source=source)
+      then
+        (inEquations, inREquations, BackendDAE.ALGORITHM(0, DAE.ALGORITHM_STMTS({DAE.STMT_TERMINATE(msg,source)}), source, DAE.NOT_EXPAND(), BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC)::inIEquations);
 
     case DAE.NORETCALL()
       equation


### PR DESCRIPTION
- handle DAE.INITIAL_TERMINATE in BackendDAECreatelowerEq
- correctly add DAE.TERMINATE to the regular equations, not the initial equations