### PR TITLE
[NF] Fix ComponentRef.transferSubscripts.

### DIFF
--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -478,7 +478,7 @@ public
         then
           dstCref;
 
-      case (CREF(), CREF()) guard referenceEq(srcCref.node, dstCref.node)
+      case (CREF(), CREF()) guard InstNode.refEqual(srcCref.node, dstCref.node)
         algorithm
           cref := transferSubscripts(srcCref.restCref, dstCref.restCref);
         then


### PR DESCRIPTION
- Use InstNode.refEqual instead of referenceEq in transferSubscripts,
  since different nodes can point to the same component instance due
  to e.g. redeclare.