### PR TITLE
[OMSI] Add OMSI C library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,8 @@ SimulationRuntime/opc/ua/open62541.c
 SimulationRuntime/opc/ua/libomopcua.dll
 SimulationRuntime/OMSI/Build_dynamic/
 SimulationRuntime/OMSI/Build_static/
+SimulationRuntime/OMSIC/Build_dynamic/
+SimulationRuntime/OMSIC/Build_static/
 
 # OpenModelicaSetup
 Compiler/OpenModelicaSetup

--- a/Makefile.omsi.common
+++ b/Makefile.omsi.common
@@ -8,20 +8,20 @@ CMAKE_FLAGS=-DCMAKE_BUILD_TYPE=$(BUILDTYPE)
 
 CMAKE_CALL=cmake -G $(CMAKE_TARGET) --build . -DPLATFORM=$(PLATFORM) $(CMAKE_FLAGS) $(IS_MINGW32) $(IS_MINGW64) -DCMAKE_INSTALL_PREFIX:PATH="$(OMBUILDDIR)" -DLIB_OMC=$(LIB_OMC) ..
 
-.PHONY: OMSIBaseClean
+.PHONY: OMSIBaseClean OMSICClean
 
 
 #############################
 # Rules for OMSI
 #############################
 
-OMSI: OMSIBaseInstall
+OMSI: OMSIBaseInstall OMSICInstall
 
 
 
-OMSI-clean: OMSIBaseClean
-	cd $(OMBUILDDIR); \
-	rm -rf include/omc/omsi; \
+OMSI-clean: OMSIBaseClean OMSICClean
+	cd $(OMBUILDDIR);                             \
+	rm -rf include/omc/omsi include/omc/omsic;    \
 	rm -rf $(LIB_OMC)/omsi;
 
 
@@ -83,6 +83,31 @@ OMSIBaseInstall: OMSIBase
 
 OMSIBaseClean:
 	cd SimulationRuntime/OMSI; \
+	$(foreach PLATFORM, $(PLATFORMS), \
+	  test -d Build_$(PLATFORM) && cd Build_$(PLATFORM) && $(MAKE) uninstall && $(MAKE) DESTDIR=$(OMBUILDDIR) clean && cd ..; \
+	  rm -R -f Build_$(PLATFORM); \
+	)
+
+
+#############################
+# Rules for OMSIC libraries
+#############################
+
+OMSIC: OMSIBaseInstall
+	cd SimulationRuntime/OMSIC; \
+	$(foreach PLATFORM, $(PLATFORMS), \
+	  mkdir -p Build_$(PLATFORM); \
+	  (cd ./Build_$(PLATFORM); echo "change to Build_$(PLATFORM)"; \
+		 $(CMAKE_CALL); \
+		 $(MAKE) ); )
+
+OMSICInstall: OMSIC
+	cd SimulationRuntime/OMSIC; \
+	$(foreach PLATFORM, $(PLATFORMS), \
+	  (cd Build_$(PLATFORM); $(MAKE) install);)
+
+OMSICClean:
+	cd SimulationRuntime/OMSIC; \
 	$(foreach PLATFORM, $(PLATFORMS), \
 	  test -d Build_$(PLATFORM) && cd Build_$(PLATFORM) && $(MAKE) uninstall && $(MAKE) DESTDIR=$(OMBUILDDIR) clean && cd ..; \
 	  rm -R -f Build_$(PLATFORM); \

--- a/SimulationRuntime/OMSI/include/omsi.h
+++ b/SimulationRuntime/OMSI/include/omsi.h
@@ -33,9 +33,11 @@
 
 /** \defgroup OMSI OpenModelica Simulation Interface
  *
- * Long description of OMSI group.
+ * \brief OpenModelica Simulation Interface
+ *
+ * OpenModelica Simulation Interface generalizing simulation runtimes for C and C++ runtimes.
+ * Containing base library and solver library used by both runtimes.
  */
-
 
 
 /** \addtogroup OMSIBase OMSI Base Library
@@ -146,25 +148,29 @@ static const omsi_string log_categories_names[NUMBER_OF_CATEGORIES] = {
 };
 
 
-/* Model FMU/ OSU states */
+/**
+ *  Model FMU/ OSU states
+ */
 typedef enum {
-  modelInstantiated       = 1<<0, /* ME and CS */
-  modelInitializationMode = 1<<1, /* ME and CS */
-  modelContinuousTimeMode = 1<<2, /* ME only */
-  modelEventMode          = 1<<3, /* ME only */
-  modelSlaveInitialized   = 1<<4, /* CS only */
-  modelTerminated         = 1<<5, /* ME and CS */
-  modelError              = 1<<6  /* ME and CS */
+  modelInstantiated       = 1<<0, /**< Model is instantiated (ME and CS). */
+  modelInitializationMode = 1<<1, /**< Model is initialized (ME and CS). */
+  modelContinuousTimeMode = 1<<2, /**< Model is in continuous time mode (ME only). */
+  modelEventMode          = 1<<3, /**< Model is in event mode (ME only). */
+  modelSlaveInitialized   = 1<<4, /**< Co-Simulation slave is initialized (CS only). */
+  modelTerminated         = 1<<5, /**< Model is terminated (ME and CS). */
+  modelError              = 1<<6  /**< Model errored (ME and CS). */
 } ModelState;
 
-/* Event informations */
+/**
+ * Event informations
+ */
 typedef struct {
-   omsi_bool newDiscreteStatesNeeded;
-   omsi_bool terminateSimulation;
-   omsi_bool nominalsOfContinuousStatesChanged;
-   omsi_bool valuesOfContinuousStatesChanged;
-   omsi_bool nextEventTimeDefined;
-   omsi_real nextEventTime;
+   omsi_bool newDiscreteStatesNeeded;           /**< New discrete states needed. */
+   omsi_bool terminateSimulation;               /**< Terminate simulation. */
+   omsi_bool nominalsOfContinuousStatesChanged; /**< Nominals of continuous states changed and need to be updated. */
+   omsi_bool valuesOfContinuousStatesChanged;   /**< Values of continuous states changed and need to be updated. */
+   omsi_bool nextEventTimeDefined;              /**< `omsi_true` if next event time is defined. */
+   omsi_real nextEventTime;                     /**< Value of next defined event time. */
 } omsi_event_info;
 
 

--- a/SimulationRuntime/OMSIC/CMakeLists.txt
+++ b/SimulationRuntime/OMSIC/CMakeLists.txt
@@ -1,0 +1,91 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
+SET(CMAKE_VERBOSE_MAKEFILE ON)
+MESSAGE(STATUS "CMake version ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}")
+
+PROJECT(OMSICSimulationRuntime)
+
+# enable warnings and use ANSI C compatible compiler
+if(CMAKE_COMPILER_IS_GNUCXX)
+    message(STATUS "GCC detected, adding compile flags")
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall -Wextra -ansi -pedantic -g")
+    IF(NOT WIN32)
+        SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+    ENDIF()
+endif(CMAKE_COMPILER_IS_GNUCXX)
+message(STATUS "Compiling with C flags: ${CMAKE_C_FLAGS}")
+
+if(NOT PLATFORM OR PLATFORM STREQUAL "dynamic")
+  set(BUILD_SHARED_LIBS ON)
+elseif(PLATFORM STREQUAL "static")
+  set(BUILD_SHARED_LIBS OFF)
+else()
+endif()
+
+IF(BUILD_SHARED_LIBS)
+  SET(LIBSUFFIX "")
+ELSE(BUILD_SHARED_LIBS)
+  SET(LIBSUFFIX "_static")
+ENDIF(BUILD_SHARED_LIBS)
+
+IF(MSVC)
+  MESSAGE(STATUS "MSVC")
+  IF(LIB_OMC)
+    SET(LIBINSTALLEXT "${LIB_OMC}/omsi/msvc" CACHE STRING "library directory" FORCE)
+  ELSE(LIB_OMC)
+    SET(LIBINSTALLEXT "omsi/msvc" CACHE STRING "library directory" FORCE)
+  ENDIF(LIB_OMC)
+ELSE(MSVC)
+  IF(LIB_OMC)
+    SET(LIBINSTALLEXT "${LIB_OMC}/omsi" CACHE STRING "library directory" FORCE)
+  ELSE(LIB_OMC)
+    SET(LIBINSTALLEXT "omsi" CACHE STRING "library directory" FORCE)
+  ENDIF(LIB_OMC)
+ENDIF(MSVC)
+message(STATUS "Libs will be installed in ${CMAKE_INSTALL_PREFIX}/${LIBINSTALLEXT}")
+
+
+SET(OMSICName ${LIBPREFIX}OMSIC${LIBSUFFIX})
+
+SET(OMSI_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../OMSI)
+
+include_directories ("${OMSI_SOURCE_DIR}/include")
+include_directories ("${OMSI_SOURCE_DIR}/include/fmi2")
+include_directories ("${OMSI_SOURCE_DIR}/base/include")
+include_directories ("${OMSI_SOURCE_DIR}/solver/include")
+
+# omsic simulation runtime
+ADD_SUBDIRECTORY(src/omsu)
+
+
+install(FILES
+  ${OMSI_SOURCE_DIR}/include/omsi.h
+  ${OMSI_SOURCE_DIR}/include/omsi_callbacks.h
+  ${OMSI_SOURCE_DIR}/include/omsi_api_functions.h
+DESTINATION include/omc/omsi)
+
+install(FILES
+  ${CMAKE_SOURCE_DIR}/include/omsic.h
+  ${CMAKE_SOURCE_DIR}/include/omsu/omsu_common.h
+  ${CMAKE_SOURCE_DIR}/include/omsu/omsu_helper.h
+  ${CMAKE_SOURCE_DIR}/include/omsu/omsu_initialization.h
+  ${CMAKE_SOURCE_DIR}/include/omsu/omsu_getters_and_setters.h
+  ${CMAKE_SOURCE_DIR}/include/omsu/omsu_continuous_simulation.h
+  ${CMAKE_SOURCE_DIR}/include/omsu/omsu_event_simulation.h
+DESTINATION include/omc/omsic)
+
+install(FILES
+  ${CMAKE_SOURCE_DIR}/include/fmi2/fmi2Functions.h
+  ${CMAKE_SOURCE_DIR}/include/fmi2/fmi2FunctionTypes.h
+  ${CMAKE_SOURCE_DIR}/include/fmi2/fmi2TypesPlatform.h
+DESTINATION include/omc/omsic/fmi2/)
+
+# uninstall target
+if(NOT TARGET uninstall)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY)
+
+    add_custom_target(uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()

--- a/SimulationRuntime/OMSIC/cmake_uninstall.cmake.in
+++ b/SimulationRuntime/OMSIC/cmake_uninstall.cmake.in
@@ -1,0 +1,19 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)

--- a/SimulationRuntime/OMSIC/include/fmi2/fmi2FunctionTypes.h
+++ b/SimulationRuntime/OMSIC/include/fmi2/fmi2FunctionTypes.h
@@ -1,0 +1,247 @@
+#ifndef fmi2FunctionTypes_h
+#define fmi2FunctionTypes_h
+
+#include "fmi2TypesPlatform.h"
+
+/* This header file must be utilized when compiling an FMU or an FMI master.
+   It declares data and function types for FMI 2.0
+
+   Revisions:
+   - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
+   - Apr.  3, 2014: Added #include <stddef.h> for size_t definition
+   - Mar. 27, 2014: Added #include "fmiTypesPlatform.h" (#179)
+   - Mar. 26, 2014: Introduced function argument "void" for the functions (#171)
+                      fmiGetTypesPlatformTYPE and fmiGetVersionTYPE
+   - Oct. 11, 2013: Functions of ModelExchange and CoSimulation merged:
+                      fmiInstantiateModelTYPE , fmiInstantiateSlaveTYPE  -> fmiInstantiateTYPE
+                      fmiFreeModelInstanceTYPE, fmiFreeSlaveInstanceTYPE -> fmiFreeInstanceTYPE
+                      fmiEnterModelInitializationModeTYPE, fmiEnterSlaveInitializationModeTYPE -> fmiEnterInitializationModeTYPE
+                      fmiExitModelInitializationModeTYPE , fmiExitSlaveInitializationModeTYPE  -> fmiExitInitializationModeTYPE
+                      fmiTerminateModelTYPE , fmiTerminateSlaveTYPE  -> fmiTerminate
+                      fmiResetSlave -> fmiReset (now also for ModelExchange and not only for CoSimulation)
+                    Functions renamed
+                      fmiUpdateDiscreteStatesTYPE -> fmiNewDiscreteStatesTYPE
+                    Renamed elements of the enumeration fmiEventInfo
+                      upcomingTimeEvent             -> nextEventTimeDefined // due to generic naming scheme: varDefined + var
+                      newUpdateDiscreteStatesNeeded -> newDiscreteStatesNeeded;
+   - June 13, 2013: Changed type fmiEventInfo
+                    Functions removed:
+                       fmiInitializeModelTYPE
+                       fmiEventUpdateTYPE
+                       fmiCompletedEventIterationTYPE
+                       fmiInitializeSlaveTYPE
+                    Functions added:
+                       fmiEnterModelInitializationModeTYPE
+                       fmiExitModelInitializationModeTYPE
+                       fmiEnterEventModeTYPE
+                       fmiUpdateDiscreteStatesTYPE
+                       fmiEnterContinuousTimeModeTYPE
+                       fmiEnterSlaveInitializationModeTYPE;
+                       fmiExitSlaveInitializationModeTYPE;
+   - Feb. 17, 2013: Added third argument to fmiCompletedIntegratorStepTYPE
+                    Changed function name "fmiTerminateType" to "fmiTerminateModelType" (due to #113)
+                    Changed function name "fmiGetNominalContinuousStateTYPE" to
+                                          "fmiGetNominalsOfContinuousStatesTYPE"
+                    Removed fmiGetStateValueReferencesTYPE.
+   - Nov. 14, 2011: First public Version
+
+
+   Copyright (C) 2011 MODELISAR consortium,
+               2012-2013 Modelica Association Project "FMI"
+               All rights reserved.
+   This file is licensed by the copyright holders under the BSD 2-Clause License
+   (http://www.opensource.org/licenses/bsd-license.html):
+
+   ----------------------------------------------------------------------------
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the copyright holders nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+   PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+   OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   ----------------------------------------------------------------------------
+
+   with the extension:
+
+   You may distribute or publicly perform any modification only under the
+   terms of this license.
+   (Note, this means that if you distribute a modified file,
+    the modified file must also be provided under this license).
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* make sure all compiler use the same alignment policies for structures */
+#if defined _MSC_VER || defined __GNUC__
+#pragma pack(push,8)
+#endif
+
+/* Include stddef.h, in order that size_t etc. is defined */
+#include <stddef.h>
+
+
+/* Type definitions */
+typedef enum {
+    fmi2OK,
+    fmi2Warning,
+    fmi2Discard,
+    fmi2Error,
+    fmi2Fatal,
+    fmi2Pending
+} fmi2Status;
+
+typedef enum {
+    fmi2ModelExchange,
+    fmi2CoSimulation
+} fmi2Type;
+
+typedef enum {
+    fmi2DoStepStatus,
+    fmi2PendingStatus,
+    fmi2LastSuccessfulTime,
+    fmi2Terminated
+} fmi2StatusKind;
+
+typedef void      (*fmi2CallbackLogger)        (fmi2ComponentEnvironment, fmi2String, fmi2Status, fmi2String, fmi2String, ...);
+typedef void*     (*fmi2CallbackAllocateMemory)(size_t, size_t);
+typedef void      (*fmi2CallbackFreeMemory)    (void*);
+typedef void      (*fmi2StepFinished)          (fmi2ComponentEnvironment, fmi2Status);
+
+typedef struct {
+   const fmi2CallbackLogger         logger;
+   const fmi2CallbackAllocateMemory allocateMemory;
+   const fmi2CallbackFreeMemory     freeMemory;
+   const fmi2StepFinished           stepFinished;
+   const fmi2ComponentEnvironment   componentEnvironment;
+} fmi2CallbackFunctions;
+
+typedef struct {
+   fmi2Boolean newDiscreteStatesNeeded;
+   fmi2Boolean terminateSimulation;
+   fmi2Boolean nominalsOfContinuousStatesChanged;
+   fmi2Boolean valuesOfContinuousStatesChanged;
+   fmi2Boolean nextEventTimeDefined;
+   fmi2Real    nextEventTime;
+} fmi2EventInfo;
+
+
+/* reset alignment policy to the one set before reading this file */
+#if defined _MSC_VER || defined __GNUC__
+#pragma pack(pop)
+#endif
+
+
+/* Define fmi2 function pointer types to simplify dynamic loading */
+
+/***************************************************
+Types for Common Functions
+****************************************************/
+
+/* Inquire version numbers of header files and setting logging status */
+   typedef const char* fmi2GetTypesPlatformTYPE(void);
+   typedef const char* fmi2GetVersionTYPE(void);
+   typedef fmi2Status  fmi2SetDebugLoggingTYPE(fmi2Component, fmi2Boolean, size_t, const fmi2String[]);
+
+/* Creation and destruction of FMU instances and setting debug status */
+   typedef fmi2Component fmi2InstantiateTYPE (fmi2String, fmi2Type, fmi2String, fmi2String, const fmi2CallbackFunctions*, fmi2Boolean, fmi2Boolean);
+   typedef void          fmi2FreeInstanceTYPE(fmi2Component);
+
+/* Enter and exit initialization mode, terminate and reset */
+   typedef fmi2Status fmi2SetupExperimentTYPE        (fmi2Component, fmi2Boolean, fmi2Real, fmi2Real, fmi2Boolean, fmi2Real);
+   typedef fmi2Status fmi2EnterInitializationModeTYPE(fmi2Component);
+   typedef fmi2Status fmi2ExitInitializationModeTYPE (fmi2Component);
+   typedef fmi2Status fmi2TerminateTYPE              (fmi2Component);
+   typedef fmi2Status fmi2ResetTYPE                  (fmi2Component);
+
+/* Getting and setting variable values */
+   typedef fmi2Status fmi2GetRealTYPE   (fmi2Component, const fmi2ValueReference[], size_t, fmi2Real   []);
+   typedef fmi2Status fmi2GetIntegerTYPE(fmi2Component, const fmi2ValueReference[], size_t, fmi2Integer[]);
+   typedef fmi2Status fmi2GetBooleanTYPE(fmi2Component, const fmi2ValueReference[], size_t, fmi2Boolean[]);
+   typedef fmi2Status fmi2GetStringTYPE (fmi2Component, const fmi2ValueReference[], size_t, fmi2String []);
+
+   typedef fmi2Status fmi2SetRealTYPE   (fmi2Component, const fmi2ValueReference[], size_t, const fmi2Real   []);
+   typedef fmi2Status fmi2SetIntegerTYPE(fmi2Component, const fmi2ValueReference[], size_t, const fmi2Integer[]);
+   typedef fmi2Status fmi2SetBooleanTYPE(fmi2Component, const fmi2ValueReference[], size_t, const fmi2Boolean[]);
+   typedef fmi2Status fmi2SetStringTYPE (fmi2Component, const fmi2ValueReference[], size_t, const fmi2String []);
+
+/* Getting and setting the internal FMU state */
+   typedef fmi2Status fmi2GetFMUstateTYPE           (fmi2Component, fmi2FMUstate*);
+   typedef fmi2Status fmi2SetFMUstateTYPE           (fmi2Component, fmi2FMUstate);
+   typedef fmi2Status fmi2FreeFMUstateTYPE          (fmi2Component, fmi2FMUstate*);
+   typedef fmi2Status fmi2SerializedFMUstateSizeTYPE(fmi2Component, fmi2FMUstate, size_t*);
+   typedef fmi2Status fmi2SerializeFMUstateTYPE     (fmi2Component, fmi2FMUstate, fmi2Byte[], size_t);
+   typedef fmi2Status fmi2DeSerializeFMUstateTYPE   (fmi2Component, const fmi2Byte[], size_t, fmi2FMUstate*);
+
+/* Getting partial derivatives */
+   typedef fmi2Status fmi2GetDirectionalDerivativeTYPE(fmi2Component, const fmi2ValueReference[], size_t,
+                                                                   const fmi2ValueReference[], size_t,
+                                                                   const fmi2Real[], fmi2Real[]);
+
+/***************************************************
+Types for Functions for FMI2 for Model Exchange
+****************************************************/
+
+/* Enter and exit the different modes */
+   typedef fmi2Status fmi2EnterEventModeTYPE         (fmi2Component);
+   typedef fmi2Status fmi2NewDiscreteStatesTYPE      (fmi2Component, fmi2EventInfo*);
+   typedef fmi2Status fmi2EnterContinuousTimeModeTYPE(fmi2Component);
+   typedef fmi2Status fmi2CompletedIntegratorStepTYPE(fmi2Component, fmi2Boolean, fmi2Boolean*, fmi2Boolean*);
+
+/* Providing independent variables and re-initialization of caching */
+   typedef fmi2Status fmi2SetTimeTYPE            (fmi2Component, fmi2Real);
+   typedef fmi2Status fmi2SetContinuousStatesTYPE(fmi2Component, const fmi2Real[], size_t);
+
+/* Evaluation of the model equations */
+   typedef fmi2Status fmi2GetDerivativesTYPE               (fmi2Component, fmi2Real[], size_t);
+#ifdef FMU_EXPERIMENTAL
+   typedef fmi2Status fmi2GetSpecificDerivativesTYPE       (fmi2Component, fmi2Real[], const fmi2ValueReference [], size_t);
+#endif
+
+   typedef fmi2Status fmi2GetEventIndicatorsTYPE           (fmi2Component, fmi2Real[], size_t);
+   typedef fmi2Status fmi2GetContinuousStatesTYPE          (fmi2Component, fmi2Real[], size_t);
+   typedef fmi2Status fmi2GetNominalsOfContinuousStatesTYPE(fmi2Component, fmi2Real[], size_t);
+
+
+/***************************************************
+Types for Functions for FMI2 for Co-Simulation
+****************************************************/
+
+/* Simulating the slave */
+   typedef fmi2Status fmi2SetRealInputDerivativesTYPE (fmi2Component, const fmi2ValueReference [], size_t, const fmi2Integer [], const fmi2Real []);
+   typedef fmi2Status fmi2GetRealOutputDerivativesTYPE(fmi2Component, const fmi2ValueReference [], size_t, const fmi2Integer [], fmi2Real []);
+
+   typedef fmi2Status fmi2DoStepTYPE     (fmi2Component, fmi2Real, fmi2Real, fmi2Boolean);
+   typedef fmi2Status fmi2CancelStepTYPE (fmi2Component);
+
+/* Inquire slave status */
+   typedef fmi2Status fmi2GetStatusTYPE       (fmi2Component, const fmi2StatusKind, fmi2Status* );
+   typedef fmi2Status fmi2GetRealStatusTYPE   (fmi2Component, const fmi2StatusKind, fmi2Real*   );
+   typedef fmi2Status fmi2GetIntegerStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2Integer*);
+   typedef fmi2Status fmi2GetBooleanStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2Boolean*);
+   typedef fmi2Status fmi2GetStringStatusTYPE (fmi2Component, const fmi2StatusKind, fmi2String* );
+
+
+#ifdef __cplusplus
+}  /* end of extern "C" { */
+#endif
+
+#endif /* fmi2FunctionTypes_h */

