### PR TITLE
[OMSI] Preparing data structure for code generation in SimCode

### DIFF
--- a/Compiler/BackEnd/BackendDAE.mo
+++ b/Compiler/BackEnd/BackendDAE.mo
@@ -279,12 +279,18 @@ uniontype VarKind "variable kind"
   record OPT_LOOP_INPUT
     .DAE.ComponentRef replaceExp;
   end OPT_LOOP_INPUT;
-  record ALG_STATE  end ALG_STATE;              // algebraic state used by inline solver
-  record ALG_STATE_OLD  end ALG_STATE_OLD;      // algebraic state old value used by inline solver
-  record DAE_RESIDUAL_VAR end DAE_RESIDUAL_VAR; // variable kind used for DAEmode
-  record DAE_AUX_VAR end DAE_AUX_VAR;           // auxiliary variable used for DAEmode
-  record LOOP_ITERATION end LOOP_ITERATION;     // used in SIMCODE, iteration variables in algebraic loops
-  record LOOP_SOLVED end LOOP_SOLVED;           // used in SIMCODE, inner variables of a torn algebraic loop
+  record ALG_STATE        "algebraic state used by inline solver"
+  end ALG_STATE;
+  record ALG_STATE_OLD    "algebraic state old value used by inline solver"
+  end ALG_STATE_OLD;
+  record DAE_RESIDUAL_VAR "variable kind used for DAEmode"
+  end DAE_RESIDUAL_VAR;
+  record DAE_AUX_VAR      "auxiliary variable used for DAEmode"
+  end DAE_AUX_VAR;
+  record LOOP_ITERATION   "used in SIMCODE, iteration variables in algebraic loops"
+  end LOOP_ITERATION;
+  record LOOP_SOLVED      "used in SIMCODE, inner variables of a torn algebraic loop"
+  end LOOP_SOLVED;
 end VarKind;
 
 public uniontype TearingSelect

--- a/Compiler/BackEnd/BackendDAE.mo
+++ b/Compiler/BackEnd/BackendDAE.mo
@@ -279,10 +279,12 @@ uniontype VarKind "variable kind"
   record OPT_LOOP_INPUT
     .DAE.ComponentRef replaceExp;
   end OPT_LOOP_INPUT;
-  record ALG_STATE  end ALG_STATE; // algebraic state used by inline solver
-  record ALG_STATE_OLD  end ALG_STATE_OLD; // algebraic state old value used by inline solver
+  record ALG_STATE  end ALG_STATE;              // algebraic state used by inline solver
+  record ALG_STATE_OLD  end ALG_STATE_OLD;      // algebraic state old value used by inline solver
   record DAE_RESIDUAL_VAR end DAE_RESIDUAL_VAR; // variable kind used for DAEmode
-  record DAE_AUX_VAR end DAE_AUX_VAR; // auxiliary variable used for DAEmode
+  record DAE_AUX_VAR end DAE_AUX_VAR;           // auxiliary variable used for DAEmode
+  record LOOP_ITERATION end LOOP_ITERATION;     // used in SIMCODE, iteration variables in algebraic loops
+  record LOOP_SOLVED end LOOP_SOLVED;           // used in SIMCODE, inner variables of a torn algebraic loop
 end VarKind;
 
 public uniontype TearingSelect

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -2485,7 +2485,7 @@ algorithm
     case BackendDAE.DAE_RESIDUAL_VAR() then "DAE_RESIDUAL_VAR";
     case BackendDAE.LOOP_ITERATION() then "LOOP_ITERATION";
     case BackendDAE.LOOP_SOLVED() then "LOOP_SOLVED";
-    else then "ERROR: BackendDump.kindString varKind not implemented";
+    else "ERROR: BackendDump.kindString varKind not implemented";
   end match;
 end kindString;
 

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -2483,6 +2483,7 @@ algorithm
     case BackendDAE.ALG_STATE()  then "ALG_STATE";
     case BackendDAE.ALG_STATE_OLD()  then "ALG_STATE_OLD";
     case BackendDAE.DAE_RESIDUAL_VAR() then "DAE_RESIDUAL_VAR";
