### PR TITLE
[NF] Use explicit scope in InstNode.scopeName.

### DIFF
--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -510,7 +510,7 @@ uniontype InstNode
     "Returns the name of a scope, which in the case of a component is the name
      of the component's type, and for a class simply the name of the class."
     input InstNode node;
-    output String outName = name(classScope(node));
+    output String outName = name(classScope(explicitScope(node)));
   end scopeName;
 
   function typeName


### PR DESCRIPTION
- Use the explicit scope in InstNode.scopeName so that error messages
  give the correct scope when errors occur in e.g. for loops.