### PR TITLE
[NF] Merge redeclared attributes in correct order.

### DIFF
--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -776,7 +776,10 @@ uniontype InstNode
     input InstNode node;
     output InstNodeType nodeType;
   algorithm
-    CLASS_NODE(nodeType = nodeType) := node;
+    nodeType := match node
+      case CLASS_NODE() then node.nodeType;
+      case COMPONENT_NODE() then node.nodeType;
+    end match;
   end nodeType;
 
   function setNodeType


### PR DESCRIPTION
- Merge the attributes from the replaced component with the redeclare
  component before instantiating the redeclare component, so that the
  attributes are correctly propagated to the redeclare's children.