### PR TITLE
[NF] Improve error checking of when-clauses.

### DIFF
--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -133,27 +133,45 @@ public
 	    ock := match ick
 	      local
 	        Expression i, ic, r, c, si, sm;
-	      case (INFERRED_CLOCK()) then DAE.INFERRED_CLOCK();
-	      case (INTEGER_CLOCK(i, r)) then DAE.INTEGER_CLOCK(Expression.toDAE(i), Expression.toDAE(r));
-	      case (REAL_CLOCK(i)) then DAE.REAL_CLOCK(Expression.toDAE(i));
-	      case (BOOLEAN_CLOCK(c, si)) then DAE.BOOLEAN_CLOCK(Expression.toDAE(c), Expression.toDAE(si));
-	      case (SOLVER_CLOCK(c, sm)) then DAE.SOLVER_CLOCK(Expression.toDAE(c), Expression.toDAE(sm));
+	      case INFERRED_CLOCK()     then DAE.INFERRED_CLOCK();
+	      case INTEGER_CLOCK(i, r)  then DAE.INTEGER_CLOCK(Expression.toDAE(i), Expression.toDAE(r));
+	      case REAL_CLOCK(i)        then DAE.REAL_CLOCK(Expression.toDAE(i));
+	      case BOOLEAN_CLOCK(c, si) then DAE.BOOLEAN_CLOCK(Expression.toDAE(c), Expression.toDAE(si));
+	      case SOLVER_CLOCK(c, sm)  then DAE.SOLVER_CLOCK(Expression.toDAE(c), Expression.toDAE(sm));
 	    end match;
 	  end toDAE;
 
-    function toString
+    function toDebugString
       input ClockKind ick;
       output String ock;
     algorithm
       ock := match ick
         local
           Expression i, ic, r, c, si, sm;
-        case (INFERRED_CLOCK()) then "INFERRED_CLOCK()";
-        case (INTEGER_CLOCK(i, r)) then "INTEGER_CLOCK(" + Expression.toString(i) + ", " + Expression.toString(r) + ")";
-        case (REAL_CLOCK(i)) then "REAL_CLOCK(" + Expression.toString(i) + ")";
-        case (BOOLEAN_CLOCK(c, si)) then "BOOLEAN_CLOCK(" + Expression.toString(c) + ", " + Expression.toString(si) + ")";
-        case (SOLVER_CLOCK(c, sm)) then "SOLVER_CLOCK(" + Expression.toString(c) + ", " + Expression.toString(sm) + ")";
+        case INFERRED_CLOCK()     then "INFERRED_CLOCK()";
+        case INTEGER_CLOCK(i, r)  then "INTEGER_CLOCK(" + Expression.toString(i) + ", " + Expression.toString(r) + ")";
+        case REAL_CLOCK(i)        then "REAL_CLOCK(" + Expression.toString(i) + ")";
+        case BOOLEAN_CLOCK(c, si) then "BOOLEAN_CLOCK(" + Expression.toString(c) + ", " + Expression.toString(si) + ")";
+        case SOLVER_CLOCK(c, sm)  then "SOLVER_CLOCK(" + Expression.toString(c) + ", " + Expression.toString(sm) + ")";
       end match;
+    end toDebugString;
+
+    function toString
+      input ClockKind ck;
+      output String str;
+    algorithm
+      str := match ck
+        local
+          Expression e1, e2;
+
+        case INFERRED_CLOCK()      then "";
+        case INTEGER_CLOCK(e1, e2) then Expression.toString(e1) + ", " + Expression.toString(e2);
+        case REAL_CLOCK(e1)        then Expression.toString(e1);
+        case BOOLEAN_CLOCK(e1, e2) then Expression.toString(e1) + ", " + Expression.toString(e2);
+        case SOLVER_CLOCK(e1, e2)  then Expression.toString(e1) + ", " + Expression.toString(e2);
+      end match;
+
+      str := "Clock(" + str + ")";
     end toString;
 	end ClockKind;
 
@@ -1480,7 +1498,7 @@ public
       case ENUM_LITERAL(ty = t as Type.ENUMERATION())
         then Absyn.pathString(t.typePath) + "." + exp.name;
 
-      case CLKCONST(clk) then "CLKCONST(" + ClockKind.toString(clk) + ")";
+      case CLKCONST(clk) then ClockKind.toString(clk);
 
       case CREF() then ComponentRef.toString(exp.cref);
       case TYPENAME() then Type.typenameString(Type.arrayElementType(exp.ty));

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -237,6 +237,16 @@ public
     end match;
   end isString;
 
+  function isClock
+    input Type ty;
+    output Boolean isClock;
+  algorithm
+    isClock := match ty
+      case CLOCK() then true;
+      else false;
+    end match;
+  end isClock;
+
   function isScalar
     input Type ty;
     output Boolean isScalar;

