### PR TITLE
ticket:5343 set the isReadOnly attribute to false

### DIFF
--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -4533,6 +4533,7 @@ algorithm
     case SOURCEINFO()
       algorithm
         outInfo.fileName := dstPath;
+        outInfo.isReadOnly := false;
       then
         ();
 


### PR DESCRIPTION
When copying the class make sure we make set `isReadOnly` attribute to false.