--- a/SimulationRuntime/OMSIC/include/fmi2/fmi2Functions.h
+++ b/SimulationRuntime/OMSIC/include/fmi2/fmi2Functions.h
@@ -1,0 +1,337 @@
+#ifndef fmi2Functions_h
+#define fmi2Functions_h
+
+/* This header file must be utilized when compiling a FMU.
+   It defines all functions of the
+         FMI 2.0 Model Exchange and Co-Simulation Interface.
+
+   In order to have unique function names even if several FMUs
+   are compiled together (e.g. for embedded systems), every "real" function name
+   is constructed by prepending the function name by "FMI2_FUNCTION_PREFIX".
+   Therefore, the typical usage is:
+
+      #define FMI2_FUNCTION_PREFIX MyModel_
+      #include "fmi2Functions.h"
+
+   As a result, a function that is defined as "fmi2GetDerivatives" in this header file,
+   is actually getting the name "MyModel_fmi2GetDerivatives".
+
+   This only holds if the FMU is shipped in C source code, or is compiled in a
+   static link library. For FMUs compiled in a DLL/sharedObject, the "actual" function
+   names are used and "FMI2_FUNCTION_PREFIX" must not be defined.
+
+   Revisions:
+   - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
+   - Mar. 26, 2014: FMI_Export set to empty value if FMI_Export and FMI_FUNCTION_PREFIX
+                    are not defined (#173)
+   - Oct. 11, 2013: Functions of ModelExchange and CoSimulation merged:
+                      fmiInstantiateModel , fmiInstantiateSlave  -> fmiInstantiate
+                      fmiFreeModelInstance, fmiFreeSlaveInstance -> fmiFreeInstance
+                      fmiEnterModelInitializationMode, fmiEnterSlaveInitializationMode -> fmiEnterInitializationMode
+                      fmiExitModelInitializationMode , fmiExitSlaveInitializationMode  -> fmiExitInitializationMode
+                      fmiTerminateModel, fmiTerminateSlave  -> fmiTerminate
+                      fmiResetSlave -> fmiReset (now also for ModelExchange and not only for CoSimulation)
+                    Functions renamed:
+                      fmiUpdateDiscreteStates -> fmiNewDiscreteStates
+   - June 13, 2013: Functions removed:
+                       fmiInitializeModel
+                       fmiEventUpdate
+                       fmiCompletedEventIteration
+                       fmiInitializeSlave
+                    Functions added:
+                       fmiEnterModelInitializationMode
+                       fmiExitModelInitializationMode
+                       fmiEnterEventMode
+                       fmiUpdateDiscreteStates
+                       fmiEnterContinuousTimeMode
+                       fmiEnterSlaveInitializationMode;
+                       fmiExitSlaveInitializationMode;
+   - Feb. 17, 2013: Portability improvements:
+                       o DllExport changed to FMI_Export
+                       o FUNCTION_PREFIX changed to FMI_FUNCTION_PREFIX
+                       o Allow undefined FMI_FUNCTION_PREFIX (meaning no prefix is used)
+                    Changed function name "fmiTerminate" to "fmiTerminateModel" (due to #113)
+                    Changed function name "fmiGetNominalContinuousState" to
+                                          "fmiGetNominalsOfContinuousStates"
+                    Removed fmiGetStateValueReferences.
+   - Nov. 14, 2011: Adapted to FMI 2.0:
+                       o Split into two files (fmiFunctions.h, fmiTypes.h) in order
+                         that code that dynamically loads an FMU can directly
+                         utilize the header files).
+                       o Added C++ encapsulation of C-part, in order that the header
+                         file can be directly utilized in C++ code.
+                       o fmiCallbackFunctions is passed as pointer to fmiInstantiateXXX
+                       o stepFinished within fmiCallbackFunctions has as first
+                         argument "fmiComponentEnvironment" and not "fmiComponent".
+                       o New functions to get and set the complete FMU state
+                         and to compute partial derivatives.
+   - Nov.  4, 2010: Adapted to specification text:
+                       o fmiGetModelTypesPlatform renamed to fmiGetTypesPlatform
+                       o fmiInstantiateSlave: Argument GUID     replaced by fmuGUID
+                                              Argument mimetype replaced by mimeType
+                       o tabs replaced by spaces
+   - Oct. 16, 2010: Functions for FMI for Co-simulation added
+   - Jan. 20, 2010: stateValueReferencesChanged added to struct fmiEventInfo (ticket #27)
+                    (by M. Otter, DLR)
+                    Added WIN32 pragma to define the struct layout (ticket #34)
+                    (by J. Mauss, QTronic)
+   - Jan.  4, 2010: Removed argument intermediateResults from fmiInitialize
+                    Renamed macro fmiGetModelFunctionsVersion to fmiGetVersion
+                    Renamed macro fmiModelFunctionsVersion to fmiVersion
+                    Replaced fmiModel by fmiComponent in decl of fmiInstantiateModel
+                    (by J. Mauss, QTronic)
+   - Dec. 17, 2009: Changed extension "me" to "fmi" (by Martin Otter, DLR).
+   - Dez. 14, 2009: Added eventInfo to meInitialize and added
+                    meGetNominalContinuousStates (by Martin Otter, DLR)
+   - Sept. 9, 2009: Added DllExport (according to Peter Nilsson's suggestion)
+                    (by A. Junghanns, QTronic)
+   - Sept. 9, 2009: Changes according to FMI-meeting on July 21:
+                    meInquireModelTypesVersion     -> meGetModelTypesPlatform
+                    meInquireModelFunctionsVersion -> meGetModelFunctionsVersion
+                    meSetStates                    -> meSetContinuousStates
+                    meGetStates                    -> meGetContinuousStates
+                    removal of meInitializeModelClass
+                    removal of meGetTime
+                    change of arguments of meInstantiateModel
+                    change of arguments of meCompletedIntegratorStep
+                    (by Martin Otter, DLR):
+   - July 19, 2009: Added "me" as prefix to file names (by Martin Otter, DLR).
+   - March 2, 2009: Changed function definitions according to the last design
+                    meeting with additional improvements (by Martin Otter, DLR).
+   - Dec. 3 , 2008: First version by Martin Otter (DLR) and Hans Olsson (Dynasim).
+
+   Copyright (C) 2008-2011 MODELISAR consortium,
+               2012-2013 Modelica Association Project "FMI"
+               All rights reserved.
+   This file is licensed by the copyright holders under the BSD 2-Clause License
+   (http://www.opensource.org/licenses/bsd-license.html):
+
+   ----------------------------------------------------------------------------
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the copyright holders nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+   PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+   OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   ----------------------------------------------------------------------------
+
+   with the extension:
+
+   You may distribute or publicly perform any modification only under the
+   terms of this license.
+   (Note, this means that if you distribute a modified file,
+    the modified file must also be provided under this license).
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "fmi2TypesPlatform.h"
+#include "fmi2FunctionTypes.h"
+#include <stdlib.h>
+
+
+/*
+  Export FMI2 API functions on Windows and under GCC.
+  If custom linking is desired then the FMI2_Export must be
+  defined before including this file. For instance,
+  it may be set to __declspec(dllimport).
+*/
+#if !defined(FMI2_Export)
+  #if !defined(FMI2_FUNCTION_PREFIX)
+    #if defined _WIN32 || defined __CYGWIN__
+     /* Note: both gcc & MSVC on Windows support this syntax. */
+        #define FMI2_Export __declspec(dllexport)
+    #else
+      #if __GNUC__ >= 4
+        #define FMI2_Export __attribute__ ((visibility ("default")))
+      #else
+        #define FMI2_Export
+      #endif
+    #endif
+  #else
+    #define FMI2_Export
+  #endif
+#endif
+
+/* Macros to construct the real function name
+   (prepend function name by FMI2_FUNCTION_PREFIX) */
+#if defined(FMI2_FUNCTION_PREFIX)
+  #define fmi2Paste(a,b)     a ## b
+  #define fmi2PasteB(a,b)    fmi2Paste(a,b)
+  #define fmi2FullName(name) fmi2PasteB(FMI2_FUNCTION_PREFIX, name)
+#else
+  #define fmi2FullName(name) name
+#endif
+
+/***************************************************
+Common Functions
+****************************************************/
+#define fmi2GetTypesPlatform         fmi2FullName(fmi2GetTypesPlatform)
+#define fmi2GetVersion               fmi2FullName(fmi2GetVersion)
+#define fmi2SetDebugLogging          fmi2FullName(fmi2SetDebugLogging)
+#define fmi2Instantiate              fmi2FullName(fmi2Instantiate)
+#define fmi2FreeInstance             fmi2FullName(fmi2FreeInstance)
+#define fmi2SetupExperiment          fmi2FullName(fmi2SetupExperiment)
+#define fmi2EnterInitializationMode  fmi2FullName(fmi2EnterInitializationMode)
+#define fmi2ExitInitializationMode   fmi2FullName(fmi2ExitInitializationMode)
+#define fmi2Terminate                fmi2FullName(fmi2Terminate)
+#define fmi2Reset                    fmi2FullName(fmi2Reset)
+#define fmi2GetReal                  fmi2FullName(fmi2GetReal)
+#define fmi2GetInteger               fmi2FullName(fmi2GetInteger)
+#define fmi2GetBoolean               fmi2FullName(fmi2GetBoolean)
+#define fmi2GetString                fmi2FullName(fmi2GetString)
+#define fmi2SetReal                  fmi2FullName(fmi2SetReal)
+#define fmi2SetInteger               fmi2FullName(fmi2SetInteger)
+#define fmi2SetBoolean               fmi2FullName(fmi2SetBoolean)
+#define fmi2SetString                fmi2FullName(fmi2SetString)
+#define fmi2GetFMUstate              fmi2FullName(fmi2GetFMUstate)
+#define fmi2SetFMUstate              fmi2FullName(fmi2SetFMUstate)
+#define fmi2FreeFMUstate             fmi2FullName(fmi2FreeFMUstate)
+#define fmi2SerializedFMUstateSize   fmi2FullName(fmi2SerializedFMUstateSize)
+#define fmi2SerializeFMUstate        fmi2FullName(fmi2SerializeFMUstate)
+#define fmi2DeSerializeFMUstate      fmi2FullName(fmi2DeSerializeFMUstate)
+#define fmi2GetDirectionalDerivative fmi2FullName(fmi2GetDirectionalDerivative)
+
+
+/***************************************************
+Functions for FMI2 for Model Exchange
+****************************************************/
+#define fmi2EnterEventMode                fmi2FullName(fmi2EnterEventMode)
+#define fmi2NewDiscreteStates             fmi2FullName(fmi2NewDiscreteStates)
+#define fmi2EnterContinuousTimeMode       fmi2FullName(fmi2EnterContinuousTimeMode)
+#define fmi2CompletedIntegratorStep       fmi2FullName(fmi2CompletedIntegratorStep)
+#define fmi2SetTime                       fmi2FullName(fmi2SetTime)
+#define fmi2SetContinuousStates           fmi2FullName(fmi2SetContinuousStates)
+#define fmi2GetDerivatives                fmi2FullName(fmi2GetDerivatives)
+#define fmi2GetSpecificDerivatives        fmi2FullName(fmi2GetSpecificDerivatives)
+#define fmi2GetEventIndicators            fmi2FullName(fmi2GetEventIndicators)
+#define fmi2GetContinuousStates           fmi2FullName(fmi2GetContinuousStates)
+#define fmi2GetNominalsOfContinuousStates fmi2FullName(fmi2GetNominalsOfContinuousStates)
+
+
+/***************************************************
+Functions for FMI2 for Co-Simulation
+****************************************************/
+#define fmi2SetRealInputDerivatives      fmi2FullName(fmi2SetRealInputDerivatives)
+#define fmi2GetRealOutputDerivatives     fmi2FullName(fmi2GetRealOutputDerivatives)
+#define fmi2DoStep                       fmi2FullName(fmi2DoStep)
+#define fmi2CancelStep                   fmi2FullName(fmi2CancelStep)
+#define fmi2GetStatus                    fmi2FullName(fmi2GetStatus)
+#define fmi2GetRealStatus                fmi2FullName(fmi2GetRealStatus)
+#define fmi2GetIntegerStatus             fmi2FullName(fmi2GetIntegerStatus)
+#define fmi2GetBooleanStatus             fmi2FullName(fmi2GetBooleanStatus)
+#define fmi2GetStringStatus              fmi2FullName(fmi2GetStringStatus)
+
+/* Version number */
+#define fmi2Version "2.0"
+
+
+/***************************************************
+Common Functions
+****************************************************/
+
+/* Inquire version numbers of header files */
+   FMI2_Export fmi2GetTypesPlatformTYPE fmi2GetTypesPlatform;
+   FMI2_Export fmi2GetVersionTYPE       fmi2GetVersion;
+   FMI2_Export fmi2SetDebugLoggingTYPE  fmi2SetDebugLogging;
+
+/* Creation and destruction of FMU instances */
+   FMI2_Export fmi2InstantiateTYPE  fmi2Instantiate;
+   FMI2_Export fmi2FreeInstanceTYPE fmi2FreeInstance;
+
+/* Enter and exit initialization mode, terminate and reset */
+   FMI2_Export fmi2SetupExperimentTYPE         fmi2SetupExperiment;
+   FMI2_Export fmi2EnterInitializationModeTYPE fmi2EnterInitializationMode;
+   FMI2_Export fmi2ExitInitializationModeTYPE  fmi2ExitInitializationMode;
+   FMI2_Export fmi2TerminateTYPE               fmi2Terminate;
+   FMI2_Export fmi2ResetTYPE                   fmi2Reset;
+
+/* Getting and setting variables values */
+   FMI2_Export fmi2GetRealTYPE    fmi2GetReal;
+   FMI2_Export fmi2GetIntegerTYPE fmi2GetInteger;
+   FMI2_Export fmi2GetBooleanTYPE fmi2GetBoolean;
+   FMI2_Export fmi2GetStringTYPE  fmi2GetString;
+
+   FMI2_Export fmi2SetRealTYPE    fmi2SetReal;
+   FMI2_Export fmi2SetIntegerTYPE fmi2SetInteger;
+   FMI2_Export fmi2SetBooleanTYPE fmi2SetBoolean;
+   FMI2_Export fmi2SetStringTYPE  fmi2SetString;
+
+/* Getting and setting the internal FMU state */
+   FMI2_Export fmi2GetFMUstateTYPE            fmi2GetFMUstate;
+   FMI2_Export fmi2SetFMUstateTYPE            fmi2SetFMUstate;
+   FMI2_Export fmi2FreeFMUstateTYPE           fmi2FreeFMUstate;
+   FMI2_Export fmi2SerializedFMUstateSizeTYPE fmi2SerializedFMUstateSize;
+   FMI2_Export fmi2SerializeFMUstateTYPE      fmi2SerializeFMUstate;
+   FMI2_Export fmi2DeSerializeFMUstateTYPE    fmi2DeSerializeFMUstate;
+
+/* Getting partial derivatives */
+   FMI2_Export fmi2GetDirectionalDerivativeTYPE fmi2GetDirectionalDerivative;
+
+
+/***************************************************
+Functions for FMI2 for Model Exchange
+****************************************************/
+
+/* Enter and exit the different modes */
+   FMI2_Export fmi2EnterEventModeTYPE               fmi2EnterEventMode;
+   FMI2_Export fmi2NewDiscreteStatesTYPE            fmi2NewDiscreteStates;
+   FMI2_Export fmi2EnterContinuousTimeModeTYPE      fmi2EnterContinuousTimeMode;
+   FMI2_Export fmi2CompletedIntegratorStepTYPE      fmi2CompletedIntegratorStep;
+
+/* Providing independent variables and re-initialization of caching */
+   FMI2_Export fmi2SetTimeTYPE             fmi2SetTime;
+   FMI2_Export fmi2SetContinuousStatesTYPE fmi2SetContinuousStates;
+
+/* Evaluation of the model equations */
+   FMI2_Export fmi2GetDerivativesTYPE                fmi2GetDerivatives;
+#ifdef FMU_EXPERIMENTAL
+   FMI2_Export fmi2GetSpecificDerivativesTYPE        fmi2GetSpecificDerivatives;
+#endif
+   FMI2_Export fmi2GetEventIndicatorsTYPE            fmi2GetEventIndicators;
+   FMI2_Export fmi2GetContinuousStatesTYPE           fmi2GetContinuousStates;
+   FMI2_Export fmi2GetNominalsOfContinuousStatesTYPE fmi2GetNominalsOfContinuousStates;
+
+
+/***************************************************
+Functions for FMI2 for Co-Simulation
+****************************************************/
+
+/* Simulating the slave */
+   FMI2_Export fmi2SetRealInputDerivativesTYPE  fmi2SetRealInputDerivatives;
+   FMI2_Export fmi2GetRealOutputDerivativesTYPE fmi2GetRealOutputDerivatives;
+
+   FMI2_Export fmi2DoStepTYPE     fmi2DoStep;
+   FMI2_Export fmi2CancelStepTYPE fmi2CancelStep;
+
+/* Inquire slave status */
+   FMI2_Export fmi2GetStatusTYPE        fmi2GetStatus;
+   FMI2_Export fmi2GetRealStatusTYPE    fmi2GetRealStatus;
+   FMI2_Export fmi2GetIntegerStatusTYPE fmi2GetIntegerStatus;
+   FMI2_Export fmi2GetBooleanStatusTYPE fmi2GetBooleanStatus;
+   FMI2_Export fmi2GetStringStatusTYPE  fmi2GetStringStatus;
+
+#ifdef __cplusplus
+}  /* end of extern "C" { */
+#endif
+
+#endif /* fmi2Functions_h */

