### PR TITLE
[NF] Implementation of expandable connectors.

### DIFF
--- a/Compiler/NFFrontEnd/NFClass.mo
+++ b/Compiler/NFFrontEnd/NFClass.mo
@@ -469,6 +469,45 @@ uniontype Class
     end match;
   end getType;
 
+  function setType
+    input Type ty;
+    input output Class cls;
+  algorithm
+    () := match cls
+      case PARTIAL_BUILTIN()
+        algorithm
+          cls.ty := ty;
+        then
+          ();
+
+      case EXPANDED_DERIVED()
+        algorithm
+          InstNode.classApply(cls.baseClass, setType, ty);
+        then
+          ();
+
+      case INSTANCED_CLASS()
+        algorithm
+          cls.ty := ty;
+        then
+          ();
+
+      case INSTANCED_BUILTIN()
+        algorithm
+          cls.ty := ty;
+        then
+          ();
+
+      case TYPED_DERIVED()
+        algorithm
+          cls.ty := ty;
+        then
+          ();
+
+      else ();
+    end match;
+  end setType;
+
   function restriction
     input Class cls;
     output Restriction res;
@@ -502,6 +541,11 @@ uniontype Class
     input Class cls;
     output Boolean isConnector = Restriction.isConnector(restriction(cls));
   end isConnectorClass;
+
+  function isNonexpandableConnectorClass
+    input Class cls;
+    output Boolean isConnector = Restriction.isNonexpandableConnector(restriction(cls));
+  end isNonexpandableConnectorClass;
 
   function isExpandableConnectorClass
     input Class cls;

--- a/Compiler/NFFrontEnd/NFComplexType.mo
+++ b/Compiler/NFFrontEnd/NFComplexType.mo
@@ -50,8 +50,12 @@ public
     list<InstNode> potentials;
     list<InstNode> flows;
     list<InstNode> streams;
-    Boolean isExpandable;
   end CONNECTOR;
+
+  record EXPANDABLE_CONNECTOR
+    list<InstNode> potentiallyPresents;
+    list<InstNode> expandableConnectors;
+  end EXPANDABLE_CONNECTOR;
 
   record RECORD
     InstNode constructor;

--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -182,6 +182,20 @@ public
     CREF(ty = ty) := cref;
   end nodeType;
 
+  function updateNodeType
+    input output ComponentRef cref;
+  algorithm
+    () := match cref
+      case CREF()
+        algorithm
+          cref.ty := InstNode.getType(cref.node);
+        then
+          ();
+
+      else ();
+    end match;
+  end updateNodeType;
+
   function firstName
     input ComponentRef cref;
     output String name;

--- a/Compiler/NFFrontEnd/NFConnection.mo
+++ b/Compiler/NFFrontEnd/NFConnection.mo
@@ -41,5 +41,12 @@ public
     NFConnector rhs;
   end CONNECTION;
 
+  function toString
+    input Connection conn;
+    output String str;
+  algorithm
+    str := "connect(" + Connector.toString(conn.lhs) + ", " + Connector.toString(conn.rhs) + ")";
+  end toString;
+
   annotation(__OpenModelica_Interface="frontend");
 end NFConnection;

--- a/Compiler/NFFrontEnd/NFConnectionSets.mo
+++ b/Compiler/NFFrontEnd/NFConnectionSets.mo
@@ -132,6 +132,9 @@ package ConnectionSets
       // when collecting the connections, but if the connectors themselves
       // contain connectors that have been deleted we need to remove them here.
       if not (Connector.isDeleted(c1) or Connector.isDeleted(c2)) then
+        // TODO: Check variability of connectors. It's an error if either
+        //       connector is constant/parameter while the other isn't.
+
         if listEmpty(broken) then
           sets := merge(c1, c2, sets);
         elseif isBroken(c1, c2, broken) then

--- a/Compiler/NFFrontEnd/NFConnections.mo
+++ b/Compiler/NFFrontEnd/NFConnections.mo
@@ -60,6 +60,13 @@ public
     output Connections conns = CONNECTIONS({}, {}, {});
   end new;
 
+  function fromConnectionList
+    input list<Connection> connl;
+    output Connections conns;
+  algorithm
+    conns := CONNECTIONS(connl, {}, {});
+  end fromConnectionList;
+
   function addConnection
     input Connection conn;
     input output Connections conns;

--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -63,6 +63,7 @@ import NFPrefixes.Direction;
 import Variable = NFVariable;
 import ComponentReference;
 import Algorithm = NFAlgorithm;
+import NFPrefixes.ConnectorType;
 
 public
 function convert
@@ -158,7 +159,7 @@ algorithm
           dty,
           binding,
           ComponentReference.crefDims(dcref),
-          Prefixes.connectorTypeToDAE(attr.connectorType),
+          ConnectorType.toDAE(attr.connectorType),
           source,
           vattr,
           comment,

--- a/Compiler/NFFrontEnd/NFEquation.mo
+++ b/Compiler/NFFrontEnd/NFEquation.mo
@@ -116,7 +116,6 @@ public
   record CONNECT
     Expression lhs;
     Expression rhs;
-    list<Equation> broken "equations which would replace a broken connect in the overconstrained connection graph";
     DAE.ElementSource source;
   end CONNECT;
 
@@ -338,7 +337,6 @@ public
     eq := match eq
       local
         Expression e1, e2, e3;
-        list<Equation> eql;
 
       case EQUALITY()
         algorithm
@@ -360,10 +358,9 @@ public
         algorithm
           e1 := func(eq.lhs);
           e2 := func(eq.rhs);
-          eql := mapExpList(eq.broken, func);
         then
           if referenceEq(e1, eq.lhs) and referenceEq(e2, eq.rhs)
-            then eq else CONNECT(e1, e2, eql, eq.source);
+            then eq else CONNECT(e1, e2, eq.source);
 
       case FOR()
         algorithm

