### PR TITLE
[NF] Split TUPLE() := TUPLE() assigments.

### DIFF
--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -345,6 +345,16 @@ public
     end match;
   end isCref;
 
+  function isWildCref
+    input Expression exp;
+    output Boolean wild;
+  algorithm
+    wild := match exp
+      case CREF(cref = ComponentRef.WILD()) then true;
+      else false;
+    end match;
+  end isWildCref;
+
   function isCall
     input Expression exp;
     output Boolean isCall;


### PR DESCRIPTION
- Split assigments where both sides are tuple expressions after
  simplification into separate assigments, since the code generation
  expects it to be done.