### PR TITLE
Add more timers for solvers

### DIFF
--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -4104,7 +4104,15 @@ template evaluateDAEResiduals(list<list<SimEqSystem>> resEquations, String model
     int evalStages;
     data->simulationInfo->callStatistics.functionEvalDAE++;
 
+  #if !defined(OMC_MINIMAL_RUNTIME)
+    <% if profileFunctions() then "" else "if (measure_time_flag) " %>rt_tick(SIM_TIMER_DAE);
+  #endif
+
     <%eqCalls%>
+
+  #if !defined(OMC_MINIMAL_RUNTIME)
+    <% if profileFunctions() then "" else "if (measure_time_flag) " %>rt_accumulate(SIM_TIMER_DAE);
+  #endif
 
     TRACE_POP
     return 0;
@@ -4229,6 +4237,9 @@ template functionDAE(list<SimEqSystem> allEquationsPlusWhen, String modelNamePre
     TRACE_PUSH
     int equationIndexes[1] = {0};<%/*reinits may use equation indexes, even though it has no equation...*/%>
     <%addRootsTempArray()%>
+  #if !defined(OMC_MINIMAL_RUNTIME)
+    <% if profileFunctions() then "" else "if (measure_time_flag) " %>rt_tick(SIM_TIMER_DAE);
+  #endif !defined(OMC_MINIMAL_RUNTIME)
 
     data->simulationInfo->needToIterate = 0;
     data->simulationInfo->discreteCall = 1;
@@ -4237,6 +4248,9 @@ template functionDAE(list<SimEqSystem> allEquationsPlusWhen, String modelNamePre
     else fncalls %>
     data->simulationInfo->discreteCall = 0;
 
+  #if !defined(OMC_MINIMAL_RUNTIME)
+    <% if profileFunctions() then "" else "if (measure_time_flag) " %>rt_accumulate(SIM_TIMER_DAE);
+  #endif !defined(OMC_MINIMAL_RUNTIME)
     TRACE_POP
     return 0;
   }

--- a/SimulationRuntime/c/util/rtclock.h
+++ b/SimulationRuntime/c/util/rtclock.h
@@ -63,9 +63,11 @@ static inline double rt_tock(int ix) {return 0.0;}
 #define SIM_TIMER_RESIDUALS      9
 #define SIM_TIMER_ALGEBRAICS     10
 #define SIM_TIMER_ZC             11
-#define SIM_TIMER_INIT_XML       12
-#define SIM_TIMER_INFO_XML       13
-#define SIM_TIMER_FIRST_FUNCTION 14
+#define SIM_TIMER_SOLVER         12
+#define SIM_TIMER_INIT_XML       13
+#define SIM_TIMER_INFO_XML       14
+#define SIM_TIMER_DAE            15
+#define SIM_TIMER_FIRST_FUNCTION 16
 
 #define SIM_PROF_TICK_FN(ix) rt_tick(ix+SIM_TIMER_FIRST_FUNCTION)
 #define SIM_PROF_ACC_FN(ix) rt_accumulate(ix+SIM_TIMER_FIRST_FUNCTION)


### PR DESCRIPTION
- dassl, ida, euler, rungekutta (default) now have a timer for
  the solver itself to separate generated and solver code slightly.
- Added timer for functionDAE