--- a/SimulationRuntime/OMSIC/include/fmi2/fmi2TypesPlatform.h
+++ b/SimulationRuntime/OMSIC/include/fmi2/fmi2TypesPlatform.h
@@ -1,0 +1,115 @@
+#ifndef fmi2TypesPlatform_h
+#define fmi2TypesPlatform_h
+
+/* Standard header file to define the argument types of the
+   functions of the Functional Mock-up Interface 2.0.
+   This header file must be utilized both by the model and
+   by the simulation engine.
+
+   Revisions:
+   - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
+   - Mar   31, 2014: New datatype fmiChar introduced.
+   - Feb.  17, 2013: Changed fmiTypesPlatform from "standard32" to "default".
+                     Removed fmiUndefinedValueReference since no longer needed
+                     (because every state is defined in ScalarVariables).
+   - March 20, 2012: Renamed from fmiPlatformTypes.h to fmiTypesPlatform.h
+   - Nov.  14, 2011: Use the header file "fmiPlatformTypes.h" for FMI 2.0
+                     both for "FMI for model exchange" and for "FMI for co-simulation"
+                     New types "fmiComponentEnvironment", "fmiState", and "fmiByte".
+                     The implementation of "fmiBoolean" is change from "char" to "int".
+                     The #define "fmiPlatform" changed to "fmiTypesPlatform"
+                     (in order that #define and function call are consistent)
+   - Oct.   4, 2010: Renamed header file from "fmiModelTypes.h" to fmiPlatformTypes.h"
+                     for the co-simulation interface
+   - Jan.   4, 2010: Renamed meModelTypes_h to fmiModelTypes_h (by Mauss, QTronic)
+   - Dec.  21, 2009: Changed "me" to "fmi" and "meModel" to "fmiComponent"
+                     according to meeting on Dec. 18 (by Martin Otter, DLR)
+   - Dec.   6, 2009: Added meUndefinedValueReference (by Martin Otter, DLR)
+   - Sept.  9, 2009: Changes according to FMI-meeting on July 21:
+                     Changed "version" to "platform", "standard" to "standard32",
+                     Added a precise definition of "standard32" as comment
+                     (by Martin Otter, DLR)
+   - July  19, 2009: Added "me" as prefix to file names, added meTrue/meFalse,
+                     and changed meValueReferenced from int to unsigned int
+                     (by Martin Otter, DLR).
+   - March  2, 2009: Moved enums and function pointer definitions to
+                     ModelFunctions.h (by Martin Otter, DLR).
+   - Dec.  3, 2008 : First version by Martin Otter (DLR) and
+                     Hans Olsson (Dynasim).
+
+
+   Copyright (C) 2008-2011 MODELISAR consortium,
+               2012-2013 Modelica Association Project "FMI"
+               All rights reserved.
+   This file is licensed by the copyright holders under the BSD 2-Clause License
+   (http://www.opensource.org/licenses/bsd-license.html):
+
+   ----------------------------------------------------------------------------
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the copyright holders nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+   PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+   OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   ----------------------------------------------------------------------------
+
+   with the extension:
+
+   You may distribute or publicly perform any modification only under the
+   terms of this license.
+   (Note, this means that if you distribute a modified file,
+    the modified file must also be provided under this license).
+*/
+
+/* Platform (unique identification of this header file) */
+#define fmi2TypesPlatform "default"
+
+/* Type definitions of variables passed as arguments
+   Version "default" means:
+
+   fmi2Component           : an opaque object pointer
+   fmi2ComponentEnvironment: an opaque object pointer
+   fmi2FMUstate            : an opaque object pointer
+   fmi2ValueReference      : handle to the value of a variable
+   fmi2Real                : double precision floating-point data type
+   fmi2Integer             : basic signed integer data type
+   fmi2Boolean             : basic signed integer data type
+   fmi2Char                : character data type
+   fmi2String              : a pointer to a vector of fmi2Char characters
+                             ('\0' terminated, UTF8 encoded)
+   fmi2Byte                : smallest addressable unit of the machine, typically one byte.
+*/
+   typedef void*           fmi2Component;               /* Pointer to FMU instance       */
+   typedef void*           fmi2ComponentEnvironment;    /* Pointer to FMU environment    */
+   typedef void*           fmi2FMUstate;                /* Pointer to internal FMU state */
+   typedef unsigned int    fmi2ValueReference;
+   typedef double          fmi2Real   ;
+   typedef int             fmi2Integer;
+   typedef int             fmi2Boolean;
+   typedef char            fmi2Char;
+   typedef const fmi2Char* fmi2String;
+   typedef char            fmi2Byte;
+
+/* Values for fmi2Boolean  */
+#define fmi2True  1
+#define fmi2False 0
+
+
+#endif /* fmi2TypesPlatform_h */

--- a/SimulationRuntime/OMSIC/include/omsic.h
+++ b/SimulationRuntime/OMSIC/include/omsic.h
@@ -1,0 +1,107 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+/** \file omsic.h
+ */
+
+/** \defgroup OMSIC OMSI C-Runtime
+ *
+ * \brief OpenModelica Simulation Interface C-Runtime
+ *
+ * Long description of OMSI group.
+ */
+
+
+/** \addtogroup OMSIC
+  *  \{ */
+
+
+#ifndef _OMSIC_H
+#define _OMSIC_H
+
+
+#include <omsi.h>
+#include <omsi_callbacks.h>
+
+/* OMSIBase includes */
+#include <omsi_global.h>
+#include <omsi_utils.h>
+
+
+#define DIVISION(a,b,c) (((b) != 0) ? ((a) / (b)) :  division_error_time(c, model_vars_and_params->time_value))
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/*
+ * ============================================================================
+ * Central structure containing all informations
+ * ============================================================================
+ */
+
+/** \brief Central structure containing data and some extra model and experiment data.
+ *
+ */
+typedef struct osu_t {
+    /* open modelica simulation interface data */
+    omsi_t*             osu_data;           /**< Pointer to omsi_data struct, contains all data for simulation. */
+    omsi_template_callback_functions_t*   osu_functions;        /**< Struct with pointer to functions in generated code. */
+
+    omsi_bool           _need_update;           /**< `omsi_true` if model needs an update. */
+    omsi_bool           _has_jacobian;          /**< `omsi_true` if model has a jacobian matrix. Defaults to `omsi_false`. */
+    ModelState          state;                  /**< Current state of model. */
+    omsi_bool*          logCategories;          /**< Pointer to `osu_data->logCategories` array. */
+    omsi_bool*          loggingOn;              /**< Pointer to `osu_data->loggingOn`. */
+    omsi_char*          GUID;                   /**< Globally Unique Identifier for OMSU instance. */
+    omsi_string         instanceName;           /**< Unique name for OMSU instance. */
+    omsi_event_info     eventInfo;              /**< Informations for simulator for event handling. */
+    omsi_bool           toleranceDefined;       /* ToDo: delete up to stopTime, redundant information. Already in osu_data->model_info */
+    omsi_real           tolerance;
+    omsi_real           startTime;
+    omsi_bool           stopTimeDefined;
+    omsi_real           stopTime;
+    omsu_type           type;                   /**< Type of OMSU. Only model exchange is supported at the moment. */
+    omsi_unsigned_int*  vrStates;               /**< Array of value references of states. */
+    omsi_unsigned_int*  vrStatesDerivatives;    /**< Array of value references of state derivatives. */
+
+    const omsi_callback_functions*  fmiCallbackFunctions;   /**< Callback functions for memory management and logging. */
+} osu_t;
+
+
+#ifdef __cplusplus
+}  /* end of extern "C" { */
+#endif
+
+#endif
+
+/** \} */

--- a/SimulationRuntime/OMSIC/include/omsu/omsu_common.h
+++ b/SimulationRuntime/OMSIC/include/omsu/omsu_common.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+/*
+ * This header file contains structs and forwards extern functions for
+ * all other OMSU c files.
+ */
+#ifndef OMSU_COMMON_H
+#define OMSU_COMMON_H
+
+#include <omsic.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* extern functions */
+extern void omsic_model_setup_data(osu_t* OSU);
+extern omsi_status setExternalFunction(osu_t* OSU, const omsi_unsigned_int vr, const void* value);
+extern void mmc_catch_dummy_fn(void);
+
+
+#ifdef __cplusplus
+extern } /* end of extern "C" */
+#endif
+
+#endif

--- a/SimulationRuntime/OMSIC/include/omsu/omsu_continuous_simulation.h
+++ b/SimulationRuntime/OMSIC/include/omsu/omsu_continuous_simulation.h
@@ -1,0 +1,96 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+/*
+ * This file defines functions for the FMI continuous simulation used via the OpenModelica
+ * Simulation Interface (OMSI). These are the functions to evaluate the
+ * model equations during continuous-time mode with OMSI.
+ */
+
+#ifndef OMSU_CONTINUOUSSIMULATION__H_
+#define OMSU_CONTINUOUSSIMULATION__H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include <omsic.h>
+
+#include <omsu_getters_and_setters.h>
+#include <omsu_event_simulation.h>
+#include <omsu_helper.h>
+
+/*#include <omsu_helper.h>
+#include <omsu_me.h>*/
+
+/* function prototypes */
+omsi_status omsi_new_discrete_state(osu_t*              OSU,
+                                    omsi_event_info*    eventInfo);
+
+omsi_status omsi_enter_continuous_time_mode(osu_t* OSU);
+
+omsi_status omsi_set_continuous_states(osu_t*               OSU,
+                                       const omsi_real      x[],
+                                       omsi_unsigned_int    nx);
+
+omsi_status omsi_get_continuous_states(osu_t*               OSU,
+                                       omsi_real            x[],
+                                       omsi_unsigned_int    nx);
+
+omsi_status omsi_get_nominals_of_continuous_states(osu_t*               OSU,
+                                                   omsi_real            x_nominal[],
+                                                   omsi_unsigned_int    nx);
+
+omsi_status omsi_completed_integrator_step(osu_t*       OSU,
+                                           omsi_bool    noSetFMUStatePriorToCurrentPoint,
+                                           omsi_bool*   enterEventMode,
+                                           omsi_bool*   terminateSimulation);
+
+omsi_status omsi_get_derivatives(osu_t*             OSU,
+                                 omsi_real          derivatives[],
+                                 omsi_unsigned_int  nx);
+
+omsi_status omsi_get_directional_derivative(osu_t*                  OSU,
+                                            const omsi_unsigned_int vUnknown_ref[],
+                                            omsi_unsigned_int       nUnknown,
+                                            const omsi_unsigned_int vKnown_ref[],
+                                            omsi_unsigned_int       nKnown,
+                                            const omsi_real         dvKnown[],
+                                            omsi_real               dvUnknown[]);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/SimulationRuntime/OMSIC/include/omsu/omsu_event_simulation.h
+++ b/SimulationRuntime/OMSIC/include/omsu/omsu_event_simulation.h
@@ -1,0 +1,65 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+/*
+ * This file defines functions for the FMI event mode used via the OpenModelica
+ * Simulation Interface (OMSI). These are the core functions to evaluate the
+ * model equations with OMSI.
+ */
+
+#ifndef OMSU_EVENTSIMULATION__H_
+#define OMSU_EVENTSIMULATION__H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include <omsic.h>
+#include <omsu_helper.h>
+#include <omsi_event_helper.h>
+
+
+omsi_status omsi_enter_event_mode(osu_t* OSU);
+
+omsi_status omsi_get_event_indicators(osu_t*            OSU,
+                                      omsi_real         eventIndicators[],
+                                      omsi_unsigned_int ni);
+
+omsi_status omsi_event_update(osu_t*              OSU,
+                              omsi_event_info*    eventInfo);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/SimulationRuntime/OMSIC/include/omsu/omsu_getters_and_setters.h
+++ b/SimulationRuntime/OMSIC/include/omsu/omsu_getters_and_setters.h
@@ -1,0 +1,132 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+/*
+ * This file defines functions for the FMI used via the OpenModelica Simulation
+ * Interface (OMSI). These are the common functions for getting and setting
+ * variables and FMI informations.
+ */
+
+#ifndef OMSU_GETTERSANDSETTERS__H_
+#define OMSU_GETTERSANDSETTERS__H_
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include <omsic.h>
+#include <omsi_input_model_variables.h>
+
+#include <omsu_common.h>
+#include <omsu_helper.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+/* function prototypes */
+
+omsi_status omsic_get_real(osu_t*                    OSU,
+                           const omsi_unsigned_int   vr[],
+                           omsi_unsigned_int         nvr,
+                           omsi_real                 value[]);
+
+omsi_status omsic_get_integer(osu_t*                     OSU,
+                              const omsi_unsigned_int    vr[],
+                              omsi_unsigned_int          nvr,
+                              omsi_int                   value[]);
+
+omsi_status omsic_get_boolean(osu_t*                     OSU,
+                              const omsi_unsigned_int    vr[],
+                              omsi_unsigned_int          nvr,
+                              omsi_bool                  value[]);
+
+omsi_status omsic_get_string(osu_t*                  OSU,
+                             const omsi_unsigned_int vr[],
+                             omsi_unsigned_int       nvr,
+                             omsi_string             value[]);
+
+omsi_status omsi_get_fmu_state(osu_t*        OSU,
+                               void **      FMUstate);
+
+omsi_status omsi_get_clock(osu_t*               OSU,
+                           const omsi_int       clockIndex[],
+                           omsi_unsigned_int    nClockIndex,
+                           omsi_bool            tick[]);
+
+omsi_status omsi_get_interval(osu_t*            OSU,
+                              const omsi_int    clockIndex[],
+                              omsi_unsigned_int nClockIndex,
+                              omsi_real         interval[]);
+
+omsi_status omsic_set_real(osu_t*                    OSU,
+                           const omsi_unsigned_int   vr[],
+                           omsi_unsigned_int         nvr,
+                           const omsi_real           value[]);
+
+omsi_status omsic_set_integer(osu_t*                     OSU,
+                              const omsi_unsigned_int    vr[],
+                              omsi_unsigned_int          nvr,
+                              const omsi_int             value[]);
+
+omsi_status omsic_set_boolean(osu_t*                     OSU,
+                              const omsi_unsigned_int    vr[],
+                              omsi_unsigned_int          nvr,
+                              const omsi_bool            value[]);
+
+omsi_status omsic_set_string(osu_t*                  OSU,
+                             const omsi_unsigned_int vr[],
+                             omsi_unsigned_int       nvr,
+                             const omsi_string       value[]);
+
+omsi_status omsi_set_time(osu_t*    OSU,
+                          omsi_real time);
+
+omsi_status omsi_set_fmu_state(osu_t*   OSU,
+                               void *   FMUstate);
+
+omsi_status omsi_set_clock(osu_t*               OSU,
+                           const omsi_int       clockIndex[],
+                           omsi_unsigned_int    nClockIndex,
+                           const omsi_bool      tick[],
+                           const omsi_bool      subactive[]);
+
+omsi_status omsi_set_interval(osu_t*            OSU,
+                              const omsi_int    clockIndex[],
+                              omsi_unsigned_int nClockIndex,
+                              const omsi_real   interval[]);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/SimulationRuntime/OMSIC/include/omsu/omsu_helper.h
+++ b/SimulationRuntime/OMSIC/include/omsu/omsu_helper.h
@@ -1,0 +1,111 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+#ifndef OMSU_HELPER_H
+#define OMSU_HELPER_H
+
+#include <stdio.h>
+#include <string.h>
+#include <stddef.h>
+
+#include <omsic.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+/* extern function prototypes
+extern void printLapackData(solver_data_lapack*    lapack_data,
+                            omsi_string     indent);*/
+
+
+/* function prototypes */
+void omsu_free_osu(osu_t* OSU);
+
+omsi_string stateToString(osu_t* OSU);
+
+omsi_bool invalidState(osu_t*       OSU,
+                       omsi_string  function_name,
+                       omsi_int     meStates,
+                       omsi_int     csStates);
+
+omsi_bool nullPointer(osu_t*        OSU,
+                      omsi_string   function_name,
+                      omsi_string   arg,
+                      const void *  pointer);
+
+omsi_bool vrOutOfRange(osu_t*               OSU,
+                       omsi_string          function_name,
+                       omsi_unsigned_int    vr,
+                       omsi_int             end);
+
+omsi_status unsupportedFunction(osu_t*      OSU,
+                                omsi_string function_name,
+                                omsi_int    statesExpected);
+
+omsi_bool invalidNumber(osu_t*          OSU,
+                        omsi_string     function_name,
+                        omsi_string     arg,
+                        omsi_int        n,
+                        omsi_int        nExpected);
+
+omsi_status omsi_set_debug_logging(osu_t*               OSU,
+                                   omsi_bool            loggingOn,
+                                   omsi_unsigned_int    nCategories,
+                                   const omsi_string    categories[]);
+
+ModelState omsic_get_model_state (void);
+
+omsi_bool omsu_discrete_changes(osu_t*  OSU,
+                                void*   threadData);
+
+void omsu_storePreValues(omsi_t* omsi_data);
+
+void omsu_update_pre_zero_crossings(sim_data_t*          sim_data,
+                                    omsi_unsigned_int    n_zero_crossings);
+
+omsi_bool omsu_values_equal(omsi_values*    vars_1,
+                            omsi_values*    vars_2);
+
+omsi_status omsu_copy_values(omsi_values*   target_vars,
+                             omsi_values*   source_vars);
+
+void omsu_print_osu (osu_t* OSU);
+
+omsi_real division_error_time(const char*   msg,
+                              omsi_real     time);
+
+#ifdef __cplusplus
+}  /* end of extern "C" { */
+#endif
+
+#endif

