### PR TITLE
Use Autoconf.mo instead of external C functions

### DIFF
--- a/Compiler/BackEnd/OpenTURNS.mo
+++ b/Compiler/BackEnd/OpenTURNS.mo
@@ -46,6 +46,7 @@ import DAE;
 
 protected
 import Array;
+import Autoconf;
 import BackendDAEOptimize;
 import BackendDAEUtil;
 import BackendEquation;
@@ -221,7 +222,7 @@ algorithm
   // varLst := listReverse(varLst);
   inputs := stringDelimitList(generateXMLLibraryInputs(varLst),"\n");
   outputs := stringDelimitList(generateXMLLibraryOutputs(varLst),"\n");
-  dllStr := " <path>" + className + cStrWrapperSuffix + System.getDllExt() + "</path>";
+  dllStr := " <path>" + className + cStrWrapperSuffix + Autoconf.dllExt + "</path>";
   funcStr := "   <function provided=\"yes\">" + className + cStrWrapperSuffix + "</function>";
 
   content :=stringDelimitList({

--- a/Compiler/Main/Main.mo
+++ b/Compiler/Main/Main.mo
@@ -42,6 +42,7 @@ encapsulated package Main
 
 protected
 import Absyn;
+import Autoconf;
 import BackendDAE;
 import BackendDAECreate;
 import BackendDAEUtil;
@@ -764,9 +765,9 @@ algorithm
   // 150M for Windows, 300M for others makes the GC try to unmap less and so it crashes less.
   // Disabling unmap is another alternative that seems to work well (but could cause the memory consumption to not be released, and requires manually calling collect and unmap
   if true then
-    GC.setForceUnmapOnGcollect(if System.os() == "Windows_NT" then true else false);
+    GC.setForceUnmapOnGcollect(if Autoconf.os == "Windows_NT" then true else false);
   else
-    GC.expandHeap(if System.os() == "Windows_NT"
+    GC.expandHeap(if Autoconf.os == "Windows_NT"
                       then 1024*1024*150
                       else 1024*1024*300);
   end if;
@@ -844,7 +845,7 @@ algorithm
   // Setup mingw path only once
   // adrpo: NEVER MOVE THIS CASE FROM HERE OR PUT ANY OTHER CASES BEFORE IT
   //        without asking Adrian.Pop@liu.se
-  if System.os() == "Windows_NT" then
+  if Autoconf.os == "Windows_NT" then
     setWindowsPaths(Settings.getInstallationDirectoryPath());
   end if;
 

--- a/Compiler/Script/CevalScript.mo
+++ b/Compiler/Script/CevalScript.mo
@@ -224,11 +224,11 @@ protected
   String omhome = Settings.getInstallationDirectoryPath(),omhome_1 = System.stringReplace(omhome, "\"", "");
   String pd = System.pathDelimiter();
   String cdWorkingDir,setMakeVars,libsfilename,libs_str,s_call,filename,winCompileMode,workDir = (if stringEq(workingDir, "") then "" else workingDir + pd);
-  String fileDLL = workDir + fileprefix + System.getDllExt(),
-         fileEXE = workDir + fileprefix + System.getExeExt(),
+  String fileDLL = workDir + fileprefix + Autoconf.dllExt,
+         fileEXE = workDir + fileprefix + Autoconf.exeExt,
          fileLOG = workDir + fileprefix + ".log";
   Integer numParallel,res;
-  Boolean isWindows = System.os() == "Windows_NT";
+  Boolean isWindows = Autoconf.os == "Windows_NT";
   list<String> makeVarsNoBinding;
 algorithm
   libsfilename := fileprefix + ".libs";
@@ -252,7 +252,7 @@ algorithm
     numParallel := if Config.getRunningTestsuite() then 1 else Config.noProc();
     cdWorkingDir := if stringEmpty(workingDir) then "" else (" -C \"" + workingDir + "\"");
     setMakeVars := sum(" "+var for var in makeVarsNoBinding);
-    s_call := stringAppendList({System.getMakeCommand()," -j",intString(numParallel),cdWorkingDir," -f ",fileprefix,".makefile",setMakeVars});
+    s_call := stringAppendList({Autoconf.make," -j",intString(numParallel),cdWorkingDir," -f ",fileprefix,".makefile",setMakeVars});
   end if;
   if Flags.isSet(Flags.DYN_LOAD) then
     Debug.traceln("compileModel: running " + s_call);
@@ -1692,11 +1692,11 @@ algorithm
                   "CONFIGURE_CMDLINE"};
         omhome = Settings.getInstallationDirectoryPath();
         omlib = Settings.getModelicaPath(Config.getRunningTestsuite());
-        omcpath = omhome + "/bin/omc" + System.getExeExt();
+        omcpath = omhome + "/bin/omc" + Autoconf.exeExt;
         systemPath = Util.makeValueOrDefault(System.readEnv,"PATH","");
         omdev = Util.makeValueOrDefault(System.readEnv,"OMDEV","");
         omcfound = System.regularFileExists(omcpath);
-        os = System.os();
+        os = Autoconf.os;
         touch_file = "omc.checksettings.create_file_test";
         usercflags = Util.makeValueOrDefault(System.readEnv,"MODELICAUSERCFLAGS","");
         workdir = System.pwd();
@@ -1705,7 +1705,7 @@ algorithm
         uname = System.readFile(touch_file);
         rm_res = 0 == System.systemCall("rm " + touch_file, "");
         // _ = System.platform();
-        senddata = System.getRTLibs();
+        senddata = Autoconf.ldflags_runtime;
         gcc = System.getCCompiler();
         have_corba = Corba.haveCorba();
         System.systemCall("rm -f " + touch_file, "");

--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -1608,7 +1608,7 @@ algorithm
         (b,cache,compileDir,executable,_,outputFormat_str,_,simflags,resultValues,vals) = buildModel(cache,env,vals,msg);
         if b then
           Values.REAL(linearizeTime) = getListNthShowError(vals,"try to get stop time",0,2);
-          executableSuffixedExe = stringAppend(executable, System.getExeExt());
+          executableSuffixedExe = stringAppend(executable, Autoconf.exeExt);
           logFile = stringAppend(executable,".log");
           if System.regularFileExists(logFile) then
             0 = System.removeFile(logFile);
@@ -2412,7 +2412,7 @@ algorithm
         pd = System.pathDelimiter();
         // create absolute path of simulation result file
         str1 = System.pwd() + pd + filename;
-        s1 = if System.os() == "Windows_NT" then ".exe" else "";
+        s1 = if Autoconf.os == "Windows_NT" then ".exe" else "";
         filename = if System.regularFileExists(str1) then str1 else filename;
         // check if plot callback is defined
         b = System.plotCallBackDefined();
@@ -2473,7 +2473,7 @@ algorithm
         pd = System.pathDelimiter();
         // create absolute path of simulation result file
         str1 = System.pwd() + pd + filename;
-        s1 = if System.os() == "Windows_NT" then ".exe" else "";
+        s1 = if Autoconf.os == "Windows_NT" then ".exe" else "";
         filename = if System.regularFileExists(str1) then str1 else filename;
         // check if plot callback is defined
         b = System.plotCallBackDefined();
@@ -2853,7 +2853,7 @@ algorithm
         pd = System.pathDelimiter();
         // create absolute path of simulation result file
         str1 = System.pwd() + pd + filename;
-        s1 = if System.os() == "Windows_NT" then ".exe" else "";
+        s1 = if Autoconf.os == "Windows_NT" then ".exe" else "";
         filename = if System.regularFileExists(str1) then str1 else filename;
         // check if plot callback is defined
         b = System.plotCallBackDefined();
@@ -2955,7 +2955,7 @@ algorithm
        then ".bat";
     case ("Cpp","WIN64")
        then ".bat";
-    else System.getExeExt();
+    else Autoconf.exeExt;
   end match;
  end getSimulationExtension;
 
@@ -3369,7 +3369,7 @@ algorithm
   if System.regularFileExists(logfile) then
     System.removeFile(logfile);
   end if;
-  nozip := System.getMakeCommand()+" -j"+intString(Config.noProc()) + " nozip";
+  nozip := Autoconf.make+" -j"+intString(Config.noProc()) + " nozip";
   includeDefaultFmi := "-I" + Settings.getInstallationDirectoryPath() + "/include/omc/c/fmi";
   finishedBuild := match Util.stringSplitAtChar(platform, " ")
     case {"dynamic"}
@@ -3378,9 +3378,9 @@ algorithm
         // replace @XX@ variables in the Makefile
         makefileStr := System.stringReplace(makefileStr, "@CC@", CC);
         makefileStr := System.stringReplace(makefileStr, "@CFLAGS@", CFLAGS);
-        makefileStr := System.stringReplace(makefileStr, "@LDFLAGS@", LDFLAGS+System.getRTLibsSim());
+        makefileStr := System.stringReplace(makefileStr, "@LDFLAGS@", LDFLAGS+Autoconf.ldflags_runtime_sim);
         makefileStr := System.stringReplace(makefileStr, "@LIBS@", "");
-        makefileStr := System.stringReplace(makefileStr, "@DLLEXT@", System.getDllExt());
+        makefileStr := System.stringReplace(makefileStr, "@DLLEXT@", Autoconf.dllExt);
         makefileStr := System.stringReplace(makefileStr, "@NEED_RUNTIME@", "");
         makefileStr := System.stringReplace(makefileStr, "@NEED_DGESV@", "");
         makefileStr := System.stringReplace(makefileStr, "@FMIPLATFORM@", System.modelicaPlatform());
@@ -3399,9 +3399,9 @@ algorithm
         // replace @XX@ variables in the Makefile
         makefileStr := System.stringReplace(makefileStr, "@CC@", CC);
         makefileStr := System.stringReplace(makefileStr, "@CFLAGS@", CFLAGS);
-        makefileStr := System.stringReplace(makefileStr, "@LDFLAGS@", LDFLAGS+" -lSimulationRuntimeFMI "+System.getRTLibsFMU());
+        makefileStr := System.stringReplace(makefileStr, "@LDFLAGS@", LDFLAGS+" -lSimulationRuntimeFMI "+Autoconf.ldflags_runtime_fmu);
         makefileStr := System.stringReplace(makefileStr, "@LIBS@", "");
-        makefileStr := System.stringReplace(makefileStr, "@DLLEXT@", System.getDllExt());
+        makefileStr := System.stringReplace(makefileStr, "@DLLEXT@", Autoconf.dllExt);
         makefileStr := System.stringReplace(makefileStr, "@NEED_RUNTIME@", "");
         makefileStr := System.stringReplace(makefileStr, "@NEED_DGESV@", "");
         makefileStr := System.stringReplace(makefileStr, "@FMIPLATFORM@", System.modelicaPlatform());
@@ -3518,7 +3518,7 @@ algorithm
 
   System.realtimeTick(ClockIndexes.RT_CLOCK_BUILD_MODEL);
 
-  isWindows := System.os() == "Windows_NT";
+  isWindows := Autoconf.os == "Windows_NT";
 
   fmutmp := filenameprefix + ".fmutmp";
   logfile := filenameprefix + ".log";
@@ -3583,7 +3583,7 @@ algorithm
     // get OPENMODELICAHOME
     omhome := Settings.getInstallationDirectoryPath();
     pd := System.pathDelimiter();
-    ext := if System.os() == "Windows_NT" then ".exe" else "";
+    ext := if Autoconf.os == "Windows_NT" then ".exe" else "";
     if encrypt then
       // create the path till packagetool
       packageTool := stringAppendList({omhome,pd,"lib",pd,"omc",pd,"SEMLA",pd,"packagetool",ext});

--- a/Compiler/Script/Figaro.mo
+++ b/Compiler/Script/Figaro.mo
@@ -1,12 +1,14 @@
 encapsulated package Figaro "Figaro support."
 
 // Imports
-public import Absyn;
-public import Error;
-public import SCode;
-public import System;
+import Absyn;
+import Error;
+import SCode;
+import SCodeUtil;
+protected
 
-protected import SCodeUtil;
+import Autoconf;
+import System;
 
 // Aliases
 public type Ident = Absyn.Ident;
@@ -55,7 +57,7 @@ algorithm
 
   // Temporary (or maybe permanent) fix because the Figaro processor works in an asynchronous way.
 
- if System.os() == "Windows_NT" then
+ if Autoconf.os == "Windows_NT" then
      System.systemCall("timeout 5");
  else
   System.systemCall("sleep 5");

--- a/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -39,6 +39,7 @@ import SimCodeVar;
 protected
 
 import Array;
+import Autoconf;
 import BaseHashTable;
 import CevalScript;
 import ComponentReference;
@@ -1773,10 +1774,10 @@ algorithm
         includes := generateExtFunctionIncludesIncludestr(mod);
         (libs, dirs, resources) := generateExtFunctionLibraryDirectoryFlags(program, path, mod, libs);
         for name in if Flags.isSet(Flags.CHECK_EXT_LIBS) then libNames else {} loop
-          if getGerneralTarget(target)=="msvc" or System.os()=="Windows_NT" then
-            fullLibNames := {name + System.getDllExt(), "lib" + name + ".a", "lib" + name + ".lib"};
+          if getGerneralTarget(target)=="msvc" or Autoconf.os=="Windows_NT" then
+            fullLibNames := {name + Autoconf.dllExt, "lib" + name + ".a", "lib" + name + ".lib"};
           else
-            fullLibNames := {"lib" + name + ".a", "lib" + name + System.getDllExt()};
+            fullLibNames := {"lib" + name + ".a", "lib" + name + Autoconf.dllExt};
           end if;
           lookForExtFunctionLibrary(fullLibNames, dirs, name, resources, path, info);
         end for;
@@ -1898,7 +1899,7 @@ algorithm
   libPaths := matchcontinue(uri,path,inLibs)
     local
       String str, platform1, platform2;
-  case(_, _,{"-lWinmm"}) guard System.os()=="Windows_NT"
+  case(_, _,{"-lWinmm"}) guard Autoconf.os=="Windows_NT"
     //Winmm has to be linked from the windows system but not from the resource directories.
     //This is a fix for M_DD since otherwise the dummy pthread.dll that breaks the built will be linked
     then {(Settings.getInstallationDirectoryPath() + "/lib/" + System.getTriple() + "/omc")};
@@ -1938,7 +1939,7 @@ algorithm
         end matchcontinue;
         str := CevalScript.getFullPathFromUri(program, str, false);
         resourcesStr := CevalScript.getFullPathFromUri(program, "modelica://" + Absyn.pathFirstIdent(path) + "/Resources", false);
-        isLinux := stringEq("linux",System.os());
+        isLinux := stringEq("linux",Autoconf.os);
         target := Flags.getConfigString(Flags.TARGET);
         // please, take care about ordering these libraries, the most specific should have the highest priority
         libs2 := getLinkerLibraryPaths(str, path, inLibs);
@@ -1997,7 +1998,7 @@ algorithm
         str = CevalScript.getFullPathFromUri(program, str, false);
         platform1 = System.openModelicaPlatform();
         platform2 = System.modelicaPlatform();
-        isLinux = stringEq("linux",System.os());
+        isLinux = stringEq("linux",Autoconf.os);
         // please, take care about ordering these libraries, the most specific should go first (in reverse here)
         libs = generateExtFunctionLibraryDirectoryPaths2(true, str, isLinux, {} );
         libs = generateExtFunctionLibraryDirectoryPaths2(not stringEq(platform2,""), str + "/" + platform2, isLinux, libs);
@@ -2009,7 +2010,7 @@ algorithm
         str = CevalScript.getFullPathFromUri(program, str, false);
         platform1 = System.openModelicaPlatform();
         platform2 = System.modelicaPlatform();
-        isLinux = stringEq("linux",System.os());
+        isLinux = stringEq("linux",Autoconf.os);
         // please, take care about ordering these libraries, the most specific should go first (in reverse here)
         libs = generateExtFunctionLibraryDirectoryPaths2(true, str, isLinux, {} );
         libs = generateExtFunctionLibraryDirectoryPaths2(not stringEq(platform2,""), str + "/" + platform2, isLinux, libs);
@@ -2060,7 +2061,7 @@ algorithm
     // omcruntime on windows needs linking with mico2313 and wsock and then some :)
     case Absyn.STRING("omcruntime")
       equation
-        true = "Windows_NT" == System.os();
+        true = "Windows_NT" == Autoconf.os;
         strs = {"f2c.lib", "initialization.lib", "libexpat.lib", "math-support.lib", "meta.lib", "ModelicaExternalC.lib", "results.lib", "simulation.lib", "solver.lib", "sundials_kinsol.lib", "sundials_nvecserial.lib", "util.lib", "lapack_win32_MT.lib"};
       then
         (strs, {});
@@ -2112,45 +2113,45 @@ algorithm
     case Absyn.STRING("Lapack") then ({},{});
 
     //pthreads is already linked under windows
-    case Absyn.STRING("pthread") guard System.os()=="Windows_NT"
+    case Absyn.STRING("pthread") guard Autoconf.os=="Windows_NT"
       equation
         Error.addCompilerNotification("pthreads library is already available. It is not linked from the external library resource directory.\n");
       then  ({},{});
 
    //do not link rt.dll for Modelica Device Drivers as it is not needed under windows
-    case Absyn.STRING("rt") guard System.os()=="Windows_NT"
+    case Absyn.STRING("rt") guard Autoconf.os=="Windows_NT"
       equation
         Error.addCompilerNotification("rt library is not needed under Windows. It is not linked from the external library resource directory.\n");
       then  ({},{});
 
    //do not link Ws2_32.dll for Modelica Device Drivers as it is not needed under windows
-    case Absyn.STRING("Ws2_32") guard System.os()=="Windows_NT"
+    case Absyn.STRING("Ws2_32") guard Autoconf.os=="Windows_NT"
       equation
         Error.addCompilerNotification("Ws2_32 library is not needed under Windows. It is not linked from the external library resource directory.\n");
       then  ({},{});
 
     //user32 is already linked under windows
-    case Absyn.STRING("User32") guard System.os()=="Windows_NT"
+    case Absyn.STRING("User32") guard Autoconf.os=="Windows_NT"
       equation
         Error.addCompilerNotification("User32 library is already available. It is not linked from the external library resource directory.\n");
       then  ({},{});
 
     //winmm is a windows system lib
-    case Absyn.STRING(str as "Winmm") guard System.os()=="Windows_NT"
+    case Absyn.STRING(str as "Winmm") guard Autoconf.os=="Windows_NT"
       equation
         str = "-l" + str;
         Error.addCompilerNotification("Winmm library is a windows system library. It is not linked from the external library resource directory.\n");
       then  ({str},{});
 
     //do not link X11.dll for Modelica Device Drivers as it is not needed under windows
-    case Absyn.STRING("X11") guard System.os()=="Windows_NT"
+    case Absyn.STRING("X11") guard Autoconf.os=="Windows_NT"
       equation
         Error.addCompilerNotification("X11 library is not needed under Windows. It is not linked from the external library resource directory.\n");
       then  ({},{});
 
     case Absyn.STRING(str as "omcruntime")
       equation
-        if "Windows_NT" == System.os() then
+        if "Windows_NT" == Autoconf.os then
           // omcruntime on windows needs linking with mico2313 and wsock and then some :)
           str = "-l" + str;
           strs = str :: "-lintl" :: "-liconv" :: "-lexpat" :: "-lsqlite3" :: "-llpsolve55" :: "-ltre" :: "-lomniORB420_rt" :: "-lomnithread40_rt" :: "-lws2_32" :: "-lRpcrt4" :: "-lregex" :: {};
@@ -2168,7 +2169,7 @@ algorithm
       then ({str},{});
 
     case Absyn.STRING("fmilib")
-      then (if System.os()=="Windows_NT" then {"-lfmilib","-lshlwapi"} else {"-lfmilib"},{});
+      then (if Autoconf.os=="Windows_NT" then {"-lfmilib","-lshlwapi"} else {"-lfmilib"},{});
 
     case Absyn.STRING(str)
       algorithm
@@ -2520,15 +2521,15 @@ algorithm
                  (if Flags.isSet(Flags.HPCOM) then System.getOMPCCompiler() else System.getCCompiler());
   cxxcompiler := if stringEq(Config.simCodeTarget(),"JavaScript") then "emcc" else System.getCXXCompiler();
   linker := if stringEq(Config.simCodeTarget(),"JavaScript") then "emcc" else System.getLinker();
-  exeext := if stringEq(Config.simCodeTarget(),"JavaScript") then ".js" else System.getExeExt();
-  dllext := System.getDllExt();
+  exeext := if stringEq(Config.simCodeTarget(),"JavaScript") then ".js" else Autoconf.exeExt;
+  dllext := Autoconf.dllExt;
   omhome := Settings.getInstallationDirectoryPath();
   omhome := System.trim(omhome, "\""); // Remove any quotation marks from omhome.
   cflags := System.getCFlags() + " " +
             (if Flags.isSet(Flags.HPCOM) then "-fopenmp" else "");
   cflags := if stringEq(Config.simCodeTarget(),"JavaScript") then "-Os -Wno-warn-absolute-paths" else cflags;
   ldflags := System.getLDFlags();
-  rtlibs := if isFunction then System.getRTLibs() else (if isFMU then System.getRTLibsFMU() else System.getRTLibsSim());
+  rtlibs := if isFunction then Autoconf.ldflags_runtime else (if isFMU then Autoconf.ldflags_runtime_fmu else Autoconf.ldflags_runtime_sim);
   platform := System.modelicaPlatform();
   compileDir :=  System.pwd() + System.pathDelimiter();
   makefileParams := SimCodeFunction.MAKEFILE_PARAMS(ccompiler, cxxcompiler, linker, exeext, dllext,

--- a/Compiler/SimCode/SimCodeMain.mo
+++ b/Compiler/SimCode/SimCodeMain.mo
@@ -54,6 +54,7 @@ import SimCode;
 
 // protected imports
 protected
+import Autoconf;
 import AvlSetString;
 import BackendDAECreate;
 import BackendDAEOptimize;
@@ -696,7 +697,7 @@ algorithm
         for path in simCode.modelInfo.resourcePaths loop
           dirname := System.dirname(path);
           // on windows, remove ":" from the path!
-          if System.os() == "Windows_NT" then
+          if Autoconf.os == "Windows_NT" then
             dirname := System.stringReplace(dirname, ":", "");
           end if;
           newdir := resourcesDir + dirname;

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -60,6 +60,7 @@ import Values;
 // protected imports
 protected
 import Array;
+import Autoconf;
 import AvlSetString;
 import BackendDAEOptimize;
 import BackendDAETransform;

--- a/Compiler/Util/Autoconf.mo.in
+++ b/Compiler/Util/Autoconf.mo.in
@@ -4,6 +4,14 @@ encapsulated package Autoconf
   constant String bstatic = if haveBStatic then "-Wl,-Bstatic" else "";
   constant String bdynamic = if haveBStatic then "-Wl,-Bdynamic" else "";
   constant String configureCommandLine = "Configured @date@ using arguments: @CONFIGURE_ARGS@";
+  constant String os = "@CONFIG_OS@";
+  constant String make = "@MAKE@";
+  constant String exeExt = "";
+  constant String dllExt = "@SHREXT@";
+  constant String ldflags_runtime = "@RT_LDFLAGS_GENERATED_CODE@";
+  constant String ldflags_runtime_sim = "@RT_LDFLAGS_GENERATED_CODE_SIM@";
+  constant String ldflags_runtime_fmu = "@RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU@";
+
 
 annotation(__OpenModelica_Interface="util");
 end Autoconf;

--- a/Compiler/Util/Autoconf.mo.omdev.mingw
+++ b/Compiler/Util/Autoconf.mo.omdev.mingw
@@ -3,6 +3,15 @@ encapsulated package Autoconf
   constant String bstatic = "-Wl,-Bstatic";
   constant String bdynamic = "-Wl,-Bdynamic";
   constant String configureCommandLine = "Manually created Makefiles for OMDev";
+  constant String os = "Windows_NT";
+  constant String make = "make";
+  constant String exeExt = ".exe";
+  constant String dllExt = ".dll";
+  constant String ldflags_basic = " -Wl,-Bstatic -lomcgc -lregex -ltre -lintl -liconv -lexpat -static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32 -llis -lumfpack -lklu -lcolamd -lbtf -lamd  -lsundials_idas -lsundials_kinsol -lsundials_nvecserial -lipopt -lcoinmumps -lpthread -lm -lgfortranbegin -lgfortran -lquadmath -lmingw32 -lgcc_eh -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32 -lopenblas -lcminpack -Wl,-Bdynamic";
+
+  constant String ldflags_runtime = " -lOpenModelicaRuntimeC" + ldflags_basic;
+  constant String ldflags_runtime_sim = " -Wl,-Bstatic -lSimulationRuntimeC -Wl,-Bdynamic" + ldflags_basic + " -lwsock32 -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic";
+  constant String ldflags_runtime_fmu = " -Wl,-Bstatic -lregex -ltre -lintl -liconv -static-libgcc -lpthread -lm -lgfortranbegin -lgfortran -lquadmath -lmingw32 -lgcc_eh -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32 -limagehlp -lopenblas -lhdf5 -lz -lszip -Wl,-Bdynamic";
 
 annotation(__OpenModelica_Interface="util");
 end Autoconf;

--- a/Compiler/Util/GraphStream.mo
+++ b/Compiler/Util/GraphStream.mo
@@ -47,6 +47,7 @@ public
 import Values;
 
 protected
+import Autoconf;
 import GraphStreamExt;
 import System;
 import Settings;
@@ -65,7 +66,7 @@ algorithm
         omhome = Settings.getInstallationDirectoryPath();
         commandWin = "start /b java -jar " + omhome + "/share/omc/java/org.omc.graphstream.jar";
         commandLinux = "java -jar " + omhome + "/share/omc/java/org.omc.graphstream.jar &";
-        command = if "Windows_NT" == System.os() then commandWin else commandLinux;
+        command = if "Windows_NT" == Autoconf.os then commandWin else commandLinux;
         status = System.systemCall(command, "");
         true = status == 0;
       then

--- a/Compiler/Util/System.mo
+++ b/Compiler/Util/System.mo
@@ -38,6 +38,9 @@ encapsulated package System
   This module contain a set of system calls, for e.g. compiling and
   executing stuff, reading and writing files and so on."
 
+protected
+import Autoconf;
+
 public function trim
 "removes chars in charsToRemove from begin and end of inString"
   input String inString;
@@ -252,24 +255,6 @@ public function getLDFlags
 
   external "C" outString=System_getLDFlags() annotation(Library = "omcruntime");
 end getLDFlags;
-
-public function getMakeCommand
-  output String outString;
-
-  external "C" outString=System_getMakeCommand() annotation(Library = "omcruntime");
-end getMakeCommand;
-
-public function getExeExt
-  output String outString;
-
-  external "C" outString=System_getExeExt() annotation(Library = "omcruntime");
-end getExeExt;
-
-public function getDllExt
-  output String outString;
-
-  external "C" outString=System_getDllExt() annotation(Library = "omcruntime");
-end getDllExt;
 
 public function getTriple "For example x86_64-linux-gnu; used to determine the location of lib-files"
   output String outString;
@@ -497,7 +482,7 @@ algorithm
   outBool := System.removeDirectory_dispatch(inString);
   // oh Windows crap: stat fails on very long paths!
   if (not outBool) then
-    if System.os() == "Windows_NT" then
+    if Autoconf.os == "Windows_NT" then
       // try rm as that somehow works on long paths
       outBool := (0 == System.systemCall("rm -r " + inString));
     end if;
@@ -574,16 +559,6 @@ using the asctime() function in time.h (libc)
   output String timeStr;
   external "C" timeStr=System_getCurrentTimeStr() annotation(Library = "omcruntime");
 end getCurrentTimeStr;
-
-public function os "Returns a string with the operating system name
-
-For linux: 'linux'
-For OSX: 'OSX'
-For Windows : 'Windows_NT' (the name of env var OS )
-"
-  output String str;
-  external "C" str = System_os() annotation(Library = "omcruntime");
-end os;
 
 public function readFileNoNumeric
   input String inString;
@@ -732,24 +707,6 @@ public function tmpTickMaximum
   output Integer maxIndex;
   external "C" maxIndex=SystemImpl_tmpTickMaximum(OpenModelica.threadData(),index) annotation(Library = "omcruntime");
 end tmpTickMaximum;
-
-public function getRTLibs
-"Returns a string containing the compiler flags used for real-time libraries"
-  output String libs;
-  external "C" libs=System_getRTLibs() annotation(Library = "omcruntime");
-end getRTLibs;
-
-public function getRTLibsSim
-"Returns a string containing the compiler flags used for simulation real-time libraries"
-  output String libs;
-  external "C" libs=System_getRTLibsSim() annotation(Library = "omcruntime");
-end getRTLibsSim;
-
-public function getRTLibsFMU
-"Returns a string containing the compiler flags used for source-code FMUs"
-  output String libs;
-  external "C" libs=System_getRTLibsFMU() annotation(Library = "omcruntime");
-end getRTLibsFMU;
 
 public function getCorbaLibs
 "Returns a string containing the compiler flags used for Corba libraries.

--- a/Compiler/Util/Util.mo
+++ b/Compiler/Util/Util.mo
@@ -84,14 +84,16 @@ public uniontype DateTime
   end DATETIME;
 end DateTime;
 
-protected import ClockIndexes;
-protected import Config;
-protected import Error;
-protected import Flags;
-protected import Global;
-protected import List;
-protected import Print;
-protected import System;
+protected
+import Autoconf;
+import ClockIndexes;
+import Config;
+import Error;
+import Flags;
+import Global;
+import List;
+import Print;
+import System;
 
 public constant SourceInfo dummyInfo = SOURCEINFO("",false,0,0,0,0,0.0);
 public constant String derivativeNamePrefix="$DER";
@@ -125,7 +127,7 @@ end isRealGreater;
 public function linuxDotSlash "If operating system is Linux/Unix, return a './', otherwise return empty string"
   output String str;
 algorithm
-  str := System.os();
+  str := Autoconf.os;
   str := if str == "linux" or str == "OSX" then "./" else "";
 end linuxDotSlash;
 
@@ -1001,7 +1003,7 @@ public function replaceWindowsBackSlashWithPathDelimiter
   input String inPath;
   output String outPath;
 algorithm
-  if System.os() == "Windows_NT" then
+  if Autoconf.os == "Windows_NT" then
     outPath := System.stringReplace(inPath, "\\", System.pathDelimiter());
   else
     outPath := inPath;
@@ -1618,7 +1620,7 @@ algorithm
 
     case (true,_)
       algorithm
-        newName := if System.os() == "Windows_NT" then System.stringReplace(name, "\\", "/") else name;
+        newName := if Autoconf.os == "Windows_NT" then System.stringReplace(name, "\\", "/") else name;
         (i,strs) := System.regex(newName, "^(.*/Compiler/)?(.*/testsuite/)?(.*/lib/omlibrary/)?(.*/build/)?(.*)$", 6, true, false);
         friendly := listGet(strs,i);
       then

--- a/Compiler/runtime/System_omc.c
+++ b/Compiler/runtime/System_omc.c
@@ -134,21 +134,6 @@ extern int System_realtimeNtick(int ix)
   return rt_ncall(ix);
 }
 
-extern const char* System_getRTLibs()
-{
-  return LDFLAGS_RT;
-}
-
-extern const char* System_getRTLibsSim()
-{
-  return LDFLAGS_RT_SIM;
-}
-
-extern const char* System_getRTLibsFMU()
-{
-  return LDFLAGS_RT_SOURCE_FMU;
-}
-
 extern const char* System_getCCompiler()
 {
   return cc;
@@ -177,21 +162,6 @@ extern const char* System_getLDFlags()
 extern const char* System_getCFlags()
 {
   return cflags;
-}
-
-extern const char* System_getExeExt()
-{
-  return CONFIG_EXE_EXT;
-}
-
-extern const char* System_getDllExt()
-{
-  return CONFIG_DLL_EXT;
-}
-
-extern const char* System_os()
-{
-  return CONFIG_OS;
 }
 
 extern const char* System_trim(const char* str, const char* chars_to_remove)
@@ -233,9 +203,44 @@ extern const char* System_dirname(const char* str)
 }
 
 #if defined(OPENMODELICA_BOOTSTRAPPING_STAGE_1)
+extern const char* System_getRTLibs()
+{
+  return "DUMMY RT LIBS";
+}
+
+extern const char* System_getRTLibsSim()
+{
+  return "DUMMY RT LIBS";
+}
+
+extern const char* System_getRTLibsFMU()
+{
+  return "DUMMY RT LIBS";
+}
+
+extern const char* System_getExeExt()
+{
+  return ".exe";
+}
+
+extern const char* System_getDllExt()
+{
+  return CONFIG_DLL_EXT;
+}
+
+extern const char* System_getMakeCommand()
+{
+  return "make";
+}
+
+extern const char* System_os()
+{
+  return "Windows_NT";
+}
+
 extern const char* System_configureCommandLine()
 {
-  return CONFIGURE_COMMANDLINE;
+  return "Dummy configure";
 }
 #endif
 
@@ -778,11 +783,6 @@ extern void System_getGCStatus(double *used, double *allocated)
 {
   *allocated = GC_get_heap_size();
   *used = *allocated - GC_get_free_bytes();
-}
-
-extern const char* System_getMakeCommand()
-{
-  return DEFAULT_MAKE;
 }
 
 extern const char* System_snprintff(const char *fmt, int len, double d)

--- a/Compiler/runtime/config.unix.h.in
+++ b/Compiler/runtime/config.unix.h.in
@@ -1,9 +1,5 @@
 /* @configure_input@ */
 #define CONFIGURE_COMMANDLINE "Configured @date@ using arguments: '@CONFIGURE_ARGS@'"
-#define LDFLAGS_RT "@RT_LDFLAGS_GENERATED_CODE@"
-#define LDFLAGS_RT_SIM "@RT_LDFLAGS_GENERATED_CODE_SIM@"
-#define LDFLAGS_RT_SOURCE_FMU "@RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU@"
-#define CONFIG_EXE_EXT ""
 #define CONFIG_DLL_EXT "@SHREXT@"
 #define CONFIG_PLATFORM "Unix"
 #define CONFIG_MODELICA_SPEC_PLATFORM "@MODELICA_SPEC_PLATFORM@"
@@ -12,7 +8,6 @@
 #define DEFAULT_CC "@RUNTIMECC@"
 #define DEFAULT_CXX "@CXX@"
 #define DEFAULT_OMPCC "@CC@ @OMPCFLAGS@"
-#define DEFAULT_MAKE "@MAKE@"
 #define DEFAULT_TRIPLE "@host_short@"
 
 #if defined(__sparc__)
@@ -27,7 +22,6 @@
 #endif
 
 #define DEFAULT_CFLAGS "@RUNTIMECFLAGS@ ${MODELICAUSERCFLAGS}"
-#define CONFIG_OS "@CONFIG_OS@"
 
 #define CONFIG_LPSOLVEINC "@LPSOLVEINC@"
 @NO_LPLIB@
@@ -73,7 +67,5 @@
 #if USE_GRAPH
 #define USE_PATOH @USE_PATOH@
 #define USE_METIS @USE_METIS@
-#define BDYNAMIC "@BDYNAMIC@"
-#define BSTATIC "@BSTATIC@"
 #endif
 @HAVE_GETTEXT@

--- a/Compiler/runtime/omc_config.h
+++ b/Compiler/runtime/omc_config.h
@@ -80,7 +80,6 @@
 #define DEFAULT_CC "gcc"
 #define DEFAULT_CXX "g++"
 #define DEFAULT_OMPCC "gcc -fopenmp"
-#define DEFAULT_MAKE "make"
 
 /* adrpo: add -loleaut32 as is used by ExternalMedia */
 #define DEFAULT_LDFLAGS "-fopenmp -Wl,-Bstatic -lregex -ltre -lintl -liconv -lexpat -lomcgc -lpthread -loleaut32 -limagehlp -lhdf5 -lz -lszip -Wl,-Bdynamic"
@@ -91,13 +90,7 @@
 #define CONFIG_DEFAULT_OPENMODELICAHOME NULL
 
 /* adrpo: add -loleaut32 as is used by ExternalMedia */
-#define BASIC_LDFLAGS_RT " -Wl,-Bstatic -lomcgc -lregex -ltre -lintl -liconv -lexpat -static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32 -llis -lumfpack -lklu -lcolamd -lbtf -lamd  -lsundials_idas -lsundials_kinsol -lsundials_nvecserial -lipopt -lcoinmumps -lpthread -lm -lgfortranbegin -lgfortran -lquadmath -lmingw32 -lgcc_eh -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32 -lopenblas -lcminpack -Wl,-Bdynamic"
-#define LDFLAGS_RT " -lOpenModelicaRuntimeC" BASIC_LDFLAGS_RT
-#define LDFLAGS_RT_SIM " -Wl,-Bstatic -lSimulationRuntimeC -Wl,-Bdynamic" BASIC_LDFLAGS_RT " -lwsock32 -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic"
-#define LDFLAGS_RT_SOURCE_FMU " -Wl,-Bstatic -lregex -ltre -lintl -liconv -static-libgcc -lpthread -lm -lgfortranbegin -lgfortran -lquadmath -lmingw32 -lgcc_eh -lmoldname -lmingwex -lmsvcrt -luser32 -lkernel32 -ladvapi32 -lshell32 -limagehlp -lopenblas -lhdf5 -lz -lszip -Wl,-Bdynamic"
-#define CONFIG_EXE_EXT ".exe"
 #define CONFIG_DLL_EXT ".dll"
-#define CONFIG_OS "Windows_NT"
 #define CONFIG_CORBALIBS "-L$(OPENMODELICAHOME)/lib/omc -lomniORB420_rt -lomnithread40_rt"
 #define CONFIG_LPSOLVEINC "lpsolve/lp_lib.h"
 /* Windows is always "special" */

--- a/Compiler/runtime/systemimpl.c
+++ b/Compiler/runtime/systemimpl.c
@@ -931,7 +931,7 @@ extern int SystemImpl__copyFile(const char *str_1, const char *str_2)
     }
   }
   if (rv == 0) {
-    const char *msg[2] = {strerror(errno), str_2, str_1};
+    const char *msg[3] = {strerror(errno), str_2, str_1};
     c_add_message(NULL,85,
       ErrorType_scripting,
       ErrorLevel_error,


### PR DESCRIPTION
This starts using Autoconf.mo for constants such as the dll extension.