### PR TITLE
[NF] Function scoping improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -1034,13 +1034,12 @@ algorithm
   comp := InstNode.component(node);
 
   element := match comp
-    case Component.TYPED_COMPONENT(ty = ty, info = info)
+    case Component.TYPED_COMPONENT(ty = ty, info = info, attributes = attr)
       algorithm
         cref := ComponentRef.fromNode(node, ty);
         binding := Binding.toDAEExp(comp.binding);
         cls := InstNode.getClass(comp.classInst);
         ty_attr := list((Modifier.name(m), Modifier.binding(m)) for m in Class.getTypeAttributes(cls));
-        attr := comp.attributes;
         var_attr := convertVarAttributes(ty_attr, ty, attr);
       then
         makeDAEVar(cref, ty, binding, attr, InstNode.visibility(node), var_attr,

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -131,7 +131,7 @@ algorithm
 
   // Look up the class to instantiate and mark it as the root class.
   cls := Lookup.lookupClassName(classPath, top, Absyn.dummyInfo, checkAccessViolations = false);
-  cls := InstNode.setNodeType(InstNodeType.ROOT_CLASS(), cls);
+  cls := InstNode.setNodeType(InstNodeType.ROOT_CLASS(InstNode.EMPTY_NODE()), cls);
 
   // Initialize the storage for automatically generated inner elements.
   top := InstNode.setInnerOuterCache(top, CachedData.TOP_SCOPE(NodeTree.new(), cls));
@@ -799,7 +799,7 @@ algorithm
         Class.EXPANDED_DERIVED(baseClass = base_node) := InstNode.getClass(node);
 
         // Merge outer modifiers and attributes.
-        mod := Modifier.fromElement(InstNode.definition(node), {node}, InstNode.parent(node));
+        mod := Modifier.fromElement(InstNode.definition(node), {node}, InstNode.rootParent(node));
         outer_mod := Modifier.merge(outerMod, Modifier.addParent(node, cls.modifier));
         mod := Modifier.merge(outer_mod, mod);
         attrs := updateClassConnectorType(cls.restriction, cls.attributes);

--- a/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/Compiler/NFFrontEnd/NFInstNode.mo
@@ -79,6 +79,8 @@ uniontype InstNodeType
 
   record ROOT_CLASS
     "The root of the instance tree, i.e. the class that the instantiation starts from."
+    InstNode parent "The parent of the class, e.g. when instantiating a function
+                     in a component where the component is the parent.";
   end ROOT_CLASS;
 
   record NORMAL_COMP
@@ -583,6 +585,28 @@ uniontype InstNode
       else EMPTY_NODE();
     end match;
   end derivedParent;
+
+  function rootParent
+    input InstNode node;
+    output InstNode parent;
+  algorithm
+    parent := match node
+      case CLASS_NODE() then rootTypeParent(node.nodeType, node);
+      else parent(node);
+    end match;
+  end rootParent;
+
+  function rootTypeParent
+    input InstNodeType nodeType;
+    input InstNode node;
+    output InstNode parent;
+  algorithm
+    parent := match nodeType
+      case InstNodeType.ROOT_CLASS() guard not isEmpty(nodeType.parent) then nodeType.parent;
+      case InstNodeType.DERIVED_CLASS() then rootTypeParent(nodeType.ty, node);
+      else parent(node);
+    end match;
+  end rootTypeParent;
 
   function parentScope
     "Returns the parent scope of a node. In the case of a class this is simply


### PR DESCRIPTION
- Use the instance scope instead of the class scope when prefixing
  functions.
- Use the correct scope when instantiating derived function modifiers.