--- a/Compiler/NFFrontEnd/NFExpandableConnectors.mo
+++ b/Compiler/NFFrontEnd/NFExpandableConnectors.mo
@@ -1,0 +1,494 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Linköping University,
+ * Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3
+ * AND THIS OSMC PUBLIC LICENSE (OSMC-PL).
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES RECIPIENT'S
+ * ACCEPTANCE OF THE OSMC PUBLIC LICENSE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from Linköping University, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS
+ * OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package NFExpandableConnectors
+
+public
+import FlatModel = NFFlatModel;
+import Connections = NFConnections;
+
+protected
+import Array;
+import BaseHashSet;
+import Binding = NFBinding;
+import ComplexType = NFComplexType;
+import ComponentRef = NFComponentRef;
+import Connection = NFConnection;
+import ConnectionSets = NFConnectionSets.ConnectionSets;
+import Connector = NFConnector;
+import DAE;
+import ElementSource;
+import NFClass.Class;
+import NFClassTree.ClassTree;
+import NFComponent.Component;
+import NFInstNode.InstNode;
+import NFPrefixes.ConnectorType;
+import NFPrefixes.Visibility;
+import Prefixes = NFPrefixes;
+import System;
+import Type = NFType;
+import Typing = NFTyping;
+import Util;
+import Variable = NFVariable;
+import MetaModelica.Dangerous.listReverseInPlace;
+import TypeCheck = NFTypeCheck;
+import NFTypeCheck.MatchKind;
+import Expression = NFExpression;
+
+public
+function elaborate
+  input output FlatModel flatModel;
+  input output Connections connections;
+protected
+  list<Connection> expandable_conns, undeclared_conns, conns;
+  list<Variable> vars;
+  ConnectionSets.Sets csets;
+  array<list<Connector>> csets_array;
+algorithm
+  // Sort the connections based on whether they involve expandable connectors,
+  // virtual/potentially present connectors, or only normal connectors.
+  (expandable_conns, undeclared_conns, conns) := sortConnections(connections.connections);
+
+  // Don't do anything if there aren't any expandable connectors in the model.
+  if listEmpty(expandable_conns) and listEmpty(undeclared_conns) then
+    return;
+  end if;
+
+  // Create a graph from the connections. Expandable connectors connect to
+  // expandable connectors, while virtual/potentially present connectors connect
+  // to the expandable connector they belong to.
+  csets := ConnectionSets.emptySets(listLength(expandable_conns) + listLength(undeclared_conns));
+  csets := addExpandableConnectorsToSets(expandable_conns, csets);
+  (undeclared_conns, csets) := List.mapFold(undeclared_conns, addUndeclaredConnectorToSets, csets);
+  // Extract the sets of connected connectors.
+  csets_array := ConnectionSets.extractSets(csets);
+
+  //for set in csets_array loop
+  //  print("Expandable connection set:\n");
+  //  print(List.toString(set, Connector.toString, "", "{", ", ", "}", true) + "\n");
+  //end for;
+
+  // Augment the expandable connectors with the necessary elements, mark
+  // connected potentially present variables as present, and add the
+  // created variables to the flat model.
+  vars := flatModel.variables;
+  for set in csets_array loop
+    vars := elaborateExpandableSet(set, vars);
+  end for;
+
+  // Update the connections and put them back in the list of connections.
+  conns := List.fold(undeclared_conns, updateUndeclaredConnection, conns);
+  conns := List.fold(expandable_conns, updateExpandableConnection, conns);
+  connections.connections := conns;
+
+  // Update the attributes of potentially present variables so that they have
+  // the same attributes as their node. Their connector type will have changed
+  // if they've been marked as present.
+  vars := list(updatePotentiallyPresentVariable(v) for v in vars);
+  flatModel.variables := vars;
+end elaborate;
+
+protected
+
+encapsulated package ExpandableSet
+  import BaseHashSet;
+  import System;
+  import Connector = NFConnector;
+  import ComponentRef = NFComponentRef;
+
+  extends BaseHashSet(redeclare type Key = Connector);
+
+  function emptySet
+    input Integer size;
+    output HashSet set;
+  algorithm
+    set := BaseHashSet.emptyHashSetWork(size,
+      (hashConnector, Connector.isNodeNameEqual, Connector.toString));
+  end emptySet;
+
+  function hashConnector
+    input Connector conn;
+    input Integer mod;
+    output Integer res;
+  algorithm
+    res := stringHashDjb2Mod(ComponentRef.firstName(conn.name), mod);
+  end hashConnector;
+
+  annotation(__OpenModelica_Interface="frontend");
+end ExpandableSet;
+
+function sortConnections
+  "Sorts the connections into different categories of connectors based on
+   whether they involve expandable connectors, virtual/potentially present
+   connector, or only normal connectors."
+  input list<Connection> conns;
+  output list<Connection> expandableConnections = {};
+  output list<Connection> undeclaredConnections = {};
+  output list<Connection> normalConnections = {};
+protected
+  Connector c1, c2;
+  Option<tuple<Error.Message, list<Connector>>> err_msg;
+  Boolean is_undeclared1, is_undeclared2, is_expandable1, is_expandable2;
+algorithm
+  for conn in conns loop
+    Connection.CONNECTION(lhs = c1, rhs = c2) := conn;
+
+    is_undeclared1 := ConnectorType.isUndeclared(c1.cty);
+    is_undeclared2 := ConnectorType.isUndeclared(c2.cty);
+    is_expandable1 := ConnectorType.isExpandable(c1.cty);
+    is_expandable2 := ConnectorType.isExpandable(c2.cty);
+
+    if is_expandable1 or is_expandable2 then
+      if is_expandable1 and is_expandable2 then
+        expandableConnections := conn :: expandableConnections;
+      else
+        // An expandable connector may only connect to another expandable connector.
+        Error.addSourceMessageAndFail(Error.EXPANDABLE_NON_EXPANDABLE_CONNECTION,
+          {Connector.toString(if is_expandable1 then c1 else c2),
+           Connector.toString(if is_expandable1 then c2 else c1)},
+          Connector.getInfo(c1));
+      end if;
+    elseif is_undeclared1 or is_undeclared2 then
+      if is_undeclared1 and is_undeclared2 then
+        // Both sides can't be undeclared, one must be a declared component.
+        Error.addSourceMessageAndFail(Error.UNDECLARED_CONNECTION,
+          {Connector.toString(c1), Connector.toString(c2)}, Connector.getInfo(c1));
+      else
+        undeclaredConnections := conn :: undeclaredConnections;
+      end if;
+    else
+      normalConnections := conn :: normalConnections;
+    end if;
+  end for;
+
+  normalConnections := listReverseInPlace(normalConnections);
+end sortConnections;
+
+function addExpandableConnectorsToSets
+  input list<Connection> conns;
+  input output ConnectionSets.Sets csets;
+protected
+  Connector c1, c2;
+algorithm
+  for conn in conns loop
+    Connection.CONNECTION(lhs = c1, rhs = c2) := conn;
+    csets := addConnectionToSets(c1, c2, csets);
+    csets := addNestedExpandableConnectorsToSets(c1, c2, csets);
+  end for;
+end addExpandableConnectorsToSets;
+
+function addNestedExpandableConnectorsToSets
+  input Connector c1;
+  input Connector c2;
+  input output ConnectionSets.Sets csets;
+protected
+  list<Connector> ecl1, ecl2;
+  Option<Connector> oec;
+algorithm
+  ecl1 := getExpandableConnectorsInConnector(c1);
+  ecl2 := getExpandableConnectorsInConnector(c2);
+
+  if listEmpty(ecl1) and listEmpty(ecl2) then
+    return;
+  end if;
+
+  for ec1 in ecl1 loop
+    (ecl2, oec) := List.deleteMemberOnTrue(ec1, ecl2, Connector.isNodeNameEqual);
+
+    if isSome(oec) then
+      csets := addConnectionToSets(ec1, Util.getOption(oec), csets);
+    end if;
+  end for;
+end addNestedExpandableConnectorsToSets;
+
+function getExpandableConnectorsInConnector
+  input Connector c1;
+  output list<Connector> ecl;
+protected
+  list<InstNode> nodes;
+  ComponentRef par_name, name;
+  Type ty;
+algorithm
+  ecl := match c1
+    case Connector.CONNECTOR(name = par_name, ty = Type.COMPLEX(
+        complexTy = ComplexType.EXPANDABLE_CONNECTOR(expandableConnectors = nodes)))
+      algorithm
+        ecl := {};
+
+        for n in nodes loop
+          ty := InstNode.getType(n);
+          name := ComponentRef.prefixCref(n, ty, {}, par_name);
+          ecl := Connector.fromCref(name, ty, ElementSource.createElementSource(InstNode.info(n))) :: ecl;
+        end for;
+      then
+        ecl;
+
+    else {};
+  end match;
+end getExpandableConnectorsInConnector;
+
+function addUndeclaredConnectorToSets
+  input output Connection conn;
+  input output ConnectionSets.Sets csets;
+protected
+  Connector c1, c2, c, ec;
+algorithm
+  Connection.CONNECTION(lhs = c1, rhs = c2) := conn;
+
+  // Figure out which connector to add, and create a virtual connector if necessary.
+  if ConnectorType.isUndeclared(c1.cty) then
+    if ConnectorType.isVirtual(c1.cty) then
+      c1 := makeVirtualConnector(c1, c2);
+      conn := Connection.CONNECTION(c1, c2);
+    end if;
+
+    c := c1;
+  else
+    if ConnectorType.isVirtual(c2.cty) then
+      c2 := makeVirtualConnector(c2, c1);
+      conn := Connection.CONNECTION(c1, c2);
+    end if;
+
+    c := c2;
+  end if;
+
+  // Create a parent connector for the undeclared connector, i.e. the expandable
+  // connector it should be added to. The type here is wrong, but it doesn't matter.
+  ec := Connector.CONNECTOR(ComponentRef.rest(c.name), c.ty, c.face, ConnectorType.EXPANDABLE, c.source);
+
+  // Add a connection between the undeclared connector and the expandable connector.
+  csets := addConnectionToSets(c, ec, csets);
+end addUndeclaredConnectorToSets;
+
+function addConnectionToSets
+  input Connector c1;
+  input Connector c2;
+  input output ConnectionSets.Sets csets;
+algorithm
+  // The connection sets are not used to represent actual connections here, only
+  // to keep track of which expandable connectors that are associated. So to
+  // make sure we only get one instance of each expandable connector in the sets
+  // we make sure the face of all the connectors we add is the same.
+  csets := ConnectionSets.merge(Connector.setOutside(c1), Connector.setOutside(c2), csets);
+end addConnectionToSets;
+
+function makeVirtualConnector
+  input Connector virtualConnector;
+  input Connector normalConnector;
+  output Connector newConnector;
+protected
+  ComponentRef virtual_cref, normal_cref;
+  Type ty;
+  InstNode node;
+algorithm
+  virtual_cref := virtualConnector.name;
+  normal_cref := normalConnector.name;
+  ty := normalConnector.ty;
+
+  // TODO: Update the virtual connector with the created node.
+  node := ComponentRef.node(normal_cref);
+  node := InstNode.clone(node);
+  node := InstNode.rename(ComponentRef.firstName(virtual_cref), node);
+  node := InstNode.setParent(ComponentRef.node(ComponentRef.rest(virtual_cref)), node);
+  virtual_cref := ComponentRef.prefixCref(node, ty, {}, ComponentRef.rest(virtual_cref));
+
+  // TODO: This needs more work, the new connector might be a complex connector.
+  newConnector := Connector.CONNECTOR(virtual_cref, ty, virtualConnector.face,
+    virtualConnector.cty, virtualConnector.source);
+end makeVirtualConnector;
+
+function elaborateExpandableSet
+  input list<Connector> set;
+  input output list<Variable> vars;
+protected
+  ExpandableSet.HashSet exp_set;
+  list<Connector> exp_conns = {}, exp_set_lst;
+algorithm
+  exp_set := ExpandableSet.emptySet(Util.nextPrime(listLength(set)));
+
+  for c in set loop
+    if ConnectorType.isExpandable(c.cty) then
+      exp_conns := c :: exp_conns;
+    elseif ConnectorType.isUndeclared(c.cty) then
+      exp_set := BaseHashSet.add(c, exp_set);
+      markComponentPresent(ComponentRef.node(Connector.name(c)));
+    end if;
+  end for;
+
+  exp_set_lst := BaseHashSet.hashSetList(exp_set);
+
+  for ec in exp_conns loop
+    vars := augmentExpandableConnector(ec, exp_set_lst, vars);
+  end for;
+end elaborateExpandableSet;
+
+function markComponentPresent
+  input InstNode node;
+protected
+  Component comp;
+  ConnectorType.Type cty;
+algorithm
+  comp := InstNode.component(node);
+  cty := Component.connectorType(comp);
+
+  if ConnectorType.isPotentiallyPresent(cty) then
+    cty := ConnectorType.setPresent(cty);
+    comp := Component.setConnectorType(cty, comp);
+    InstNode.updateComponent(comp, node);
+  end if;
+end markComponentPresent;
+
+function augmentExpandableConnector
+  input Connector conn;
+  input list<Connector> expandableSet;
+  input output list<Variable> vars;
+protected
+  ComponentRef exp_name, elem_name;
+  InstNode exp_node, comp_node, cls_node, node;
+  Class cls;
+  ClassTree cls_tree;
+  Component comp;
+  list<InstNode> nodes = {};
+  Variable var;
+  Type ty;
+  ComplexType complex_ty;
+algorithm
+  exp_name := Connector.name(conn);
+  exp_node := ComponentRef.node(exp_name);
+  cls_node := InstNode.classScope(exp_node);
+  cls := InstNode.getClass(cls_node);
+  cls_tree := Class.classTree(cls);
+
+  // Go through the union of elements the expandable connector should have.
+  for c in expandableSet loop
+    elem_name := Connector.name(c);
+    node := ComponentRef.node(elem_name);
+
+    try
+      comp_node := ClassTree.lookupElement(InstNode.name(node), cls_tree);
+    else
+      comp_node := InstNode.EMPTY_NODE();
+    end try;
+
+    if InstNode.isEmpty(comp_node) then
+      // If the element doesn't already exist, add it to the list of elements to be
+      // added to the connector.
+      nodes := node :: nodes;
+      ty := c.ty;
+      elem_name := ComponentRef.prefixCref(node, ty, {}, exp_name);
+      // TODO: This needs more work, the new connector might be a complex connector.
+      var := Variable.VARIABLE(elem_name, ty, NFBinding.EMPTY_BINDING,
+        Visibility.PUBLIC, NFComponent.DEFAULT_ATTR, {},
+        SOME(SCode.COMMENT(NONE(), SOME("virtual variable in expandable connector"))),
+        ElementSource.getInfo(c.source));
+      vars := var :: vars;
+    else
+      comp_node := ClassTree.lookupElement(InstNode.name(node), cls_tree);
+      comp_node := InstNode.resolveInner(comp_node);
+
+      if InstNode.isComponent(comp_node) then
+        // If the element already exists and is a potentially present component,
+        // change it to be present.
+        markComponentPresent(comp_node);
+      else
+        Error.addInternalError(getInstanceName() + " got non-component element", sourceInfo());
+      end if;
+    end if;
+  end for;
+
+  if not listEmpty(nodes) then
+    cls_tree := ClassTree.addElementsToFlatTree(nodes, cls_tree);
+    cls := Class.setClassTree(cls_tree, cls);
+  end if;
+
+  // Create a normal non-expandable complex type for the augmented expandable connector.
+  complex_ty := Typing.makeConnectorType(cls_tree, isExpandable = false);
+  ty := Type.COMPLEX(cls_node, complex_ty);
+  cls := Class.setType(ty, cls);
+  InstNode.updateClass(cls, cls_node);
+  InstNode.componentApply(exp_node, Component.setType, ty);
+end augmentExpandableConnector;
+
+function updateUndeclaredConnection
+  input Connection conn;
+  input output list<Connection> conns;
+algorithm
+  conns := conn :: conns;
+end updateUndeclaredConnection;
+
+function updateExpandableConnection
+  input Connection conn;
+  input output list<Connection> conns;
+protected
+  Connector c1, c2;
+  Type ty1, ty2;
+  MatchKind mk;
+  Expression e1, e2;
+algorithm
+  Connection.CONNECTION(lhs = c1, rhs = c2) := conn;
+  (c1, ty1) := updateExpandableConnector(c1);
+  (c2, ty2) := updateExpandableConnector(c2);
+
+  // Check that the types match now that the connectors have been augmented.
+  e1 := Expression.CREF(ty1, Connector.name(c1));
+  e2 := Expression.CREF(ty2, Connector.name(c2));
+  (_, _, _, mk) := TypeCheck.matchExpressions(e1, ty1, e2, ty2, allowUnknown = true);
+
+  if TypeCheck.isIncompatibleMatch(mk) then
+    Error.addSourceMessageAndFail(Error.INVALID_CONNECTOR_VARIABLE,
+      {Expression.toString(e1), Expression.toString(e2)}, Connector.getInfo(c1));
+  end if;
+
+  conns := Connection.CONNECTION(c1, c2) :: conns;
+end updateExpandableConnection;
+
+function updateExpandableConnector
+  input output Connector conn;
+        output Type ty;
+protected
+  ComponentRef name;
+algorithm
+  Connector.CONNECTOR(name = name, ty = ty) := conn;
+  name := ComponentRef.updateNodeType(name);
+  ty := Type.setArrayElementType(ty, Type.arrayElementType(ComponentRef.nodeType(name)));
+  conn := Connector.CONNECTOR(name, ty, conn.face, conn.cty, conn.source);
+end updateExpandableConnector;
+
+function updatePotentiallyPresentVariable
+  input output Variable var;
+algorithm
+  if ConnectorType.isPotentiallyPresent(var.attributes.connectorType) then
+    var.attributes := Component.getAttributes(InstNode.component(ComponentRef.node(var.name)));
+  end if;
+end updatePotentiallyPresentVariable;
+
+annotation(__OpenModelica_Interface="frontend");
+end NFExpandableConnectors;

