### PR TITLE
Handle uses-annotation according to the standard.

### DIFF
--- a/Compiler/Script/CevalScriptBackend.mo
+++ b/Compiler/Script/CevalScriptBackend.mo
@@ -3074,13 +3074,8 @@ algorithm
     // print(stringDelimitList(list(Absyn.pathString(path) for path in Interactive.getTopClassnames(p)), ",") + "\n");
     SymbolTable.setAbsyn(p);
   end try;
-  try
-    absynClass := Interactive.getPathedClassInProgram(className, p);
-  else
-    success := true; /* Let derived classes possibly be handled by runFrontEndWork */
-    return;
-  end try;
-  (p,success) := CevalScript.loadModel(Interactive.getUsesAnnotationOrDefault(Absyn.PROGRAM({absynClass},Absyn.TOP()), false),Settings.getModelicaPath(Config.getRunningTestsuite()),p,false,true,true,false);
+
+  (p,success) := CevalScript.loadModel(Interactive.getUsesAnnotationOrDefault(p, false),Settings.getModelicaPath(Config.getRunningTestsuite()),p,false,true,true,false);
   SymbolTable.setAbsyn(p);
   // Always update the SCode structure; otherwise the cache plays tricks on us
   SymbolTable.clearSCode();
@@ -3150,7 +3145,6 @@ algorithm
         re = Absyn.restrString(restriction);
         Error.assertionOrAddSourceMessage(relaxedFrontEnd or not (Absyn.isFunctionRestriction(restriction) or Absyn.isPackageRestriction(restriction)),
           Error.INST_INVALID_RESTRICTION,{str,re},Absyn.dummyInfo);
-        (p,true) = CevalScript.loadModel(Interactive.getUsesAnnotationOrDefault(Absyn.PROGRAM({absynClass},Absyn.TOP()), false),Settings.getModelicaPath(Config.getRunningTestsuite()),p,false,true,true,false);
 
         //System.stopTimer();
         //print("\nExists+Dependency: " + realString(System.getTimerIntervalTime()));

--- a/Compiler/Script/Interactive.mo
+++ b/Compiler/Script/Interactive.mo
@@ -11221,25 +11221,29 @@ algorithm
   end matchcontinue;
 end getNamedAnnotation;
 
+constant Absyn.Path USES_PATH = Absyn.Path.IDENT("uses");
+
 public function getUsesAnnotation
-"This function takes a Path and a Program and returns a comma separated
-  string of values for the Documentation annotation for the class named by the
-  first argument."
-  input Absyn.Program p;
-  output list<tuple<Absyn.Path,list<String>,Boolean>> usesStr;
+  "Returns the uses-annotations of the top-level classes in the given program."
+  input Absyn.Program program;
+  output list<Annotation> outUses = {};
+
+  type Annotation = tuple<Absyn.Path, list<String>, Boolean>;
+protected
+  Option<list<Annotation>> opt_uses;
+  list<Annotation> uses;
+  list<Absyn.Class> classes;
 algorithm
-  usesStr := matchcontinue (p)
-    local
-      Absyn.Class cdef;
+  Absyn.PROGRAM(classes = classes) := program;
 
-    case (Absyn.PROGRAM(classes={cdef}))
-      equation
-        SOME(usesStr) = Absyn.getNamedAnnotationInClass(cdef,Absyn.IDENT("uses"),getUsesAnnotationString);
-      then
-        usesStr;
+  for cls in classes loop
+    opt_uses := Absyn.getNamedAnnotationInClass(cls, USES_PATH, getUsesAnnotationString);
 
-    else {};
-  end matchcontinue;
+    if isSome(opt_uses) then
+      SOME(uses) := opt_uses;
+      outUses := listAppend(uses, outUses);
+    end if;
+  end for;
 end getUsesAnnotation;
 
 public function getUsesAnnotationOrDefault


### PR DESCRIPTION
- Only consider uses-annotations on top-level classes when deciding
  which models/libraries to load.