### PR TITLE
[NF] Fix when-branch cref set check.

### DIFF
--- a/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -568,6 +568,18 @@ public
     end match;
   end isEqual;
 
+  function isLess
+    input ComponentRef cref1;
+    input ComponentRef cref2;
+    output Boolean isLess = compare(cref1, cref2) < 0;
+  end isLess;
+
+  function isGreater
+    input ComponentRef cref1;
+    input ComponentRef cref2;
+    output Boolean isGreater = compare(cref1, cref2) > 0;
+  end isGreater;
+
   function isPrefix
     input ComponentRef cref1;
     input ComponentRef cref2;

--- a/Compiler/Util/BaseAvlSet.mo
+++ b/Compiler/Util/BaseAvlSet.mo
@@ -175,25 +175,6 @@ algorithm
   end match;
 end isEmpty;
 
-function isEqual
-  input Tree tree1;
-  input Tree tree2;
-  output Boolean isEqual;
-algorithm
-  isEqual := match (tree1, tree2)
-    case (NODE(), NODE())
-      then tree1.height == tree2.height and
-           keyCompare(tree1.key, tree2.key) == 0 and
-           isEqual(tree1.left, tree2.left) and
-           isEqual(tree1.right, tree2.right);
-
-    case (LEAF(), LEAF())
-      then keyCompare(tree1.key, tree2.key) == 0;
-
-    else true;
-  end match;
-end isEqual;
-
 function listKeys
   "Converts the tree to a flat list of keys (in order)."
   input Tree inTree;


### PR DESCRIPTION
- Use lists instead of AVL trees for the sets, since the order of
  insertion changes the structure of the trees such that structural
  equality can't be used for the check.
- Remove BaseAvlSet.isEqual, it's no longer needed and might be
  misleading due to only checking structural equality.