--- a/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/Compiler/NFFrontEnd/NFFlatten.mo
@@ -89,6 +89,8 @@ import Restriction = NFRestriction;
 import EvalConstants = NFEvalConstants;
 import SimplifyModel = NFSimplifyModel;
 import InstNodeType = NFInstNode.InstNodeType;
+import ExpandableConnectors = NFExpandableConnectors;
+
 
 public
 type FunctionTree = FunctionTreeImpl.Tree;
@@ -921,9 +923,8 @@ algorithm
       algorithm
         e1 := flattenExp(eq.lhs, prefix);
         e2 := flattenExp(eq.rhs, prefix);
-        eql := flattenEquations(eq.broken, prefix);
       then
-        Equation.CONNECT(e1, e2, eql, eq.source) :: equations;
+        Equation.CONNECT(e1, e2, eq.source) :: equations;
 
     case Equation.IF()
       then flattenIfEquation(eq, prefix, equations);
@@ -1165,16 +1166,18 @@ protected
   CardinalityTable.Table ctable;
   Connections.BrokenEdges broken = {};
 algorithm
+  // get the connections from the model
+  (flatModel, conns) := Connections.collect(flatModel);
+  // Elaborate expandable connectors.
+  (flatModel, conns) := ExpandableConnectors.elaborate(flatModel, conns);
   // handle overconstrained connections
   // - build the graph
   // - evaluate the Connections.* operators
   // - generate the equations to replace the broken connects
   // - return the broken connects + the equations
   if  System.getHasOverconstrainedConnectors() then
