### PR TITLE
[SimCode] Remove unnecessary verbose SimCode dump

### DIFF
--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -8370,7 +8370,6 @@ algorithm
         s = s +dumpWhenOps(whenStmtLst);
         if isSome(elseWhen) then
           s = s + " ELSEWHEN: ";
-          dumpSimEqSystem(Util.getOption(elseWhen));
           s = s + simEqSystemString(Util.getOption(elseWhen));
         end if;
       then s;


### PR DESCRIPTION
  - Repeats the same information
  - Dump size grows factorially with number of elsewhen statements