+    case BackendDAE.DAE_AUX_VAR() then "DAE_AUX_VAR";
     case BackendDAE.LOOP_ITERATION() then "LOOP_ITERATION";
     case BackendDAE.LOOP_SOLVED() then "LOOP_SOLVED";
     else "ERROR: BackendDump.kindString varKind not implemented";

--- a/Compiler/BackEnd/BackendDump.mo
+++ b/Compiler/BackEnd/BackendDump.mo
@@ -2483,7 +2483,9 @@ algorithm
     case BackendDAE.ALG_STATE()  then "ALG_STATE";
     case BackendDAE.ALG_STATE_OLD()  then "ALG_STATE_OLD";
     case BackendDAE.DAE_RESIDUAL_VAR() then "DAE_RESIDUAL_VAR";
-    case BackendDAE.DAE_AUX_VAR() then "DAE_AUX_VAR";
+    case BackendDAE.LOOP_ITERATION() then "LOOP_ITERATION";
+    case BackendDAE.LOOP_SOLVED() then "LOOP_SOLVED";
+    else then "ERROR: BackendDump.kindString varKind not implemented";
   end match;
 end kindString;
 

--- a/Compiler/BackEnd/BackendVariable.mo
+++ b/Compiler/BackEnd/BackendVariable.mo
@@ -659,6 +659,8 @@ algorithm
     case BackendDAE.VAR(varKind=BackendDAE.OPT_TGRID()) then true;
     case BackendDAE.VAR(varKind=BackendDAE.OPT_LOOP_INPUT()) then true;
     case BackendDAE.VAR(varKind=BackendDAE.ALG_STATE()) then true;
+    case BackendDAE.VAR(varKind=BackendDAE.LOOP_ITERATION()) then true;
+    case BackendDAE.VAR(varKind=BackendDAE.LOOP_SOLVED()) then true;
     else false;
   end match;
 end isNonStateVar;

--- a/Compiler/BackEnd/HpcOmScheduler.mo
+++ b/Compiler/BackEnd/HpcOmScheduler.mo
@@ -51,6 +51,7 @@ import DAE;
 import Error;
 import Expression;
 import Flags;
+import HashTableCrefSimVar;
 import HpcOmSchedulerExt;
 import HpcOmSimCodeMain;
 import List;
@@ -3887,7 +3888,7 @@ algorithm
   simVarIdx2 := simVarIdx + numVars;
 
   //update hashtable, create replacement rules and build new simEqSystems
-  ht := List.fold(simVarDupl,SimCodeUtil.addSimVarToHashTable,ht);
+  ht := List.fold(simVarDupl,HashTableCrefSimVar.addSimVarToHashTable,ht);
   repl := BackendVarTransform.addReplacements(replIn,crefs,crefsDuplExp,NONE());
   //BackendVarTransform.dumpReplacements(repl);
   simEqSysts := List.map1(simEqSysIdcs,SimCodeUtil.getSimEqSysForIndex,List.flatten(odes));

--- a/Compiler/SimCode/SerializeModelInfo.mo
+++ b/Compiler/SimCode/SerializeModelInfo.mo
@@ -46,6 +46,7 @@ import SimCode;
 
 protected
 import Algorithm;
+import Config;
 import DAEDump;
 import Error;
 import Expression;
@@ -75,7 +76,11 @@ algorithm
       list<SimCode.SimEqSystem> eqs;
     case SimCode.SIMCODE(modelInfo=mi as SimCode.MODELINFO(vars=vars))
       equation
