### PR TITLE
Rename System.stringHashDjb2Mod alias.

### DIFF
--- a/Compiler/BackEnd/BinaryTree.mo
+++ b/Compiler/BackEnd/BinaryTree.mo
@@ -118,7 +118,7 @@ protected
   Integer keyhash;
 algorithm
   keystr := ComponentReference.printComponentRefStr(key);
-  keyhash := System.stringHashDjb2Mod(keystr,BaseHashTable.hugeBucketSize);
+  keyhash := stringHashDjb2Mod(keystr,BaseHashTable.hugeBucketSize);
   v := treeGet3(bt, keystr, keyhash, treeGet2(bt, keystr, keyhash));
 end treeGet;
 
@@ -207,7 +207,7 @@ protected
 algorithm
   str := ComponentReference.printComponentRefStr(inKey);
   // We use modulo hashes in order to avoid problems with boxing/unboxing of integers in bootstrapped OMC
-  outBinTree := treeAdd2(inBinTree,inKey,System.stringHashDjb2Mod(str,BaseHashTable.hugeBucketSize),str,inValue);
+  outBinTree := treeAdd2(inBinTree,inKey,stringHashDjb2Mod(str,BaseHashTable.hugeBucketSize),str,inValue);
 end treeAdd;
 
 protected function treeAdd2 "author: PA

--- a/Compiler/BackEnd/Unit.mo
+++ b/Compiler/BackEnd/Unit.mo
@@ -182,7 +182,7 @@ protected
   String str;
 algorithm
   str := unit2string(inKey);
-  outHash := System.stringHashDjb2Mod(str, inMod);
+  outHash := stringHashDjb2Mod(str, inMod);
 end hashUnitMod;
 
 public function unitEqual

--- a/Compiler/FrontEnd/Patternm.mo
+++ b/Compiler/FrontEnd/Patternm.mo
@@ -954,7 +954,7 @@ algorithm
 
     case (DAE.PAT_CONSTANT(exp=DAE.SCONST(str))::pats,_,_,_,_)
       equation
-        ix = System.stringHashDjb2Mod(str,65536);
+        ix = stringHashDjb2Mod(str,65536);
         false = listMember(ix,ixs);
         (ty,extraarg) = findPatternToConvertToSwitch2(pats,ix::ixs,DAE.T_STRING_DEFAULT,allSubPatternsMatch,numPatternsInMatrix);
       then (ty,extraarg);

--- a/Compiler/NFFrontEnd/NFCardinalityTable.mo
+++ b/Compiler/NFFrontEnd/NFCardinalityTable.mo
@@ -72,7 +72,7 @@ encapsulated package NFCardinalityTable
     input Integer size;
     output Table table;
   algorithm
-    table := BaseHashTable.emptyHashTableWork(size, (System.stringHashDjb2Mod, stringEq, Util.id, intString));
+    table := BaseHashTable.emptyHashTableWork(size, (stringHashDjb2Mod, stringEq, Util.id, intString));
   end emptyCardinalityTable;
 
   function fromConnections

--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -660,7 +660,7 @@ public
   function hash
     input ComponentRef cref;
     input Integer mod;
-    output Integer hash = System.stringHashDjb2Mod(toString(cref), mod);
+    output Integer hash = stringHashDjb2Mod(toString(cref), mod);
   end hash;
 
   function toPath

--- a/Compiler/NFFrontEnd/NFHashTableStringToUnit.mo
+++ b/Compiler/NFFrontEnd/NFHashTableStringToUnit.mo
@@ -109,7 +109,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size, (System.stringHashDjb2Mod, stringEq, Util.id, NFUnit.unit2string));
+  hashTable := BaseHashTable.emptyHashTableWork(size, (stringHashDjb2Mod, stringEq, Util.id, NFUnit.unit2string));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/Compiler/NFFrontEnd/NFUnit.mo
+++ b/Compiler/NFFrontEnd/NFUnit.mo
@@ -182,7 +182,7 @@ protected
   String str;
 algorithm
   str := unit2string(inKey);
-  outHash := System.stringHashDjb2Mod(str, inMod);
+  outHash := stringHashDjb2Mod(str, inMod);
 end hashUnitMod;
 
 public function unitEqual

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -185,6 +185,12 @@ package builtin
     output TypeVar head;
   end listHead;
 
+  function stringHashDjb2Mod
+    input String str;
+    input Integer mod;
+    output Integer hash;
+  end stringHashDjb2Mod;
+
   uniontype SourceInfo "The Info attribute provides location information for elements and classes."
     record SOURCEINFO
       String fileName;
@@ -1492,12 +1498,6 @@ package System
     input String s;
     output Integer result;
   end unescapedStringLength;
-
-  function stringHashDjb2Mod
-    input String str;
-    input Integer mod;
-    output Integer hash;
-  end stringHashDjb2Mod;
 
   function escapedString
     input String unescapedString;

