### PR TITLE
Fix wrong linkage of expat lib for OMSI FMUs

### DIFF
--- a/Compiler/Template/CodegenOMSIC.tpl
+++ b/Compiler/Template/CodegenOMSIC.tpl
@@ -187,7 +187,7 @@ template createMakefile(SimCode simCode, String target, String makeflieName)
     INCLUDE_DIR_OMSIC_FMI2=$(OMHOME)/include/omc/omsic/fmi2
 
     # Libraries
-    EXPAT_LIBDIR=$(OMHOME)/../OMCompiler/3rdParty/FMIL/build/ExpatEx
+    EXPAT_LIBDIR=$(OMLIB)/omc/omsi
     EXPAT_LIB=expat
 
     LAPACK_LIBDIR=<%lapackDirWin%>

--- a/SimulationRuntime/OMSI/base/CMakeLists.txt
+++ b/SimulationRuntime/OMSI/base/CMakeLists.txt
@@ -40,6 +40,9 @@ set(CMAKE_INSTALL_RPATH "${LIBINSTALLEXT}")
 
 install(TARGETS ${OSUBaseName} DESTINATION ${LIBINSTALLEXT})
 
+install(FILES ${CMAKE_SOURCE_DIR}/../../3rdParty/FMIL/build/ExpatEx/libexpat.a DESTINATION ${LIBINSTALLEXT})
+
+
 install(FILES
   ${CMAKE_SOURCE_DIR}/base/include/omsi_event_helper.h
   ${CMAKE_SOURCE_DIR}/base/include/omsi_getters_and_setters.h


### PR DESCRIPTION
Expat is used in OMSI FMUs and now installed to `build/lib/<system-triple>/omc/omsi`.
Makefile to create FMUs copies from new location.