-        fileName = code.fileNamePrefix + "_info.json";
+        if Config.simCodeTarget() == "omsic" then
+          fileName = code.fullPathPrefix + System.pathDelimiter() + code.fileNamePrefix + "_info.json";
+        else
+          fileName = code.fileNamePrefix + "_info.json";
+        end if;
         File.open(file,fileName,File.Mode.Write);
         File.write(file, "{\"format\":\"Transformational debugger info\",\"version\":1,\n\"info\":{\"name\":");
         serializePath(file, mi.name);

--- a/Compiler/SimCode/SimCode.mo
+++ b/Compiler/SimCode/SimCode.mo
@@ -304,7 +304,7 @@ end OMSIData;
 uniontype OMSIFunction
   "contains equations and variables for initialization or simulation problem"
   record OMSI_FUNCTION
-    list<SimEqSystem>       equations   "list of single equations and systems of equations";
+    list<SimEqSystem>       equations   "causalized list of single equations and systems of equations";
     list<SimCodeVar.SimVar> inputVars   "list of simcode variables determining input variables for equation(s)";
     list<SimCodeVar.SimVar> outputVars  "list of simcode variables determining output variables for equation(s)";
     list<SimCodeVar.SimVar> innerVars   "list of simcode variables determining inner variables for equation(s), e.g $DER(x)";

--- a/Compiler/SimCode/SimCode.mo
+++ b/Compiler/SimCode/SimCode.mo
@@ -286,7 +286,7 @@ uniontype DaeModeData
   record DAEMODEDATA
     list<list<SimEqSystem>> daeEquations "daeModel residuals equations";
     Option<JacobianMatrix> sparsityPattern "contains the sparsity pattern for the daeMode";
-    list<SimCodeVar.SimVar> residualVars;  // variable used to calculate residuals of a DAE form, they are real
+    list<SimCodeVar.SimVar> residualVars "variable used to calculate residuals of a DAE form, they are real";
     list<SimCodeVar.SimVar> algebraicVars;
     list<SimCodeVar.SimVar> auxiliaryVars;
     DaeModeConfig modeCreated; // indicates the mode in which
@@ -429,10 +429,10 @@ uniontype SimEqSystem
   end SES_ALIAS;
 
   record SES_ALGEBRAIC_SYSTEM
-    Integer index;            // equation index
-    Integer algSysIndex;      // index of algebraic system
+    Integer index "equation index";
+    Integer algSysIndex "index of algebraic system";
 
-    Integer dim_n;            // dimension of algebraic loop (after tearing)
+    Integer dim_n "dimension of algebraic loop (after tearing)";
 
     Boolean partOfMixed;
     Boolean tornSystem;
@@ -465,7 +465,7 @@ uniontype DerivativeMatrix
                                         // innerVars:  inner column vars
                                         // outputVars: result vars of the column
 
-    String matrixName;                  // unique matrix name
+    String matrixName "unique matrix name";
     SparsityPattern sparsity;
     SparsityPattern sparsityT;
     list<list<Integer>> coloredCols;

--- a/Compiler/SimCode/SimCodeFunction.mo
+++ b/Compiler/SimCode/SimCodeFunction.mo
@@ -229,7 +229,7 @@ uniontype Context
   end DAE_MODE_CONTEXT;
 
   record OMSI_CONTEXT
-    Option<HashTableCrefSimVar.HashTable> hashTable;    // used to get local SimVars and corresponding value references
+    Option<HashTableCrefSimVar.HashTable> hashTable "used to get local SimVars and corresponding value references";
   end OMSI_CONTEXT;
 end Context;
 

--- a/Compiler/SimCode/SimCodeFunction.mo
+++ b/Compiler/SimCode/SimCodeFunction.mo
@@ -36,8 +36,8 @@ encapsulated package SimCodeFunction
 public
 import Absyn;
 import DAE;
-import HashTableStringToPath;
 import HashTableCrefSimVar;
+import HashTableStringToPath;
 import Tpl;
 
 uniontype FunctionCode
@@ -228,6 +228,9 @@ uniontype Context
   record DAE_MODE_CONTEXT
   end DAE_MODE_CONTEXT;
 