--- a/SimulationRuntime/OMSIC/include/omsu/omsu_initialization.h
+++ b/SimulationRuntime/OMSIC/include/omsu/omsu_initialization.h
@@ -1,0 +1,91 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+/*
+ * This file defines functions for the FMI used via the OpenModelica Simulation
+ * Interface (OMSI). These functions are used for instantiation and initialization
+ * of the FMU.
+ */
+
+#ifndef OMSU_INITIALIZATION__H_
+#define OMSU_INITIALIZATION__H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+
+#include <omsic.h>
+
+#include <omsi_initialization.h>
+
+#include <omsu_helper.h>
+#include <omsu_common.h>
+
+
+/* extern functions */
+extern void omsic_model_setup_data(osu_t* OSU);
+
+osu_t* omsic_instantiate(omsi_string                            instanceName,
+                         omsu_type                              fmuType,
+                         omsi_string                            fmuGUID,
+                         omsi_string                            fmuResourceLocation,
+                         const omsi_callback_functions*         functions,
+                         omsi_bool                              __attribute__((unused)) visible,
+                         omsi_bool                              loggingOn);
+
+omsi_status omsi_enter_initialization_mode(osu_t* OSU);
+
+omsi_status omsi_exit_initialization_mode(osu_t* OSU);
+
+omsi_status omsi_setup_experiment(osu_t*     OSU,
+                                  omsi_bool  toleranceDefined,
+                                  omsi_real  tolerance,
+                                  omsi_real  startTime,
+                                  omsi_bool  stopTimeDefined,
+                                  omsi_real  stopTime);
+
+void omsi_free_instance(osu_t* OSU);
+
+omsi_status omsi_reset(osu_t* OSU);
+
+omsi_status omsi_terminate(osu_t* OSU);
+
+
+/* Extern function prototypes */
+extern void initialize_start_function (omsi_template_callback_functions_t* callback);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/SimulationRuntime/OMSIC/src/fmi2/omsi_fmi2_wrapper.c
+++ b/SimulationRuntime/OMSIC/src/fmi2/omsi_fmi2_wrapper.c
@@ -1,0 +1,571 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+/** \file omsi_fmi2_wrapper.c
+ *
+ *  \brief Wrapper function for FMI compability.
+ */
+
+/** \defgroup FMI2Wrapper FMI 2.0 Wrapper
+ *  \ingroup OMSIC
+ *
+ * \brief FMI Wrapper
+ *
+ * Wrapper functions to use FMI2 functions to interact with an OMSU.
+ * See the <a href="https://fmi-standard.org/downloads/">FMI-standard specification</a> for Model Exchange and Co-Simulation 2.0 for more details on how to use these functions.
+ */
+
+/** \addtogroup FMI2Wrapper
+  *  \{ */
+
+
+/* TODO: implement external functions in FMU wrapper for c++ target
+ */
+
+#include <omsi.h>
+#include <omsi_fmi2_wrapper.h>
+#include <omsi_utils.h>
+#include <omsu_initialization.h>
+#include <omsu_getters_and_setters.h>
+#include <omsu_continuous_simulation.h>
+
+
+/**
+ * \brief Uniquely identify the header file used for compilation of a binary.
+ * \return              Returns the string to uniquely identify the "fmi2TypesPlatform.h"
+ *                      header file used for compilation of the functions of the FMU.
+ */
+FMI2_Export const char* fmi2GetTypesPlatform(void) {
+    return fmi2TypesPlatform;
+}
+
+
+/**
+ * \brief Return the version of the "fmi2Functions.h" header file.
+ *
+ * \return              Return "fmiVersion" which is defaults to "2.0".
+ */
+FMI2_Export const char* fmi2GetVersion(void) {
+    return fmi2Version;
+}
+
+
+/**
+ * \brief Enable or disable debug logging.
+ *
+ * \param [in]  c               FMI 2.0 component
+ * \param [in]  loggingOn       Set logging on or off.
+ * \param [in]  nCategories     Number of categories of FMU. Set in modelDescription.xml.
+ * \param [in]  categories      Allowed categories. Set in modelDescription.xml.
+ * \return      fmi2Status
+ */
+FMI2_Export fmi2Status fmi2SetDebugLogging(fmi2Component    c,
+                                           fmi2Boolean      loggingOn,
+                                           size_t           nCategories,
+                                           const fmi2String categories[]) {
+
+    return omsi_set_debug_logging(c, loggingOn, nCategories, categories);
+}
+
+
+/**
+ * \brief Return new instance of FMU.
+ *
+ * \param [in]  instanceName            Unique identifier for FMU instance.
+ * \param [in]  fmuType                 Is `fmi2ModelExchange` or `fmi2CoSimulation`.
+ *                                      Only model exchange is supported at the moment.
+ * \param [in]  fmuGUID                 Globally Unique Identifier from modelDescription.xml.
+ * \param [in]  fmuResourceLocation     URI to resource directory of unzippedFMU.
+ * \param [in]  functions               Callback functions used in FMU.
+ * \param [in]  visible                 Defines if interaction with user should be reduced
+ *                                      or be interactive. Ignored at the moment.
+ * \param [in]  loggingOn               Enable or disable debug logging.
+ * \return New FMU / OMSU or `NULL` if instantiation failed.
+ */
+FMI2_Export fmi2Component fmi2Instantiate(fmi2String                    instanceName,
+                                          fmi2Type                      fmuType,
+                                          fmi2String                    fmuGUID,
+                                          fmi2String                    fmuResourceLocation,
+                                          const fmi2CallbackFunctions*  functions,
+                                          fmi2Boolean                   visible,
+                                          fmi2Boolean                   loggingOn)
+{
+
+    return (fmi2Component) omsic_instantiate(instanceName, fmuType, fmuGUID, fmuResourceLocation, (const omsi_callback_functions*)functions, visible, loggingOn);
+}
+
+
+/**
+ * \brief Free FMU instance.
+ * \param [in]  c       FMU
+ */
+FMI2_Export void fmi2FreeInstance(fmi2Component c) {
+    omsi_free_instance(c);
+}
+
+
+/**
+ * \brief Inform the FMU / OMSU  to setup the experiment.
+ *
+ * \param [in]  c                   FMI 2.0 component.
+ * \param [in]  toleranceDefined    Boolean if tolerance is defined.
+ * \param [in]  tolerance           Value of tolerance, if defined.
+ * \param [in]  startTime           Start time for experiment.
+ * \param [in]  stopTimeDefined     If a stop time is defined.
+ * \param [in]  stopTime            Value of stop time, if defined.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2SetupExperiment(fmi2Component    c,
+                                           fmi2Boolean      toleranceDefined,
+                                           fmi2Real         tolerance,
+                                           fmi2Real         startTime,
+                                           fmi2Boolean      stopTimeDefined,
+                                           fmi2Real         stopTime) {
+
+    return omsi_setup_experiment(c, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
+}
+
+
+/**
+ * \brief Informs the FMU to enter initialization mode.
+ *
+ * \param [in,out]      c           FMI 2.0 component.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2EnterInitializationMode(fmi2Component c) {
+    return omsi_enter_initialization_mode(c);
+}
+
+
+
+/**
+ * \brief Informs the FMU to exit initialization mode.
+ *
+ * \param [in,out]      c           FMI 2.0 component.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2ExitInitializationMode(fmi2Component c) {
+    return omsi_exit_initialization_mode(c);
+}
+
+
+/**
+ * \brief Informs the FMU that the simulation run is terminated.
+ *
+ * \param [in,out]      c           FMI 2.0 component.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2Terminate(fmi2Component c) {
+    return omsi_terminate(c);
+}
+
+
+/**
+ * \brief Reset the FMU after a simulation run.
+ *
+ * \param [in,out]      c           FMI 2.0 component.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2Reset(fmi2Component c) {
+    return omsi_reset(c);
+}
+
+
+/**
+ * \brief Get real variables of FMU.
+ *
+ * \param [in]          c           FMI 2.0 component.
+ * \param [in]          vr          Array of value references of variables to get.
+ * \param [in]          nvr         Length of array `vr`.
+ * \param [out]         value       Array with values of variables.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2GetReal(fmi2Component            c,
+                                   const fmi2ValueReference vr[],
+                                   size_t                   nvr,
+                                   fmi2Real                 value[]) {
+
+    /* ToDo: Check for Update */
+
+    return omsic_get_real(c, vr, nvr, value);
+}
+
+
+/**
+ * \brief Get integer variables of FMU.
+ *
+ * \param [in]          c           FMI 2.0 component.
+ * \param [in]          vr          Array of value references of variables to get.
+ * \param [in]          nvr         Length of array `vr`.
+ * \param [out]         value       Array with values of variables.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2GetInteger(fmi2Component             c,
+                                      const fmi2ValueReference  vr[],
+                                      size_t                    nvr,
+                                      fmi2Integer               value[]) {
+
+    return omsic_get_integer(c, vr, nvr, value);
+}
+
+
+/**
+ * \brief Get boolean variables of FMU.
+ *
+ * \param [in]          component   FMI 2.0 component.
+ * \param [in]          vr          Array of value references of variables to get.
+ * \param [in]          nvr         Length of array `vr`.
+ * \param [out]         value       Array with values of variables.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2GetBoolean(fmi2Component             component,
+                                      const fmi2ValueReference  vr[],
+                                      size_t                    nvr,
+                                      fmi2Boolean               value[]) {
+
+    return omsic_get_boolean(component, vr, nvr, value);
+}
+
+
+/**
+ * \brief Get string variables of FMU.
+ *
+ * \param [in]          c           FMI 2.0 component.
+ * \param [in]          vr          Array of value references of variables to get.
+ * \param [in]          nvr         Length of array `vr`.
+ * \param [out]         value       Array with values of variables.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2GetString(fmi2Component              c,
+                                     const fmi2ValueReference   vr[],
+                                     size_t                     nvr,
+                                     fmi2String                 value[]) {
+
+    return omsic_get_string(c, vr, nvr, value);
+}
+
+
+/**
+ * \brief Set real variables of FMU.
+ *
+ * \param [in,out]      c           FMI 2.0 component.
+ * \param [in]          vr          Array of value references for variables to set.
+ * \param [in]          nvr         Length of array `vr`.
+ * \param [in]          value       Array with values for variables.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2SetReal(fmi2Component            c,
+                                   const fmi2ValueReference vr[],
+                                   size_t                   nvr,
+                                   const fmi2Real           value[]) {
+
+    return omsic_set_real(c, vr, nvr, value);
+}
+
+
+/**
+ * \brief Set integer variables of FMU.
+ *
+ * \param [in,out]      c           FMI 2.0 component.
+ * \param [in]          vr          Array of value references for variables to set.
+ * \param [in]          nvr         Length of array `vr`.
+ * \param [in]          value       Array with values for variables.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2SetInteger(fmi2Component             c,
+                                      const fmi2ValueReference  vr[],
+                                      size_t                    nvr,
+                                      const fmi2Integer         value[]) {
+
+    return omsic_set_integer(c, vr, nvr, value);
+}
+
+
+/**
+ * \brief Set boolean variables of FMU.
+ *
+ * \param [in,out]      c           FMI 2.0 component.
+ * \param [in]          vr          Array of value references for variables to set.
+ * \param [in]          nvr         Length of array `vr`.
+ * \param [in]          value       Array with values for variables.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2SetBoolean(fmi2Component             c,
+                                      const fmi2ValueReference  vr[],
+                                      size_t                    nvr,
+                                      const fmi2Boolean         value[]) {
+
+    return omsic_set_boolean(c, vr, nvr, value);
+}
+
+
+/**
+ * \brief Set string variables of FMU.
+ *
+ * \param [in,out]      c           FMI 2.0 component.
+ * \param [in]          vr          Array of value references for variables to set.
+ * \param [in]          nvr         Length of array `vr`.
+ * \param [in]          value       Array with values for variables.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2SetString(fmi2Component              c,
+                                     const fmi2ValueReference   vr[],
+                                     size_t                     nvr,
+                                     const fmi2String           value[]) {
+
+    return omsic_set_string(c, vr, nvr, value);
+}
+
+
+/* Not supported */
+FMI2_Export fmi2Status fmi2GetFMUstate(fmi2Component c,
+                                       fmi2FMUstate* FMUstate) {
+
+    return omsi_get_fmu_state(c, FMUstate);
+}
+
+
+/* Not supported */
+FMI2_Export fmi2Status fmi2SetFMUstate(fmi2Component    c,
+                                       fmi2FMUstate     FMUstate) {
+
+    return omsi_set_fmu_state(c, FMUstate);
+}
+
+
+/* Not supported */
+FMI2_Export fmi2Status fmi2FreeFMUstate(__attribute__((unused)) fmi2Component c,
+                                        __attribute__((unused)) fmi2FMUstate* FMUstate) {
+
+    /*return omsi_free_fmu_state(c, FMUstate);*/
+    return fmi2Error;
+}
+
+
+/* Not supported */
+FMI2_Export fmi2Status fmi2SerializedFMUstateSize(__attribute__((unused)) fmi2Component c,
+                                                  __attribute__((unused)) fmi2FMUstate  FMUstate,
+                                                  __attribute__((unused)) size_t*       size) {
+
+    /*return omsi_serialized_fmu_state_size(c, FMUstate, size);*/
+    return fmi2Error;
+}
+
+
+/* Not supported */
+FMI2_Export fmi2Status fmi2SerializeFMUstate(__attribute__((unused)) fmi2Component  c,
+                                             __attribute__((unused)) fmi2FMUstate   FMUstate,
+                                             __attribute__((unused)) fmi2Byte       serializedState[],
+                                             __attribute__((unused))  size_t         size) {
+
+    /*return omsi_serialize_fmu_state(c, FMUstate, serializedState, size);*/
+    return fmi2Error;
+}
+
+
+/* Not supported */
+FMI2_Export fmi2Status fmi2DeSerializeFMUstate(__attribute__((unused)) fmi2Component    c,
+                                               __attribute__((unused)) const fmi2Byte   serializedState[],
+                                               __attribute__((unused)) size_t size,
+                                               __attribute__((unused)) fmi2FMUstate* FMUstate) {
+
+    /*return omsi_de_serialize_fmu_state(c, serializedState, size, FMUstate);*/
+    return fmi2Error;
+}
+
+
+/* Not supported */
+FMI2_Export fmi2Status fmi2GetDirectionalDerivative(__attribute__((unused)) fmi2Component               c,
+                                                    __attribute__((unused)) const fmi2ValueReference    vUnknown_ref[],
+                                                    __attribute__((unused)) size_t                      nUnknown,
+                                                    __attribute__((unused)) const fmi2ValueReference    vKnown_ref[],
+                                                    __attribute__((unused)) size_t                      nKnown,
+                                                    __attribute__((unused)) const fmi2Real              dvKnown[],
+                                                    __attribute__((unused)) fmi2Real                    dvUnknown[]) {
+
+    /*return omsi_get_directional_derivative(c, vUnknown_ref, nUnknown, vKnown_ref, nKnown, dvKnown, dvUnknown);*/
+    return fmi2Error;
+}
+
+
+/**
+ * \brief FMU enters event mode.
+ *
+ * \param [in,out]      c           FMI 2.0 component.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2EnterEventMode(fmi2Component c) {
+
+    return omsi_enter_event_mode(c);
+}
+
+
+/**
+ * \brief Evaluate discrete model equations.
+ *
+ * Only allowed if FMU is in event mode.
+ *
+ * \param [in,out]      c               FMI 2.0 component.
+ * \param [out]         fmiEventInfo    Informations about the event for integrator.
+ * \return      fmi2Status              Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2NewDiscreteStates(fmi2Component  c,
+                                             fmi2EventInfo* fmiEventInfo) {
+
+    return omsi_new_discrete_state(c, (omsi_event_info*) fmiEventInfo);
+}
+
+
+/**
+ * \brief FMU enters continuous-time mode.
+ *
+ * \param [in,out]      c           FMI 2.0 component.
+ * \return      fmi2Status          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2EnterContinuousTimeMode(fmi2Component c) {
+
+    return omsi_enter_continuous_time_mode(c);
+}
+
+
+/**
+ * \brief Has to be called after every completed integrator step.
+ *
+ * Unless capability flag `completedIntegratorStepNotNeeded = true`.
+ *
+ * \param [in,out]      c                                   FMI 2.0 component.
+ * \param [in]          noSetFMUStatePriorToCurrentPoint    `true` if `fmi2SetFMUState` will no longer be called for time instants prior to current time in this simulation.
+ * \param [out]         enterEventMode                      Signal if environment shall call `fmi2EnterEventMode`.
+ * \param [out]         terminateSimulation                 Signal if the simulation should be terminated.
+ * \return              fmi2Status                          Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2CompletedIntegratorStep(fmi2Component    c,
+                                                   fmi2Boolean      noSetFMUStatePriorToCurrentPoint,
+                                                   fmi2Boolean*     enterEventMode,
+                                                   fmi2Boolean*     terminateSimulation) {
+
+    return omsi_completed_integrator_step(c, noSetFMUStatePriorToCurrentPoint, enterEventMode, terminateSimulation);
+}
+
+
+/**
+ * \brief Set new time instant and re-initialize time-dependent caching variables.
+ *
+ * \param [in,out]      c           FMI 2.0 component.
+ * \param [in]          time        Time to set in FMU.
+ * \return              fmi2Status  Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2SetTime(fmi2Component    c,
+                                   fmi2Real         time) {
+
+    return omsi_set_time(c, time);
+}
+
+
+/**
+ * \brief Set a new continuous state vector and re-initalize depend states.
+ *
+ * \param [in,out]      c           FMI 2.0 component.
+ * \param [in]          x           Array with values for continuous states.
+ * \param [in]          nx          Length of array `x`.
+ * \return              fmi2Status  Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2SetContinuousStates(fmi2Component    c,
+                                               const fmi2Real   x[],
+                                               size_t           nx) {
+
+    return omsi_set_continuous_states(c, x, nx);
+}
+
+
+/**
+ * \brief Compute state derivatives.
+ *
+ * \param [in]          c               FMI 2.0 component.
+ * \param [out]         derivatives     Array with computed state derivatives.
+ * \param [in]          nx              Size of array `derivatives`
+ * \return              fmi2Status      Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2GetDerivatives(fmi2Component c,
+                                          fmi2Real      derivatives[],
+                                          size_t        nx) {
+
+    return omsi_get_derivatives(c, derivatives, nx);
+}
+
+
+/**
+ * \brief Compute event indicators.
+ *
+ * \param [in]          c               FMI 2.0 component.
+ * \param [out]         eventIndicators Array with values of event indicators.
+ * \param [in]          ni              Length of array `eventIndicators`.
+ * \return              fmi2Status      Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2GetEventIndicators(fmi2Component c,
+                                              fmi2Real      eventIndicators[],
+                                              size_t        ni) {
+
+    return omsi_get_event_indicators(c, eventIndicators, ni);
+}
+
+
+/**
+ * \brief Get new (continuous) state vector.
+ *
+ * \param [in]          c               FMI 2.0 component.
+ * \param [out]         x               Array with values of continuous states.
+ * \param [in]          nx              Length of array `x`.
+ * \return              fmi2Status      Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2GetContinuousStates(fmi2Component    c,
+                                               fmi2Real         x[],
+                                               size_t           nx) {
+
+    return omsi_get_continuous_states(c, x, nx);
+}
+
+
+/**
+ * \brief Return the nominal values of the continuous states.
+ *
+ * \param [in]          c               FMI 2.0 component.
+ * \param [out]         x_nominal       Array with nominal values of continuous states.ds
+ * \param [in]          nx              Length of array `x`.
+ * \return              fmi2Status      Exit status of function.
+ */
+FMI2_Export fmi2Status fmi2GetNominalsOfContinuousStates(fmi2Component  c,
+                                                         fmi2Real       x_nominal[],
+                                                         size_t         nx) {
+
+    return omsi_get_nominals_of_continuous_states(c, x_nominal, nx);
+}
+
+/** \} */

