### PR TITLE
Add referencePointerString debug function.

### DIFF
--- a/Compiler/FrontEnd/MetaModelicaBuiltin.mo
+++ b/Compiler/FrontEnd/MetaModelicaBuiltin.mo
@@ -854,6 +854,14 @@ you can use referenceEq instead of structural equality (<a href=\"modelica://Met
 </html>"));
 end referenceEq;
 
+function referencePointerString<A>
+  "Returns the pointer address of a reference as a hexadecimal string that can
+   be used for debugging."
+  input A ref;
+  output String str;
+external "builtin";
+end referencePointerString;
+
 function clock
   "Use the diff to compare two time samples to each other. Not very accurate."
   output Real t;

--- a/SimulationRuntime/c/meta/meta_modelica_builtin.c
+++ b/SimulationRuntime/c/meta/meta_modelica_builtin.c
@@ -710,6 +710,14 @@ metamodelica_string referenceDebugString(modelica_metatype fnptr)
 }
 #endif
 
+metamodelica_string referencePointerString(modelica_metatype ptr)
+{
+  // 2 chars per byte + 3 for "0x" and null terminator.
+  char str[sizeof(void*)*2 + 3];
+  snprintf(str, sizeof(void*)*2 + 3, "%p", ptr);
+  return mmc_mk_scon(str);
+}
+
 const char* SourceInfo_SOURCEINFO__desc__fields[7] = {"fileName","isReadOnly","lineNumberStart","columnNumberStart","lineNumberEnd","columnNumberEnd","lastEditTime"};
 struct record_description SourceInfo_SOURCEINFO__desc = {
   "SourceInfo_SOURCEINFO",

--- a/SimulationRuntime/c/meta/meta_modelica_builtin.h
+++ b/SimulationRuntime/c/meta/meta_modelica_builtin.h
@@ -214,6 +214,7 @@ extern modelica_integer intMaxLit(void);
 
 extern modelica_boolean setStackOverflowSignal(modelica_boolean);
 extern metamodelica_string referenceDebugString(modelica_metatype fnptr);
+extern metamodelica_string referencePointerString(modelica_metatype ptr);
 
 #include "meta_modelica_builtin_boxvar.h"
 


### PR DESCRIPTION
- Add referencePointerString that returns the address of a reference
  as a string.