+  record OMSI_CONTEXT
+    Option<HashTableCrefSimVar.HashTable> hashTable;    // used to get local SimVars and corresponding value references
+  end OMSI_CONTEXT;
 end Context;
 
 public constant Context contextSimulationNonDiscrete  = SIMULATION_CONTEXT(false);
@@ -243,6 +246,7 @@ public constant Context contextZeroCross              = ZEROCROSSINGS_CONTEXT();
 public constant Context contextOptimization           = OPTIMIZATION_CONTEXT();
 public constant Context contextFMI                    = FMI_CONTEXT();
 public constant Context contextDAEmode                = DAE_MODE_CONTEXT();
+public constant Context contextOMSI                   = OMSI_CONTEXT(NONE());
 
 constant list<DAE.Exp> listExpLength1 = {DAE.ICONST(0)} "For CodegenC.tpl";
 constant list<Variable> boxedRecordOutVars = VARIABLE(DAE.CREF_IDENT("",DAE.T_COMPLEX_DEFAULT_RECORD,{}),DAE.T_COMPLEX_DEFAULT_RECORD,NONE(),{},DAE.NON_PARALLEL(),DAE.VARIABLE())::{} "For CodegenC.tpl";

--- a/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -2051,7 +2051,6 @@ algorithm
   (strs,names) := matchcontinue exp
     local
       String str;
-      list<String> strs1, strs2, names1, names2;
 
     // seems lapack can show on Lapack form or lapack (different case) (MLS revision 6155)
     // Lapack on MinGW/Windows is linked against f2c
@@ -2079,23 +2078,9 @@ algorithm
 
     // If the string starts with a -, it's probably -l or -L gcc flags
     case Absyn.STRING(str)
-      algorithm
-        if str=="ModelicaStandardTables" then
-          (strs1,names1) := getLibraryStringInMSVCFormat(Absyn.STRING("ModelicaIO"));
-          (strs2,names2) := getLibraryStringInMSVCFormat(Absyn.STRING("ModelicaMatIO"));
-          strs := listAppend(strs1, strs2);
-          names := listAppend(names1, names2);
-        else
-          strs := {};
-          names := {};
-        end if;
-        if System.regularFileExists(str) or "-" == stringGetStringChar(str, 1) then
-          strs := str::strs;
-        else
-          strs := (str + ".lib")::strs;
-          names := str::names;
-        end if;
-      then (strs,names);
+      equation
+        true = "-" == stringGetStringChar(str, 1);
+      then ({str},{});
 
     case Absyn.STRING(str)
       equation

--- a/Compiler/SimCode/SimCodeMain.mo
+++ b/Compiler/SimCode/SimCodeMain.mo
@@ -677,9 +677,7 @@ algorithm
     local
       String str, newdir, newpath, resourcesDir, dirname;
       String fmutmp;
-      String guid;
       Boolean b;
-      String fileprefix;
     case (SimCode.SIMCODE(),"C")
       algorithm
         fmutmp := simCode.fileNamePrefix + ".fmutmp";
@@ -795,7 +793,6 @@ algorithm
       Boolean isFMI2;
       String fmiVersion;
       BackendDAE.SymbolicJacobians fmiDer;
-      Boolean symJacBackup;
       DAE.FunctionTree funcs;
       list<Option<Integer>> allRoots;
 

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -283,7 +283,7 @@ protected
   SimCode.JacobianMatrix dataReconSimJac;
   String fullPathPrefix;
 
-  SimCode.OMSIFunction omsiAllEquations, omsiInitEquations;
+  SimCode.OMSIFunction omsiInitEquations, omsiSimEquations;
   Option<SimCode.OMSIData> omsiOptData;
 
   constant Boolean debug = false;
@@ -381,14 +381,14 @@ algorithm
       equationSccMapping := {};
       eqBackendSimCodeMapping := {};
       sccOffset := 0;