--- a/SimulationRuntime/OMSIC/src/omsu/CMakeLists.txt
+++ b/SimulationRuntime/OMSIC/src/omsu/CMakeLists.txt
@@ -1,0 +1,26 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
+#OpenModelica Simulation Unit C Runtime
+PROJECT(OMSU)
+SET(CMAKE_VERBOSE_MAKEFILE ON)
+
+#set OMSIBase lib
+if(NOT PLATFORM OR PLATFORM STREQUAL "dynamic")
+  set (libOMSIBase ${CMAKE_INSTALL_PREFIX}/${LIBINSTALLEXT}/libOMSIBase${SHREXT})
+elseif(PLATFORM STREQUAL "static")
+  set (libOMSIBase ${CMAKE_INSTALL_PREFIX}/${LIBINSTALLEXT}/libOMSIBase${LIBSUFFIX}.a)
+else()
+endif()
+MESSAGE(STATUS "OMSI Base Library: ${libOMSIBase}")
+
+
+include_directories ("${CMAKE_SOURCE_DIR}/include")
+include_directories ("${CMAKE_SOURCE_DIR}/include/solver")
+include_directories ("${CMAKE_SOURCE_DIR}/include/omsu")
+include_directories ("${CMAKE_SOURCE_DIR}/include/fmi2")
+include_directories ("${OMSI_SOURCE_DIR}/base/include")
+
+add_library(${OMSICName} STATIC omsu_helper.c omsu_initialization.c omsu_getters_and_setters.c omsu_event_simulation.c omsu_continuous_simulation.c ../fmi2/omsi_fmi2_wrapper.c)
+
+target_link_libraries(${OMSICName} ${CMAKE_DL_LIBS} ${libOMSIBase})
+
+install(TARGETS ${OMSICName} DESTINATION ${LIBINSTALLEXT})

--- a/SimulationRuntime/OMSIC/src/omsu/omsu_continuous_simulation.c
+++ b/SimulationRuntime/OMSIC/src/omsu/omsu_continuous_simulation.c
@@ -1,0 +1,467 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+/** \file omsu_continuous_simulation.c
+ *
+ *  \brief Functions for OMSI continuous simulation.
+ *
+ * This file defines functions for the continuous simulation with OpenModelica
+ * Simulation Interface (OMSI). These are the functions to evaluate the
+ * model equations during continuous-time mode with OMSI.
+ */
+
+/** \defgroup ContinuousSimulation Continuous Simulation
+ *  \ingroup OMSIC
+ *
+ * \brief Functions used for continuous simulation
+ */
+
+/** \addtogroup ContinuousSimulation
+  *  \{ */
+
+#include <omsu_continuous_simulation.h>
+
+#define UNUSED(x) (void)(x)     /* ToDo: delete later */
+
+
+/**
+ * \brief Evaluate discrete model equations.
+ *
+ * Only allowed if OMSU is in event mode.
+ * Can be called with fmi2 wrapper function `fmi2NewDiscreteStates`.
+ *
+ * \param [in,out]      OSU             OMSU component.
+ * \param [out]         eventInfo       Informations about the event for the integrator.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_new_discrete_state(osu_t*              OSU,
+                                    omsi_event_info*    eventInfo) {
+
+    /* Variables */
+    omsi_status status;
+
+    /* Check inputs */
+    if (invalidState(OSU, "fmi2NewDiscreteStates", modelEventMode, ~0)) {
+        return omsi_error;
+    }
+
+    /* Log function call */
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2NewDiscreteStates");
+
+    /* Set event info */
+    eventInfo->newDiscreteStatesNeeded = omsi_false;
+    eventInfo->terminateSimulation = omsi_false;
+    eventInfo->nominalsOfContinuousStatesChanged = omsi_false;
+    eventInfo->valuesOfContinuousStatesChanged = omsi_false;
+    eventInfo->nextEventTimeDefined = omsi_false;
+    eventInfo->nextEventTime = 0;
+
+    status = omsi_event_update(OSU, eventInfo);
+
+    return status;
+}
+
+
+/**
+ * \brief OMSU enters continuous-time mode.
+ *
+ * The model enters Continuous-Time Mode and all discrete-time equations become
+ * inactive and all relations are "frozen".
+ * Can be called with fmi2 wrapper function `fmi2EnterContinuousTimeMode`.
+ *
+ * \param [in,out]      OSU             OMSU component.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_enter_continuous_time_mode(osu_t* OSU) {
+
+    if (invalidState(OSU, "fmi2EnterContinuousTimeMode", modelEventMode, ~0)) {
+        return omsi_error;
+    }
+
+    /* Log function call */
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2EnterContinuousTimeMode");
+
+    OSU->state = modelContinuousTimeMode;
+
+    return omsi_ok;
+}
+
+
+/**
+ * \brief Set a new continuous state vector and re-initalize depend states.
+ *
+ * Can be called with fmi2 wrapper `fmi2SetContinuousStates`.
+ *
+ * \param [in,out]      OSU             OMSU component.
+ * \param [in]          x               Array with values for continuous states.
+ * \param [in]          nx              Length of array `x`.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_set_continuous_states(osu_t*               OSU,
+                                       const omsi_real      x[],
+                                       omsi_unsigned_int    nx) {
+
+    /* Variables */
+    omsi_unsigned_int i, vr;
+
+    /* According to FMI RC2 specification fmi2SetContinuousStates should only be
+     * allowed in Continuous-Time Mode. The following code is done only to make
+     * the FMUs compatible with Dymola because Dymola is trying to call
+     * fmi2SetContinuousStates after fmi2EnterInitializationMode.
+     */
+    if (invalidState(OSU, "fmi2SetContinuousStates", modelInstantiated | modelInitializationMode | modelEventMode | modelContinuousTimeMode, ~0)) {
+        return omsi_error;
+    }
+    if (invalidNumber(OSU, "fmi2SetContinuousStates", "nx", nx, OSU->osu_data->model_data->n_states)) {
+        return omsi_error;
+    }
+    if (nullPointer(OSU, "fmi2SetContinuousStates", "x[]", x)) {
+        return omsi_error;
+    }
+
+    /* Log function call */
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2SetContinuousStates");
+
+    /* Set continuous states */
+    for (i = 0; i < nx; i++) {
+        vr = OSU->vrStates[i];
+        filtered_base_logger(global_logCategories, log_all, omsi_ok,
+                "fmi2SetContinuousStates: #r%d# = %.16g", vr, x[i]);
+        if (setReal(OSU->osu_data, vr, x[i]) != omsi_ok) {
+            return omsi_error;
+        }
+    }
+    OSU->_need_update = omsi_true;
+
+    return omsi_ok;
+}
+
+/**
+ * \brief Get new (continuous) state vector.
+ *
+ * Can be called with fmi2 wrapper `fmi2GetContinuousStates`.
+ *
+ * \param [in,out]      OSU             OMSU component.
+ * \param [out]         x               Array with values of continuous states.
+ * \param [in]          nx              Length of array `x`.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_get_continuous_states(osu_t*               OSU,
+                                       omsi_real            x[],
+                                       omsi_unsigned_int    nx) {
+
+    /* Variables */
+    omsi_unsigned_int i, vr;
+
+    if (invalidState(OSU, "fmi2GetContinuousStates", modelInitializationMode | modelEventMode | modelContinuousTimeMode | modelTerminated | modelError, ~0)) {
+        return omsi_error;
+    }
+    if (invalidNumber(OSU, "fmi2GetContinuousStates", "nx", nx, OSU->osu_data->model_data->n_states)) {
+        return omsi_error;
+    }
+    if (nullPointer(OSU, "fmi2GetContinuousStates", "states[]", x)) {
+        return omsi_error;
+    }
+
+    /* Log call */
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2GetContinuousStates");
+
+    for (i = 0; i < nx; i++) {
+        vr = OSU->vrStates[i];
+        x[i] = getReal(OSU->osu_data, vr);
+
+        filtered_base_logger(global_logCategories, log_all, omsi_ok,
+                "fmi2GetContinuousStates: #r%u# = %.16g", vr, x[i]);
+    }
+
+    return omsi_ok;
+}
+
+
+/**
+ * \brief Return the nominal values of the continuous states.
+ *
+ * Since the component environment has no information about the nominal value of
+ * the continuous states 1.0 is returned.
+ * Can be called with fmi2 wrapper `fmi2GetNominalsOfContinuousStates`.
+ *
+ * \param [in,out]      OSU             OMSU component.
+ * \param [out]         x_nominal       Array with nominal values of continuous states.ds
+ * \param [in]          nx              Length of array `x`.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_get_nominals_of_continuous_states(osu_t*               OSU,
+                                                   omsi_real            x_nominal[],
+                                                   omsi_unsigned_int    nx) {
+
+    /* Variables */
+    omsi_unsigned_int i;
+
+    if (invalidState(OSU, "fmi2GetNominalsOfContinuousStates", modelInstantiated | modelEventMode | modelContinuousTimeMode | modelTerminated | modelError, ~0)) {
+        return omsi_error;
+    }
+    if (invalidNumber(OSU, "fmi2GetNominalsOfContinuousStates", "nx", nx, OSU->osu_data->model_data->n_states)) {
+        return omsi_error;
+    }
+    if (nullPointer(OSU, "fmi2GetNominalsOfContinuousStates", "x_nominal[]", x_nominal)) {
+        return omsi_error;
+    }
+
+    /* Log function call */
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2GetNominalsOfContinuousStates: x_nominal[0, ... , %d] = 1.0",
+            nx - 1);
+
+    x_nominal[0] = 1;       /* ToDo: What happens for nx = 0, otherwise this line is unneccessary */
+
+    for (i = 0; i < nx; i++) {
+        x_nominal[i] = 1;
+    }
+
+    return omsi_ok;
+}
+
+
+/**
+ * \brief Has to be called after every completed integrator step.
+ *
+ * ...provided the capability flag `completedIntegratorStepNotNeeded = false`.
+ * The function returns enterEventMode to signal to the environment if the OMSU
+ * shall call omsu_enter_event_mode, and it returns terminateSimulation to signal
+ * if the simulation shall be terminated.
+ *
+ * \param [in,out]      OSU                                 OMSU component.
+ * \param [in]          noSetFMUStatePriorToCurrentPoint    `omsi_true` if `fmi2SetFMUState` will no longer be called for
+ *                                                          time instants prior to current time in this simulation.
+ * \param [out]         enterEventMode                      Signal if environment shall call `fmi2EnterEventMode`.
+ * \param [out]         terminateSimulation                 Signal if the simulation should be terminated.
+ * \return              omsi_status                         Exit status of function.
+ */
+omsi_status omsi_completed_integrator_step(osu_t*       OSU,
+                                           omsi_bool    noSetFMUStatePriorToCurrentPoint,
+                                           omsi_bool*   enterEventMode,
+                                           omsi_bool*   terminateSimulation) {
+
+    /* Variables */
+    omsi_status status;
+    /*threadData_t *threadData = OSU->threadData;*/
+
+    UNUSED(noSetFMUStatePriorToCurrentPoint);
+
+    if (invalidState(OSU, "fmi2CompletedIntegratorStep", modelContinuousTimeMode, ~0)) {
+        return omsi_error;
+    }
+    if (nullPointer(OSU, "fmi2CompletedIntegratorStep", "enterEventMode", enterEventMode)) {
+        return omsi_error;
+    }
+    if (nullPointer(OSU, "fmi2CompletedIntegratorStep", "terminateSimulation", terminateSimulation)) {
+        return omsi_error;
+    }
+
+    /* Log function call */
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2CompletedIntegratorStep");
+
+    /* ToDo: Do something useful with noSetFMUStatePriorToCurrentPoint */
+
+    /* ToDo: try */
+    /* MMC_TRY_INTERNAL (simulationJumpBuffer) */
+
+    /* ToDo: evaluate stuff ... */
+    /*OSU->osu_functions->functionAlgebraics(OSU->old_data, threadData);
+    OSU->osu_functions->output_function(OSU->old_data, threadData);
+    OSU->osu_functions->function_storeDelayed(OSU->old_data, threadData);
+
+
+    storePreValues(OSU->osu_data); */
+
+  if (OSU->_need_update)
+  {
+    status = OSU->osu_data->sim_data->simulation->evaluate (
+        OSU->osu_data->sim_data->simulation,
+        OSU->osu_data->sim_data->model_vars_and_params, NULL);
+    OSU->_need_update = omsi_false;
+  }
+  else
+  {
+    status = omsi_ok;
+  }
+
+
+    *enterEventMode = omsi_false;
+    *terminateSimulation = omsi_false;
+
+    /******** check state selection ********/
+/*#if !defined(OMC_NO_STATESELECTION) */
+#if 0
+    if (stateSelection(OSU->old_data, threadData, 1, 0)) {
+        /* if new set is calculated reinit the solver */
+        *enterEventMode = omsi_true;
+        LOG_FILTER(OSU, LOG_ALL,
+            global_callback->logger(OSU, global_instance_name, omsi_ok, logCategoriesNames[LOG_ALL],
+            "fmi2CompletedIntegratorStep: Need to iterate state values changed!"))
+    }
+#endif
+    /* TODO: fix the extrapolation in non-linear system
+     *       then we can stop to save all variables in
+     *       in the whole ringbuffer
+     */
+
+    /* overwriteOldSimulationData(OSU->old_data); */
+    return status;
+
+    /* ToDo: catch */
+    /* MMC_CATCH_INTERNAL (simulationJumpBuffer)
+
+    FILTERED_LOG(OSU, omsi_error, LOG_FMI2_CALL,
+            "fmi2CompletedIntegratorStep: terminated by an assertion.")
+    return omsi_error;*/
+}
+
+
+/**
+ * \brief Computes state derivatives at the current time instant and for the current states.
+ *
+ * \param   [in,out]    OSU             OMSU component.
+ * \param   [out]       derivatives     Array with values of derivatives.
+ * \param   [in]        nx              Length of array `x`.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_get_derivatives(osu_t*             OSU,
+                                 omsi_real          derivatives[],
+                                 omsi_unsigned_int  nx) {
+
+    /* Variables */
+    omsi_unsigned_int i, vr;
+
+    /* threadData_t *threadData = OSU->threadData; */
+
+    if (invalidState(OSU, "fmi2GetDerivatives",  modelEventMode | modelContinuousTimeMode | modelTerminated | modelError, ~0)) {
+        return omsi_error;
+    }
+    if (invalidNumber(OSU, "fmi2GetDerivatives", "nx", nx, OSU->osu_data->model_data->n_states)) {
+        return omsi_error;
+    }
+    if (nullPointer(OSU, "fmi2GetDerivatives", "derivatives[]", derivatives)) {
+        return omsi_error;
+    }
+
+    /* ToDo: try */
+    /* MMC_TRY_INTERNAL (simulationJumpBuffer) */
+
+    /* Log function call */
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2GetDerivatives");
+
+
+    /* Evaluate needed equations */
+    if (OSU->_need_update) {
+        OSU->osu_data->sim_data->simulation->evaluate (OSU->osu_data->sim_data->simulation, OSU->osu_data->sim_data->model_vars_and_params, NULL);
+        OSU->_need_update = omsi_false;
+    }
+
+    for (i = 0; i < nx; i++) {
+        vr = nx + i;
+        derivatives[i] = getReal(OSU->osu_data, vr);
+        filtered_base_logger(global_logCategories, log_all, omsi_ok,
+                "fmi2GetDerivatives: #r%d# = %.16g", vr, derivatives[i]);
+    }
+
+    return omsi_ok;
+
+    /* ToDo: catch */
+    /* MMC_CATCH_INTERNAL (simulationJumpBuffer)
+
+    FILTERED_LOG(OSU, omsi_error, LOG_FMI2_CALL,
+            "fmi2GetDerivatives: terminated by an assertion.")
+    return omsi_error;*/
+}
+
+/*
+ * ToDo: Comment me
+ * Actually does nothing at the moment ¯\_(ツ)_/¯
+ */
+omsi_status omsi_get_directional_derivative(osu_t*                  OSU,
+                                            const omsi_unsigned_int vUnknown_ref[],
+                                            omsi_unsigned_int       nUnknown,
+                                            const omsi_unsigned_int vKnown_ref[],
+                                            omsi_unsigned_int       nKnown,
+                                            const omsi_real         dvKnown[],
+                                            omsi_real               dvUnknown[]) {
+
+    UNUSED(vUnknown_ref); UNUSED(nUnknown); UNUSED(vKnown_ref); UNUSED(nKnown);  UNUSED(dvKnown); UNUSED(dvUnknown);
+
+    if (invalidState(OSU, "fmi2GetDirectionalDerivative", modelInstantiated | modelEventMode | modelContinuousTimeMode, ~0)) {
+        return omsi_error;
+    }
+
+    /* Log function call */
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2GetDirectionalDerivative");
+
+    if (!OSU->_has_jacobian) {
+        unsupportedFunction(OSU, "fmi2GetDirectionalDerivative", modelInitializationMode | modelEventMode | modelContinuousTimeMode | modelTerminated | modelError);
+        return  omsi_error;
+    }
+
+#if 0
+    /***************************************/
+    // This code assumes that the FMU variables are always sorted,
+    // states first and then derivatives.
+    // This is true for the actual OMC FMUs.
+    // Anyway we will check that the references are in the valid range
+    for (i = 0; i < nUnknown; i++) {
+        if (vUnknown_ref[i] >= OSU->osu_data->model_data->n_states)
+            // We are only computing the A part of the Jacobian for now
+            // so unknowns can only be states
+            return omsi_error;
+    }
+    for (i = 0; i < nKnown; i++) {
+        if (vKnown_ref[i] >= 2 * OSU->osu_data->model_data->n_states) {
+            // We are only computing the A part of the Jacobian for now
+            // so knowns can only be states derivatives
+            return omsi_error;
+        }
+    }
+    OSU->osu_functions->functionFMIJacobian(OSU->old_data, OSU->threadData,
+            vUnknown_ref, nUnknown, vKnown_ref, nKnown, (double*) dvKnown,
+            dvUnknown);
+
+    /***************************************/
+#endif
+
+    return omsi_ok;
+}
+
+/** \} */

