### PR TITLE
Disable mmap in FMUs

### DIFF
--- a/SimulationRuntime/c/util/omc_mmap.h
+++ b/SimulationRuntime/c/util/omc_mmap.h
@@ -35,7 +35,12 @@
 extern "C" {
 #endif
 
+#include "../omc_simulation_settings.h"
 #include <stdio.h>
+
+#if !defined(HAVE_MMAP) && OMC_FMI_RUNTIME
+#define HAVE_MMAP 0
+#endif
 
 #if !defined(HAVE_MMAP)
 #if defined(unix) || defined(__APPLE__)


### PR DESCRIPTION
Some platforms are unreliable and might say mmap exists for one set of
includes and say it does not in another.