### PR TITLE
[NF] Fix equation counting for _.

### DIFF
--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -262,7 +262,7 @@ public
       case CREF()
         then getSubscriptedType2(cref.restCref, Type.subscript(cref.ty, cref.subscripts));
       case EMPTY() then Type.UNKNOWN();
-      case WILD() then Type.ANY();
+      case WILD() then Type.UNKNOWN();
     end match;
   end getSubscriptedType;
 

--- a/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -2589,7 +2589,13 @@ algorithm
   end if;
 
   for ty2 in tyl2 loop
+    // Skip matching if the rhs is _.
+    if Type.isUnknown(ty2) then
+      continue;
+    end if;
+
     ty1 :: tyl1 := tyl1;
+
     (_, _, matchKind) := matchTypes(ty1, ty2, expression, allowUnknown);
 
     if matchKind <> MatchKind.EXACT then


### PR DESCRIPTION
- Set wildcard crefs (_) to be Type.UNKNOWN() instead of Type.ANY(),
  to avoid them being counted when counting equations.