### PR TITLE
[NF] Real range fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFCeval.mo
+++ b/Compiler/NFFrontEnd/NFCeval.mo
@@ -753,7 +753,7 @@ algorithm
     result := {Expression.REAL(start)};
   else
     result := {Expression.REAL(stop)};
-    for i in steps-1:-1:1 loop
+    for i in steps-2:-1:1 loop
       result := Expression.REAL(start + i * step) :: result;
     end for;
     result := Expression.REAL(start) :: result;

--- a/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -398,7 +398,7 @@ function simplifyBinaryOp
   import NFOperator.Op;
 algorithm
   if Expression.isLiteral(exp1) and Expression.isLiteral(exp2) then
-    outExp := Ceval.evalBinaryOp(exp1, op, exp2);
+    outExp := Ceval.evalBinaryOp(ExpandExp.expand(exp1), op, ExpandExp.expand(exp2));
   else
     outExp := match op.op
       case Op.ADD then simplifyBinaryAdd(exp1, op, exp2);


### PR DESCRIPTION
- Fix constant evaluation of real ranges.
- Expand expressions in SimplifyExp.simplifyBinaryOp before delegating
  to Ceval.evalBinaryOp, since Ceval.evalBinaryOp doesn't handle ranges.