### PR TITLE
[NF] Fix Call.reductionDefaultValue.

### DIFF
--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -1681,6 +1681,11 @@ public
     end match;
   end toDAE;
 
+  function toDAEValueOpt
+    input Option<Expression> exp;
+    output Option<Values.Value> value = Util.applyOption(exp, toDAEValue);
+  end toDAEValueOpt;
+
   function toDAEValue
     input Expression exp;
     output Values.Value value;


### PR DESCRIPTION
- Return no default value for reductions of arrays. The array type might
  contain unknown dimensions in functions, and the old frontend does the
  same thing.