### PR TITLE
[NF] Don't evaluate external objects.

### DIFF
--- a/Compiler/NFFrontEnd/NFComponent.mo
+++ b/Compiler/NFFrontEnd/NFComponent.mo
@@ -697,6 +697,17 @@ uniontype Component
     output Boolean isConnector = ConnectorType.isExpandable(connectorType(component));
   end isExpandableConnector;
 
+  function isExternalObject
+    input Component component;
+    output Boolean isEO;
+  algorithm
+    isEO := match component
+      case UNTYPED_COMPONENT() then Class.isExternalObject(InstNode.getClass(component.classInst));
+      case TYPED_COMPONENT() then Type.isExternalObject(component.ty);
+      else false;
+    end match;
+  end isExternalObject;
+
   function isIdentical
     input Component comp1;
     input Component comp2;

--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -3270,6 +3270,9 @@ algorithm
     if not Component.getFixedAttribute(component) then
       // Except non-fixed parameters.
       isStructural := false;
+    elseif Component.isExternalObject(component) then
+      // Except external objects.
+      isStructural := false;
     elseif Binding.isUnbound(compBinding) then
       // Except parameters with no bindings.
       if not evalAllParams then
@@ -3344,6 +3347,7 @@ algorithm
             isNotFixed := false;
           elseif var == Variability.PARAMETER and
                  (not requireFinal or Component.isFinal(c)) and
+                 not Component.isExternalObject(c) and
                  Component.getFixedAttribute(c) then
             isNotFixed := isBindingNotFixed(Component.getBinding(c), requireFinal, depth + 1);
           else

--- a/Compiler/NFFrontEnd/NFType.mo
+++ b/Compiler/NFFrontEnd/NFType.mo
@@ -352,6 +352,16 @@ public
     end match;
   end isExpandableConnector;
 
+  function isExternalObject
+    input Type ty;
+    output Boolean isEO;
+  algorithm
+    isEO := match ty
+      case COMPLEX(complexTy = ComplexType.EXTERNAL_OBJECT()) then true;
+      else false;
+    end match;
+  end isExternalObject;
+
   function isRecord
     input Type ty;
     output Boolean isRecord;


### PR DESCRIPTION
- Ignore external objects when -d=evaluateAllParameters is used.