-    (flatModel, broken) := NFOCConnectionGraph.handleOverconstrainedConnections(flatModel, name);
+    (flatModel, broken) := NFOCConnectionGraph.handleOverconstrainedConnections(flatModel, conns, name);
   end if;
-  // get the connections from the model
-  (flatModel, conns) := Connections.collect(flatModel);
   // add the broken connections
   conns := Connections.addBroken(broken, conns);
   // build the sets, check the broken connects
@@ -1190,6 +1193,7 @@ algorithm
 
   // add the equations to the flat model
   flatModel.equations := listAppend(conn_eql, flatModel.equations);
+  flatModel.variables := list(v for v guard Variable.isPresent(v) in flatModel.variables);
 
   ctable := CardinalityTable.fromConnections(conns);
 

--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -1764,7 +1764,7 @@ protected
     input InstNode component;
     output Direction direction;
   protected
-    ConnectorType cty;
+    ConnectorType.Type cty;
     InnerOuter io;
     Visibility vis;
     Variability var;
@@ -1778,9 +1778,9 @@ protected
     var := Component.variability(InstNode.component(component));
 
     // Function components may not be connectors.
-    if cty == ConnectorType.FLOW or cty == ConnectorType.STREAM then
+    if ConnectorType.isFlowOrStream(cty) then
       Error.addSourceMessage(Error.INNER_OUTER_FORMAL_PARAMETER,
-        {Prefixes.connectorTypeString(cty), InstNode.name(component)},
+        {ConnectorType.toString(cty), InstNode.name(component)},
         InstNode.info(component));
       fail();
     end if;

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -677,7 +677,7 @@ function instDerivedAttributes
   input SCode.Attributes scodeAttr;
   output Component.Attributes attributes;
 protected
-  ConnectorType cty;
+  ConnectorType.Type cty;
   Variability var;
   Direction dir;
 algorithm
@@ -690,7 +690,7 @@ algorithm
 
     else
       algorithm
-        cty := Prefixes.connectorTypeFromSCode(scodeAttr.connectorType);
+        cty := ConnectorType.fromSCode(scodeAttr.connectorType);
         var := Prefixes.variabilityFromSCode(scodeAttr.variability);
         dir := Prefixes.directionFromSCode(scodeAttr.direction);
       then
@@ -738,12 +738,14 @@ protected
   Modifier mod, outer_mod;
   Restriction res;
   Type ty;
+  Component.Attributes attrs;
 algorithm
   () := match cls
-    case Class.EXPANDED_CLASS()
+    case Class.EXPANDED_CLASS(restriction = res)
       algorithm
         (node, par) := ClassTree.instantiate(node, parent);
         updateComponentType(parent, node);
+        attributes := updateClassConnectorType(res, attributes);
         inst_cls as Class.EXPANDED_CLASS(elements = cls_tree) := InstNode.getClass(node);
 
         // Fetch modification on the class definition (for class extends).
@@ -790,7 +792,8 @@ algorithm
         mod := Modifier.fromElement(InstNode.definition(node), {node}, InstNode.parent(node));
         outer_mod := Modifier.merge(outerMod, Modifier.addParent(node, cls.modifier));
         mod := Modifier.merge(outer_mod, mod);
