### PR TITLE
[NF] Fix structural analysis of if-condition.

### DIFF
--- a/Compiler/NFFrontEnd/NFInst.mo
+++ b/Compiler/NFFrontEnd/NFInst.mo
@@ -3486,7 +3486,6 @@ algorithm
     local
       Expression exp;
       list<Equation> eql;
-      Boolean all_params;
 
     case Equation.EQUALITY()
       algorithm
@@ -3511,18 +3510,10 @@ algorithm
 
     case Equation.IF()
       algorithm
-        all_params := true;
-
         for branch in eq.branches loop
           () := match branch
             case Equation.Branch.BRANCH()
               algorithm
-                if all_params and Expression.variability(branch.condition) == Variability.PARAMETER then
-                  markStructuralParamsExp(branch.condition);
-                else
-                  all_params := false;
-                end if;
-
                 updateImplicitVariabilityEql(branch.body, inWhen);
               then
                 ();


### PR DESCRIPTION
- Remove marking of conditions in if-equations as structural during the
  instantiation, it can't be done correctly at that point and is already
  done correctly during the typing anyway.