### PR TITLE
[NF] Improved parameter evaluation analysis.

### DIFF
--- a/Compiler/NFFrontEnd/NFBinding.mo
+++ b/Compiler/NFFrontEnd/NFBinding.mo
@@ -605,6 +605,24 @@ public
     end match;
   end mapExp;
 
+  function containsExp
+    input Binding binding;
+    input PredFunc predFn;
+    output Boolean res;
+
+    partial function PredFunc
+      input Expression exp;
+      output Boolean res;
+    end PredFunc;
+  algorithm
+    res := match binding
+      case UNTYPED_BINDING() then Expression.contains(binding.bindingExp, predFn);
+      case TYPED_BINDING()   then Expression.contains(binding.bindingExp, predFn);
+      case FLAT_BINDING()    then Expression.contains(binding.bindingExp, predFn);
+      case CEVAL_BINDING()   then Expression.contains(binding.bindingExp, predFn);
+      else false;
+    end match;
+  end containsExp;
 end Binding;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -826,7 +826,7 @@ uniontype Component
       return;
     end if;
 
-    fixed := fixed and Expression.isTrue(Binding.getTypedExp(binding));
+    fixed := fixed and Expression.isTrue(Binding.getExp(binding));
 
   end getFixedAttribute;
 

--- a/Compiler/NFFrontEnd/NFModifier.mo
+++ b/Compiler/NFFrontEnd/NFModifier.mo
@@ -479,6 +479,16 @@ public
     end match;
   end isEach;
 
+  function isFinal
+    input Modifier mod;
+    output Boolean isFinal;
+  algorithm
+    isFinal := match mod
+      case MODIFIER(finalPrefix = SCode.FINAL()) then true;
+      else false;
+    end match;
+  end isFinal;
+
   function map
     input output Modifier mod;
     input FuncT func;

--- a/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/Compiler/NFFrontEnd/NFSubscript.mo
@@ -316,6 +316,34 @@ public
     res := false;
   end listContainsExp;
 
+  function containsExpShallow
+    input Subscript subscript;
+    input Expression.ContainsPred func;
+    output Boolean res;
+  algorithm
+    res := match subscript
+      case UNTYPED() then func(subscript.exp);
+      case INDEX() then func(subscript.index);
+      case SLICE() then func(subscript.slice);
+      else false;
+    end match;
+  end containsExpShallow;
+
+  function listContainsExpShallow
+    input list<Subscript> subscripts;
+    input Expression.ContainsPred func;
+    output Boolean res;
+  algorithm
+    for s in subscripts loop
+      if containsExpShallow(s, func) then
+        res := true;
+        return;
+      end if;
+    end for;
+
+    res := false;
+  end listContainsExpShallow;
+
   function applyExp
     input Subscript subscript;
     input ApplyFunc func;


### PR DESCRIPTION
- Avoid evaluating parameters that are non-final or depend on non-final
  parameters when Evaluate=true or -d=evaluateAllParameters is used.
- Evaluate parameters that are both fixed and final if their bindings
  are also fixed and final.
- Propagate finalness from modifiers to components, to better exploit
  the above optimization.