### PR TITLE
[NF] Fix expandable connector lookup.

### DIFF
--- a/Compiler/NFFrontEnd/NFLookup.mo
+++ b/Compiler/NFFrontEnd/NFLookup.mo
@@ -778,6 +778,7 @@ algorithm
   try
     n := Class.lookupElement(name, cls);
   else
+    true := InstNode.isComponent(node);
     n := InstNode.NAME_NODE(name);
   end try;
 


### PR DESCRIPTION
- Only allow lookup of undeclared elements in components, not classes.