### PR TITLE
[NF] inStream/actualStream improvements.

### DIFF
--- a/Compiler/NFFrontEnd/NFFunction.mo
+++ b/Compiler/NFFrontEnd/NFFunction.mo
@@ -1380,6 +1380,7 @@ uniontype Function
         special := match Absyn.pathFirstIdent(path)
           // Can have variable number of arguments.
           case "array" then true;
+          case "actualStream" then true;
           case "branch" then true;
           case "cardinality" then true;
           case "cat" then true;
@@ -1395,6 +1396,7 @@ uniontype Function
           case "getInstanceName" then true;
           // Always discrete.
           case "initial" then true;
+          case "inStream" then true;
           case "isRoot" then true;
           // Arguments can be scalar, vector, matrix, 3d array .... basically anything
           // We need to make sure size(Arg,i) = 1 for 2 < i <= ndims(Arg).


### PR DESCRIPTION
- Fix infinite loop when inStream/actualStream is used in reductions,
  by expanding the reduction argument instead of treating it like an
  array constructor (since reductions does not expand to arrays).
- Added checking of the argument to inStream/actualStream to make sure
  it's a stream variable with parameter subscripts.