--- a/Compiler/NFFrontEnd/NFVerifyModel.mo
+++ b/Compiler/NFFrontEnd/NFVerifyModel.mo
@@ -1,0 +1,178 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Linköping University,
+ * Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3
+ * AND THIS OSMC PUBLIC LICENSE (OSMC-PL).
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES RECIPIENT'S
+ * ACCEPTANCE OF THE OSMC PUBLIC LICENSE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from Linköping University, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS
+ * OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated uniontype NFVerifyModel
+  import FlatModel = NFFlatModel;
+
+protected
+  import List;
+  import Error;
+  import BaseAvlSet;
+  import DAE;
+  import ElementSource;
+  import ExecStat.execStat;
+  import ComponentRef = NFComponentRef;
+  import Equation = NFEquation;
+  import Expression = NFExpression;
+
+public
+  function verify
+    input FlatModel flatModel;
+  algorithm
+    for eq in flatModel.equations loop
+      verifyEquation(eq);
+    end for;
+
+    execStat(getInstanceName());
+  end verify;
+
+protected
+  type CrefSet = CrefSetImpl.Tree;
+
+  encapsulated package CrefSetImpl
+    import BaseAvlSet;
+    import ComponentRef = NFComponentRef;
+    extends BaseAvlSet;
+
+    redeclare type Key = ComponentRef;
+
+    redeclare function extends keyStr
+    algorithm
+      outString := ComponentRef.toString(inKey);
+    end keyStr;
+
+    redeclare function extends keyCompare
+    algorithm
+      outResult := ComponentRef.compare(inKey1, inKey2);
+    end keyCompare;
+  end CrefSetImpl;
+
+  function verifyEquation
+    input Equation eq;
+  algorithm
+    () := match eq
+      case Equation.WHEN()
+        algorithm
+          verifyWhenEquation(eq.branches, eq.source);
+        then
+          ();
+
+      else ();
+    end match;
+  end verifyEquation;
+
+  function verifyWhenEquation
+    "Checks that each branch in a when-equation has the same set of crefs on the lhs."
+    input list<Equation.Branch> branches;
+    input DAE.ElementSource source;
+  protected
+    CrefSet crefs1, crefs2;
+    list<Equation.Branch> rest_branches;
+    list<Equation> body;
+  algorithm
+    // Only when-equation with more than one branch needs to be checked.
+    if List.hasOneElement(branches) then
+      return;
+    end if;
+
+    Equation.Branch.BRANCH(body = body) :: rest_branches := branches;
+    crefs1 := whenEquationBranchCrefs(body);
+
+    for branch in rest_branches loop
+      Equation.Branch.BRANCH(body = body) := branch;
+      crefs2 := whenEquationBranchCrefs(body);
+
+      if not CrefSet.isEqual(crefs1, crefs2) then
+        Error.addSourceMessage(Error.DIFFERENT_VARIABLES_SOLVED_IN_ELSEWHEN,
+          {}, ElementSource.getInfo(source));
+        fail();
+      end if;
+    end for;
+  end verifyWhenEquation;
+
+  function whenEquationBranchCrefs
+    "Helper function to verifyWhenEquation, returns the set of crefs that the
+     given list of equations contains on the lhs."
+    input list<Equation> eql;
+    output CrefSet crefs;
+  algorithm
+    crefs := CrefSet.new();
+
+    for eq in eql loop
+      crefs := match eq
+        case Equation.EQUALITY() then whenEquationEqualityCrefs(eq.lhs, crefs);
+        case Equation.IF()       then whenEquationIfCrefs(eq.branches, eq.source, crefs);
+      end match;
+    end for;
+  end whenEquationBranchCrefs;
+
+  function whenEquationEqualityCrefs
+    input Expression lhsExp;
+    input output CrefSet crefs;
+  algorithm
+    crefs := match lhsExp
+      case Expression.CREF() then CrefSet.add(crefs, lhsExp.cref);
+      case Expression.TUPLE()
+        then List.fold(lhsExp.elements, whenEquationEqualityCrefs, crefs);
+    end match;
+  end whenEquationEqualityCrefs;
+
+  function whenEquationIfCrefs
+    "Checks that the left-hand sides of the given if-equation branches consists
+     of the same set of crefs, and adds that set to the given set of crefs."
+    input list<Equation.Branch> branches;
+    input DAE.ElementSource source;
+    input output CrefSet crefs;
+  protected
+    CrefSet crefs1, crefs2;
+    list<Equation.Branch> rest_branches;
+    list<Equation> body;
+  algorithm
+    Equation.Branch.BRANCH(body = body) :: rest_branches := branches;
+    crefs1 := whenEquationBranchCrefs(body);
+
+    for branch in rest_branches loop
+      Equation.Branch.BRANCH(body = body) := branch;
+      crefs2 := whenEquationBranchCrefs(body);
+
+      // All the branches must have the same set of crefs on the lhs.
+      if not CrefSet.isEqual(crefs1, crefs2) then
+        Error.addSourceMessage(Error.WHEN_IF_VARIABLE_MISMATCH,
+          {}, ElementSource.getInfo(source));
+        fail();
+      end if;
+    end for;
+
+    crefs := CrefSet.join(crefs, crefs1);
+  end whenEquationIfCrefs;
+
+  annotation(__OpenModelica_Interface="frontend");
+end NFVerifyModel;

