### PR TITLE
[NF] Inner/outer fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/Compiler/NFFrontEnd/NFClassTree.mo
@@ -692,7 +692,7 @@ public
           algorithm
             node := InstNode.setNodeType(
               InstNodeType.BASE_CLASS(clsNode, InstNode.definition(node)), node);
-            (node, _, classCount, compCount) := instantiate(node);
+            (node, instance, classCount, compCount) := instantiate(node, instance, scope);
             cls.baseClass := node;
           then
             ();

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -362,6 +362,16 @@ uniontype InstNode
     end match;
   end isUserdefinedClass;
 
+  function isDerivedClass
+    input InstNode node;
+    output Boolean isDerived;
+  algorithm
+    isDerived := match node
+      case CLASS_NODE(nodeType = InstNodeType.DERIVED_CLASS()) then true;
+      else false;
+    end match;
+  end isDerivedClass;
+
   function isFunction
     input InstNode node;
     output Boolean isFunc;


### PR DESCRIPTION
- Fix lookup of inner components by instantiating the class tree of a
  derived class earlier, to make sure that the node inside the
  InstNodeType.BASE_CLASS() of the base class node points to the
  instance created by Inst.instClass and not the shared expanded node.
- Fix adding generated inner components when the class being
  instantiated is a short class definition.