### PR TITLE
Allow parsing the Text(textColor = ...) annotation

### DIFF
--- a/Compiler/FrontEnd/Constants.mo
+++ b/Compiler/FrontEnd/Constants.mo
@@ -335,6 +335,7 @@ record Text
   Real extent[2,2]/*(each final unit=\"mm\")*/;
   String textString;
   Real fontSize = 0 \"unit pt\";
+  Integer textColor[3] = {-1, -1, -1} \"defaults to fillColor\";
   String fontName;
   TextStyle textStyle[:];
   TextAlignment horizontalAlignment = TextAlignment.Center;


### PR DESCRIPTION
As I understand the Modelica specification, `textColor` obsoletes the `GraphicalItem`'s color fields. Anyway, without it, the OMEdit generates loads of warnings when icons contain `Text` with `textColor`.

**Closely related to OpenModelica/OpenModelica#142**