### PR TITLE
[NF] Try to detect instantiation loops.

### DIFF
--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -824,6 +824,8 @@ public constant Message VARIABLE_BINDING_DIMS_MISMATCH = MESSAGE(347, TRANSLATIO
   Util.gettext("Type mismatch in binding ‘%s = %s‘, expected array dimensions %s, got %s."));
 public constant Message MODIFIER_NON_ARRAY_TYPE_ERROR = MESSAGE(348, TRANSLATION(), ERROR(),
   Util.gettext("Non-array modification ‘%s‘ for array component ‘%s‘, possibly due to missing ‘each‘."));
+public constant Message INST_RECURSION_LIMIT_REACHED = MESSAGE(349, TRANSLATION(), ERROR(),
+  Util.gettext("Recursion limit reached while instantiating ‘%s‘."));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),


### PR DESCRIPTION
- Set a limit on the depth of the instance tree, to be able to give an
  error message instead of overflowing the stack when a model contains
  mutually dependent classes.