### PR TITLE
[NF] More fixes for checking when-clauses.

### DIFF
--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -161,8 +161,6 @@ algorithm
   flat_model := SimplifyModel.simplify(flat_model);
   funcs := Flatten.collectFunctions(flat_model, name);
 
-  VerifyModel.verify(flat_model);
-
   // Collect package constants that couldn't be substituted with their values
   // (e.g. because they where used with non-constant subscripts), and add them
   // to the model.
@@ -175,6 +173,8 @@ algorithm
     // Remove empty arrays from variables
     flat_model.variables := List.filterOnFalse(flat_model.variables, Variable.isEmptyArray);
   end if;
+
+  VerifyModel.verify(flat_model);
 
   // Convert the flat model to a DAE.
   (dae, daeFuncs) := ConvertDAE.convert(flat_model, funcs, name, InstNode.info(inst_cls));

--- a/Compiler/NFFrontEnd/NFTyping.mo
+++ b/Compiler/NFFrontEnd/NFTyping.mo
@@ -2943,8 +2943,8 @@ algorithm
 
   // The first argument must be a continuous time variable.
   // Check the variability of the cref instead of the variability returned by
-  // typeExp, since expressions in when-equation count as discrete.
-  if ComponentRef.nodeVariability(cref) <> Variability.CONTINUOUS then
+  // typeExp, since expressions in when-equations count as discrete.
+  if ComponentRef.nodeVariability(cref) < Variability.IMPLICITLY_DISCRETE then
     Error.addSourceMessage(Error.REINIT_MUST_BE_VAR,
       {Expression.toString(crefExp),
        Prefixes.variabilityString(ComponentRef.nodeVariability(cref))}, info);


### PR DESCRIPTION
- Handle all kinds of equations when checking when-clauses.
- Make the componentref set check more robust.
- Fix variability check for reinit.
- Do model verification after scalarization, it takes a negligible
  amount of time anyway.