--- a/SimulationRuntime/OMSIC/src/omsu/omsu_event_simulation.c
+++ b/SimulationRuntime/OMSIC/src/omsu/omsu_event_simulation.c
@@ -1,0 +1,249 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+/*
+ * This file defines functions for the FMI event mode used via the OpenModelica
+ * Simulation Interface (OMSI). These are the core functions to evaluate the
+ * model equations with OMSI.
+ */
+
+/** \file omsu_event_simulation.c
+ *
+ *  \brief Functions for OMSI event handling.
+ *
+ * This file defines functions for the OpenModelica Simulation Interface (OMSI).
+ * These are the core functions to handle events with OMSI.
+ */
+
+/** \defgroup EventHandling Event simulation
+ *  \ingroup OMSIC
+ *
+ * \brief Functions used for event simulation
+ */
+
+/** \addtogroup EventHandling
+  *  \{ */
+
+#include <omsu_event_simulation.h>
+
+#define UNUSED(x) (void)(x)     /* ToDo: delete later */
+
+/*
+ * The model enters Event Mode from the Continuous-Time Mode and discrete-time
+ * equations may become active (and relations are not “frozen”).
+ */
+omsi_status omsi_enter_event_mode(osu_t* OSU) {
+
+    if (invalidState(OSU, "fmi2EnterEventMode", modelInitializationMode|modelContinuousTimeMode|modelEventMode, ~0)) {
+        return omsi_error;
+    }
+
+    /* Log call */
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2EnterEventMode");
+
+    OSU->state = modelEventMode;
+    return omsi_ok;
+}
+
+
+/**
+ * \brief Compute event indicators.
+ *
+ * Allowed to call in event mode, continuous-time mode and terminated.
+ *
+ * \param   [in,out]    OSU                 OMSU component.
+ * \param   [out]       event_indicators    Array with values of event indicators.
+ * \param   [in]        n_event_indicators  Length of array `event_indicators`.
+ * \return              omsi_status         Exit status of function.
+ */
+omsi_status omsi_get_event_indicators(osu_t*            OSU,
+                                      omsi_real*        event_indicators,
+                                      omsi_unsigned_int n_event_indicators)
+{
+    /* Variables */
+    omsi_unsigned_int i;
+
+    if (invalidState(OSU, "fmi2GetEventIndicators",
+            modelInstantiated|modelInitializationMode|modelContinuousTimeMode|
+            modelEventMode|modelTerminated|modelError, ~0)) {
+        return omsi_error;
+    }
+    /* Check if number of event indicators n_event_indicators is valid */
+    if (invalidNumber(OSU, "fmi2GetEventIndicators", "n_event_indicators",
+            n_event_indicators, OSU->osu_data->model_data->n_zerocrossings)) {
+        return omsi_error;
+    }
+
+    /* Log call */
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2GetEventIndicators");
+
+    /* If there are no event indicator there is nothing to do */
+    if (OSU->osu_data->model_data->n_zerocrossings == 0) {
+        return omsi_ok;
+    }
+
+    /* ToDo: try */
+    /* MMC_TRY_INTERNAL(simulationJumpBuffer)*/
+
+    /* Evaluate needed equations */
+    if (OSU->_need_update) {
+        OSU->osu_data->sim_data->simulation->evaluate (OSU->osu_data->sim_data->simulation, OSU->osu_data->sim_data->model_vars_and_params, NULL);
+        OSU->_need_update = omsi_false;
+    }
+
+    /* Get event indicators */
+    /*OSU->osu_functions->function_ZeroCrossings(OSU->osu_data->sim_data->simulation, OSU->osu_data->sim_data->model_vars_and_params, NULL);*/
+    for (i=0; i<n_event_indicators; i++) {
+        event_indicators[i] = OSU->osu_data->sim_data->zerocrossings_vars[i];
+        filtered_base_logger(global_logCategories, log_events, omsi_ok,
+                        "fmi2GetEventIndicators: z%d = %.16g", i, event_indicators[i]);
+    }
+
+    return omsi_ok;
+
+    /* ToDo: catch */
+    /* MMC_CATCH_INTERNAL(simulationJumpBuffer)
+
+    FILTERED_LOG(OSU, omsi_ok, LOG_FMI2_CALL, "error", "fmi2GetEventIndicators: terminated by an assertion.");
+    return omsi_error;*/
+}
+
+
+
+/**
+ * \brief Event iteration to update discrete values.
+ *
+ * Update pre values, evaluate discrete equations and update discrete variables.
+ * Computes next sample event time.
+ * Called from function `omsi_new_discrete_state`.
+ *
+ * \param   [in,out]    OSU             OMSU component.
+ * \param   [out]       eventInfo       Informations about the event for integrator.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_event_update(osu_t*              OSU,
+                              omsi_event_info*    eventInfo) {
+
+    /* Variables */
+    omsi_status status;
+    omsi_real nextSampleEvent;
+
+    if (nullPointer(OSU, "fmi2EventUpdate", "eventInfo", eventInfo)) {
+        return omsi_error;
+    }
+
+    /* Log function call */
+    filtered_base_logger(global_logCategories, log_all, omsi_ok,
+            "fmi2EventUpdate: Start Event Update!");
+
+    /* ToDo: try */
+    /* MMC_TRY_INTERNAL(simulationJumpBuffer)*/
+
+#if 0
+#if !defined(OMC_NO_STATESELECTION)
+    if (stateSelection(OSU->old_data, OSU->threadData, 1, 1)) {
+        LOG_FILTER(OSU, LOG_FMI2_CALL,
+            global_callback->logger(OSU, global_instance_name, omsi_ok, logCategoriesNames[LOG_ALL],
+            "fmi2EventUpdate: Need to iterate state values changed!"))
+        /* if new set is calculated reinit the solver */
+        eventInfo->valuesOfContinuousStatesChanged = omsi_true;
+    }
+#endif
+#endif
+
+    /* Store pre values */
+    omsu_storePreValues(OSU->osu_data);
+    omsu_update_pre_zero_crossings(OSU->osu_data->sim_data, OSU->osu_data->model_data->n_zerocrossings);
+
+    /*evaluate functionDAE */
+    status = OSU->osu_data->sim_data->simulation->evaluate(OSU->osu_data->sim_data->simulation, OSU->osu_data->sim_data->simulation->function_vars, NULL);
+    if (status != omsi_ok) {
+        return status;
+    }
+
+    /* Check for discrete changes */
+    if (omsi_check_discrete_changes(OSU->osu_data) || eventInfo->newDiscreteStatesNeeded) {
+        filtered_base_logger(global_logCategories, log_all, omsi_ok,
+                "fmi2EventUpdate:  Need to iterate(discrete changes)!");
+        eventInfo->newDiscreteStatesNeeded = omsi_true;
+        eventInfo->valuesOfContinuousStatesChanged = omsi_true;         /* ToDo: Is this correct? */
+    } else {
+        eventInfo->newDiscreteStatesNeeded = omsi_false;
+    }
+
+    filtered_base_logger(global_logCategories, log_all, omsi_ok,
+            "fmi2EventUpdate: newDiscreteStatesNeeded %s",
+            eventInfo->newDiscreteStatesNeeded ? "true" : "false");
+
+#if 0
+    /* due to an event overwrite old values */
+    overwriteOldSimulationData(OSU->old_data);
+
+    /* TODO: check the event iteration for relation
+     * in fmi2 import and export. This is an workaround,
+     * since the iteration seem not starting.
+     */
+
+    /* ToDo: enable, when preValues are implemented */
+    /* omsu_storePreValues(OSU->osu_data); */
+    updateRelationsPre(OSU->old_data);
+#endif
+
+    /* Get Next Event Time */
+    nextSampleEvent = omsi_compute_next_event_time(
+            OSU->osu_data->sim_data->model_vars_and_params->time_value,
+            OSU->osu_data->sim_data->sample_events,
+            OSU->osu_data->model_data->n_samples);
+    if (nextSampleEvent < 0) {
+        eventInfo->nextEventTimeDefined = omsi_false;
+    } else {
+        eventInfo->nextEventTimeDefined = omsi_true;
+        eventInfo->nextEventTime = nextSampleEvent;
+    }
+
+    filtered_base_logger(global_logCategories, log_all, omsi_ok,
+            "fmi2EventUpdate: Checked for Sample Events! Next Sample Event %f",
+            eventInfo->nextEventTime);
+
+    return omsi_ok;
+
+
+    /* ToDo: catch */
+    /* MMC_CATCH_INTERNAL(simulationJumpBuffer)
+
+    FILTERED_LOG(OSU, omsi_error, LOG_FMI2_CALL,
+            "fmi2EventUpdate: terminated by an assertion.")
+    OSU->_need_update = omsi_true;
+    return omsi_error; */
+}
+
+/** \} */

--- a/SimulationRuntime/OMSIC/src/omsu/omsu_getters_and_setters.c
+++ b/SimulationRuntime/OMSIC/src/omsu/omsu_getters_and_setters.c
@@ -1,0 +1,420 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+/** \file omsu_getters_and_setters.c
+ *
+ *  \brief Getter and setter functions for OMSIC.
+ *
+ * This file defines functions for the FMI used via the OpenModelica Simulation
+ * Interface (OMSI). These are the common functions for getting and setting
+ * variables and FMI informations.
+ */
+
+/** \defgroup GetterAndSetter Get and set functions
+ *  \ingroup OMSIC
+ *
+ * \brief Get and set functions using OMSI Base functions.
+ */
+
+/** \addtogroup GetterAndSetter
+  *  \{ */
+
+#include <omsu_getters_and_setters.h>
+
+#define UNUSED(x) (void)(x)     /* ToDo: delete later */
+
+/*
+ * ============================================================================
+ * Getters
+ * ============================================================================
+ */
+
+
+/**
+ * \brief Get real variables of OMSU.
+ *
+ * \param   [in]        OSU             OMSU component.
+ * \param   [in]        vr              Array of value references of variables to get.
+ * \param   [in]        nvr             Length of array `vr`.
+ * \param   [out]       value           Array with values of variables.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsic_get_real(osu_t*                    OSU,
+                           const omsi_unsigned_int   vr[],
+                           omsi_unsigned_int         nvr,
+                           omsi_real                 value[]){
+
+    /* Variables */
+    omsi_bool return_status;
+
+    if (invalidState(OSU, "fmi2GetReal", modelInitializationMode|modelEventMode|modelContinuousTimeMode|modelTerminated|modelError, ~0)) {
+      return omsi_error;
+    }
+
+    /* OMSIBase function call */
+    return_status = omsi_get_real(OSU->osu_data, vr, nvr, value);
+    if (return_status != omsi_ok) {
+        OSU->state = modelError;
+    }
+
+    return return_status;
+}
+
+
+/**
+ * \brief Get integer variables of OMSU.
+ *
+ * \param   [in]        OSU             OMSU component.
+ * \param   [in]        vr              Array of value references of variables to get.
+ * \param   [in]        nvr             Length of array `vr`.
+ * \param   [out]       value           Array with values of variables.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsic_get_integer(osu_t*                     OSU,
+                              const omsi_unsigned_int    vr[],
+                              omsi_unsigned_int          nvr,
+                              omsi_int                   value[]){
+
+    /* Variables */
+    omsi_bool return_status;
+
+    if (invalidState(OSU, "fmi2GetInteger", modelInitializationMode|modelEventMode|modelContinuousTimeMode|modelTerminated|modelError, ~0)) {
+      return omsi_error;
+    }
+
+    /* OMSIBase function call */
+    return_status = omsi_get_integer(OSU->osu_data, vr, nvr, value);
+    if (return_status != omsi_ok) {
+        OSU->state = modelError;
+    }
+
+    return return_status;
+}
+
+
+/**
+ * \brief Get boolean variables of OMSU.
+ *
+ * \param   [in]        OSU             OMSU component.
+ * \param   [in]        vr              Array of value references of variables to get.
+ * \param   [in]        nvr             Length of array `vr`.
+ * \param   [out]       value           Array with values of variables.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsic_get_boolean(osu_t*                     OSU,
+                              const omsi_unsigned_int    vr[],
+                              omsi_unsigned_int          nvr,
+                              omsi_bool                  value[]) {
+
+    /* Variables */
+    omsi_bool return_status;
+
+    if (invalidState(OSU, "fmi2GetBoolean", modelInitializationMode|modelEventMode|modelContinuousTimeMode|modelTerminated|modelError, ~0)) {
+        return omsi_error;
+    }
+
+    return_status = omsi_get_boolean(OSU->osu_data, vr, nvr, value);
+    if (return_status != omsi_ok) {
+        OSU->state = modelError;
+    }
+
+    return return_status;
+}
+
+
+/**
+ * \brief Get string variables of OMSU.
+ *
+ * \param   [in]        OSU             OMSU component.
+ * \param   [in]        vr              Array of value references of variables to get.
+ * \param   [in]        nvr             Length of array `vr`.
+ * \param   [out]       value           Array with values of variables.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsic_get_string(osu_t*                  OSU,
+                             const omsi_unsigned_int vr[],
+                             omsi_unsigned_int       nvr,
+                             omsi_string             value[]){
+
+    /* Variables */
+    omsi_bool return_status;
+
+    if (invalidState(OSU, "fmi2GetString", modelInitializationMode|modelEventMode|modelContinuousTimeMode|modelTerminated|modelError, ~0)) {
+        return omsi_error;
+    }
+    if (nvr>0 && nullPointer(OSU, "fmi2GetString", "vr[]", vr))
+        return omsi_error;
+    if (nvr>0 && nullPointer(OSU, "fmi2GetString", "value[]", value))
+        return omsi_error;
+
+    /* OMSIBase function call */
+    return_status = omsi_get_string(OSU->osu_data, vr, nvr, value);
+    if (return_status != omsi_ok) {
+        OSU->state = modelError;
+    }
+
+    return return_status;
+}
+
+
+omsi_status omsi_get_fmu_state(osu_t*        OSU,
+                               void **      FMUstate) {
+
+    /* TODO: implement */
+    UNUSED(OSU); UNUSED (FMUstate);
+    return omsi_error;
+}
+
+omsi_status omsi_get_clock(osu_t*               OSU,
+                           const omsi_int       clockIndex[],
+                           omsi_unsigned_int    nClockIndex,
+                           omsi_bool            tick[]) {
+
+    /* TODO: implement */
+    UNUSED(OSU); UNUSED(clockIndex); UNUSED(nClockIndex); UNUSED(tick);
+    return omsi_error;
+}
+
+omsi_status omsi_get_interval(osu_t*            OSU,
+                              const omsi_int    clockIndex[],
+                              omsi_unsigned_int nClockIndex,
+                              omsi_real         interval[]) {
+
+    /* TODO: implement */
+    UNUSED(OSU); UNUSED(clockIndex); UNUSED(nClockIndex); UNUSED(interval);
+    return omsi_error;
+}
+
+
+/*
+ * ============================================================================
+ * Setters
+ * ============================================================================
+ */
+
+
+/**
+ * \brief Set real variables of OMSU.
+ *
+ * \param   [in,out]    OSU             OMSU component.
+ * \param   [in]        vr              Array of value references of variables to set.
+ * \param   [in]        nvr             Length of array `vr`.
+ * \param   [in]        value           Array with values of variables.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsic_set_real(osu_t*                    OSU,
+                           const omsi_unsigned_int   vr[],
+                           omsi_unsigned_int         nvr,
+                           const omsi_real           value[]) {
+
+    /* Variables */
+    omsi_bool return_status;
+    omsi_int meStates, csStates;
+
+    meStates = modelInstantiated|modelInitializationMode|modelEventMode|modelContinuousTimeMode;
+    csStates = modelInstantiated|modelInitializationMode|modelEventMode|modelContinuousTimeMode;
+
+    if (invalidState(OSU, "fmi2SetReal", meStates, csStates))
+        return omsi_error;
+
+    /* OMSIBase function call */
+    return_status = omsi_set_real(OSU->osu_data, vr, nvr, value);
+    if (return_status != omsi_ok) {
+        OSU->state = modelError;
+    }
+
+    OSU->_need_update = omsi_true;
+
+    return return_status;
+}
+
+
+/**
+ * \brief Set integer variables of OMSU.
+ *
+ * \param   [in,out]    OSU             OMSU component.
+ * \param   [in]        vr              Array of value references of variables to set.
+ * \param   [in]        nvr             Length of array `vr`.
+ * \param   [in]        value           Array with values of variables.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsic_set_integer(osu_t*                     OSU,
+                              const omsi_unsigned_int    vr[],
+                              omsi_unsigned_int          nvr,
+                              const omsi_int             value[]) {
+
+    /* Variables */
+    omsi_bool return_status;
+    omsi_int meStates, csStates;
+
+    meStates = modelInstantiated|modelInitializationMode|modelEventMode;
+    csStates = modelInstantiated|modelInitializationMode|modelEventMode|modelContinuousTimeMode;
+
+    if (invalidState(OSU, "fmi2SetInteger", meStates, csStates))
+        return omsi_error;
+
+    /* OMSIBase function call */
+    return_status = omsi_set_integer(OSU->osu_data, vr, nvr, value);
+    if (return_status != omsi_ok) {
+        OSU->state = modelError;
+    }
+
+    OSU->_need_update = omsi_true;
+
+    return return_status;
+}
+
+
+/**
+ * \brief Set boolean variables of OMSU.
+ *
+ * \param   [in,out]    OSU             OMSU component.
+ * \param   [in]        vr              Array of value references of variables to set.
+ * \param   [in]        nvr             Length of array `vr`.
+ * \param   [in]        value           Array with values of variables.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsic_set_boolean(osu_t*                     OSU,
+                              const omsi_unsigned_int    vr[],
+                              omsi_unsigned_int          nvr,
+                              const omsi_bool            value[]) {
+
+    /* Variables */
+    omsi_bool return_status;
+    omsi_int meStates, csStates;
+
+    meStates = modelInstantiated|modelInitializationMode|modelEventMode;
+    csStates = modelInstantiated|modelInitializationMode|modelEventMode|modelContinuousTimeMode;
+
+    if (invalidState(OSU, "fmi2SetBoolean", meStates, csStates))
+        return omsi_error;
+
+    /* OMSIBase function call */
+    return_status = omsi_set_boolean(OSU->osu_data, vr, nvr, value);
+    if (return_status != omsi_ok) {
+        OSU->state = modelError;
+    }
+
+    OSU->_need_update = omsi_true;
+
+    return return_status;
+}
+
+
+/**
+ * \brief Set string variables of OMSU.
+ *
+ * \param   [in,out]    OSU             OMSU component.
+ * \param   [in]        vr              Array of value references of variables to set.
+ * \param   [in]        nvr             Length of array `vr`.
+ * \param   [in]        value           Array with values of variables.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsic_set_string(osu_t*                  OSU,
+                             const omsi_unsigned_int vr[],
+                             omsi_unsigned_int       nvr,
+                             const omsi_string       value[]) {
+
+    /* Variables */
+    omsi_bool return_status;
+    omsi_int meStates, csStates;
+
+    meStates = modelInstantiated|modelInitializationMode|modelEventMode;
+    csStates = modelInstantiated|modelInitializationMode|modelEventMode|modelContinuousTimeMode;
+
+    if (invalidState(OSU, "fmi2SetString", meStates, csStates))
+        return omsi_error;
+
+    /* OMSIBase function call */
+    return_status = omsi_set_string(OSU->osu_data, vr, nvr, value);
+    if (return_status != omsi_ok) {
+        OSU->state = modelError;
+    }
+
+    OSU->_need_update = omsi_true;
+
+    return return_status;
+}
+
+
+/**
+ * \brief Set time of OSU.
+ *
+ * \param   [in,out]    OSU             OMSU component.
+ * \param   [in]        time            Time value to set.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_set_time(osu_t*    OSU,
+                          omsi_real time) {
+
+    if (invalidState(OSU, "fmi2SetTime", modelInstantiated|modelEventMode|modelContinuousTimeMode, ~0))
+        return omsi_error;
+
+    filtered_base_logger(global_logCategories, log_all, omsi_ok,
+            "fmi2SetTime: time=%.16g", time);
+
+    OSU->osu_data->sim_data->model_vars_and_params->time_value = time;
+    OSU->_need_update = omsi_true;
+    return omsi_ok;
+}
+
+
+omsi_status omsi_set_fmu_state(osu_t*   OSU,
+                               void *   FMUstate) {
+
+    /* TODO: implement */
+    UNUSED(OSU); UNUSED(FMUstate);
+    return omsi_error;
+}
+
+
+omsi_status omsi_set_clock(osu_t*               OSU,
+                           const omsi_int       clockIndex[],
+                           omsi_unsigned_int    nClockIndex,
+                           const omsi_bool      tick[],
+                           const omsi_bool      subactive[]) {
+
+    /* TODO: implement */
+    UNUSED(OSU); UNUSED(clockIndex); UNUSED(nClockIndex); UNUSED(tick); UNUSED(subactive);
+    return omsi_error;
+}
+
+
+omsi_status omsi_set_interval(osu_t*            OSU,
+                              const omsi_int    clockIndex[],
+                              omsi_unsigned_int nClockIndex,
+                              const omsi_real   interval[]) {
+
+    /* TODO: implement */
+    UNUSED(OSU); UNUSED(clockIndex); UNUSED(nClockIndex); UNUSED(interval);
+    return omsi_error;
+}
+
+/** \} */

