### PR TITLE
[NF] Various fixes.

### DIFF
--- a/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -121,7 +121,7 @@ public
       case Expression.CREF(cref = ComponentRef.CREF())
         algorithm
           if Type.hasZeroDimension(crefExp.ty) then
-            arrayExp := Expression.makeEmptyArray(Type.ARRAY(Type.arrayElementType(crefExp.ty), {Dimension.fromInteger(0)}));
+            arrayExp := Expression.makeEmptyArray(crefExp.ty);
             expanded := true;
           elseif Type.hasKnownSize(crefExp.ty) then
             subs := expandCref2(crefExp.cref);

--- a/Compiler/NFFrontEnd/NFExpression.mo
+++ b/Compiler/NFFrontEnd/NFExpression.mo
@@ -778,6 +778,7 @@ public
       case ENUM_LITERAL()    then exp.ty;
       case CLKCONST()        then Type.CLOCK();
       case CREF()            then exp.ty;
+      case TYPENAME()        then exp.ty;
       case ARRAY()           then exp.ty;
       case RANGE()           then exp.ty;
       case TUPLE()           then exp.ty;

--- a/Compiler/Util/Error.mo
+++ b/Compiler/Util/Error.mo
@@ -827,6 +827,8 @@ public constant Message INST_RECURSION_LIMIT_REACHED = MESSAGE(349, TRANSLATION(
   Util.gettext("Recursion limit reached while instantiating ‘%s‘."));
 public constant Message WHEN_IF_VARIABLE_MISMATCH = MESSAGE(350, TRANSLATION(), ERROR(),
   Util.gettext("The branches of an if-equation inside a when-equation must have the same set of component references on the left-hand side."));
+public constant Message DIMENSION_DEDUCTION_FROM_BINDING_FAILURE = MESSAGE(351, TRANSLATION(), ERROR(),
+  Util.gettext("Dimension %s of ‘%s‘ could not be deduced from the component's binding equation ‘%s‘."));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),


### PR DESCRIPTION
- Changed ExpandExp.expandCref to return an array with the same
  dimensions as the input cref, even when the cref's type has
  zero-dimensions.
- Added case for Expression.TYPENAME in Expression.typeOf.
- Added better error checking when deducing unknown dimensions.
- Added check for negative dimension sizes.