--- a/Compiler/Util/BaseAvlSet.mo
+++ b/Compiler/Util/BaseAvlSet.mo
@@ -175,6 +175,25 @@ algorithm
   end match;
 end isEmpty;
 
+function isEqual
+  input Tree tree1;
+  input Tree tree2;
+  output Boolean isEqual;
+algorithm
+  isEqual := match (tree1, tree2)
+    case (NODE(), NODE())
+      then tree1.height == tree2.height and
+           keyCompare(tree1.key, tree2.key) == 0 and
+           isEqual(tree1.left, tree2.left) and
+           isEqual(tree1.right, tree2.right);
+
+    case (LEAF(), LEAF())
+      then keyCompare(tree1.key, tree2.key) == 0;
+
+    else true;
+  end match;
+end isEqual;
+
 function listKeys
   "Converts the tree to a flat list of keys (in order)."
   input Tree inTree;

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -317,7 +317,7 @@ public constant Message NOT_ARRAY_TYPE_IN_FOR_STATEMENT = MESSAGE(93, TRANSLATIO
 public constant Message NON_CLASS_IN_COMP_FUNC_NAME = MESSAGE(94, TRANSLATION(), ERROR(),
   Util.gettext("Found non-class %s while looking for function via component. The only valid form is c.C1..CN.f where c is a scalar component and C1..CN are classes."));
 public constant Message DIFFERENT_VARIABLES_SOLVED_IN_ELSEWHEN = MESSAGE(95, SYMBOLIC(), ERROR(),
-  Util.gettext("The same variables must me solved in elsewhen clause as in the when clause."));
+  Util.gettext("The same variables must be solved in elsewhen clause as in the when clause."));
 public constant Message CLASS_IN_COMPOSITE_COMP_NAME = MESSAGE(96, TRANSLATION(), ERROR(),
   Util.gettext("Found class %s during lookup of composite component name '%s', expected component."));
 public constant Message MODIFIER_DECLARATION_TYPE_MISMATCH_ERROR = MESSAGE(97, TRANSLATION(), ERROR(),
@@ -826,6 +826,8 @@ public constant Message MODIFIER_NON_ARRAY_TYPE_ERROR = MESSAGE(348, TRANSLATION
   Util.gettext("Non-array modification ‘%s‘ for array component ‘%s‘, possibly due to missing ‘each‘."));
 public constant Message INST_RECURSION_LIMIT_REACHED = MESSAGE(349, TRANSLATION(), ERROR(),
   Util.gettext("Recursion limit reached while instantiating ‘%s‘."));
+public constant Message WHEN_IF_VARIABLE_MISMATCH = MESSAGE(350, TRANSLATION(), ERROR(),
+  Util.gettext("The branches of an if-equation inside a when-equation must have the same set of component references on the left-hand side."));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),

--- a/Compiler/boot/LoadCompilerSources.mos
+++ b/Compiler/boot/LoadCompilerSources.mos
@@ -353,6 +353,7 @@ if true then /* Suppress output */
     "../NFFrontEnd/NFHashTableCrToUnit.mo",
     "../NFFrontEnd/NFUnit.mo",
     "../NFFrontEnd/NFVariable.mo",
+    "../NFFrontEnd/NFVerifyModel.mo",
 
     "../Lexers/LexerJSON.mo",
     "../Lexers/LexerModelicaDiff.mo",


### PR DESCRIPTION
- Moved the check of equations inside when-equations from Inst to
  Typing, to allow skipping the check if the when is clocked.
- Mark lhs subscripts in when-equations as structural.
- Added check that clocked when doesn't have an elsewhen.
- Added check that non-clocked when doesn't have a clocked elsewhen.
- Made clocked when illegal in algorithm.
- Added new phase VerifyModel that checks for errors that can't be
  detected until after flattening and constant evaluation.
  It currently checks that each branch of a when-equation contains
  the same set of crefs.
- Implemented BaseAvlSet.isEqual.
- Renamed Expression.ClockKind.toString to toDebugString, and
  implemented new toString that doesn't leak implementation details.