-        attributes := mergeDerivedAttributes(attributes, cls.attributes, parent);
+        attrs := updateClassConnectorType(cls.restriction, cls.attributes);
+        attributes := mergeDerivedAttributes(attrs, attributes, parent);
 
         // Mark the base class node as a base class.
         base_node := InstNode.setNodeType(
@@ -863,6 +866,17 @@ algorithm
     component := InstNode.componentApply(component, Component.setClassInstance, cls);
   end if;
 end updateComponentType;
+
+function updateClassConnectorType
+  input Restriction res;
+  input output Component.Attributes attrs;
+algorithm
+  if Restriction.isExpandableConnector(res) then
+    attrs.connectorType := ConnectorType.setExpandable(attrs.connectorType);
+  elseif Restriction.isConnector(res) then
+    attrs.connectorType := ConnectorType.setConnector(attrs.connectorType);
+  end if;
+end updateClassConnectorType;
 
 function instExternalObjectStructors
   "Instantiates the constructor and destructor for an ExternalObject class."
@@ -1303,7 +1317,8 @@ algorithm
 
   if Modifier.isRedeclare(outer_mod) then
     checkOuterComponentMod(outer_mod, def, comp_node);
-    instComponentDef(def, Modifier.NOMOD(), cc_mod, NFComponent.DEFAULT_ATTR, useBinding, comp_node, parent);
+    instComponentDef(def, Modifier.NOMOD(), cc_mod, NFComponent.DEFAULT_ATTR, useBinding,
+      comp_node, parent, isRedeclared = true);
 
     Modifier.REDECLARE(element = rdcl_node, mod = outer_mod) := outer_mod;
     cc_smod := SCode.getConstrainingMod(def);
@@ -1329,6 +1344,7 @@ function instComponentDef
   input Boolean useBinding;
   input InstNode node;
   input InstNode parent;
+  input Boolean isRedeclared = false;
 algorithm
   () := match component
     local
@@ -1340,7 +1356,8 @@ algorithm
       Component inst_comp;
       InstNode ty_node;
       Class ty;
-      Boolean use_binding, in_function;
+      Boolean in_function;
+      Restriction parent_res, res;
 
     case SCode.COMPONENT(info = info)
       algorithm
@@ -1354,16 +1371,14 @@ algorithm
         binding := if useBinding then Modifier.binding(mod) else NFBinding.EMPTY_BINDING;
         condition := Binding.fromAbsyn(component.condition, false, {node}, parent, info);
 
-        // This is used to ignore the bindings of a component's children when the
-        // component iself has a binding that overrides those. This is to ensure
-        // that constant evaluation of e.g. a record field uses the correct binding.
-        use_binding := useBinding and not Binding.isBound(binding);
-
         // Instantiate the component's attributes, and merge them with the
         // attributes of the component's parent (e.g. constant SomeComplexClass c).
+        parent_res := Class.restriction(InstNode.getClass(parent));
         attr := instComponentAttributes(component.attributes, component.prefixes);
-        attr := mergeComponentAttributes(attributes, attr, node,
-          Class.isFunction(InstNode.getClass(parent)));
+        attr := checkDeclaredComponentAttributes(attr, parent_res, node);
+        //attr := mergeComponentAttributes(attributes, attr, node,
+        //  Restriction.isFunction(parent_res));
+        attr := mergeComponentAttributes(attributes, attr, node, parent_res);
 
         // Create the untyped component and update the node with it. We need the
         // untyped component in instClass to make sure everything is scoped
@@ -1381,6 +1396,10 @@ algorithm
 
         // Update the component's variability based on its type (e.g. Integer is discrete).
         ty_attr := updateComponentVariability(ty_attr, ty, ty_node);
+        // Update the component's connector type now that we have its type.
+        res := Class.restriction(InstNode.getClass(ty_node));
+        ty_attr := updateComponentConnectorType(ty_attr, res, isRedeclared, node);
+
         if not referenceEq(attr, ty_attr) then
           InstNode.componentApply(node, Component.setAttributes, ty_attr);
         end if;
@@ -1388,6 +1407,49 @@ algorithm
         ();
   end match;
 end instComponentDef;
+
+function updateComponentConnectorType
+  input output Component.Attributes attributes;
+  input Restriction restriction;
+  input Boolean isRedeclared;
+  input InstNode component;
+protected
+  ConnectorType.Type cty = attributes.connectorType;
+algorithm
+  if ConnectorType.isConnectorType(cty) then
+    if Restriction.isConnector(restriction) then
+      if Restriction.isExpandableConnector(restriction) then
+        cty := ConnectorType.setPresent(cty);
+      else
+        cty := intBitAnd(cty, intBitNot(ConnectorType.EXPANDABLE));
+      end if;
+    else
+      // The connector type might have the connector or expandable bits set
+      // because of a parent node, but they should be unset if the component
+      // itself isn't a connector.
+      cty := intBitAnd(cty,
+        intBitNot(intBitOr(ConnectorType.CONNECTOR, ConnectorType.EXPANDABLE)));
+    end if;
+
+    // Connector elements that are not flow/stream are potentials.
+    if not ConnectorType.isFlowOrStream(cty) then
+      cty := ConnectorType.setPotential(cty);
+    end if;
+
+    if cty <> attributes.connectorType then
+      attributes.connectorType := cty;
+    end if;
+  elseif ConnectorType.isFlowOrStream(cty) and not isRedeclared then
+    // The Modelica specification forbids using stream outside connector
+    // declarations, but has no such restriction for flow. To compromise we
+    // print a warning for both flow and stream.
+    Error.addSourceMessage(Error.CONNECTOR_PREFIX_OUTSIDE_CONNECTOR,
+      {ConnectorType.toString(cty)}, InstNode.info(component));
+
+    // Remove the erroneous flow/stream prefix and keep going.
+    attributes.connectorType := ConnectorType.unsetFlowStream(cty);
+  end if;
+end updateComponentConnectorType;
 
 function redeclareComponent
   input InstNode redeclareNode;
@@ -1438,10 +1500,8 @@ algorithm
 
         condition := orig_comp.condition;
 
-        // Merge the attributes of the redeclare and the original element, and
-        // then with any outer attributes applied to the scope.
+        // Merge the attributes of the redeclare and the original element.
         attr := mergeRedeclaredComponentAttributes(orig_comp.attributes, rdcl_comp.attributes, redeclareNode);
-        //attr := mergeComponentAttributes(outerAttr, attr, redeclareNode);
 
         // Use the dimensions of the redeclare if any, otherwise take them from the original.
         dims := if arrayEmpty(rdcl_comp.dimensions) then orig_comp.dimensions else rdcl_comp.dimensions;
@@ -1482,7 +1542,7 @@ function instComponentAttributes
   input SCode.Prefixes compPrefs;
   output Component.Attributes attributes;
 protected
-  ConnectorType cty;
+  ConnectorType.Type cty;
   Parallelism par;
   Variability var;
   Direction dir;
@@ -1505,7 +1565,7 @@ algorithm
 
     else
       algorithm
-        cty := Prefixes.connectorTypeFromSCode(compAttr.connectorType);
+        cty := ConnectorType.fromSCode(compAttr.connectorType);
         par := Prefixes.parallelismFromSCode(compAttr.parallelism);
         var := Prefixes.variabilityFromSCode(compAttr.variability);
         dir := Prefixes.directionFromSCode(compAttr.direction);
@@ -1522,27 +1582,29 @@ function mergeComponentAttributes
   input Component.Attributes outerAttr;
   input Component.Attributes innerAttr;
   input InstNode node;
-  input Boolean inFunction;
+  input Restriction parentRestriction;
   output Component.Attributes attr;
 protected
-  ConnectorType cty;
+  ConnectorType.Type cty;
   Parallelism par;
   Variability var;
   Direction dir;
   Boolean fin, redecl;
   Replaceable repl;
 algorithm
-  if referenceEq(outerAttr, NFComponent.DEFAULT_ATTR) then
+  if referenceEq(outerAttr, NFComponent.DEFAULT_ATTR) and innerAttr.connectorType == 0 then
     attr := innerAttr;
   elseif referenceEq(innerAttr, NFComponent.DEFAULT_ATTR) then
-    attr := outerAttr;
-    attr.innerOuter := InnerOuter.NOT_INNER_OUTER;
+    cty := ConnectorType.merge(outerAttr.connectorType, innerAttr.connectorType, node);
+    attr := Component.Attributes.ATTRIBUTES(cty, outerAttr.parallelism,
+      outerAttr.variability, outerAttr.direction, innerAttr.innerOuter, outerAttr.isFinal,
+      innerAttr.isRedeclare, innerAttr.isReplaceable);
   else
-    cty := Prefixes.mergeConnectorType(outerAttr.connectorType, innerAttr.connectorType, node);
+    cty := ConnectorType.merge(outerAttr.connectorType, innerAttr.connectorType, node);
     par := Prefixes.mergeParallelism(outerAttr.parallelism, innerAttr.parallelism, node);
     var := Prefixes.variabilityMin(outerAttr.variability, innerAttr.variability);
 
-    if inFunction then
+    if Restriction.isFunction(parentRestriction) then
       dir := innerAttr.direction;
     else
       dir := Prefixes.mergeDirection(outerAttr.direction, innerAttr.direction, node);
@@ -1555,13 +1617,47 @@ algorithm
   end if;
 end mergeComponentAttributes;
 
+function checkDeclaredComponentAttributes
+  input output Component.Attributes attr;
+  input Restriction parentRestriction;
+  input InstNode component;
+algorithm
+  () := match parentRestriction
+    case Restriction.CONNECTOR()
+      algorithm
+        // Components of a connector may not have prefixes 'inner' or 'outer'.
+        if attr.innerOuter <> InnerOuter.NOT_INNER_OUTER then
+          Error.addSourceMessageAndFail(Error.INVALID_COMPONENT_PREFIX,
+            {Prefixes.innerOuterString(attr.innerOuter), InstNode.name(component)},
+            InstNode.info(component));
+        end if;
+
+        if parentRestriction.isExpandable then
+          // Components of an expandable connector may not have the prefix 'flow'.
+
+          if ConnectorType.isFlowOrStream(attr.connectorType) then
+            Error.addSourceMessageAndFail(Error.INVALID_COMPONENT_PREFIX,
+              {ConnectorType.toString(attr.connectorType), InstNode.name(component), Restriction.toString(parentRestriction)},
+              InstNode.info(component));
+          end if;
+
+          // Mark components in expandable connectors as potentially present.
+          attr.connectorType := intBitOr(attr.connectorType, ConnectorType.POTENTIALLY_PRESENT);
+        end if;
+      then
+        ();
+
+    else ();
+  end match;
+end checkDeclaredComponentAttributes;
+
 function mergeDerivedAttributes
   input Component.Attributes outerAttr;
   input Component.Attributes innerAttr;
   input InstNode node;
   output Component.Attributes attr;
 protected
-  ConnectorType cty;
+  ConnectorType.Type cty;
   Parallelism par;
   Variability var;
   Direction dir;
@@ -1569,13 +1665,13 @@ protected
   Boolean fin, redecl;
   Replaceable repl;
 algorithm
-  if referenceEq(innerAttr, NFComponent.DEFAULT_ATTR) then
+  if referenceEq(innerAttr, NFComponent.DEFAULT_ATTR) and outerAttr.connectorType == 0 then
     attr := outerAttr;
-  elseif referenceEq(outerAttr, NFComponent.DEFAULT_ATTR) then
+  elseif referenceEq(outerAttr, NFComponent.DEFAULT_ATTR) and innerAttr.connectorType == 0 then
     attr := innerAttr;
   else
     Component.Attributes.ATTRIBUTES(cty, par, var, dir, io, fin, redecl, repl) := outerAttr;
-    cty := Prefixes.mergeConnectorType(cty, innerAttr.connectorType, node);
+    cty := ConnectorType.merge(cty, innerAttr.connectorType, node, isClass = true);
     var := Prefixes.variabilityMin(var, innerAttr.variability);
     dir := Prefixes.mergeDirection(dir, innerAttr.direction, node, allowSame = true);
     attr := Component.Attributes.ATTRIBUTES(cty, par, var, dir, io, fin, redecl, repl);
@@ -1588,7 +1684,7 @@ function mergeRedeclaredComponentAttributes
   input InstNode node;
   output Component.Attributes attr;
 protected
-  ConnectorType cty, rcty;
+  ConnectorType.Type cty, rcty, cty_fs, rcty_fs;
   Parallelism par, rpar;
   Variability var, rvar;
   Direction dir, rdir;
@@ -1612,12 +1708,12 @@ algorithm
     // final which is always taken from the redeclare (since redeclaring a final
     // element isn't allowed).
 
-    if rcty <> ConnectorType.POTENTIAL then
-      if cty <> ConnectorType.POTENTIAL and cty <> rcty then
-        printRedeclarePrefixError(node, Prefixes.connectorTypeString(rcty), Prefixes.connectorTypeString(cty));
+    rcty_fs := intBitAnd(rcty, ConnectorType.FLOW_STREAM_MASK);
+    cty_fs := intBitAnd(cty, ConnectorType.FLOW_STREAM_MASK);
+    if rcty_fs > 0 then
+      if cty_fs > 0 and rcty_fs <> cty_fs then
+        printRedeclarePrefixError(node, ConnectorType.toString(rcty), ConnectorType.toString(cty));
       end if;
-
-      cty := rcty;
     end if;
 
     if rpar <> Parallelism.NON_PARALLEL then
@@ -1652,7 +1748,7 @@ algorithm
       io := rio;
     end if;
 
-    attr := Component.Attributes.ATTRIBUTES(cty, par, var, dir, io, fin, redecl, repl);
+    attr := Component.Attributes.ATTRIBUTES(rcty, par, var, dir, io, fin, redecl, repl);
   end if;
 end mergeRedeclaredComponentAttributes;
 
@@ -2558,10 +2654,10 @@ algorithm
           fail();
         end if;
 
-        exp1 := instCref(scodeEq.crefLeft, scope, info);
-        exp2 := instCref(scodeEq.crefRight, scope, info);
+        exp1 := instConnectorCref(scodeEq.crefLeft, scope, info);
+        exp2 := instConnectorCref(scodeEq.crefRight, scope, info);
       then
-        Equation.CONNECT(exp1, exp2, {}, makeSource(scodeEq.comment, info));
+        Equation.CONNECT(exp1, exp2, makeSource(scodeEq.comment, info));
 
     case SCode.EEquation.EQ_FOR(info = info)
       algorithm
@@ -2656,6 +2752,26 @@ algorithm
 
   end match;
 end instEEquation;
+
+function instConnectorCref
+  input Absyn.ComponentRef absynCref;
+  input InstNode scope;
+  input SourceInfo info;
+  output Expression outExp;
+protected
+  ComponentRef cref, prefix;
+  InstNode found_scope;
+algorithm
+  (cref, found_scope) := Lookup.lookupConnector(absynCref, scope, info);
+  cref := instCrefSubscripts(cref, scope, info);
+
+  prefix := ComponentRef.fromNodeList(InstNode.scopeList(scope));
+  if not ComponentRef.isEmpty(prefix) then
+    cref := ComponentRef.append(cref, prefix);
+  end if;
+
+  outExp := Expression.CREF(Type.UNKNOWN(), cref);
+end instConnectorCref;
 
 function makeSource
   input SCode.Comment comment;

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -413,12 +413,23 @@ uniontype InstNode
     end match;
   end isImplicit;
 
+  function isName
+    input InstNode node;
+    output Boolean isName;
+  algorithm
+    isName := match node
+      case NAME_NODE() then true;
+      else false;
+    end match;
+  end isName;
+
   function isConnector
     input InstNode node;
     output Boolean isConnector;
   algorithm
     isConnector := match node
       case COMPONENT_NODE() then Component.isConnector(component(node));
+      case NAME_NODE() then true;
       else false;
     end match;
   end isConnector;
@@ -1210,6 +1221,12 @@ uniontype InstNode
       else false;
     end match;
   end refEqual;
+
+  function nameEqual
+    input InstNode node1;
+    input InstNode node2;
+    output Boolean equal = InstNode.name(node1) == InstNode.name(node2);
+  end nameEqual;
 
   function isSame
     input InstNode node1;

--- a/Compiler/NFFrontEnd/NFLookupState.mo
+++ b/Compiler/NFFrontEnd/NFLookupState.mo
@@ -384,7 +384,7 @@ uniontype LookupState
     input InstNode node;
     output LookupState state;
   algorithm
-    if InstNode.isComponent(node) then
+    if InstNode.isComponent(node) or InstNode.isName(node) then
       state := COMP();
     else
       state := elementState(InstNode.definition(node));

--- a/Compiler/NFFrontEnd/NFRestriction.mo
+++ b/Compiler/NFFrontEnd/NFRestriction.mo
@@ -116,6 +116,16 @@ public
     end match;
   end isExpandableConnector;
 
+  function isNonexpandableConnector
+    input Restriction res;
+    output Boolean isNonexpandable;
+  algorithm
+    isNonexpandable := match res
+      case CONNECTOR() then not res.isExpandable;
+      else false;
+    end match;
+  end isNonexpandableConnector;
+
   function isExternalObject
     input Restriction res;
     output Boolean isExternalObject;
@@ -182,12 +192,15 @@ public
   algorithm
     str := match res
       case CLASS() then "class";
+      case CONNECTOR()
+        then if res.isExpandable then "expandable connector" else "connector";
       case ENUMERATION() then "enumeration";
       case EXTERNAL_OBJECT() then "ExternalObject";
       case FUNCTION() then "function";
       case MODEL() then "model";
       case OPERATOR() then "operator";
       case RECORD() then "record";
+      case RECORD_CONSTRUCTOR() then "record";
       case TYPE() then "type";
       case CLOCK() then "clock";
       else "unknown";

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -332,6 +332,16 @@ public
     end match;
   end isConnector;
 
+  function isExpandableConnector
+    input Type ty;
+    output Boolean isExpandable;
+  algorithm
+    isExpandable := match ty
+      case COMPLEX(complexTy = ComplexType.EXPANDABLE_CONNECTOR()) then true;
+      else false;
+    end match;
+  end isExpandableConnector;
+
   function isRecord
     input Type ty;
     output Boolean isRecord;

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -288,13 +288,14 @@ protected
   Class cls, ty_cls;
   InstNode node;
   Function fn;
+  Boolean is_expandable;
 algorithm
   cls := InstNode.getClass(clsNode);
 
   ty := match cls
-    case Class.INSTANCED_CLASS(restriction = Restriction.CONNECTOR())
+    case Class.INSTANCED_CLASS(restriction = Restriction.CONNECTOR(isExpandable = is_expandable))
       algorithm
-        ty := Type.COMPLEX(clsNode, makeConnectorType(cls.elements));
+        ty := Type.COMPLEX(clsNode, makeConnectorType(cls.elements, is_expandable));
         cls.ty := ty;
         InstNode.updateClass(cls, clsNode);
       then
@@ -354,27 +355,42 @@ end typeClassType;
 
 function makeConnectorType
   input ClassTree ctree;
+  input Boolean isExpandable;
   output ComplexType connectorTy;
 protected
-  list<InstNode> pots = {}, flows = {}, streams = {};
-  ConnectorType cty;
+  list<InstNode> pots = {}, flows = {}, streams = {}, exps = {};
+  ConnectorType.Type cty;
 algorithm
-  for c in ClassTree.enumerateComponents(ctree) loop
-    cty := Component.connectorType(InstNode.component(c));
+  if isExpandable then
+    for c in ClassTree.enumerateComponents(ctree) loop
+      cty := Component.connectorType(InstNode.component(c));
 
-    if cty == ConnectorType.FLOW then
-      flows := c :: flows;
-    elseif cty == ConnectorType.STREAM then
-      streams := c :: streams;
-    elseif cty == ConnectorType.POTENTIAL then
-      pots := c :: pots;
-    else
-      Error.addInternalError("Invalid connector type on component " + InstNode.name(c), InstNode.info(c));
-      fail();
-    end if;
-  end for;
+      if intBitAnd(cty, ConnectorType.EXPANDABLE) > 0 then
+        exps := c :: exps;
+      else
+        pots := c :: pots;
+      end if;
+    end for;
 
-  connectorTy := ComplexType.CONNECTOR(pots, flows, streams, false);
+    connectorTy := ComplexType.EXPANDABLE_CONNECTOR(pots, exps);
+  else
+    for c in ClassTree.enumerateComponents(ctree) loop
+      cty := Component.connectorType(InstNode.component(c));
+
+      if intBitAnd(cty, ConnectorType.FLOW) > 0 then
+        flows := c :: flows;
+      elseif intBitAnd(cty, ConnectorType.STREAM) > 0 then
+        streams := c :: streams;
+      elseif intBitAnd(cty, ConnectorType.POTENTIAL) > 0 then
+        pots := c :: pots;
+      else
+        Error.addInternalError("Invalid connector type on component " + InstNode.name(c), InstNode.info(c));
+        fail();
+      end if;
+    end for;
+
+    connectorTy := ComplexType.CONNECTOR(pots, flows, streams);
+  end if;
 end makeConnectorType;
 
 function typeComponent
@@ -397,9 +413,6 @@ algorithm
         ty := Type.liftArrayLeftList(ty, arrayList(c.dimensions));
         InstNode.updateComponent(Component.setType(ty, c), node);
 
-        // Check that the component's attributes are valid.
-        checkComponentAttributes(c.attributes, component);
-
         // Type the component's children.
         typeComponents(c.classInst, origin);
       then
@@ -419,40 +432,6 @@ algorithm
 
   end match;
 end typeComponent;
-
-// TODO: Make this check part of the check that a class adheres to its
-//       restriction.
-function checkComponentAttributes
-  input Component.Attributes attributes;
-  input InstNode component;
-protected
-  Component.Attributes attr = attributes;
-  ConnectorType cty;
-algorithm
-  () := match attr
-    case Component.ATTRIBUTES(connectorType = cty)
-      algorithm
-        // The Modelica specification forbids using stream outside connector
-        // declarations, but has no such restriction for flow. To compromise we
-        // print a warning for both flow and stream.
-        if not checkConnectorType(component) then
-          if (cty == ConnectorType.STREAM or cty == ConnectorType.FLOW) then
-            Error.addSourceMessage(Error.CONNECTOR_PREFIX_OUTSIDE_CONNECTOR,
-              {Prefixes.connectorTypeString(cty)}, InstNode.info(component));
-          end if;
-          // Remove the prefix from the component, to avoid issues like a flow
-          // equation being generated for it.
-          if not (InstNode.isEmpty(component) or InstNode.isInnerOuterNode(component)) then
-            attr.connectorType := ConnectorType.NON_CONNECTOR;
-            InstNode.componentApply(component, Component.setAttributes, attr);
-          end if;
-        end if;
-      then
-        ();
-
-    else ();
-  end match;
-end checkComponentAttributes;
 
 function checkConnectorType
   input InstNode node;
@@ -2479,144 +2458,53 @@ algorithm
   end if;
 
   next_origin := ExpOrigin.setFlag(origin, ExpOrigin.CONNECT);
+  (lhs, lhs_ty) := typeConnector(lhsConn, next_origin, info);
+  (rhs, rhs_ty) := typeConnector(rhsConn, next_origin, info);
 
-  try // try the normal stuff first!
-    (lhs, lhs_ty, lhs_var) := typeExp(lhsConn, next_origin, info);
-    (rhs, rhs_ty, rhs_var) := typeExp(rhsConn, next_origin, info);
-  else // either is an error or there are expandable connectors in there
-    // check if any of them are expandable connectors!
-    if InstNode.hasParentExpandableConnector(ComponentRef.node(Expression.toCref(lhsConn))) or
-       InstNode.hasParentExpandableConnector(ComponentRef.node(Expression.toCref(rhsConn)))
-    then // handle expandable
-      (lhs, rhs, lhs_ty, lhs_var, rhs_ty, rhs_var) := typeExpandableConnectors(lhsConn, rhsConn, next_origin, info);
+  // Check that the connectors have matching types, but only if they're not expandable.
+  // Expandable connectors can only be type checked after they've been augmented during
+  // the connection handling.
+  if not (Type.isExpandableConnector(lhs_ty) or Type.isExpandableConnector(rhs_ty)) then
+    (lhs, rhs, _, mk) := TypeCheck.matchExpressions(lhs, lhs_ty, rhs, rhs_ty, allowUnknown = true);
+
+    if TypeCheck.isIncompatibleMatch(mk) then
+      // TODO: Better error message.
+      Error.addSourceMessage(Error.INVALID_CONNECTOR_VARIABLE,
+        {Expression.toString(lhsConn), Expression.toString(rhsConn)}, info);
+      fail();
     end if;
-  end try;
-
-  checkConnector(lhs, info);
-  checkConnector(rhs, info);
-
-  (lhs, rhs, _, mk) := TypeCheck.matchExpressions(lhs, lhs_ty, rhs, rhs_ty);
-
-  if TypeCheck.isIncompatibleMatch(mk) then
-    // TODO: Better error message.
-    Error.addSourceMessage(Error.INVALID_CONNECTOR_VARIABLE,
-      {Expression.toString(lhsConn), Expression.toString(rhsConn)}, info);
-    fail();
   end if;
 
-  // TODO: No point in doing this here since connectors aren't allowed to have
-  //       variability prefixes. We should check each individual connection once
-  //       the connections have been expanded during flattening instead.
-  // It's an error if either connector is constant/parameter while the other isn't.
-  //if (lhs_var <= Variability.PARAMETER) <> (rhs_var <= Varibility.PARAMETER then
-  //  if lhs_var > Variability.PARAMETER then
-  //    (lhs, rhs, lhs_var) := (rhs, lhs, rhs_var);
-  //  end if;
-
-  //  Error.addSourceMessage(Error.INCOMPATIBLE_CONNECTOR_VARIABILITY,
-  //    {Expression.toString(lhs), Prefixes.variabilityString(lhs_var),
-  //     Expression.toString(rhs)}, info);
-  //  fail();
-  //end if;
-
-  connEq := Equation.CONNECT(lhs, rhs, {}, source);
+  connEq := Equation.CONNECT(lhs, rhs, source);
 end typeConnect;
 
-function typeExpandableConnectors
-  input output Expression lhs;
-  input output Expression rhs;
+function typeConnector
+  input output Expression connExp;
   input ExpOrigin.Type origin;
   input SourceInfo info;
-        output Type tyLHS;
-        output Variability variabilityLHS;
-        output Type tyRHS;
-        output Variability variabilityRHS;
+        output Type ty;
 algorithm
-  // first, try to type both of them, they might already exist
-  try
-    (lhs, tyLHS, variabilityLHS) := typeExp(lhs, origin, info);
-    (rhs, tyRHS, variabilityRHS) := typeExp(rhs, origin, info);
-    return;
-  else
-    // do nothing, continue
-  end try;
-
-  // lhs existing, type it and use it!
-  if InstNode.isConnector(ComponentRef.node(Expression.toCref(lhs))) then
-    (lhs, tyLHS, variabilityLHS) := typeExp(lhs, origin, info);
-    tyRHS := tyLHS;
-    variabilityRHS := variabilityLHS;
-    rhs := updateVirtualCrefExp(rhs, lhs, tyLHS, variabilityLHS);
-    return;
-  end if;
-
-  // rhs existing, reuse the case above
-  (rhs, lhs, tyRHS, variabilityRHS, tyLHS, variabilityLHS) := typeExpandableConnectors(rhs, lhs, origin, info);
-
-  if InstNode.hasParentExpandableConnector(ComponentRef.node(Expression.toCref(rhs))) or
-     InstNode.hasParentExpandableConnector(ComponentRef.node(Expression.toCref(rhs)))
-  then
-    // error, we don't handle this case yet!
-  end if;
-end typeExpandableConnectors;
-
-function updateVirtualCrefExp
-  input output Expression virtual;
-  input Expression existing;
-  input Type ty;
-  input Variability var;
-protected
-  ComponentRef v, e;
-algorithm
-  virtual := match(virtual, existing)
-    case (Expression.CREF(_, v), Expression.CREF(_, e)) then Expression.CREF(ty, updateVirtualCref(v, e, ty, var));
-  end match;
-end updateVirtualCrefExp;
-
-function updateVirtualCref
-  input output ComponentRef virtual;
-  input ComponentRef existing;
-  input Type ty;
-  input Variability var;
-protected
-  InstNode e;
-algorithm
- virtual := match (virtual, existing)
-      case (ComponentRef.CREF(), ComponentRef.CREF())
-        algorithm
-          virtual.ty := existing.ty;
-          // set the correct parrent
-          e := InstNode.setParent(existing.node, ComponentRef.node(virtual.restCref));
-          // change the name!
-          e := InstNode.rename(InstNode.name(virtual.node), e);
-          virtual.node := e;
-          virtual.origin := existing.origin;
-        then
-          virtual;
-
-    end match;
-end updateVirtualCref;
+  (connExp, ty, _) := typeExp(connExp, origin, info);
+  checkConnector(connExp, info);
+end typeConnector;
 
 function checkConnector
   input Expression connExp;
   input SourceInfo info;
 protected
-  ComponentRef cr, rest_cr;
+  ComponentRef cr;
 algorithm
   () := match connExp
     case Expression.CREF(cref = cr as ComponentRef.CREF(origin = Origin.CREF))
       algorithm
         if not InstNode.isConnector(cr.node) then
-          if not InstNode.hasParentExpandableConnector(cr.node) then
-            Error.addSourceMessage(Error.INVALID_CONNECTOR_TYPE,
-              {ComponentRef.toString(cr)}, info);
-            fail();
-          end if;
+          Error.addSourceMessageAndFail(Error.INVALID_CONNECTOR_TYPE,
+            {ComponentRef.toString(cr)}, info);
         end if;
 
-        // expandable connectors can have the form eC.C.m, eC.m
-        if not InstNode.hasParentExpandableConnector(cr.node) then
-          checkConnectorForm(cr, info);
+        if not checkConnectorForm(cr) then
+          Error.addSourceMessageAndFail(Error.INVALID_CONNECTOR_FORM,
+            {ComponentRef.toString(cr)}, info);
         end if;
       then
         ();
@@ -2634,25 +2522,17 @@ function checkConnectorForm
   "Helper function for checkConnector. Checks that a connector cref uses the
    correct form, i.e. either c1.c2...cn or m.c."
   input ComponentRef cref;
-  input SourceInfo info;
-  input Boolean foundConnector = true;
+  input Boolean isConnector = true;
+  output Boolean valid;
 algorithm
-  () := match cref
+  valid := match cref
+    // The only part of the connector reference allowed to not be a
+    // non-connector is the very last part.
     case ComponentRef.CREF(origin = Origin.CREF)
-      algorithm
-        // The only part of the connector reference allowed to not be a
-        // non-connector is the very last part.
-        if not foundConnector then
-          Error.addSourceMessage(Error.INVALID_CONNECTOR_FORM,
-            {ComponentRef.toString(cref)}, info);
-          fail();
-        end if;
+      then if isConnector then
+        checkConnectorForm(cref.restCref, InstNode.isConnector(cref.node)) else false;
 
-        checkConnectorForm(cref.restCref, info, InstNode.isConnector(cref.node));
-      then
-        ();
-
-    else ();
+    else true;
   end match;
 end checkConnectorForm;
 

--- a/Compiler/NFFrontEnd/NFVariable.mo
+++ b/Compiler/NFFrontEnd/NFVariable.mo
@@ -37,6 +37,7 @@ encapsulated uniontype NFVariable
   import NFInstNode.InstNode;
   import NFPrefixes.Visibility;
   import NFPrefixes.Variability;
+  import NFPrefixes.ConnectorType;
   import Type = NFType;
 
 protected
@@ -89,6 +90,21 @@ public
     input Variable variable;
     output Boolean isEmpty = Type.isEmptyArray(variable.ty);
   end isEmptyArray;
+
+  function isDeleted
+    input Variable variable;
+    output Boolean deleted;
+  protected
+    InstNode node;
+  algorithm
+    node := ComponentRef.node(variable.name);
+    deleted := InstNode.isComponent(node) and Component.isDeleted(InstNode.component(node));
+  end isDeleted;
+
+  function isPresent
+    input Variable variable;
+    output Boolean present = not ConnectorType.isPotentiallyPresent(variable.attributes.connectorType);
+  end isPresent;
 
   function toString
     input Variable var;

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -816,6 +816,8 @@ public constant Message NO_SUCH_INPUT_PARAMETER = MESSAGE(343, TRANSLATION(), ER
   Util.gettext("Function %s has no input parameter named %s."));
 public constant Message INVALID_REDUCTION_TYPE = MESSAGE(344, TRANSLATION(), ERROR(),
   Util.gettext("Invalid expression ‘%s‘ of type %s in %s reduction, expected %s."));
+public constant Message INVALID_COMPONENT_PREFIX = MESSAGE(345, TRANSLATION(), ERROR(),
+  Util.gettext("Prefix ‘%s‘ on component ‘%s‘ not allowed in class specialization ‘%s‘."));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -310,6 +310,7 @@ if true then /* Suppress output */
     "../NFFrontEnd/NFEvalConstants.mo",
     "../NFFrontEnd/NFEvalFunction.mo",
     "../NFFrontEnd/NFEvalFunctionExt.mo",
+    "../NFFrontEnd/NFExpandableConnectors.mo",
     "../NFFrontEnd/NFExpandExp.mo",
     "../NFFrontEnd/NFExpression.mo",
     "../NFFrontEnd/NFExpressionIterator.mo",


### PR DESCRIPTION
- Added new module ExpandableConnectors that handles expandable
  connections.
- Changed Prefixes.ConnectorType from an enumeration into a bit field,
  so that it also can keep track of whether something is a connector,
  expandable connector, or expandable connector element.
- Fixed connector form error message so that the whole connector name is
  printed out.
- Changed OCConnectionGraph.handleOverconstrainedConnections to take a
  Connections record, so it only needs to be created once and so that
  expandable connector can be handled first.

- Removed the list of broken equations from Equation.CONNECT since it
  wasn't used.