### PR TITLE
[NF] Restrict cardinality usage.

### DIFF
--- a/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -1281,6 +1281,15 @@ protected
     Function fn;
     InstNode node;
   algorithm
+    // cardinality may only be used in a condition of an assert or
+    // if-statement/equation (the specification says only if-statement,
+    // but e.g. the MSL only uses them in if-equations and asserts).
+    if not (ExpOrigin.flagSet(origin, ExpOrigin.CONDITION) and
+       (ExpOrigin.flagSet(origin, ExpOrigin.IF) or
+        ExpOrigin.flagSet(origin, ExpOrigin.ASSERT))) then
+      Error.addSourceMessageAndFail(Error.INVALID_CARDINALITY_CONTEXT, {}, info);
+    end if;
+
     Call.UNTYPED_CALL(ref = fn_ref, arguments = args, named_args = named_args) := call;
     assertNoNamedParams("cardinality", named_args, info);
 

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -818,6 +818,8 @@ public constant Message INVALID_REDUCTION_TYPE = MESSAGE(344, TRANSLATION(), ERR
   Util.gettext("Invalid expression ‘%s‘ of type %s in %s reduction, expected %s."));
 public constant Message INVALID_COMPONENT_PREFIX = MESSAGE(345, TRANSLATION(), ERROR(),
   Util.gettext("Prefix ‘%s‘ on component ‘%s‘ not allowed in class specialization ‘%s‘."));
+public constant Message INVALID_CARDINALITY_CONTEXT = MESSAGE(346, TRANSLATION(), ERROR(),
+  Util.gettext("cardinality may only be used in the condition of an if-statement/equation or an assert."));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),


### PR DESCRIPTION
- Implemented stricter checks for where cardinality is allowed to be
  used, to improve the user feedback.