--- a/SimulationRuntime/OMSIC/src/omsu/omsu_helper.c
+++ b/SimulationRuntime/OMSIC/src/omsu/omsu_helper.c
@@ -1,0 +1,520 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+/** \file omsu_helper.c
+ *
+ *  \brief Helper functions and functions for logging and debugging.
+ *
+ * This file defines helper functions used all over OMSI C-runtime. Also functions
+ * for logging and debugging.
+ */
+
+/** \defgroup Logging Logging and Debugging
+ *  \ingroup OMSIC
+ *
+ * \brief Functions used for logging and debugging
+ */
+
+/** \addtogroup Logging
+  *  \{ */
+
+#include <omsu_helper.h>
+
+#define UNUSED(x) (void)(x)     /* ToDo: delete later */
+
+/*
+ * ============================================================================
+ * Stuff I don't know where to put yet. ToDo: Do the thing!
+ * ============================================================================
+ */
+
+/*
+ * Helper function for logging.
+ * Returns current state of component as string.
+ */
+omsi_string stateToString(osu_t* OSU) {
+    switch (OSU->state) {
+        case modelInstantiated: return "Instantiated";
+        case modelInitializationMode: return "Initialization Mode";
+        case modelEventMode: return "Event Mode";
+        case modelContinuousTimeMode: return "Continuous-Time Mode";
+        case modelTerminated: return "Terminated";
+        case modelError: return "Error";
+        default: break;
+    }
+    return "Unknown";
+}
+
+
+/*
+ * Checks if component environment is allowed to execute function_name in its
+ * current state.
+ */
+omsi_bool invalidState(osu_t*       OSU,            /* OSU component */
+                       omsi_string  function_name,  /* name of function */
+                       omsi_int     meStates,       /* valid Model Exchange states for function */
+                       omsi_int     csStates) {     /* valid Co-Simulation state for function */
+
+    /* Variables */
+    omsi_int statesExpected;
+
+    if (!OSU) {
+        return omsi_true;
+    }
+
+    if (omsi_model_exchange == OSU->type) {
+        statesExpected = meStates;
+    }
+    else { /* CoSimulation */
+        statesExpected = csStates;
+    }
+
+    if (!(OSU->state & statesExpected)) {
+        OSU->state = statesExpected;
+
+        filtered_base_logger(global_logCategories, log_statuserror, omsi_error,
+                "%s: Illegal call sequence. %s is not allowed in %s state.",
+                function_name, function_name, stateToString(OSU));
+
+        OSU->state = modelError;
+        return omsi_true;
+    }
+
+    return omsi_false;
+}
+
+
+/*
+ * Returns true if pointer is NULL pointer, emits error message and sets
+ * model state to modelError.
+ * Otherwise it returns false.
+ */
+omsi_bool nullPointer(osu_t*        OSU,
+                      omsi_string   function_name,
+                      omsi_string   arg,
+                      const void *  pointer) {
+
+    if (!pointer) {
+        OSU->state = modelError;
+        filtered_base_logger(global_logCategories, log_statuserror, omsi_error,
+                "%s: Invalid argument %s = NULL.", function_name, arg);
+
+        return omsi_true;
+    }
+    return omsi_false;
+}
+
+
+/*
+ * Returns true if vr is out of range of end, emits error message and sets
+ * model state to modelError.
+ * Otherwise it returns false.
+ */
+omsi_bool vrOutOfRange(osu_t*               OSU,
+                       omsi_string          function_name,
+                       omsi_unsigned_int    vr,
+                       omsi_int             end) {
+
+    if ((omsi_int)vr >= end) {
+        OSU->state = modelError;
+        filtered_base_logger(global_logCategories, log_statuserror, omsi_error,
+                "%s: Illegal value reference %u.", function_name, vr);
+        return omsi_true;
+    }
+    return omsi_false;
+}
+
+
+/*
+ * Logs error for call of unsupported function.
+ */
+omsi_status unsupportedFunction(osu_t*      OSU,
+                                omsi_string function_name,
+                                omsi_int    statesExpected) {
+
+    if (invalidState(OSU, function_name, statesExpected, ~0)) {
+        return omsi_error;
+    }
+    filtered_base_logger(global_logCategories, log_statuserror, omsi_error,
+            "%s: Function not implemented.", function_name);
+    return omsi_error;
+}
+
+
+/*
+ * Returns true if n is not equal to nExpected, emits error message and sets
+ * model state to modelError.
+ * Otherwise it returns false.
+ */
+omsi_bool invalidNumber(osu_t*          OSU,
+                        omsi_string     function_name,
+                        omsi_string     arg,
+                        omsi_int        n,
+                        omsi_int        nExpected) {
+
+    if (n != nExpected) {
+        OSU->state = modelError;
+        filtered_base_logger(global_logCategories, log_statuserror, omsi_error,
+                "%s: Invalid argument %s = %d. Expected %d.",
+                function_name, arg, n, nExpected);
+        return omsi_true;
+    }
+    return omsi_false;
+}
+
+
+/**
+ * \brief Enable or disable debug logging.
+ *
+ * \param   [in]        OSU             OMSU component.
+ * \param   [in]        loggingOn       Set logging on or off.
+ * \param   [in]        nCategories     Number of categories of OMSU. Set in modelDescription.xml.
+ * \param   [in]        categories      Allowed categories. Set in modelDescription.xml.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_set_debug_logging(osu_t*               OSU,
+                                   omsi_bool            loggingOn,
+                                   omsi_unsigned_int    nCategories,
+                                   const omsi_string    categories[]) {
+
+    /* Variables */
+    omsi_unsigned_int i, j;
+    omsi_bool categoryFound;
+
+    OSU->osu_data->loggingOn = loggingOn;
+
+    for (i = 0; i < NUMBER_OF_CATEGORIES; i++) {
+        OSU->osu_data->logCategories[i] = omsi_false;
+    }
+    for (i = 0; i < nCategories; i++) {
+        categoryFound = omsi_false;
+        for (j = 0; j < NUMBER_OF_CATEGORIES; j++) {
+            if (strcmp(log_categories_names[j], categories[i]) == 0) {
+                OSU->osu_data->logCategories[j] = loggingOn;
+                categoryFound = omsi_true;
+                break;
+            }
+        }
+        if (!categoryFound) {
+            filtered_base_logger(NULL, log_statuswarning, omsi_warning,
+                    "logging category '%s' is not supported by model", categories[i]);
+        }
+    }
+
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2SetDebugLogging");
+
+    return omsi_ok;
+}
+
+
+/*
+ * \brief Returns model state of OSU.
+ *
+ * \return
+ */
+ModelState omsic_get_model_state (void)
+{
+    return *global_model_state;
+}
+
+
+/*
+ * Checks for discrete changes.
+ * Returns omsi_true if changes were found, otherwise omsi_false;
+ */
+omsi_bool omsu_discrete_changes(osu_t*  OSU,
+                                void*   threadData) {     /* ToDo: threadData not implemented yet */
+
+    /* ToDo: Log all changed variables */
+    if (OSU->logCategories[log_all]) {
+        /* ToDo: implement */
+        return omsi_false;
+    }
+    else {
+        return omsu_values_equal(OSU->osu_data->sim_data->model_vars_and_params, threadData);
+    }
+}
+
+
+/*
+ * Stores pre values of omsi_data->sim_data->model_vars_and_params.
+ */
+void omsu_storePreValues(omsi_t* omsi_data) {
+
+    omsu_copy_values(omsi_data->sim_data->pre_vars, omsi_data->sim_data->model_vars_and_params);
+}
+
+
+/*
+ * \brief Update values of `pre_zero_crossing` array.
+ *
+ * \param sim_data
+ * \param n_zero_crossings
+ */
+void omsu_update_pre_zero_crossings(sim_data_t*          sim_data,
+                                    omsi_unsigned_int    n_zero_crossings)
+{
+    /* Variables */
+    omsi_unsigned_int i;
+
+    for (i=0; i<n_zero_crossings; i++) {
+        sim_data->pre_zerocrossings_vars[i] = sim_data->zerocrossings_vars[i];
+    }
+
+
+}
+
+
+/*
+ * ============================================================================
+ * Section for data copying, comparing and such stuff
+ * ============================================================================
+ */
+
+/*
+ * Compare memory of vars_1 and vars_2 and returns omsi_true if they are equal.
+ * Otherwise omsi_false is returned.
+ */
+omsi_bool omsu_values_equal(omsi_values*    vars_1,
+                            omsi_values*    vars_2) {
+
+    omsi_unsigned_int size;
+
+    /* Check reals */
+    if (vars_1->n_reals != vars_2->n_reals) {
+        return omsi_false;
+    }
+    size = vars_1->n_reals*sizeof(omsi_real);
+    if (0 != memcmp(vars_1->reals, vars_2->reals, size)) {
+        return omsi_false;
+    }
+
+    /* Check ints */
+    if (vars_1->n_ints != vars_2->n_ints) {
+        return omsi_false;
+    }
+    size = vars_1->n_ints*sizeof(omsi_int);
+    if (0 != memcmp(vars_1->ints, vars_2->ints, size)) {
+        return omsi_false;
+    }
+
+    /* Check bools */
+    if (vars_1->n_bools != vars_2->n_bools) {
+        return omsi_false;
+    }
+    size = vars_1->n_bools*sizeof(omsi_bool);
+    if (0 != memcmp(vars_1->bools, vars_2->bools, size)) {
+        return omsi_false;
+    }
+
+    /* Check strings */
+    if (vars_1->n_strings != vars_2->n_strings) {
+        return omsi_false;
+    }
+    size = vars_1->n_strings*sizeof(omsi_string);
+    if (0 != memcmp(vars_1->strings, vars_2->strings, size)) {
+        return omsi_false;
+    }
+
+    /* Check externs */
+    if (vars_1->n_externs != vars_2->n_externs) {
+        return omsi_false;
+    }
+    size = vars_1->n_externs*sizeof(void*);
+    if (0 != memcmp(vars_1->externs, vars_2->externs, size)) {
+        return omsi_false;
+    }
+
+    /* Check time_value */
+    if (0 != memcmp(&vars_1->time_value, &vars_2->time_value, sizeof(omsi_real))) {
+        return omsi_false;
+    }
+
+    return omsi_true;
+}
+
+
+/*
+ * Copies source_vars to target_vars.
+ */
+omsi_status omsu_copy_values(omsi_values*   target_vars,
+                             omsi_values*   source_vars) {
+
+    omsi_unsigned_int size;
+
+    if (target_vars == NULL || source_vars == NULL) {
+        filtered_base_logger(global_logCategories, log_statuserror, omsi_error,
+                "copy_values: Pointer is NULL.");
+        return omsi_error;
+    }
+
+    /* Copy values */
+    size = sizeof(omsi_real)*source_vars->n_reals;
+    memcpy(target_vars->reals, source_vars->reals, size);
+
+    size = sizeof(omsi_int)*source_vars->n_reals;
+    memcpy(target_vars->reals, source_vars->reals, size);
+
+    size = sizeof(omsi_bool)*source_vars->n_bools;
+    memcpy(target_vars->bools, source_vars->bools, size);
+
+    size = sizeof(omsi_string)*source_vars->n_strings;
+    memcpy(target_vars->strings, source_vars->strings, size);
+
+    size = sizeof(void*)*source_vars->n_externs;
+    memcpy(target_vars->externs, source_vars->externs, size);
+
+    target_vars->time_value = source_vars->time_value;
+
+    /* Copy meta information */
+    target_vars->n_reals = source_vars->n_reals;
+    target_vars->n_ints = source_vars->n_ints;
+    target_vars->n_bools = source_vars->n_bools;
+    target_vars->n_strings = source_vars->n_strings;
+    target_vars->n_externs = source_vars->n_externs;
+
+    return omsi_ok;
+}
+
+
+/*
+ * ============================================================================
+ * Section for print and debug functions
+ * ============================================================================
+ */
+
+/**
+ * \brief Print all data in osu_t structure.
+ *
+ * Used for debugging.
+ *
+ * \param   [in]    OSU     OMSU component.
+ */
+void omsu_print_osu (osu_t* OSU) {
+
+    omsi_unsigned_int i;
+
+    printf("\n========== omsu_print_osu start ==========\n");
+
+    omsu_print_omsi_t(OSU->osu_data, "");
+
+    /* print informations contained directly in OSU */
+    printf("_need_update: \t\t%s\n", OSU->_need_update?"true":"false"); fflush(stdout);
+    printf("_has_jacobian: \t\t%s\n", OSU->_has_jacobian?"true":"false");
+
+    printf("state:\t\t\t");
+    switch (OSU->state) {
+    case modelInstantiated:
+        printf("modelInstantiated\n");
+        break;
+    case modelInitializationMode:
+        printf("modelInitializationMode\n");
+        break;
+    case modelContinuousTimeMode:
+        printf("modelContinuousTimeMode\n");
+        break;
+    case modelEventMode:
+        printf("modelEventMode\n");
+        break;
+    case modelSlaveInitialized:
+        printf("modelSlaveInitialized\n");
+        break;
+    case modelTerminated:
+        printf("modelTerminated\n");
+        break;
+    case modelError:
+        printf("modelError\n");
+        break;
+    default:
+        printf("unknown\n");
+    }
+
+    printf("GUID: \t\t\t%s\n", OSU->GUID);
+    printf("instanceName: \t\t%s\n", OSU->instanceName);
+
+
+
+    printf("toleranceDefined: \t%s\n", OSU->toleranceDefined?"true":"false");
+    printf("tolerance: \t\t%f\n", OSU->tolerance);
+    printf("startTime: \t\t%f\n", OSU->startTime);
+    printf("stopTimeDefined: \t%s\n", OSU->stopTimeDefined?"true":"false");
+    printf("stopTime: \t\t%f\n", OSU->stopTime);
+
+    printf("type:\t\t\t");
+    switch(OSU->type) {
+    case omsi_model_exchange:
+        printf("omsi_model_exchange\n");
+        break;
+    case omsi_co_simulation:
+        printf("omsi_model_exchange\n");
+        break;
+    default:
+        printf("unknown\n");
+    }
+
+    printf("vrStates: \t\t{ ");
+    for (i=0; i<OSU->osu_data->model_data->n_states; i++) {
+        printf("%u ", OSU->vrStates[i]);
+    }
+    printf("}\n");
+
+    printf("vrStatesDerivatives: \t{ ");
+    for (i=0; i<OSU->osu_data->model_data->n_states; i++) {
+        printf("%u ", OSU->vrStatesDerivatives[i]);
+    }
+    printf("}\n");
+
+    printf("\n==========  omsu_print_osu end  ==========\n\n");
+}
+
+
+/*
+ *  division error logging
+ */
+omsi_real division_error_time(const char*   msg,
+                              omsi_real     time) {
+
+  /* call an assert after lgging */
+  filtered_base_logger(global_logCategories, log_all, omsi_warning, "DIVISION: Divisor %s is zero at t = %f!", msg, time);
+  return 0;
+}
+
+
+/*
+ *  Modelica built-in homotopy function
+ */
+omsi_real homotopy(omsi_real actual, omsi_real siple) {
+
+  /* call an assert after logging */
+  return actual;
+}
+
+/** \} */