--- a/Compiler/Util/HashSetString.mo
+++ b/Compiler/Util/HashSetString.mo
@@ -88,7 +88,7 @@ public function emptyHashSetSized
   input Integer size;
   output HashSet hashSet;
 algorithm
-  hashSet := BaseHashSet.emptyHashSetWork(size,(System.stringHashDjb2Mod,stringEq,Util.id));
+  hashSet := BaseHashSet.emptyHashSetWork(size,(stringHashDjb2Mod,stringEq,Util.id));
 end emptyHashSetSized;
 
 annotation(__OpenModelica_Interface="util");

--- a/Compiler/Util/HashTable5.mo
+++ b/Compiler/Util/HashTable5.mo
@@ -88,7 +88,7 @@ protected
   String crstr;
 algorithm
   crstr := Dump.printComponentRefStr(cr);
-  res := System.stringHashDjb2Mod(crstr,mod);
+  res := stringHashDjb2Mod(crstr,mod);
 end hashFunc;
 
 public function emptyHashTable

--- a/Compiler/Util/HashTableCrToExp.mo
+++ b/Compiler/Util/HashTableCrToExp.mo
@@ -106,7 +106,7 @@ protected function calcHashValue
   input Integer imod;
   output Integer value;
 algorithm
-  value := System.stringHashDjb2Mod(ComponentReference.printComponentRefStr(cr),imod);
+  value := stringHashDjb2Mod(ComponentReference.printComponentRefStr(cr),imod);
 end calcHashValue;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/Compiler/Util/HashTableCrToExpOption.mo
+++ b/Compiler/Util/HashTableCrToExpOption.mo
@@ -118,7 +118,7 @@ protected function calcHashValue
   input Integer imod;
   output Integer value;
 algorithm
-  value := System.stringHashDjb2Mod(ComponentReference.printComponentRefStr(cr),imod);
+  value := stringHashDjb2Mod(ComponentReference.printComponentRefStr(cr),imod);
 end calcHashValue;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/Compiler/Util/HashTableStringToPath.mo
+++ b/Compiler/Util/HashTableStringToPath.mo
@@ -97,7 +97,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(System.stringHashDjb2Mod,stringEq,Util.id,Absyn.pathStringDefault));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(stringHashDjb2Mod,stringEq,Util.id,Absyn.pathStringDefault));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/Compiler/Util/HashTableStringToProgram.mo
+++ b/Compiler/Util/HashTableStringToProgram.mo
@@ -97,7 +97,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(System.stringHashDjb2Mod, stringEq, Util.id, dummyStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(stringHashDjb2Mod, stringEq, Util.id, dummyStr));
 end emptyHashTableSized;
 
 protected

--- a/Compiler/Util/HashTableStringToUnit.mo
+++ b/Compiler/Util/HashTableStringToUnit.mo
@@ -109,7 +109,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size, (System.stringHashDjb2Mod, stringEq, Util.id, Unit.unit2string));
+  hashTable := BaseHashTable.emptyHashTableWork(size, (stringHashDjb2Mod, stringEq, Util.id, Unit.unit2string));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="backend");

--- a/Compiler/Util/HashTableTypeToExpType.mo
+++ b/Compiler/Util/HashTableTypeToExpType.mo
@@ -96,7 +96,7 @@ protected
   DAE.Type t;
 algorithm
   //str := Types.printTypeStr(inTy);
-  //hash := System.stringHashDjb2Mod(str, hashMod);
+  //hash := stringHashDjb2Mod(str, hashMod);
   //print("hash: " + intString(hash) + " for " + str + "\n");
   (tt, _) := inTy;
   t := (tt, NONE());

--- a/SimulationRuntime/c/meta/meta_modelica_builtin.h
+++ b/SimulationRuntime/c/meta/meta_modelica_builtin.h
@@ -87,10 +87,6 @@ extern modelica_integer stringHashSdbm(metamodelica_string_const str);
 #define substring(X,Y,Z) boxptr_substring(threadData,X,mmc_mk_icon(Y),mmc_mk_icon(Z))
 extern modelica_metatype boxptr_substring(threadData_t *,metamodelica_string_const str, modelica_metatype start, modelica_metatype stop);
 
-#define System_stringHashDjb2Mod stringHashDjb2Mod
-#define boxptr_System_stringHashDjb2Mod boxptr_stringHashDjb2Mod
-#define boxvar_System_stringHashDjb2Mod boxvar_stringHashDjb2Mod
-
 extern modelica_metatype boxptr_stringHashDjb2Mod(threadData_t*,modelica_metatype v,modelica_metatype mod);
 
 /* List Operations */


### PR DESCRIPTION
- Replace all calls to System.stringHashDjb2Mod with the builtin
  stringHashDjb2Mod, and remove the alias in meta_modelica_builtin.h.