-      (omsiAllEquations, uniqueEqIndex) :=
+      (omsiSimEquations, uniqueEqIndex) :=
           createAllEquationOMSI(contSysts, shared, zeroCrossings, uniqueEqIndex);
 
       // Add removed equations (e.g. reinit)
       ((uniqueEqIndex, removedEquations)) := BackendEquation.traverseEquationArray(removedEqs, traversedlowEqToSimEqSystem, (uniqueEqIndex, {}));
-      omsiAllEquations.equations := listAppend(omsiAllEquations.equations, removedEquations);
+      omsiSimEquations.equations := listAppend(omsiSimEquations.equations, removedEquations);
 
-      omsiOptData := SOME(SimCode.OMSI_DATA(simulation=omsiAllEquations, initialization=omsiInitEquations));
+      omsiOptData := SOME(SimCode.OMSI_DATA(simulation=omsiSimEquations, initialization=omsiInitEquations));
 
       // debug print
       if debug then

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -4997,7 +4997,7 @@ algorithm
     Option<DAE.VariableAttributes> dae_var_attr;
     Boolean isProtected;
     Boolean hideResult = false;
-    Integer resIndex, tmpIndex=0;
+    Integer resIndex=inResIndex, tmpIndex=inTmpIndex;
     BackendDAE.VarKind varkind;
 
     case ({}) then (listReverse(tmpVars), listReverse(resVars));

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -8934,14 +8934,9 @@ algorithm
     outHT := List.fold(vars.intConstVars, HashTableCrefSimVar.addSimVarToHashTable, outHT);
     outHT := List.fold(vars.boolConstVars, HashTableCrefSimVar.addSimVarToHashTable, outHT);
     outHT := List.fold(vars.stringConstVars, HashTableCrefSimVar.addSimVarToHashTable, outHT);
-    if (Config.simCodeTarget()=="Cpp" or Config.simCodeTarget()=="omsicpp") then
-      // Not needed in the hashtable (actually breaks code generation
-      // due to bad indexes, no information that they are seed variables
-      // and so on...
-      outHT := List.fold(vars.sensitivityVars, HashTableCrefSimVar.addSimVarToHashTable, outHT);
-      outHT := List.fold(vars.jacobianVars, HashTableCrefSimVar.addSimVarToHashTable, outHT);
-      outHT := List.fold(vars.seedVars, HashTableCrefSimVar.addSimVarToHashTable, outHT);
-    end if;
+    outHT := List.fold(vars.sensitivityVars, HashTableCrefSimVar.addSimVarToHashTable, outHT);
+    outHT := List.fold(vars.jacobianVars, HashTableCrefSimVar.addSimVarToHashTable, outHT);
+    outHT := List.fold(vars.seedVars, HashTableCrefSimVar.addSimVarToHashTable, outHT);
     outHT := List.fold(vars.realOptimizeConstraintsVars, HashTableCrefSimVar.addSimVarToHashTable, outHT);
     outHT := List.fold(vars.realOptimizeFinalConstraintsVars, HashTableCrefSimVar.addSimVarToHashTable, outHT);
   else


### PR DESCRIPTION
First commit for new OpenModelica Simulation Interface .
 - Added new FMU types for simCodeTarget `omsic` or `omsicpp`
  - Added new uniontypes and recors. Among others:
    * `OMSIData`
    * `OMSIFunction`
    * `SES_ALGEBRAIC_SYSTEM`
    * `DerivativeMatrix`
  - Added hashTable for each `OMSIFunction` for local indices
  - Moved  function `addSimVarToHashTable` from Compiler/SimCode/SimCodeUtil.mo to Compiler/Util/HashTableCrefSimVar.mo
  - Added helper functions to generate `OMSIData`
    * generate equations, algebraic loops
    * dump and print functions for some OMSI data strucutres
    * helper functions to get simvar or local index for a cref in `OMSIFunction`

Co-authored-by: niklwors
Co-authored-by: wibraun