--- a/SimulationRuntime/OMSIC/src/omsu/omsu_initialization.c
+++ b/SimulationRuntime/OMSIC/src/omsu/omsu_initialization.c
@@ -1,0 +1,403 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+/** \file omsu_initialization.c
+ *
+ *  \brief Functions for instantiation and initialization, termination and
+ *  deallocation of OMSUs.
+ *
+ * This file defines functions for the OpenModelica Simulation Interface (OMSI).
+ * These functions are used for instantiation and initialization
+ * of an OMSU. Terminate and restart a simulation. Set experiment informations
+ * and free an OMSU.
+ */
+
+/** \defgroup InitializationOMSIC Initialization and deallocation
+ *  \ingroup OMSIC
+ *
+ * \brief Functions for instantiation and initialization, termination and
+ * deallocation of OMSUs.
+ */
+
+/** \addtogroup InitializationOMSIC
+  *  \{ */
+
+#define DEBUG omsi_false
+#define DEBUG_PRINT(function) if (DEBUG) {                                     \
+    printf("\nDEBUG PRINT\n");                                                 \
+    printf("=====================================================\n");         \
+    fflush(stdout);                                                            \
+    function; fflush(stdout);                                                  \
+    }                                                                          \
+
+#include <omsu_initialization.h>
+#include <omsi_posix_func.h>
+
+
+/**
+ * \brief Return new instance of OMSU.
+ *
+ * \param [in]  instanceName            Unique identifier for FMU instance.
+ * \param [in]  fmuType                 Is `fmi2ModelExchange` or `fmi2CoSimulation`.
+ *                                      Only model exchange is supported at the moment.
+ * \param [in]  fmuGUID                 Globally Unique Identifier from modelDescription.xml.
+ * \param [in]  fmuResourceLocation     URI to resource directory of unzippedFMU.
+ * \param [in]  functions               Callback functions used in FMU.
+ * \param [in]  visible                 Defines if interaction with user should be reduced
+ *                                      or be interactive. Unused at the moment.
+ * \param [in]  loggingOn               Enable or disable debug logging.
+ * \return New OMSU or `NULL` if instantiation failed.
+ */
+osu_t* omsic_instantiate(omsi_string                            instanceName,
+                         omsu_type                              fmuType,
+                         omsi_string                            fmuGUID,
+                         omsi_string                            fmuResourceLocation,
+                         const omsi_callback_functions*         functions,
+                         omsi_bool                              __attribute__((unused)) visible,
+                         omsi_bool                              loggingOn)
+{
+    /* Variables */
+    osu_t *OSU;
+    omsi_unsigned_int i;
+
+    /* set global callback functions */
+    global_callback = (omsi_callback_functions*) functions;
+    global_instance_name = instanceName;
+
+    /* allocate memory for OpenModelica Simulation Unit */
+    OSU = functions->allocateMemory(1, sizeof(osu_t));
+    if (!OSU) {
+        filtered_base_logger(NULL, log_statuserror, omsi_error,
+                "fmi2Instantiate: Not enough memory.");
+        filtered_base_logger(global_logCategories, log_statusfatal, omsi_error,
+                "Could not instantiate OSU component.");
+        return NULL;
+    }
+    global_callback->componentEnvironment = functions->componentEnvironment;
+
+    /* set general OSU data */
+    OSU->GUID = (omsi_char*) functions->allocateMemory(1, strlen(fmuGUID) + 1);
+    if (!OSU->GUID) {
+        filtered_base_logger(NULL, log_statuserror, omsi_error,
+                        "fmi2Instantiate: Not enough memory.");
+        omsu_free_osu(OSU);
+        filtered_base_logger(global_logCategories, log_statusfatal, omsi_error,
+                        "Could not instantiate OSU component.");
+        return NULL;
+    }
+
+    strcpy(OSU->GUID, fmuGUID);
+    OSU->instanceName = omsi_strdup((omsi_char*)instanceName);
+    OSU->type = fmuType;
+    OSU->fmiCallbackFunctions = functions;
+
+    OSU->osu_functions = (omsi_template_callback_functions_t*) functions->allocateMemory(1, sizeof(omsi_template_callback_functions_t));
+    if (!OSU->osu_functions || !OSU->instanceName) {
+        filtered_base_logger(NULL, log_statuserror, omsi_error,
+                "fmi2Instantiate: Not enough memory.");
+        omsu_free_osu(OSU);
+        filtered_base_logger(global_logCategories, log_statusfatal, omsi_error,
+                "Could not instantiate OSU component.");
+        return NULL;
+    }
+
+    /* Set template function pointers */
+    filtered_base_logger(NULL, log_all, omsi_ok,
+            "fmi2Instantiate: Set callback functions from generated C-Code");
+    initialize_start_function(OSU->osu_functions);      /* ToDo: At the moment only for static compilation */
+
+    /* Call OMSIBase function for initialization of osu_data */
+    OSU->osu_data = omsi_instantiate(instanceName, fmuType, fmuGUID, fmuResourceLocation, functions, OSU->osu_functions, visible, loggingOn, &OSU->state);
+    if (OSU->osu_data == NULL || OSU->state==modelError) {
+        omsu_free_osu(OSU);
+        filtered_base_logger(global_logCategories, log_statusfatal, omsi_error,
+                "Could not instantiate OSU component.");
+        return NULL;
+    }
+
+    /* Initialize callbacks for initialization and simulation omsi_functions */
+    omsi_intialize_callbacks(OSU->osu_data, OSU->osu_functions);
+
+    /* Initialize sample events */
+    OSU->osu_functions->initialize_samples(OSU->osu_data->sim_data->sample_events);
+
+    OSU->vrStates = (omsi_unsigned_int *) functions->allocateMemory(OSU->osu_data->model_data->n_states, sizeof(omsi_unsigned_int));
+    OSU->vrStatesDerivatives = (omsi_unsigned_int *) functions->allocateMemory(OSU->osu_data->model_data->n_states, sizeof(omsi_unsigned_int));
+    if (!OSU->vrStates || !OSU->vrStatesDerivatives) {
+        omsu_free_osu(OSU);
+        filtered_base_logger(global_logCategories, log_statusfatal, omsi_error,
+                "Could not instantiate OSU component.");
+        return NULL;
+    }
+
+    /* Set OSU value reference arrays */
+    for (i=0; i < OSU->osu_data->model_data->n_states; i++) {
+        OSU->vrStates[i] = i;
+        OSU->vrStatesDerivatives[i] = i+OSU->osu_data->model_data->n_states;
+    }
+
+    /* Set pointer to logCategories and loggingOn */
+    OSU->logCategories = OSU->osu_data->logCategories;
+    OSU->loggingOn = &OSU->osu_data->loggingOn;
+
+    /* Set state and log informations */
+    OSU->osu_data->state = &OSU->state;
+    OSU->state = modelInstantiated;
+    filtered_base_logger(global_logCategories, log_all, omsi_ok,
+            "fmi2Instantiate: GUID=%s", fmuGUID);
+
+
+    DEBUG_PRINT(omsu_print_osu(OSU))
+
+    return OSU;
+}
+
+
+/**
+ * \brief Informs the OMSU to enter initialization mode.
+ *
+ * \param   [in,out]    OSU             OMSU component.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_enter_initialization_mode(osu_t* OSU) {
+
+    /* Variables */
+    omsi_status status;
+
+    if (invalidState(OSU, "fmi2EnterInitializationMode", modelInstantiated, ~0)) {
+        filtered_base_logger(global_logCategories, log_statuserror, omsi_error,
+                "fmi2EnterInitializationMode: Call was not allowed.");
+        return omsi_error;
+    }
+
+    /* Log function call */
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2EnterInitializationMode: Initialize model.");
+
+    OSU->state = modelInitializationMode;
+
+    /* ToDo: Is this the right location to solve initialization problem */
+    /* Evaluate functionDAE for initialization problem */
+    status = OSU->osu_data->sim_data->initialization->evaluate(OSU->osu_data->sim_data->initialization, OSU->osu_data->sim_data->initialization->function_vars, NULL);
+    if (status != omsi_ok) {
+        filtered_base_logger(global_logCategories, log_fmi2_call, status,
+                    "fmi2EnterInitializationMode: Could not solve initialization problem.");
+        return status;
+
+    }
+    filtered_base_logger(global_logCategories, log_all, omsi_ok,
+            "fmi2EnterInitializationMode: Solved initialization problem successfully.");
+
+    return omsi_ok;
+}
+
+
+/**
+ * \brief Informs the OMSU to exit initialization mode.
+ *
+ * \param   [in,out]    OSU             OMSU component.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_exit_initialization_mode(osu_t* OSU) {
+
+    if (invalidState(OSU, "fmi2ExitInitializationMode", modelInitializationMode, ~0))
+        return omsi_error;
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2ExitInitializationMode: ....");
+
+    /* Set zero crossings */
+    OSU->osu_data->sim_data->simulation->evaluate (OSU->osu_data->sim_data->simulation, OSU->osu_data->sim_data->model_vars_and_params, NULL);
+
+    OSU->state = modelEventMode;
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2ExitInitializationMode: Success.");
+
+    return omsi_ok;
+}
+
+
+/**
+ * \brief Inform the OMSU  to setup the experiment.
+ *
+ * \param   [in,out]    OSU                 OMSU component.
+ * \param   [in]        toleranceDefined    Boolean if tolerance is defined.
+ * \param   [in]        tolerance           Value of tolerance, if defined.
+ * \param   [in]        startTime           Start time for experiment.
+ * \param   [in]        stopTimeDefined     If a stop time is defined.
+ * \param   [in]        stopTime            Value of stop time, if defined.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_setup_experiment(osu_t*     OSU,
+                                  omsi_bool  toleranceDefined,
+                                  omsi_real  tolerance,
+                                  omsi_real  startTime,
+                                  omsi_bool  stopTimeDefined,
+                                  omsi_real  stopTime) {
+
+    if (invalidState(OSU, "fmi2SetupExperiment", modelInstantiated, ~0))
+        return omsi_error;
+
+    if (toleranceDefined) {
+        OSU->osu_data->experiment->tolerance = tolerance;
+    }
+    else {
+        OSU->osu_data->experiment->tolerance = 1e-5;    /* default tolerance */
+    }
+    OSU->osu_data->experiment->start_time = startTime;
+    if (stopTimeDefined) {
+        OSU->osu_data->experiment->stop_time = stopTime;
+    }
+    else {
+        OSU->osu_data->experiment->stop_time = startTime+1;     /* default stop time */
+    }
+    OSU->osu_data->experiment->step_size = (OSU->osu_data->experiment->stop_time
+                                            - OSU->osu_data->experiment->start_time) / 500;
+
+    /* Log function call */
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2SetupExperiment: toleranceDefined=%s, tolerance=%g, startTime=%g, stopTimeDefined=%s, stopTime=%g",
+            toleranceDefined ? "true" : "false", OSU->osu_data->experiment->tolerance, startTime,
+            stopTimeDefined ? "true" : "false", OSU->osu_data->experiment->stop_time);
+
+    return omsi_ok;
+}
+
+
+/**
+ * \brief Free OMSU instance.
+ *
+ * Frees all allocated memory for the Openmodelica Simulation Unit.
+ * Does nothing if a null pointer is provided.
+ *
+ * \param   [in,out]    OSU                 OMSU component.
+ */
+void omsi_free_instance(osu_t* OSU) {
+
+    /* Variables */
+    omsi_int meStates;
+    omsi_int csStates;
+
+    if (OSU==NULL) {
+        return;
+    }
+
+    meStates = modelInstantiated|modelInitializationMode|modelEventMode|modelContinuousTimeMode|modelTerminated|modelError;
+    csStates = modelInstantiated|modelInitializationMode|modelEventMode|modelContinuousTimeMode|modelTerminated|modelError;
+
+    if (invalidState(OSU, "fmi2FreeInstance", meStates, csStates)) {
+        return;
+    }
+    filtered_base_logger(global_logCategories, log_fmi2_call, omsi_ok,
+            "fmi2FreeInstance");
+
+
+    /* free OSU data */
+    omsu_free_osu_data(OSU->osu_data);
+    omsu_free_osu(OSU);
+
+}
+
+
+/**
+ * \brief Reset the OMSU after a simulation run.
+ *
+ * \param   [in,out]    OSU                 OMSU component.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_reset(osu_t* OSU) {
+
+    if (invalidState(OSU, "fmi2Reset", modelInstantiated|modelInitializationMode|modelEventMode|modelContinuousTimeMode|modelTerminated|modelError, ~0))
+        return omsi_error;
+
+    filtered_base_logger(global_logCategories, log_all, omsi_ok,
+            "fmi2Reset");
+
+    if (OSU->state & modelTerminated) {
+      /* initialize OSU */
+      /* omsic_model_setup_data(OSU);*/            /* ToDo: implement */
+    }
+    /* reset the values to start */
+    /*setDefaultStartValues(OSU);*/     /* ToDo: implement */
+
+    OSU->state = modelInstantiated;
+    return omsi_ok;
+}
+
+
+/**
+ * \brief Informs the OMSU that the simulation run is terminated.
+ *
+ * \param   [in,out]    OSU                 OMSU component.
+ * \return              omsi_status     Exit status of function.
+ */
+omsi_status omsi_terminate(osu_t* OSU) {
+
+    if (invalidState(OSU, "fmi2Terminate", modelEventMode|modelContinuousTimeMode, ~0))
+        return omsi_error;
+
+    filtered_base_logger(global_logCategories, log_all, omsi_ok,
+            "fmi2Terminate");
+
+    OSU->state = modelTerminated;
+    return omsi_ok;
+}
+
+
+/**
+ * \brief Free OMSU
+ *
+ * \param [in,out]      OSU     OMSU component.
+ */
+void omsu_free_osu(osu_t* OSU) {
+
+    /* Log function call */
+    if (OSU->state == modelError || OSU->state == 0) {      /* global logCategories already freed */
+        filtered_base_logger(NULL, log_all, omsi_error,
+                "Free OSU component.");
+    }
+    else {
+        filtered_base_logger(NULL, log_all, omsi_ok,
+                "Free OSU component.");
+    }
+
+    if (OSU==NULL) {
+        return;
+    }
+
+    global_callback->freeMemory((omsi_char*) OSU->instanceName);
+    global_callback->freeMemory(OSU->osu_functions);
+    global_callback->freeMemory(OSU->vrStatesDerivatives);
+    global_callback->freeMemory(OSU->vrStates);
+    global_callback->freeMemory(OSU->GUID);
+
+    global_callback->freeMemory(OSU);
+}
+
+/** \} */


### PR DESCRIPTION
## Purpose
Simulation runtime for FMU/OMSU simulation in ANSI C.

 - Added OMSIC build
   - Added OMSIC to existing omsi-Makefiles
   - Use CMake to build SimultaionRuntime/OMSIC
 - Added OMSIC in Simulation Runtime
   - Using OMSIBase library for base functionalities shared with OMSICpp runtime
   - Wrapper for FMI 2.0 ModelExchange functions
     - Functions for continuous simulation of FMU/OMSU
     - Functions for event simulation of FMU/OMSU
     - Getter and Setter functions for FMU/OMSU
     - Logging and some debugging functionalities
     - Initialization and deallocation of FMU/OMSU
 - Documentation with Doxygen
   - Doxyfile not included

## Changed Files
- Makefile.omsi.common
- SimulationRuntime/OMSI/include/omsi.h

## New Files
- SimulationRuntime/OMSIC/CMakeLists.txt
- SimulationRuntime/OMSIC/cmake_uninstall.cmake.in
- SimulationRuntime/OMSIC/include/fmi2/fmi2FunctionTypes.h
- SimulationRuntime/OMSIC/include/fmi2/fmi2Functions.h
- SimulationRuntime/OMSIC/include/fmi2/fmi2TypesPlatform.h
- SimulationRuntime/OMSIC/include/omsic.h
- SimulationRuntime/OMSIC/include/omsu/omsu_common.h
- SimulationRuntime/OMSIC/include/omsu/omsu_continuous_simulation.h
- SimulationRuntime/OMSIC/include/omsu/omsu_event_simulation.h
- SimulationRuntime/OMSIC/include/omsu/omsu_getters_and_setters.h
- SimulationRuntime/OMSIC/include/omsu/omsu_helper.h
- SimulationRuntime/OMSIC/include/omsu/omsu_initialization.h
- SimulationRuntime/OMSIC/src/fmi2/omsi_fmi2_wrapper.c
- SimulationRuntime/OMSIC/src/omsu/CMakeLists.txt
- SimulationRuntime/OMSIC/src/omsu/omsu_continuous_simulation.c
- SimulationRuntime/OMSIC/src/omsu/omsu_event_simulation.c
- SimulationRuntime/OMSIC/src/omsu/omsu_getters_and_setters.c
- SimulationRuntime/OMSIC/src/omsu/omsu_helper.c
- SimulationRuntime/OMSIC/src/omsu/omsu_initialization.c

Co-authored-by: @niklwors 
Co-authored-by: @wibraun 